### PR TITLE
Remove 'stacked avatars' display for the comments

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -164,39 +164,6 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'newspack_comment_avatar' ) ) :
-	/**
-	 * Returns the HTML markup to generate a user avatar.
-	 */
-	function newspack_get_user_avatar_markup( $id_or_email = null ) {
-
-		if ( ! isset( $id_or_email ) ) {
-			$id_or_email = get_current_user_id();
-		}
-
-		return sprintf( '<div class="comment-user-avatar comment-author vcard">%s</div>', get_avatar( $id_or_email, newspack_get_avatar_size() ) );
-	}
-endif;
-
-if ( ! function_exists( 'newspack_discussion_avatars_list' ) ) :
-	/**
-	 * Displays a list of avatars involved in a discussion for a given post.
-	 */
-	function newspack_discussion_avatars_list( $comment_authors ) {
-		if ( empty( $comment_authors ) ) {
-			return;
-		}
-		echo '<ol class="discussion-avatar-list">', "\n";
-		foreach ( $comment_authors as $id_or_email ) {
-			printf(
-				"<li>%s</li>\n",
-				newspack_get_user_avatar_markup( $id_or_email )
-			);
-		}
-		echo '</ol><!-- .discussion-avatar-list -->', "\n";
-	}
-endif;
-
 if ( ! function_exists( 'newspack_comment_form' ) ) :
 	/**
 	 * Documentation for function.

--- a/sass/site/header/_site-featured-image.scss
+++ b/sass/site/header/_site-featured-image.scss
@@ -150,10 +150,6 @@
 					vertical-align: middle;
 					margin-right: 0.5em;
 				}
-
-				.discussion-avatar-list {
-					display: none;
-				}
 			}
 
 			&.has-discussion {
@@ -172,12 +168,6 @@
 					.entry-meta .comment-count {
 						position: absolute;
 						right: 0;
-					}
-
-					.entry-meta .discussion-avatar-list {
-						display: block;
-						position: absolute;
-						bottom: 100%;
 					}
 				}
 			}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4120,10 +4120,6 @@ body.page .main-navigation {
   margin-left: 0.5em;
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
-  display: none;
-}
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
     display: flex;
@@ -4135,11 +4131,6 @@ body.page .main-navigation {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
     position: absolute;
     left: 0;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -4126,10 +4126,6 @@ body.page .main-navigation {
   margin-right: 0.5em;
 }
 
-.site-header.featured-image .site-featured-image .entry-header .entry-meta .discussion-avatar-list {
-  display: none;
-}
-
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta {
     display: flex;
@@ -4141,11 +4137,6 @@ body.page .main-navigation {
   .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .comment-count {
     position: absolute;
     right: 0;
-  }
-  .site-header.featured-image .site-featured-image .entry-header.has-discussion .entry-meta .discussion-avatar-list {
-    display: block;
-    position: absolute;
-    bottom: 100%;
   }
 }
 

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -14,11 +14,6 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 	<?php newspack_posted_by(); ?>
 	<?php newspack_posted_on(); ?>
 	<span class="comment-count">
-		<?php
-		if ( ! empty( $discussion ) ) {
-			newspack_discussion_avatars_list( $discussion->authors );
-		}
-		?>
 		<?php newspack_comment_count(); ?>
 	</span>
 	<?php

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -18,11 +18,6 @@ if ( $has_responses ) {
 ?>
 
 <div class="discussion-meta">
-	<?php
-	if ( $has_responses ) {
-		newspack_discussion_avatars_list( $discussion->authors );
-	}
-	?>
 	<p class="discussion-meta-info">
 		<?php echo newspack_get_icon_svg( 'comment', 24 ); ?>
 		<span><?php echo esc_html( $meta_label ); ?></span>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is the first in a set to remove some of the more opinionated functionality from Twenty Nineteen, as we prep it to use as the base of the Newspack theme. 

This one removes the 'stacked avatars' displayed for the comments on the current single post. This is overlaid on the featured image at the top, if present, or next to the comments section if not. 

Examples:

![image](https://user-images.githubusercontent.com/177561/54633545-9da7ef80-4a3d-11e9-99e2-5175a02cca3c.png)

![image](https://user-images.githubusercontent.com/177561/54633585-b57f7380-4a3d-11e9-9114-a098d97e75de.png)

Closes #4 .

### How to test the changes in this Pull Request:

**Posts with featured images:**
1. Start with a single post with a featured image, that has comments.
2. Confirm that a set of commenters' avatars displays in the bottom-right corner of the featured image, with the comment count.
3. Apply the PR.
4. Confirm that the avatars are no longer there, and that there are no errors. The comment count should still be present.

**Posts without featured images:**
1. Start with a single post without a featured image, that has comments.
2. Confirm that a set of commenters' avatars displays next to the 'Join the Conversation' header, above the comment section of the post.
3. Apply the PR.
4. Confirm that the avatars are no longer there, and that there are no errors. The comment count should still be present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
