### PR TITLE
Fix alignment in editor

### DIFF
--- a/style-editor.css
+++ b/style-editor.css
@@ -557,8 +557,8 @@ body .wp-block[data-align="full"] {
   body .editor-post-title__block,
   body .editor-default-block-appender,
   body .editor-block-list__block {
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
   body .wp-block[data-align="wide"] {
     width: 100%;

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -33,8 +33,8 @@ body {
 		.editor-post-title__block,
 		.editor-default-block-appender,
 		.editor-block-list__block {
-			margin-left: 0;
-			margin-right: 0;
+			margin-left: auto;
+			margin-right: auto;
 		}
 
 		.wp-block[data-align="wide"] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The slight content offset was already removed from the styles before they were committed, but it still remained in the editor. This PR removes it. 

Closes #6.

### How to test the changes in this Pull Request:

1. Edit a post or page.
2. Make the browser window at least 1700px wide. 
3. Note how the content in the editor isn't centred, but sits slightly to the left -- this becomes more pronounced the wider the screen is:

![image](https://user-images.githubusercontent.com/177561/54957329-aa31b980-4f0f-11e9-92ec-5f9e82a9c4af.png)

4. Apply patch.
5. Confirm that the content in the editor is now centred.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
