### PR TITLE
Add option to hide the page title on the static front page

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -80,6 +80,29 @@ function newspack_customize_register( $wp_customize ) {
 			)
 		)
 	);
+
+	// Add option to hide page title on static front page.
+	$wp_customize->add_setting(
+		'hide_front_page_title',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+
+	$wp_customize->add_control(
+		'hide_front_page_title',
+		array(
+			'label'       => esc_html__( 'Hide Homepage Title', 'newspack' ),
+			'description' => esc_html__( 'Check to hide the page title, if your homepage is set to display a static page.', 'newspack' ),
+			'section'     => 'static_front_page',
+			'priority'    => 10,
+			'type'        => 'checkbox',
+			'settings'    => 'hide_front_page_title',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 
@@ -142,4 +165,19 @@ function newspack_sanitize_color_option( $choice ) {
 	}
 
 	return 'default';
+}
+
+/**
+ * Sanitize the checkbox.
+ *
+ * @param boolean $input Value of checkbox.
+ *
+ * @return boolean true if is 1 or '1', false if anything else
+ */
+function newspack_sanitize_checkbox( $input ) {
+	if ( 1 == $input ) {
+		return true;
+	} else {
+		return false;
+	}
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -26,6 +26,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'newspack-customizer';
 	endif;
 
+	$hide_title = get_theme_mod( 'hide_front_page_title', false );
+	if ( true === $hide_title ) {
+		$classes[] = 'hide-homepage-title';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -46,4 +46,15 @@
 		});
 	});
 
+	 // Hide Front Page Title
+	wp.customize( 'hide_front_page_title', function( value ) {
+		value.bind( function( to ) {
+			if ( true === to ) {
+				$( 'body' ).addClass( 'hide-homepage-title' );
+			} else {
+				$( 'body' ).removeClass( 'hide-homepage-title' );
+			}
+		} );
+	} );
+
 })( jQuery );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -222,6 +222,14 @@
 	}
 }
 
+/* Hide page title on the homepage */
+
+.page.home.hide-homepage-title {
+	.entry-header {
+		display: none;
+	}
+}
+
 /* Author description */
 
 .author-bio {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2499,6 +2499,11 @@ body.page .main-navigation {
   }
 }
 
+/* Hide page title on the homepage */
+.page.home.hide-homepage-title .entry-header {
+  display: none;
+}
+
 /* Author description */
 .author-bio {
   margin: calc(2 * 1rem) 1rem 1rem;

--- a/style.css
+++ b/style.css
@@ -2505,6 +2505,11 @@ body.page .main-navigation {
   }
 }
 
+/* Hide page title on the homepage */
+.page.home.hide-homepage-title .entry-header {
+  display: none;
+}
+
 /* Author description */
 .author-bio {
   margin: calc(2 * 1rem) 1rem 1rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to the Customizer to hide the page title on the static front page. 

It may not always be needed in layouts; this makes sure it can be hidden without a work-around (like leaving the 'title' field empty on the page). 

Closes #12.

### How to test the changes in this Pull Request:

1. Apply the patch. 
2. Navigate to Customize > Homepage Settings.
3. If it's not already, switch the test site to use a static front page.
4. Check the 'Hide Homepage Title' checkbox.
5. Make sure the preview works as expected, and the title hides and re-shows.
6. Make sure the changes publish correctly.
7. Make sure the setting doesn't affect other pages.
8. Make sure the setting doesn't affect the blog posts page when set to the front page. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
