### PR TITLE
Add basic WooCommerce support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -337,3 +337,10 @@ require get_template_directory() . '/inc/customizer.php';
 if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
+
+/**
+ * Load WooCommerce compatibility file.
+ */
+if ( class_exists( 'WooCommerce' ) ) {
+	require get_template_directory() . '/inc/woocommerce.php';
+}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -30,6 +30,7 @@ function newspack_woocommerce_setup() {
 }
 add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
 
+
 /**
  * Add theme's WooCommerce styles.
  *
@@ -43,7 +44,7 @@ add_action( 'wp_enqueue_scripts', 'newspack_woocommerce_scripts' );
 
 
 /**
- * Remove specific WooCommerce styles.
+ * Remove WooCommerce general styles.
  */
 function newspack_dequeue_styles( $enqueue_styles ) {
 	unset( $enqueue_styles['woocommerce-general'] );
@@ -77,6 +78,11 @@ function newspack_woo_custom_colors_css( $css, $primary_color, $saturation ) {
 add_filter( 'newspack_custom_colors_css', 'newspack_woo_custom_colors_css', 10, 3 );
 
 
+/**
+ * Remove WooCommerce sidebar - this theme doesn't have a traditional sidebar.
+ */
+remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
 
 /**
  * Remove default WooCommerce wrapper.
@@ -84,10 +90,6 @@ add_filter( 'newspack_custom_colors_css', 'newspack_woo_custom_colors_css', 10, 
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
 
-/**
- * Remove WooCommerce sidebar - this theme doesn't have a traditional sidebar.
- */
-remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
 
 if ( ! function_exists( 'newspack_woocommerce_wrapper_before' ) ) {
 	/**

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -23,10 +23,6 @@ function newspack_woocommerce_setup() {
 			'single_image_width'    => 706,
 		)
 	);
-
-	add_theme_support( 'wc-product-gallery-zoom' );
-	add_theme_support( 'wc-product-gallery-lightbox' );
-	add_theme_support( 'wc-product-gallery-slider' );
 }
 add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
 

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * WooCommerce Compatibility File
+ *
+ * @link https://woocommerce.com/
+ *
+ * @package Newspack
+ */
+
+/**
+ * WooCommerce setup function.
+ *
+ * @link https://docs.woocommerce.com/document/third-party-custom-theme-compatibility/
+ * @link https://github.com/woocommerce/woocommerce/wiki/Enabling-product-gallery-features-(zoom,-swipe,-lightbox)-in-3.0.0
+ *
+ * @return void
+ */
+function newspack_woocommerce_setup() {
+	add_theme_support(
+		'woocommerce',
+		array(
+			'thumbnail_image_width' => 300,
+			'single_image_width'    => 706,
+		)
+	);
+
+	add_theme_support( 'wc-product-gallery-zoom' );
+	add_theme_support( 'wc-product-gallery-lightbox' );
+	add_theme_support( 'wc-product-gallery-slider' );
+}
+add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
+
+/**
+ * Add theme's WooCommerce styles.
+ *
+ * @return void
+ */
+function newspack_woocommerce_scripts() {
+	wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/woocommerce.css' );
+	wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );
+}
+add_action( 'wp_enqueue_scripts', 'newspack_woocommerce_scripts' );
+
+
+/**
+ * Remove specific WooCommerce styles.
+ */
+function newspack_dequeue_styles( $enqueue_styles ) {
+	unset( $enqueue_styles['woocommerce-general'] );
+	return $enqueue_styles;
+}
+add_filter( 'woocommerce_enqueue_styles', 'newspack_dequeue_styles' );
+
+
+/**
+ * Use theme's custom color for WooCommerce elements.
+ */
+function newspack_woo_custom_colors_css( $css, $primary_color, $saturation ) {
+	if ( function_exists( 'register_block_type' ) && is_admin() ) {
+		return $css;
+	}
+	$lightness = absint( apply_filters( 'newspack_custom_colors_lightness', 33 ) );
+	$lightness = $lightness . '%';
+	$css      .= '
+		.onsale,
+		.woocommerce-info,
+		.woocommerce-store-notice {
+			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
+		}
+		.woocommerce-tabs ul li.active a {
+			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
+			box-shadow: 0 2px 0 hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
+		}
+	';
+	return $css;
+}
+add_filter( 'newspack_custom_colors_css', 'newspack_woo_custom_colors_css', 10, 3 );
+
+
+
+/**
+ * Remove default WooCommerce wrapper.
+ */
+remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
+remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
+
+/**
+ * Remove WooCommerce sidebar - this theme doesn't have a traditional sidebar.
+ */
+remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
+if ( ! function_exists( 'newspack_woocommerce_wrapper_before' ) ) {
+	/**
+	 * Before Content.
+	 *
+	 * Wraps all WooCommerce content in wrappers which match the theme markup.
+	 *
+	 * @return void
+	 */
+	function newspack_woocommerce_wrapper_before() { ?>
+		<section id="primary" class="content-area">
+			<main id="main" class="site-main">
+		<?php
+	}
+}
+add_action( 'woocommerce_before_main_content', 'newspack_woocommerce_wrapper_before' );
+
+if ( ! function_exists( 'newspack_woocommerce_wrapper_after' ) ) {
+	/**
+	 * After Content.
+	 *
+	 * Closes the wrapping divs.
+	 *
+	 * @return void
+	 */
+	function newspack_woocommerce_wrapper_after() {
+		?>
+			</main><!-- #main -->
+		</section><!-- #primary -->
+		<?php
+	}
+}
+add_action( 'woocommerce_after_main_content', 'newspack_woocommerce_wrapper_after' );

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "build:style": "node-sass style.scss style.css --output-style expanded && postcss -r style.css",
     "build:style-editor": "node-sass style-editor.scss style-editor.css --output-style expanded && postcss -r style-editor.css",
     "build:style-editor-customizer": "node-sass style-editor-customizer.scss style-editor-customizer.css --output-style expanded && postcss -r style-editor-customizer.css",
+    "build:style-woocommerce": "node-sass sass/plugins/woocommerce.scss woocommerce.css --output-style expanded && postcss -r woocommerce.css",
     "build:rtl": "rtlcss style.css style-rtl.css",
+    "build:rtl-woocommerce": "rtlcss woocommerce.css woocommerce-rtl.css",
     "build:print": "node-sass print.scss print.css --output-style expanded && postcss -r print.css",
     "build": "run-p \"build:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -446,6 +446,7 @@ table.variations {
 	th {
 		border: 0;
 		padding-left: 0;
+		vertical-align: top;
 		word-break: normal;
 	}
 

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -1,0 +1,1393 @@
+/**
+ * Sass variables
+ */
+
+$headings: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+	Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+$body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+
+$body-color: #111;
+$highlights-color: #0073aa;
+
+/**
+ * Fonts
+ */
+@font-face {
+	font-family: "star";
+	src: url("../fonts/star.eot");
+	src: url("../fonts/star.eot?#iefix") format("embedded-opentype"),
+		url("../fonts/star.woff") format("woff"),
+		url("../fonts/star.ttf") format("truetype"),
+		url("../fonts/star.svg#star") format("svg");
+	font-weight: normal;
+	font-style: normal;
+}
+
+@font-face {
+	font-family: "WooCommerce";
+	src: url("../fonts/WooCommerce.eot");
+	src: url("../fonts/WooCommerce.eot?#iefix") format("embedded-opentype"),
+		url("../fonts/WooCommerce.woff") format("woff"),
+		url("../fonts/WooCommerce.ttf") format("truetype"),
+		url("../fonts/WooCommerce.svg#WooCommerce") format("svg");
+	font-weight: normal;
+	font-style: normal;
+}
+
+/**
+ * Global elements
+ */
+a.button {
+	display: inline-block;
+	text-align: center;
+	box-sizing: border-box;
+	word-break: break-all;
+	color: #fff;
+	text-decoration: none !important;
+
+	&:hover,
+	&:visited {
+		color: #fff;
+	}
+}
+
+.woocommerce {
+	form .form-row {
+		.required {
+			color: firebrick;
+			text-decoration: none;
+			visibility: hidden; // Only show optional by default.
+
+			&[title] {
+				border: 0 !important;
+			}
+		}
+
+		.optional {
+			visibility: visible;
+		}
+	}
+}
+
+.woocommerce-breadcrumb {
+	margin-bottom: 3rem;
+	font-size: 0.88889em;
+	font-family: $headings;
+}
+
+.woocommerce-pagination {
+	font-family: $headings;
+	font-size: 0.88889em;
+
+	ul.page-numbers {
+		margin: 0;
+		padding: 0;
+		display: block;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.2;
+	}
+
+	span.page-numbers,
+	a.page-numbers,
+	.next.page-numbers,
+	.prev.page-numbers {
+		padding: 0 calc(0.5 * 1rem);
+		display: inline-block;
+	}
+}
+
+.onsale {
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: inline-block;
+	background: $highlights-color;
+	color: #fff;
+	display: inline-block;
+	font-family: $headings;
+	font-size: 0.71111em;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	line-height: 1.2;
+	padding: 0.5rem;
+	position: absolute;
+	text-transform: uppercase;
+	top: 0;
+	z-index: 1;
+}
+
+.price {
+	font-family: $headings;
+
+	del {
+		opacity: 0.5;
+		display: inline-block;
+	}
+	ins {
+		display: inline-block;
+	}
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+	margin-bottom: 1.5rem;
+	padding: 1rem;
+	background: #eee;
+	font-size: 0.88889em;
+	font-family: $headings;
+	list-style: none;
+	overflow: hidden;
+}
+
+.woocommerce-message {
+	background: #eee;
+	color: $body-color;
+}
+
+.woocommerce-error,
+.woocommerce-info {
+	color: #fff;
+
+	a {
+		color: #fff;
+
+		&:hover {
+			color: #fff;
+		}
+
+		&.button {
+			background: #111;
+		}
+	}
+}
+
+.woocommerce-error {
+	background: firebrick;
+}
+
+.woocommerce-info {
+	background: $highlights-color;
+}
+
+.woocommerce-store-notice {
+	background: $highlights-color;
+	color: #fff;
+	padding: 1rem;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+	top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+	float: right;
+	color: #fff;
+
+	&:hover {
+		text-decoration: underline;
+		color: #fff;
+	}
+}
+
+/**
+* Tables
+*/
+.woocommerce,
+.woocommerce-page {
+	table.shop_table,
+	table.shop_attributes {
+		td,
+		th {
+			border-width: 1px !important;
+			word-break: normal;
+		}
+
+		th {
+			text-align: left;
+		}
+	}
+}
+
+/**
+ * Shop page
+ */
+.woocommerce-products-header__title.page-title {
+	font-size: 1.6875em;
+	font-weight: 700;
+	font-family: $headings;
+}
+
+.woocommerce-result-count {
+	margin: 0;
+	padding: 0.75rem 0;
+}
+
+/**
+ * Products
+ */
+ul.products {
+	margin: 0;
+	padding: 0;
+
+	li.product {
+		list-style: none;
+
+		.woocommerce-loop-product__link {
+			display: block;
+		}
+
+		.woocommerce-loop-product__title {
+			margin: 0.8rem 0;
+			font-size: 0.88889em;
+
+			&:before {
+				content: none;
+			}
+		}
+
+		.woocommerce-loop-product__title,
+		.price,
+		.star-rating {
+			color: $body-color;
+		}
+
+		.star-rating {
+			margin-bottom: 0.8rem;
+		}
+
+		.price {
+			margin-bottom: 1.3rem;
+		}
+
+		.price,
+		.star-rating {
+			display: block;
+			font-size: 0.88889em;
+		}
+
+		.woocommerce-placeholder {
+			border: 1px solid #f2f2f2;
+		}
+
+		.button {
+			vertical-align: middle;
+
+			&.loading {
+				opacity: 0.5;
+			}
+		}
+
+		.added_to_cart {
+			margin-left: 0.5rem;
+			font-size: 0.88889em;
+			font-family: $headings;
+		}
+	}
+}
+
+.star-rating {
+	overflow: hidden;
+	position: relative;
+	height: 1em;
+	line-height: 1;
+	font-size: 1em;
+	width: 5.4em;
+	font-family: "star";
+
+	&::before {
+		content: "\73\73\73\73\73";
+		float: left;
+		top: 0;
+		left: 0;
+		position: absolute;
+	}
+
+	span {
+		overflow: hidden;
+		float: left;
+		top: 0;
+		left: 0;
+		position: absolute;
+		padding-top: 1.5em;
+	}
+
+	span::before {
+		content: "\53\53\53\53\53";
+		top: 0;
+		position: absolute;
+		left: 0;
+	}
+}
+
+a.remove {
+	display: inline-block;
+	width: 20px;
+	height: 20px;
+	line-height: 17px;
+	font-size: 20px;
+	font-weight: 700;
+	text-align: center;
+	border-radius: 100%;
+	text-decoration: none !important;
+	background: firebrick;
+	color: #fff;
+
+	&:hover {
+		background: #000;
+		color: #fff !important;
+	}
+}
+
+dl.variation,
+.wc-item-meta {
+	list-style: none outside;
+
+	dt,
+	.wc-item-meta-label {
+		float: left;
+		clear: both;
+		margin-right: 0.25rem;
+		list-style: none outside;
+	}
+
+	dd {
+		margin: 0;
+	}
+
+	p,
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+/**
+ * Single product
+ */
+.single-product {
+	div.product {
+		position: relative;
+	}
+
+	.single-featured-image-header {
+		display: none;
+	}
+
+	.entry {
+		.entry-title {
+			margin-top: 0;
+
+			&:before {
+				margin-top: 0;
+			}
+		}
+	}
+
+	.summary {
+		p.price {
+			margin-bottom: 2rem;
+		}
+	}
+
+	.woocommerce-product-rating {
+		margin-bottom: 2rem;
+		line-height: 1;
+
+		.star-rating {
+			float: left;
+			margin-right: 0.25rem;
+		}
+	}
+
+	form.cart {
+		.quantity {
+			float: left;
+			margin-right: 0.5rem;
+		}
+
+		input {
+			width: 5em;
+		}
+	}
+
+	.woocommerce-variation-add-to-cart {
+		.button {
+			padding-top: 0.72rem;
+			padding-bottom: 0.72rem;
+		}
+
+		.button.disabled {
+			opacity: 0.2;
+		}
+	}
+}
+
+table.variations {
+	td,
+	th {
+		border: 0;
+		word-break: normal;
+	}
+
+	label {
+		margin: 0;
+	}
+
+	select {
+		display: block;
+		margin-right: 0.5rem;
+	}
+}
+
+.woocommerce-product-gallery {
+	position: relative;
+	margin-bottom: 3rem;
+
+	figure {
+		margin: 0;
+		padding: 0;
+	}
+
+	.woocommerce-product-gallery__wrapper {
+		margin: 0;
+		padding: 0;
+	}
+
+	.zoomImg {
+		background-color: #fff;
+		opacity: 0;
+	}
+
+	.woocommerce-product-gallery__image--placeholder {
+		border: 1px solid #f2f2f2;
+	}
+
+	.woocommerce-product-gallery__image:nth-child(n + 2) {
+		width: 25%;
+		display: inline-block;
+	}
+
+	.flex-control-thumbs {
+		li {
+			list-style: none;
+			cursor: pointer;
+			float: left;
+		}
+
+		img {
+			opacity: 0.5;
+
+			&:hover,
+			&.flex-active {
+				opacity: 1;
+			}
+		}
+	}
+
+	img {
+		display: block;
+		height: auto;
+	}
+}
+
+.woocommerce-product-gallery--columns-3 {
+	.flex-control-thumbs li {
+		width: 33.3333%;
+	}
+
+	.flex-control-thumbs li:nth-child(3n + 1) {
+		clear: left;
+	}
+}
+
+.woocommerce-product-gallery--columns-4 {
+	.flex-control-thumbs li {
+		width: 25%;
+	}
+
+	.flex-control-thumbs li:nth-child(4n + 1) {
+		clear: left;
+	}
+}
+
+.woocommerce-product-gallery--columns-5 {
+	.flex-control-thumbs li {
+		width: 20%;
+	}
+
+	.flex-control-thumbs li:nth-child(5n + 1) {
+		clear: left;
+	}
+}
+
+.woocommerce-product-gallery__trigger {
+	position: absolute;
+	top: 1rem;
+	right: 1rem;
+	z-index: 99;
+}
+
+.woocommerce-tabs {
+	margin: 0 0 2rem;
+
+	ul {
+		margin: 0 0 1.5rem;
+		padding: 0;
+		font-family: $headings;
+
+		li {
+			margin-right: 1rem;
+
+			a {
+				color: $body-color;
+				text-decoration: none;
+				font-weight: 700;
+			}
+
+			&.active {
+				a {
+					color: $highlights-color;
+					box-shadow: 0 2px 0 $highlights-color;
+				}
+			}
+		}
+	}
+
+	.panel {
+		> * {
+			margin-top: 0 !important;
+		}
+
+		h1,
+		h2 {
+			&:before {
+				content: none;
+			}
+		}
+
+		h2:first-of-type {
+			font-size: 1em;
+			margin: 0 0 1rem;
+		}
+	}
+
+	#comments {
+		padding-top: 0;
+	}
+
+	.comment-reply-title {
+		font-family: $headings;
+		font-size: 1em;
+		font-weight: bold;
+		margin: 0 0 0.75rem;
+		display: block;
+	}
+
+	#reviews {
+		ol.commentlist {
+			padding: 0;
+		}
+
+		li.review,
+		li.comment {
+			list-style: none;
+			margin-right: 0;
+			margin-bottom: 2.5rem;
+
+			.avatar {
+				max-height: 36px;
+				width: auto;
+				float: right;
+			}
+
+			p.meta {
+				margin-bottom: 0.5em;
+			}
+		}
+
+		p.stars {
+			margin-top: 0;
+
+			a {
+				position: relative;
+				height: 1em;
+				width: 1em;
+				text-indent: -999em;
+				display: inline-block;
+				text-decoration: none;
+				box-shadow: none;
+
+				&::before {
+					display: block;
+					position: absolute;
+					top: 0;
+					left: 0;
+					width: 1em;
+					height: 1em;
+					line-height: 1;
+					font-family: "WooCommerce";
+					content: "\e021";
+					text-indent: 0;
+				}
+
+				&:hover {
+					~ a::before {
+						content: "\e021";
+					}
+				}
+			}
+
+			&:hover {
+				a {
+					&::before {
+						content: "\e020";
+					}
+				}
+			}
+
+			&.selected {
+				a.active {
+					&::before {
+						content: "\e020";
+					}
+
+					~ a::before {
+						content: "\e021";
+					}
+				}
+
+				a:not(.active) {
+					&::before {
+						content: "\e020";
+					}
+				}
+			}
+		}
+	}
+}
+
+/**
+ * Widgets
+ */
+.widget.woocommerce {
+	ul {
+		padding-left: 0;
+
+		li {
+			list-style: none;
+		}
+	}
+}
+
+.widget .product_list_widget,
+.site-footer .widget .product_list_widget {
+	margin-bottom: 1.5rem;
+
+	a {
+		display: block;
+		box-shadow: none;
+
+		&:hover {
+			box-shadow: none;
+		}
+	}
+
+	li {
+		padding: 0.5rem 0;
+
+		a.remove {
+			float: left;
+			margin-top: 7px;
+			line-height: 20px;
+			color: #fff;
+			margin-right: 0.5rem;
+		}
+	}
+
+	img {
+		display: none;
+	}
+}
+
+.widget_shopping_cart {
+	.buttons {
+		a {
+			display: inline-block;
+			margin: 0 0.5rem 0 0;
+		}
+	}
+}
+
+.widget_layered_nav {
+	.chosen {
+		&:before {
+			content: "×";
+			display: inline-block;
+			width: 16px;
+			height: 16px;
+			line-height: 16px;
+			font-size: 16px;
+			text-align: center;
+			border-radius: 100%;
+			border: 1px solid black;
+			margin-right: 0.25rem;
+		}
+	}
+}
+
+.widget_price_filter {
+	.price_slider {
+		margin-bottom: 1rem;
+	}
+
+	.price_slider_amount {
+		text-align: right;
+		line-height: 2.4;
+		font-size: 0.8751em;
+
+		.button {
+			float: left;
+			padding: 0.4rem 1rem;
+		}
+	}
+
+	.ui-slider {
+		position: relative;
+		text-align: left;
+		margin-left: 0.5rem;
+		margin-right: 0.5rem;
+	}
+
+	.ui-slider .ui-slider-handle {
+		position: absolute;
+		z-index: 2;
+		width: 1em;
+		height: 1em;
+		background-color: #000;
+		border-radius: 1em;
+		cursor: ew-resize;
+		outline: none;
+		top: -0.3em;
+		margin-left: -0.5em;
+	}
+
+	.ui-slider .ui-slider-range {
+		position: absolute;
+		z-index: 1;
+		font-size: 0.7em;
+		display: block;
+		border: 0;
+		border-radius: 1em;
+		background-color: #000;
+	}
+
+	.price_slider_wrapper .ui-widget-content {
+		border-radius: 1em;
+		background-color: #666;
+		border: 0;
+	}
+
+	.ui-slider-horizontal {
+		height: 0.5em;
+	}
+
+	.ui-slider-horizontal .ui-slider-range {
+		top: 0;
+		height: 100%;
+	}
+
+	.ui-slider-horizontal .ui-slider-range-min {
+		left: -1px;
+	}
+
+	.ui-slider-horizontal .ui-slider-range-max {
+		right: -1px;
+	}
+}
+
+.widget_rating_filter {
+	li {
+		text-align: right;
+
+		.star-rating {
+			float: left;
+			margin-top: 0.3rem;
+		}
+	}
+}
+
+.widget_product_search {
+	form {
+		position: relative;
+	}
+
+	.search-field {
+		padding-right: 100px;
+	}
+
+	input[type="submit"] {
+		position: absolute;
+		top: 0.5rem;
+		right: 0.5rem;
+		padding-left: 1rem;
+		padding-right: 1rem;
+	}
+}
+
+/**
+ * Account section
+ */
+.woocommerce-account {
+	.woocommerce-MyAccount-navigation {
+		font-family: $headings;
+		margin: 0 0 2rem;
+
+		ul {
+			margin: 0;
+			padding: 0;
+		}
+
+		li {
+			list-style: none;
+			padding: 0.5rem 0;
+			border-bottom: 1px solid #ccc;
+
+			&:first-child {
+				padding-top: 0;
+			}
+
+			a {
+				box-shadow: none;
+				text-decoration: none;
+				font-weight: 600;
+
+				&:hover {
+					color: #005177;
+					text-decoration: underline;
+				}
+			}
+
+			&.is-active {
+				a {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+
+	table.account-orders-table {
+		.button {
+			margin: 0 0.35rem 0.35rem 0;
+		}
+	}
+}
+
+/**
+ * Cart
+ */
+.woocommerce-cart-form {
+	img {
+		max-width: 42px;
+		height: auto;
+		display: block;
+	}
+
+	dl.variation {
+		margin-top: 0;
+
+		p,
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.product-remove {
+		text-align: center;
+	}
+
+	.actions {
+		.input-text {
+			width: 200px !important;
+			float: left;
+			margin-right: 0.25rem;
+		}
+	}
+
+	.quantity {
+		input {
+			width: 4rem;
+		}
+	}
+}
+
+.cart_totals {
+	th,
+	td {
+		vertical-align: top;
+	}
+
+	th {
+		padding-right: 1rem;
+	}
+
+	.woocommerce-shipping-destination {
+		margin-bottom: 0;
+	}
+}
+
+.shipping-calculator-button {
+	margin-top: 0.5rem;
+	display: inline-block;
+}
+
+.shipping-calculator-form {
+	margin: 1rem 0 0 0;
+}
+
+#shipping_method {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	li {
+		margin-bottom: 0.5rem;
+
+		input {
+			float: left;
+			margin-top: 0.17rem;
+		}
+
+		label {
+			line-height: 1.5rem;
+		}
+	}
+}
+
+.checkout-button {
+	display: block;
+	padding: 1rem 2rem;
+	border: 2px solid #000;
+	text-align: center;
+	font-weight: 800;
+
+	&:hover {
+		border-color: #999;
+	}
+
+	&:after {
+		content: "→";
+		margin-left: 0.5rem;
+	}
+}
+
+/**
+ * Checkout
+ */
+#ship-to-different-address {
+	font-size: 1em;
+	display: inline-block;
+	margin: 1.41rem 0;
+
+	label {
+		font-weight: 300;
+		cursor: pointer;
+
+		span {
+			position: relative;
+			display: block;
+			text-align: right;
+			padding-right: 45px;
+
+			&:before {
+				content: "";
+				display: block;
+				height: 16px;
+				width: 30px;
+				border: 2px solid #bbb;
+				background: #bbb;
+				border-radius: 13rem;
+				box-sizing: content-box;
+				transition: all ease-in-out 0.3s;
+				position: absolute;
+				top: 4px;
+				right: 0;
+			}
+
+			&:after {
+				content: "";
+				display: block;
+				width: 14px;
+				height: 14px;
+				background: white;
+				position: absolute;
+				top: 7px;
+				right: 17px;
+				border-radius: 13rem;
+				transition: all ease-in-out 0.3s;
+			}
+		}
+
+		input[type="checkbox"] {
+			display: none;
+		}
+
+		input[type="checkbox"]:checked + span:after {
+			right: 3px;
+		}
+
+		input[type="checkbox"]:checked + span:before {
+			border-color: #000;
+			background: #000;
+		}
+	}
+}
+
+.woocommerce-no-js {
+	form.woocommerce-form-login,
+	form.woocommerce-form-coupon {
+		display: block !important;
+	}
+	.woocommerce-form-login-toggle,
+	.woocommerce-form-coupon-toggle,
+	.showcoupon {
+		display: none !important;
+	}
+}
+
+.woocommerce-terms-and-conditions {
+	border: 1px solid rgba(0, 0, 0, 0.2);
+	box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+	background: rgba(0, 0, 0, 0.05);
+}
+
+.woocommerce-terms-and-conditions-link {
+	display: inline-block;
+
+	&:after {
+		content: "";
+		display: inline-block;
+		border-style: solid;
+		margin-bottom: 2px;
+		margin-left: 0.25rem;
+		border-width: 6px 6px 0 6px;
+		border-color: $body-color transparent transparent transparent;
+	}
+	&.woocommerce-terms-and-conditions-link--open:after {
+		border-width: 0 6px 6px 6px;
+		border-color: transparent transparent $body-color transparent;
+	}
+}
+
+.woocommerce-checkout {
+	.woocommerce-input-wrapper {
+		.description {
+			background: royalblue;
+			color: #fff;
+			border-radius: 3px;
+			padding: 1rem;
+			margin: 0.5rem 0 0;
+			clear: both;
+			display: none;
+			position: relative;
+
+			a {
+				color: #fff;
+				text-decoration: underline;
+				border: 0;
+				box-shadow: none;
+			}
+
+			&:before {
+				left: 50%;
+				top: 0%;
+				margin-top: -4px;
+				transform: translatex(-50%) rotate(180deg);
+				content: "";
+				position: absolute;
+				border-width: 4px 6px 0 6px;
+				border-style: solid;
+				border-color: royalblue transparent transparent transparent;
+				z-index: 100;
+				display: block;
+			}
+		}
+	}
+
+	.select2-choice,
+	.select2-choice:hover {
+		box-shadow: none !important;
+	}
+	.select2-choice {
+		padding: 0.7rem 0 0.7rem 0.7rem;
+	}
+	.select2-container .select2-selection--single {
+		height: 48px;
+	}
+	.select2-container .select2-selection--single .select2-selection__rendered {
+		line-height: 48px;
+	}
+	.select2-container--default
+		.select2-selection--single
+		.select2-selection__arrow {
+		height: 46px;
+	}
+	.select2-container--focus .select2-selection {
+		border-color: black;
+	}
+}
+
+.woocommerce-checkout-review-order-table {
+	td {
+		padding: 1rem 0.5rem;
+	}
+
+	dl.variation {
+		margin: 0;
+
+		p {
+			margin: 0;
+		}
+	}
+}
+
+.woocommerce-checkout-review-order {
+	ul {
+		margin: 2rem 0 1rem;
+		padding-left: 0;
+	}
+}
+
+.wc_payment_method {
+	list-style: none;
+
+	.payment_box {
+		padding: 1rem;
+		background: #eee;
+
+		ul,
+		ol {
+			&:last-of-type {
+				margin-bottom: 0;
+			}
+		}
+
+		fieldset {
+			padding: 1.5rem;
+			padding-bottom: 0;
+			border: 0;
+			background: #f6f6f6;
+		}
+
+		li {
+			list-style: none;
+		}
+
+		p {
+			&:first-child {
+				margin-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+
+	> label:first-of-type {
+		display: block;
+		margin: 1rem 0;
+
+		img {
+			max-height: 24px;
+			max-width: 200px;
+			float: right;
+		}
+	}
+
+	label {
+		cursor: pointer;
+	}
+
+	input.input-radio[name="payment_method"] {
+		display: none;
+
+		& + label {
+			&:before {
+				content: "";
+				display: inline-block;
+				width: 16px;
+				height: 16px;
+				border: 2px solid white;
+				box-shadow: 0 0 0 2px black;
+				background: white;
+				margin-left: 4px;
+				margin-right: 0.5rem;
+				border-radius: 100%;
+				transform: translateY(2px);
+			}
+		}
+
+		&:checked + label {
+			&:before {
+				background: black;
+			}
+		}
+	}
+}
+
+.woocommerce-order-overview {
+	margin-bottom: 2rem;
+}
+
+.woocommerce-table--order-details {
+	margin-bottom: 2rem;
+}
+
+/**
+ * Layout stuff
+ */
+.woocommerce {
+	.content-area {
+		.site-main {
+			margin: calc(2 * 1rem) 1rem;
+		}
+	}
+}
+
+@media only screen and (max-width: 768px) {
+	.woocommerce,
+	.woocommerce-page {
+		table.shop_table_responsive {
+			tr {
+				margin: 0 0 1.5rem;
+
+				&:first-child {
+					border-top: 1px solid;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+
+				td {
+					border-bottom-width: 0;
+
+					&:last-child {
+						border-bottom-width: 1px;
+					}
+				}
+			}
+		}
+	}
+}
+
+@media only screen and (min-width: 768px) {
+	/**
+	* Tables
+	*/
+	.woocommerce,
+	.woocommerce-page {
+		table.shop_table {
+			tbody {
+				tr {
+					font-size: 0.88889em;
+				}
+			}
+		}
+	}
+
+	/**
+	* Shop page
+	*/
+	.woocommerce-products-header__title.page-title {
+		font-size: 2.25em;
+	}
+
+	.woocommerce-pagination {
+		span.page-numbers,
+		a.page-numbers,
+		.next.page-numbers,
+		.prev.page-numbers {
+			padding: 1rem;
+		}
+	}
+
+	/**
+	* Account section
+	*/
+	.woocommerce-account {
+		.woocommerce-MyAccount-navigation {
+			float: none;
+			width: 100%;
+			margin-bottom: 1.5rem;
+
+			li {
+				display: inline-block;
+				margin: 0 1rem 0 0;
+				padding: 0;
+				border-bottom: 0;
+
+				&:last-child {
+					margin-right: 0;
+				}
+			}
+		}
+
+		.woocommerce-MyAccount-content {
+			float: none;
+			width: 100%;
+		}
+	}
+
+	/**
+	* Checkout
+	*/
+	#ship-to-different-address {
+		display: block;
+	}
+
+	/**
+	* Layout stuff
+	*/
+	.woocommerce {
+		.content-area {
+			margin: 0 calc(10% + 60px);
+
+			.site-main {
+				margin: 0;
+				max-width: calc(8 * (100vw / 12) - 28px);
+			}
+		}
+	}
+
+	.single-product {
+		.entry {
+			.entry-content,
+			.entry-summary {
+				max-width: none;
+				margin: 0 0 3rem;
+				padding: 0;
+
+				> * {
+					max-width: none;
+				}
+			}
+		}
+	}
+}
+
+@media only screen and (min-width: 1168px) {
+	.woocommerce {
+		.content-area {
+			.site-main {
+				max-width: calc(6 * (100vw / 12) - 28px);
+			}
+		}
+	}
+}

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -9,6 +9,9 @@ $body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
 $body-color: #111;
 $highlights-color: #0073aa;
 
+@import "sass/variables-site/variables-site";
+@import "sass/mixins/mixins-master";
+
 /**
  * Fonts
  */
@@ -205,7 +208,6 @@ a.button {
 	table.shop_attributes {
 		td,
 		th {
-			border-width: 1px !important;
 			word-break: normal;
 		}
 
@@ -1255,7 +1257,10 @@ table.variations {
 .woocommerce {
 	.content-area {
 		.site-main {
-			margin: calc(2 * 1rem) 1rem;
+			margin: 32px 0;
+			max-width: 100%;
+
+			@include postContentMaxWidth();
 		}
 	}
 }
@@ -1285,6 +1290,18 @@ table.variations {
 			}
 		}
 	}
+
+	.woocommerce-breadcrumb,
+	.woocommerce-product-gallery .woocommerce-product-gallery__wrapper,
+	.woocommerce-tabs ul,
+	.woocommerce-checkout {
+		margin-left: 1rem;
+		margin-right: 1rem;
+	}
+
+	.woocommerce-product-gallery__trigger {
+		right: 1rem;
+	}
 }
 
 @media only screen and (min-width: 768px) {
@@ -1293,7 +1310,8 @@ table.variations {
 	*/
 	.woocommerce,
 	.woocommerce-page {
-		table.shop_table {
+		table.shop_table,
+		table.shop_attributes {
 			tbody {
 				tr {
 					font-size: 0.88889em;
@@ -1360,7 +1378,7 @@ table.variations {
 			margin: 0 calc(10% + 60px);
 
 			.site-main {
-				margin: 0;
+				margin: 0 auto;
 				max-width: calc(8 * (100vw / 12) - 28px);
 			}
 		}

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -294,6 +294,17 @@ ul.products {
 	}
 }
 
+/* Name your price */
+.product .nyp {
+	label {
+		display: block;
+	}
+
+	.nyp-input {
+		margin-bottom: 0;
+	}
+}
+
 .star-rating {
 	overflow: hidden;
 	position: relative;
@@ -434,6 +445,7 @@ table.variations {
 	td,
 	th {
 		border: 0;
+		padding-left: 0;
 		word-break: normal;
 	}
 

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -428,6 +428,7 @@ table.variations td,
 table.variations th {
   border: 0;
   padding-right: 0;
+  vertical-align: top;
   word-break: normal;
 }
 

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -1,0 +1,1272 @@
+@charset "UTF-8";
+/**
+ * Sass variables
+ */
+/**
+ * Fonts
+ */
+@font-face {
+  font-family: "star";
+  src: url("../fonts/star.eot");
+  src: url("../fonts/star.eot?#iefix") format("embedded-opentype"), url("../fonts/star.woff") format("woff"), url("../fonts/star.ttf") format("truetype"), url("../fonts/star.svg#star") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "WooCommerce";
+  src: url("../fonts/WooCommerce.eot");
+  src: url("../fonts/WooCommerce.eot?#iefix") format("embedded-opentype"), url("../fonts/WooCommerce.woff") format("woff"), url("../fonts/WooCommerce.ttf") format("truetype"), url("../fonts/WooCommerce.svg#WooCommerce") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+
+/**
+ * Global elements
+ */
+a.button {
+  display: inline-block;
+  text-align: center;
+  box-sizing: border-box;
+  word-break: break-all;
+  color: #fff;
+  text-decoration: none !important;
+}
+
+a.button:hover, a.button:visited {
+  color: #fff;
+}
+
+.woocommerce form .form-row .required {
+  color: firebrick;
+  text-decoration: none;
+  visibility: hidden;
+}
+
+.woocommerce form .form-row .required[title] {
+  border: 0 !important;
+}
+
+.woocommerce form .form-row .optional {
+  visibility: visible;
+}
+
+.woocommerce-breadcrumb {
+  margin-bottom: 3rem;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-pagination {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+}
+
+.woocommerce-pagination ul.page-numbers {
+  margin: 0;
+  padding: 0;
+  display: block;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.woocommerce-pagination span.page-numbers,
+.woocommerce-pagination a.page-numbers,
+.woocommerce-pagination .next.page-numbers,
+.woocommerce-pagination .prev.page-numbers {
+  padding: 0 calc(0.5 * 1rem);
+  display: inline-block;
+}
+
+.onsale {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-block;
+  background: #0073aa;
+  color: #fff;
+  display: inline-block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.71111em;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  padding: 0.5rem;
+  position: absolute;
+  text-transform: uppercase;
+  top: 0;
+  z-index: 1;
+}
+
+.price {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.price del {
+  opacity: 0.5;
+  display: inline-block;
+}
+
+.price ins {
+  display: inline-block;
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #eee;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  list-style: none;
+  overflow: hidden;
+}
+
+.woocommerce-message {
+  background: #eee;
+  color: #111;
+}
+
+.woocommerce-error,
+.woocommerce-info {
+  color: #fff;
+}
+
+.woocommerce-error a,
+.woocommerce-info a {
+  color: #fff;
+}
+
+.woocommerce-error a:hover,
+.woocommerce-info a:hover {
+  color: #fff;
+}
+
+.woocommerce-error a.button,
+.woocommerce-info a.button {
+  background: #111;
+}
+
+.woocommerce-error {
+  background: firebrick;
+}
+
+.woocommerce-info {
+  background: #0073aa;
+}
+
+.woocommerce-store-notice {
+  background: #0073aa;
+  color: #fff;
+  padding: 1rem;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+  top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+  float: left;
+  color: #fff;
+}
+
+.woocommerce-store-notice__dismiss-link:hover {
+  text-decoration: underline;
+  color: #fff;
+}
+
+/**
+* Tables
+*/
+.woocommerce table.shop_table td,
+.woocommerce table.shop_table th,
+.woocommerce table.shop_attributes td,
+.woocommerce table.shop_attributes th,
+.woocommerce-page table.shop_table td,
+.woocommerce-page table.shop_table th,
+.woocommerce-page table.shop_attributes td,
+.woocommerce-page table.shop_attributes th {
+  border-width: 1px;
+  word-break: normal;
+}
+
+.woocommerce table.shop_table th,
+.woocommerce table.shop_attributes th,
+.woocommerce-page table.shop_table th,
+.woocommerce-page table.shop_attributes th {
+  text-align: right;
+}
+
+/**
+ * Shop page
+ */
+.woocommerce-products-header__title.page-title {
+  font-size: 1.6875em;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-result-count {
+  margin: 0;
+  padding: 0.75rem 0;
+}
+
+/**
+ * Products
+ */
+ul.products {
+  margin: 0;
+  padding: 0;
+}
+
+ul.products li.product {
+  list-style: none;
+}
+
+ul.products li.product .woocommerce-loop-product__link {
+  display: block;
+}
+
+ul.products li.product .woocommerce-loop-product__title {
+  margin: 0.8rem 0;
+  font-size: 0.88889em;
+}
+
+ul.products li.product .woocommerce-loop-product__title:before {
+  content: none;
+}
+
+ul.products li.product .woocommerce-loop-product__title,
+ul.products li.product .price,
+ul.products li.product .star-rating {
+  color: #111;
+}
+
+ul.products li.product .star-rating {
+  margin-bottom: 0.8rem;
+}
+
+ul.products li.product .price {
+  margin-bottom: 1.3rem;
+}
+
+ul.products li.product .price,
+ul.products li.product .star-rating {
+  display: block;
+  font-size: 0.88889em;
+}
+
+ul.products li.product .woocommerce-placeholder {
+  border: 1px solid #f2f2f2;
+}
+
+ul.products li.product .button {
+  vertical-align: middle;
+}
+
+ul.products li.product .button.loading {
+  opacity: 0.5;
+}
+
+ul.products li.product .added_to_cart {
+  margin-right: 0.5rem;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.star-rating {
+  overflow: hidden;
+  position: relative;
+  height: 1em;
+  line-height: 1;
+  font-size: 1em;
+  width: 5.4em;
+  font-family: "star";
+}
+
+.star-rating::before {
+  content: "\73\73\73\73\73";
+  float: right;
+  top: 0;
+  right: 0;
+  position: absolute;
+}
+
+.star-rating span {
+  overflow: hidden;
+  float: right;
+  top: 0;
+  right: 0;
+  position: absolute;
+  padding-top: 1.5em;
+}
+
+.star-rating span::before {
+  content: "\53\53\53\53\53";
+  top: 0;
+  position: absolute;
+  right: 0;
+}
+
+a.remove {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  line-height: 17px;
+  font-size: 20px;
+  font-weight: 700;
+  text-align: center;
+  border-radius: 100%;
+  text-decoration: none !important;
+  background: firebrick;
+  color: #fff;
+}
+
+a.remove:hover {
+  background: #000;
+  color: #fff !important;
+}
+
+dl.variation,
+.wc-item-meta {
+  list-style: none outside;
+}
+
+dl.variation dt,
+dl.variation .wc-item-meta-label,
+.wc-item-meta dt,
+.wc-item-meta .wc-item-meta-label {
+  float: right;
+  clear: both;
+  margin-left: 0.25rem;
+  list-style: none outside;
+}
+
+dl.variation dd,
+.wc-item-meta dd {
+  margin: 0;
+}
+
+dl.variation p, dl.variation:last-child,
+.wc-item-meta p,
+.wc-item-meta:last-child {
+  margin-bottom: 0;
+}
+
+/**
+ * Single product
+ */
+.single-product div.product {
+  position: relative;
+}
+
+.single-product .single-featured-image-header {
+  display: none;
+}
+
+.single-product .entry .entry-title {
+  margin-top: 0;
+}
+
+.single-product .entry .entry-title:before {
+  margin-top: 0;
+}
+
+.single-product .summary p.price {
+  margin-bottom: 2rem;
+}
+
+.single-product .woocommerce-product-rating {
+  margin-bottom: 2rem;
+  line-height: 1;
+}
+
+.single-product .woocommerce-product-rating .star-rating {
+  float: right;
+  margin-left: 0.25rem;
+}
+
+.single-product form.cart .quantity {
+  float: right;
+  margin-left: 0.5rem;
+}
+
+.single-product form.cart input {
+  width: 5em;
+}
+
+.single-product .woocommerce-variation-add-to-cart .button {
+  padding-top: 0.72rem;
+  padding-bottom: 0.72rem;
+}
+
+.single-product .woocommerce-variation-add-to-cart .button.disabled {
+  opacity: 0.2;
+}
+
+table.variations td,
+table.variations th {
+  border: 0;
+  word-break: normal;
+}
+
+table.variations label {
+  margin: 0;
+}
+
+table.variations select {
+  display: block;
+  margin-left: 0.5rem;
+}
+
+.woocommerce-product-gallery {
+  position: relative;
+  margin-bottom: 3rem;
+}
+
+.woocommerce-product-gallery figure {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__wrapper {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-product-gallery .zoomImg {
+  background-color: #fff;
+  opacity: 0;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__image--placeholder {
+  border: 1px solid #f2f2f2;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__image:nth-child(n + 2) {
+  width: 25%;
+  display: inline-block;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs li {
+  list-style: none;
+  cursor: pointer;
+  float: right;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs img {
+  opacity: 0.5;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs img:hover, .woocommerce-product-gallery .flex-control-thumbs img.flex-active {
+  opacity: 1;
+}
+
+.woocommerce-product-gallery img {
+  display: block;
+  height: auto;
+}
+
+.woocommerce-product-gallery--columns-3 .flex-control-thumbs li {
+  width: 33.3333%;
+}
+
+.woocommerce-product-gallery--columns-3 .flex-control-thumbs li:nth-child(3n + 1) {
+  clear: right;
+}
+
+.woocommerce-product-gallery--columns-4 .flex-control-thumbs li {
+  width: 25%;
+}
+
+.woocommerce-product-gallery--columns-4 .flex-control-thumbs li:nth-child(4n + 1) {
+  clear: right;
+}
+
+.woocommerce-product-gallery--columns-5 .flex-control-thumbs li {
+  width: 20%;
+}
+
+.woocommerce-product-gallery--columns-5 .flex-control-thumbs li:nth-child(5n + 1) {
+  clear: right;
+}
+
+.woocommerce-product-gallery__trigger {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 99;
+}
+
+.woocommerce-tabs {
+  margin: 0 0 2rem;
+}
+
+.woocommerce-tabs ul {
+  margin: 0 0 1.5rem;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-tabs ul li {
+  margin-left: 1rem;
+}
+
+.woocommerce-tabs ul li a {
+  color: #111;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.woocommerce-tabs ul li.active a {
+  color: #0073aa;
+  box-shadow: 0 2px 0 #0073aa;
+}
+
+.woocommerce-tabs .panel > * {
+  margin-top: 0 !important;
+}
+
+.woocommerce-tabs .panel h1:before,
+.woocommerce-tabs .panel h2:before {
+  content: none;
+}
+
+.woocommerce-tabs .panel h2:first-of-type {
+  font-size: 1em;
+  margin: 0 0 1rem;
+}
+
+.woocommerce-tabs #comments {
+  padding-top: 0;
+}
+
+.woocommerce-tabs .comment-reply-title {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 0 0 0.75rem;
+  display: block;
+}
+
+.woocommerce-tabs #reviews ol.commentlist {
+  padding: 0;
+}
+
+.woocommerce-tabs #reviews li.review,
+.woocommerce-tabs #reviews li.comment {
+  list-style: none;
+  margin-left: 0;
+  margin-bottom: 2.5rem;
+}
+
+.woocommerce-tabs #reviews li.review .avatar,
+.woocommerce-tabs #reviews li.comment .avatar {
+  max-height: 36px;
+  width: auto;
+  float: left;
+}
+
+.woocommerce-tabs #reviews li.review p.meta,
+.woocommerce-tabs #reviews li.comment p.meta {
+  margin-bottom: 0.5em;
+}
+
+.woocommerce-tabs #reviews p.stars {
+  margin-top: 0;
+}
+
+.woocommerce-tabs #reviews p.stars a {
+  position: relative;
+  height: 1em;
+  width: 1em;
+  text-indent: -999em;
+  display: inline-block;
+  text-decoration: none;
+  box-shadow: none;
+}
+
+.woocommerce-tabs #reviews p.stars a::before {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  font-family: "WooCommerce";
+  content: "\e021";
+  text-indent: 0;
+}
+
+.woocommerce-tabs #reviews p.stars a:hover ~ a::before {
+  content: "\e021";
+}
+
+.woocommerce-tabs #reviews p.stars:hover a::before {
+  content: "\e020";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a.active::before {
+  content: "\e020";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a.active ~ a::before {
+  content: "\e021";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a:not(.active)::before {
+  content: "\e020";
+}
+
+/**
+ * Widgets
+ */
+.widget.woocommerce ul {
+  padding-right: 0;
+}
+
+.widget.woocommerce ul li {
+  list-style: none;
+}
+
+.widget .product_list_widget,
+.site-footer .widget .product_list_widget {
+  margin-bottom: 1.5rem;
+}
+
+.widget .product_list_widget a,
+.site-footer .widget .product_list_widget a {
+  display: block;
+  box-shadow: none;
+}
+
+.widget .product_list_widget a:hover,
+.site-footer .widget .product_list_widget a:hover {
+  box-shadow: none;
+}
+
+.widget .product_list_widget li,
+.site-footer .widget .product_list_widget li {
+  padding: 0.5rem 0;
+}
+
+.widget .product_list_widget li a.remove,
+.site-footer .widget .product_list_widget li a.remove {
+  float: right;
+  margin-top: 7px;
+  line-height: 20px;
+  color: #fff;
+  margin-left: 0.5rem;
+}
+
+.widget .product_list_widget img,
+.site-footer .widget .product_list_widget img {
+  display: none;
+}
+
+.widget_shopping_cart .buttons a {
+  display: inline-block;
+  margin: 0 0 0 0.5rem;
+}
+
+.widget_layered_nav .chosen:before {
+  content: "×";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  font-size: 16px;
+  text-align: center;
+  border-radius: 100%;
+  border: 1px solid black;
+  margin-left: 0.25rem;
+}
+
+.widget_price_filter .price_slider {
+  margin-bottom: 1rem;
+}
+
+.widget_price_filter .price_slider_amount {
+  text-align: left;
+  line-height: 2.4;
+  font-size: 0.8751em;
+}
+
+.widget_price_filter .price_slider_amount .button {
+  float: right;
+  padding: 0.4rem 1rem;
+}
+
+.widget_price_filter .ui-slider {
+  position: relative;
+  text-align: right;
+  margin-right: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.widget_price_filter .ui-slider .ui-slider-handle {
+  position: absolute;
+  z-index: 2;
+  width: 1em;
+  height: 1em;
+  background-color: #000;
+  border-radius: 1em;
+  cursor: ew-resize;
+  outline: none;
+  top: -0.3em;
+  margin-right: -0.5em;
+}
+
+.widget_price_filter .ui-slider .ui-slider-range {
+  position: absolute;
+  z-index: 1;
+  font-size: 0.7em;
+  display: block;
+  border: 0;
+  border-radius: 1em;
+  background-color: #000;
+}
+
+.widget_price_filter .price_slider_wrapper .ui-widget-content {
+  border-radius: 1em;
+  background-color: #666;
+  border: 0;
+}
+
+.widget_price_filter .ui-slider-horizontal {
+  height: 0.5em;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range {
+  top: 0;
+  height: 100%;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range-min {
+  right: -1px;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range-max {
+  left: -1px;
+}
+
+.widget_rating_filter li {
+  text-align: left;
+}
+
+.widget_rating_filter li .star-rating {
+  float: right;
+  margin-top: 0.3rem;
+}
+
+.widget_product_search form {
+  position: relative;
+}
+
+.widget_product_search .search-field {
+  padding-left: 100px;
+}
+
+.widget_product_search input[type="submit"] {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+/**
+ * Account section
+ */
+.woocommerce-account .woocommerce-MyAccount-navigation {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  margin: 0 0 2rem;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li {
+  list-style: none;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #ccc;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li:first-child {
+  padding-top: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a {
+  box-shadow: none;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a:hover {
+  color: #005177;
+  text-decoration: underline;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li.is-active a {
+  text-decoration: underline;
+}
+
+.woocommerce-account table.account-orders-table .button {
+  margin: 0 0 0.35rem 0.35rem;
+}
+
+/**
+ * Cart
+ */
+.woocommerce-cart-form img {
+  max-width: 42px;
+  height: auto;
+  display: block;
+}
+
+.woocommerce-cart-form dl.variation {
+  margin-top: 0;
+}
+
+.woocommerce-cart-form dl.variation p, .woocommerce-cart-form dl.variation:last-child {
+  margin-bottom: 0;
+}
+
+.woocommerce-cart-form .product-remove {
+  text-align: center;
+}
+
+.woocommerce-cart-form .actions .input-text {
+  width: 200px !important;
+  float: right;
+  margin-left: 0.25rem;
+}
+
+.woocommerce-cart-form .quantity input {
+  width: 4rem;
+}
+
+.cart_totals th,
+.cart_totals td {
+  vertical-align: top;
+}
+
+.cart_totals th {
+  padding-left: 1rem;
+}
+
+.cart_totals .woocommerce-shipping-destination {
+  margin-bottom: 0;
+}
+
+.shipping-calculator-button {
+  margin-top: 0.5rem;
+  display: inline-block;
+}
+
+.shipping-calculator-form {
+  margin: 1rem 0 0 0;
+}
+
+#shipping_method {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#shipping_method li {
+  margin-bottom: 0.5rem;
+}
+
+#shipping_method li input {
+  float: right;
+  margin-top: 0.17rem;
+}
+
+#shipping_method li label {
+  line-height: 1.5rem;
+}
+
+.checkout-button {
+  display: block;
+  padding: 1rem 2rem;
+  border: 2px solid #000;
+  text-align: center;
+  font-weight: 800;
+}
+
+.checkout-button:hover {
+  border-color: #999;
+}
+
+.checkout-button:after {
+  content: "→";
+  margin-right: 0.5rem;
+}
+
+/**
+ * Checkout
+ */
+#ship-to-different-address {
+  font-size: 1em;
+  display: inline-block;
+  margin: 1.41rem 0;
+}
+
+#ship-to-different-address label {
+  font-weight: 300;
+  cursor: pointer;
+}
+
+#ship-to-different-address label span {
+  position: relative;
+  display: block;
+  text-align: left;
+  padding-left: 45px;
+}
+
+#ship-to-different-address label span:before {
+  content: "";
+  display: block;
+  height: 16px;
+  width: 30px;
+  border: 2px solid #bbb;
+  background: #bbb;
+  border-radius: 13rem;
+  box-sizing: content-box;
+  transition: all ease-in-out 0.3s;
+  position: absolute;
+  top: 4px;
+  left: 0;
+}
+
+#ship-to-different-address label span:after {
+  content: "";
+  display: block;
+  width: 14px;
+  height: 14px;
+  background: white;
+  position: absolute;
+  top: 7px;
+  left: 17px;
+  border-radius: 13rem;
+  transition: all ease-in-out 0.3s;
+}
+
+#ship-to-different-address label input[type="checkbox"] {
+  display: none;
+}
+
+#ship-to-different-address label input[type="checkbox"]:checked + span:after {
+  left: 3px;
+}
+
+#ship-to-different-address label input[type="checkbox"]:checked + span:before {
+  border-color: #000;
+  background: #000;
+}
+
+.woocommerce-no-js form.woocommerce-form-login,
+.woocommerce-no-js form.woocommerce-form-coupon {
+  display: block !important;
+}
+
+.woocommerce-no-js .woocommerce-form-login-toggle,
+.woocommerce-no-js .woocommerce-form-coupon-toggle,
+.woocommerce-no-js .showcoupon {
+  display: none !important;
+}
+
+.woocommerce-terms-and-conditions {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.woocommerce-terms-and-conditions-link {
+  display: inline-block;
+}
+
+.woocommerce-terms-and-conditions-link:after {
+  content: "";
+  display: inline-block;
+  border-style: solid;
+  margin-bottom: 2px;
+  margin-right: 0.25rem;
+  border-width: 6px 6px 0 6px;
+  border-color: #111 transparent transparent transparent;
+}
+
+.woocommerce-terms-and-conditions-link.woocommerce-terms-and-conditions-link--open:after {
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent #111 transparent;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description {
+  background: royalblue;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1rem;
+  margin: 0.5rem 0 0;
+  clear: both;
+  display: none;
+  position: relative;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description a {
+  color: #fff;
+  text-decoration: underline;
+  border: 0;
+  box-shadow: none;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description:before {
+  right: 50%;
+  top: 0%;
+  margin-top: -4px;
+  transform: translatex(50%) rotate(-180deg);
+  content: "";
+  position: absolute;
+  border-width: 4px 6px 0 6px;
+  border-style: solid;
+  border-color: royalblue transparent transparent transparent;
+  z-index: 100;
+  display: block;
+}
+
+.woocommerce-checkout .select2-choice,
+.woocommerce-checkout .select2-choice:hover {
+  box-shadow: none !important;
+}
+
+.woocommerce-checkout .select2-choice {
+  padding: 0.7rem 0.7rem 0.7rem 0;
+}
+
+.woocommerce-checkout .select2-container .select2-selection--single {
+  height: 48px;
+}
+
+.woocommerce-checkout .select2-container .select2-selection--single .select2-selection__rendered {
+  line-height: 48px;
+}
+
+.woocommerce-checkout .select2-container--default
+.select2-selection--single
+.select2-selection__arrow {
+  height: 46px;
+}
+
+.woocommerce-checkout .select2-container--focus .select2-selection {
+  border-color: black;
+}
+
+.woocommerce-checkout-review-order-table td {
+  padding: 1rem 0.5rem;
+}
+
+.woocommerce-checkout-review-order-table dl.variation {
+  margin: 0;
+}
+
+.woocommerce-checkout-review-order-table dl.variation p {
+  margin: 0;
+}
+
+.woocommerce-checkout-review-order ul {
+  margin: 2rem 0 1rem;
+  padding-right: 0;
+}
+
+.wc_payment_method {
+  list-style: none;
+}
+
+.wc_payment_method .payment_box {
+  padding: 1rem;
+  background: #eee;
+}
+
+.wc_payment_method .payment_box ul:last-of-type,
+.wc_payment_method .payment_box ol:last-of-type {
+  margin-bottom: 0;
+}
+
+.wc_payment_method .payment_box fieldset {
+  padding: 1.5rem;
+  padding-bottom: 0;
+  border: 0;
+  background: #f6f6f6;
+}
+
+.wc_payment_method .payment_box li {
+  list-style: none;
+}
+
+.wc_payment_method .payment_box p:first-child {
+  margin-top: 0;
+}
+
+.wc_payment_method .payment_box p:last-child {
+  margin-bottom: 0;
+}
+
+.wc_payment_method > label:first-of-type {
+  display: block;
+  margin: 1rem 0;
+}
+
+.wc_payment_method > label:first-of-type img {
+  max-height: 24px;
+  max-width: 200px;
+  float: left;
+}
+
+.wc_payment_method label {
+  cursor: pointer;
+}
+
+.wc_payment_method input.input-radio[name="payment_method"] {
+  display: none;
+}
+
+.wc_payment_method input.input-radio[name="payment_method"] + label:before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 2px black;
+  background: white;
+  margin-right: 4px;
+  margin-left: 0.5rem;
+  border-radius: 100%;
+  transform: translateY(2px);
+}
+
+.wc_payment_method input.input-radio[name="payment_method"]:checked + label:before {
+  background: black;
+}
+
+.woocommerce-order-overview {
+  margin-bottom: 2rem;
+}
+
+.woocommerce-table--order-details {
+  margin-bottom: 2rem;
+}
+
+/**
+ * Layout stuff
+ */
+.woocommerce .content-area .site-main {
+  margin: calc(2 * 1rem) 1rem;
+}
+
+@media only screen and (max-width: 768px) {
+  .woocommerce table.shop_table_responsive tr,
+  .woocommerce-page table.shop_table_responsive tr {
+    margin: 0 0 1.5rem;
+  }
+  .woocommerce table.shop_table_responsive tr:first-child,
+  .woocommerce-page table.shop_table_responsive tr:first-child {
+    border-top: 1px solid;
+  }
+  .woocommerce table.shop_table_responsive tr:last-child,
+  .woocommerce-page table.shop_table_responsive tr:last-child {
+    margin-bottom: 0;
+  }
+  .woocommerce table.shop_table_responsive tr td,
+  .woocommerce-page table.shop_table_responsive tr td {
+    border-bottom-width: 0;
+  }
+  .woocommerce table.shop_table_responsive tr td:last-child,
+  .woocommerce-page table.shop_table_responsive tr td:last-child {
+    border-bottom-width: 1px;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  /**
+	* Tables
+	*/
+  .woocommerce table.shop_table tbody tr,
+  .woocommerce-page table.shop_table tbody tr {
+    font-size: 0.88889em;
+  }
+  /**
+	* Shop page
+	*/
+  .woocommerce-products-header__title.page-title {
+    font-size: 2.25em;
+  }
+  .woocommerce-pagination span.page-numbers,
+  .woocommerce-pagination a.page-numbers,
+  .woocommerce-pagination .next.page-numbers,
+  .woocommerce-pagination .prev.page-numbers {
+    padding: 1rem;
+  }
+  /**
+	* Account section
+	*/
+  .woocommerce-account .woocommerce-MyAccount-navigation {
+    float: none;
+    width: 100%;
+    margin-bottom: 1.5rem;
+  }
+  .woocommerce-account .woocommerce-MyAccount-navigation li {
+    display: inline-block;
+    margin: 0 0 0 1rem;
+    padding: 0;
+    border-bottom: 0;
+  }
+  .woocommerce-account .woocommerce-MyAccount-navigation li:last-child {
+    margin-left: 0;
+  }
+  .woocommerce-account .woocommerce-MyAccount-content {
+    float: none;
+    width: 100%;
+  }
+  /**
+	* Checkout
+	*/
+  #ship-to-different-address {
+    display: block;
+  }
+  /**
+	* Layout stuff
+	*/
+  .woocommerce .content-area {
+    margin: 0 calc(10% + 60px);
+  }
+  .woocommerce .content-area .site-main {
+    margin: 0;
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+  .single-product .entry .entry-content,
+  .single-product .entry .entry-summary {
+    max-width: none;
+    margin: 0 0 3rem;
+    padding: 0;
+  }
+  .single-product .entry .entry-content > *,
+  .single-product .entry .entry-summary > * {
+    max-width: none;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -285,6 +285,15 @@ ul.products li.product .added_to_cart {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+/* Name your price */
+.product .nyp label {
+  display: block;
+}
+
+.product .nyp .nyp-input {
+  margin-bottom: 0;
+}
+
 .star-rating {
   overflow: hidden;
   position: relative;
@@ -418,6 +427,7 @@ dl.variation p, dl.variation:last-child,
 table.variations td,
 table.variations th {
   border: 0;
+  padding-right: 0;
   word-break: normal;
 }
 

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -2,6 +2,11 @@
 /**
  * Sass variables
  */
+/* If we add the border using a regular CSS border, it won't look good on non-retina devices,
+ * since its edges can look jagged due to lack of antialiasing. In this case, we are several
+ * layers of box-shadow to add the border visually, which will render the border smoother. */
+/* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /**
  * Fonts
  */
@@ -193,7 +198,6 @@ a.button:hover, a.button:visited {
 .woocommerce-page table.shop_table th,
 .woocommerce-page table.shop_attributes td,
 .woocommerce-page table.shop_attributes th {
-  border-width: 1px;
   word-break: normal;
 }
 
@@ -1170,7 +1174,20 @@ table.variations select {
  * Layout stuff
  */
 .woocommerce .content-area .site-main {
-  margin: calc(2 * 1rem) 1rem;
+  margin: 32px 0;
+  max-width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
 }
 
 @media only screen and (max-width: 768px) {
@@ -1194,6 +1211,16 @@ table.variations select {
   .woocommerce-page table.shop_table_responsive tr td:last-child {
     border-bottom-width: 1px;
   }
+  .woocommerce-breadcrumb,
+  .woocommerce-product-gallery .woocommerce-product-gallery__wrapper,
+  .woocommerce-tabs ul,
+  .woocommerce-checkout {
+    margin-right: 1rem;
+    margin-left: 1rem;
+  }
+  .woocommerce-product-gallery__trigger {
+    left: 1rem;
+  }
 }
 
 @media only screen and (min-width: 768px) {
@@ -1201,7 +1228,9 @@ table.variations select {
 	* Tables
 	*/
   .woocommerce table.shop_table tbody tr,
-  .woocommerce-page table.shop_table tbody tr {
+  .woocommerce table.shop_attributes tbody tr,
+  .woocommerce-page table.shop_table tbody tr,
+  .woocommerce-page table.shop_attributes tbody tr {
     font-size: 0.88889em;
   }
   /**
@@ -1250,7 +1279,7 @@ table.variations select {
     margin: 0 calc(10% + 60px);
   }
   .woocommerce .content-area .site-main {
-    margin: 0;
+    margin: 0 auto;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
   .single-product .entry .entry-content,

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -2,6 +2,11 @@
 /**
  * Sass variables
  */
+/* If we add the border using a regular CSS border, it won't look good on non-retina devices,
+ * since its edges can look jagged due to lack of antialiasing. In this case, we are several
+ * layers of box-shadow to add the border visually, which will render the border smoother. */
+/* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
 /**
  * Fonts
  */
@@ -193,7 +198,6 @@ a.button:hover, a.button:visited {
 .woocommerce-page table.shop_table th,
 .woocommerce-page table.shop_attributes td,
 .woocommerce-page table.shop_attributes th {
-  border-width: 1px !important;
   word-break: normal;
 }
 
@@ -1170,7 +1174,20 @@ table.variations select {
  * Layout stuff
  */
 .woocommerce .content-area .site-main {
-  margin: calc(2 * 1rem) 1rem;
+  margin: 32px 0;
+  max-width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
 }
 
 @media only screen and (max-width: 768px) {
@@ -1194,6 +1211,16 @@ table.variations select {
   .woocommerce-page table.shop_table_responsive tr td:last-child {
     border-bottom-width: 1px;
   }
+  .woocommerce-breadcrumb,
+  .woocommerce-product-gallery .woocommerce-product-gallery__wrapper,
+  .woocommerce-tabs ul,
+  .woocommerce-checkout {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+  .woocommerce-product-gallery__trigger {
+    right: 1rem;
+  }
 }
 
 @media only screen and (min-width: 768px) {
@@ -1201,7 +1228,9 @@ table.variations select {
 	* Tables
 	*/
   .woocommerce table.shop_table tbody tr,
-  .woocommerce-page table.shop_table tbody tr {
+  .woocommerce table.shop_attributes tbody tr,
+  .woocommerce-page table.shop_table tbody tr,
+  .woocommerce-page table.shop_attributes tbody tr {
     font-size: 0.88889em;
   }
   /**
@@ -1250,7 +1279,7 @@ table.variations select {
     margin: 0 calc(10% + 60px);
   }
   .woocommerce .content-area .site-main {
-    margin: 0;
+    margin: 0 auto;
     max-width: calc(8 * (100vw / 12) - 28px);
   }
   .single-product .entry .entry-content,

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -285,6 +285,15 @@ ul.products li.product .added_to_cart {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+/* Name your price */
+.product .nyp label {
+  display: block;
+}
+
+.product .nyp .nyp-input {
+  margin-bottom: 0;
+}
+
 .star-rating {
   overflow: hidden;
   position: relative;
@@ -418,6 +427,7 @@ dl.variation p, dl.variation:last-child,
 table.variations td,
 table.variations th {
   border: 0;
+  padding-left: 0;
   word-break: normal;
 }
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -428,6 +428,7 @@ table.variations td,
 table.variations th {
   border: 0;
   padding-left: 0;
+  vertical-align: top;
   word-break: normal;
 }
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1,0 +1,1272 @@
+@charset "UTF-8";
+/**
+ * Sass variables
+ */
+/**
+ * Fonts
+ */
+@font-face {
+  font-family: "star";
+  src: url("../fonts/star.eot");
+  src: url("../fonts/star.eot?#iefix") format("embedded-opentype"), url("../fonts/star.woff") format("woff"), url("../fonts/star.ttf") format("truetype"), url("../fonts/star.svg#star") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "WooCommerce";
+  src: url("../fonts/WooCommerce.eot");
+  src: url("../fonts/WooCommerce.eot?#iefix") format("embedded-opentype"), url("../fonts/WooCommerce.woff") format("woff"), url("../fonts/WooCommerce.ttf") format("truetype"), url("../fonts/WooCommerce.svg#WooCommerce") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+
+/**
+ * Global elements
+ */
+a.button {
+  display: inline-block;
+  text-align: center;
+  box-sizing: border-box;
+  word-break: break-all;
+  color: #fff;
+  text-decoration: none !important;
+}
+
+a.button:hover, a.button:visited {
+  color: #fff;
+}
+
+.woocommerce form .form-row .required {
+  color: firebrick;
+  text-decoration: none;
+  visibility: hidden;
+}
+
+.woocommerce form .form-row .required[title] {
+  border: 0 !important;
+}
+
+.woocommerce form .form-row .optional {
+  visibility: visible;
+}
+
+.woocommerce-breadcrumb {
+  margin-bottom: 3rem;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-pagination {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+}
+
+.woocommerce-pagination ul.page-numbers {
+  margin: 0;
+  padding: 0;
+  display: block;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.woocommerce-pagination span.page-numbers,
+.woocommerce-pagination a.page-numbers,
+.woocommerce-pagination .next.page-numbers,
+.woocommerce-pagination .prev.page-numbers {
+  padding: 0 calc(0.5 * 1rem);
+  display: inline-block;
+}
+
+.onsale {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: inline-block;
+  background: #0073aa;
+  color: #fff;
+  display: inline-block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.71111em;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  padding: 0.5rem;
+  position: absolute;
+  text-transform: uppercase;
+  top: 0;
+  z-index: 1;
+}
+
+.price {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.price del {
+  opacity: 0.5;
+  display: inline-block;
+}
+
+.price ins {
+  display: inline-block;
+}
+
+.woocommerce-message,
+.woocommerce-error,
+.woocommerce-info {
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: #eee;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  list-style: none;
+  overflow: hidden;
+}
+
+.woocommerce-message {
+  background: #eee;
+  color: #111;
+}
+
+.woocommerce-error,
+.woocommerce-info {
+  color: #fff;
+}
+
+.woocommerce-error a,
+.woocommerce-info a {
+  color: #fff;
+}
+
+.woocommerce-error a:hover,
+.woocommerce-info a:hover {
+  color: #fff;
+}
+
+.woocommerce-error a.button,
+.woocommerce-info a.button {
+  background: #111;
+}
+
+.woocommerce-error {
+  background: firebrick;
+}
+
+.woocommerce-info {
+  background: #0073aa;
+}
+
+.woocommerce-store-notice {
+  background: #0073aa;
+  color: #fff;
+  padding: 1rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 999;
+}
+
+.admin-bar .woocommerce-store-notice {
+  top: 32px;
+}
+
+.woocommerce-store-notice__dismiss-link {
+  float: right;
+  color: #fff;
+}
+
+.woocommerce-store-notice__dismiss-link:hover {
+  text-decoration: underline;
+  color: #fff;
+}
+
+/**
+* Tables
+*/
+.woocommerce table.shop_table td,
+.woocommerce table.shop_table th,
+.woocommerce table.shop_attributes td,
+.woocommerce table.shop_attributes th,
+.woocommerce-page table.shop_table td,
+.woocommerce-page table.shop_table th,
+.woocommerce-page table.shop_attributes td,
+.woocommerce-page table.shop_attributes th {
+  border-width: 1px !important;
+  word-break: normal;
+}
+
+.woocommerce table.shop_table th,
+.woocommerce table.shop_attributes th,
+.woocommerce-page table.shop_table th,
+.woocommerce-page table.shop_attributes th {
+  text-align: left;
+}
+
+/**
+ * Shop page
+ */
+.woocommerce-products-header__title.page-title {
+  font-size: 1.6875em;
+  font-weight: 700;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-result-count {
+  margin: 0;
+  padding: 0.75rem 0;
+}
+
+/**
+ * Products
+ */
+ul.products {
+  margin: 0;
+  padding: 0;
+}
+
+ul.products li.product {
+  list-style: none;
+}
+
+ul.products li.product .woocommerce-loop-product__link {
+  display: block;
+}
+
+ul.products li.product .woocommerce-loop-product__title {
+  margin: 0.8rem 0;
+  font-size: 0.88889em;
+}
+
+ul.products li.product .woocommerce-loop-product__title:before {
+  content: none;
+}
+
+ul.products li.product .woocommerce-loop-product__title,
+ul.products li.product .price,
+ul.products li.product .star-rating {
+  color: #111;
+}
+
+ul.products li.product .star-rating {
+  margin-bottom: 0.8rem;
+}
+
+ul.products li.product .price {
+  margin-bottom: 1.3rem;
+}
+
+ul.products li.product .price,
+ul.products li.product .star-rating {
+  display: block;
+  font-size: 0.88889em;
+}
+
+ul.products li.product .woocommerce-placeholder {
+  border: 1px solid #f2f2f2;
+}
+
+ul.products li.product .button {
+  vertical-align: middle;
+}
+
+ul.products li.product .button.loading {
+  opacity: 0.5;
+}
+
+ul.products li.product .added_to_cart {
+  margin-left: 0.5rem;
+  font-size: 0.88889em;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.star-rating {
+  overflow: hidden;
+  position: relative;
+  height: 1em;
+  line-height: 1;
+  font-size: 1em;
+  width: 5.4em;
+  font-family: "star";
+}
+
+.star-rating::before {
+  content: "\73\73\73\73\73";
+  float: left;
+  top: 0;
+  left: 0;
+  position: absolute;
+}
+
+.star-rating span {
+  overflow: hidden;
+  float: left;
+  top: 0;
+  left: 0;
+  position: absolute;
+  padding-top: 1.5em;
+}
+
+.star-rating span::before {
+  content: "\53\53\53\53\53";
+  top: 0;
+  position: absolute;
+  left: 0;
+}
+
+a.remove {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  line-height: 17px;
+  font-size: 20px;
+  font-weight: 700;
+  text-align: center;
+  border-radius: 100%;
+  text-decoration: none !important;
+  background: firebrick;
+  color: #fff;
+}
+
+a.remove:hover {
+  background: #000;
+  color: #fff !important;
+}
+
+dl.variation,
+.wc-item-meta {
+  list-style: none outside;
+}
+
+dl.variation dt,
+dl.variation .wc-item-meta-label,
+.wc-item-meta dt,
+.wc-item-meta .wc-item-meta-label {
+  float: left;
+  clear: both;
+  margin-right: 0.25rem;
+  list-style: none outside;
+}
+
+dl.variation dd,
+.wc-item-meta dd {
+  margin: 0;
+}
+
+dl.variation p, dl.variation:last-child,
+.wc-item-meta p,
+.wc-item-meta:last-child {
+  margin-bottom: 0;
+}
+
+/**
+ * Single product
+ */
+.single-product div.product {
+  position: relative;
+}
+
+.single-product .single-featured-image-header {
+  display: none;
+}
+
+.single-product .entry .entry-title {
+  margin-top: 0;
+}
+
+.single-product .entry .entry-title:before {
+  margin-top: 0;
+}
+
+.single-product .summary p.price {
+  margin-bottom: 2rem;
+}
+
+.single-product .woocommerce-product-rating {
+  margin-bottom: 2rem;
+  line-height: 1;
+}
+
+.single-product .woocommerce-product-rating .star-rating {
+  float: left;
+  margin-right: 0.25rem;
+}
+
+.single-product form.cart .quantity {
+  float: left;
+  margin-right: 0.5rem;
+}
+
+.single-product form.cart input {
+  width: 5em;
+}
+
+.single-product .woocommerce-variation-add-to-cart .button {
+  padding-top: 0.72rem;
+  padding-bottom: 0.72rem;
+}
+
+.single-product .woocommerce-variation-add-to-cart .button.disabled {
+  opacity: 0.2;
+}
+
+table.variations td,
+table.variations th {
+  border: 0;
+  word-break: normal;
+}
+
+table.variations label {
+  margin: 0;
+}
+
+table.variations select {
+  display: block;
+  margin-right: 0.5rem;
+}
+
+.woocommerce-product-gallery {
+  position: relative;
+  margin-bottom: 3rem;
+}
+
+.woocommerce-product-gallery figure {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__wrapper {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-product-gallery .zoomImg {
+  background-color: #fff;
+  opacity: 0;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__image--placeholder {
+  border: 1px solid #f2f2f2;
+}
+
+.woocommerce-product-gallery .woocommerce-product-gallery__image:nth-child(n + 2) {
+  width: 25%;
+  display: inline-block;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs li {
+  list-style: none;
+  cursor: pointer;
+  float: left;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs img {
+  opacity: 0.5;
+}
+
+.woocommerce-product-gallery .flex-control-thumbs img:hover, .woocommerce-product-gallery .flex-control-thumbs img.flex-active {
+  opacity: 1;
+}
+
+.woocommerce-product-gallery img {
+  display: block;
+  height: auto;
+}
+
+.woocommerce-product-gallery--columns-3 .flex-control-thumbs li {
+  width: 33.3333%;
+}
+
+.woocommerce-product-gallery--columns-3 .flex-control-thumbs li:nth-child(3n + 1) {
+  clear: left;
+}
+
+.woocommerce-product-gallery--columns-4 .flex-control-thumbs li {
+  width: 25%;
+}
+
+.woocommerce-product-gallery--columns-4 .flex-control-thumbs li:nth-child(4n + 1) {
+  clear: left;
+}
+
+.woocommerce-product-gallery--columns-5 .flex-control-thumbs li {
+  width: 20%;
+}
+
+.woocommerce-product-gallery--columns-5 .flex-control-thumbs li:nth-child(5n + 1) {
+  clear: left;
+}
+
+.woocommerce-product-gallery__trigger {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 99;
+}
+
+.woocommerce-tabs {
+  margin: 0 0 2rem;
+}
+
+.woocommerce-tabs ul {
+  margin: 0 0 1.5rem;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.woocommerce-tabs ul li {
+  margin-right: 1rem;
+}
+
+.woocommerce-tabs ul li a {
+  color: #111;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.woocommerce-tabs ul li.active a {
+  color: #0073aa;
+  box-shadow: 0 2px 0 #0073aa;
+}
+
+.woocommerce-tabs .panel > * {
+  margin-top: 0 !important;
+}
+
+.woocommerce-tabs .panel h1:before,
+.woocommerce-tabs .panel h2:before {
+  content: none;
+}
+
+.woocommerce-tabs .panel h2:first-of-type {
+  font-size: 1em;
+  margin: 0 0 1rem;
+}
+
+.woocommerce-tabs #comments {
+  padding-top: 0;
+}
+
+.woocommerce-tabs .comment-reply-title {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 0 0 0.75rem;
+  display: block;
+}
+
+.woocommerce-tabs #reviews ol.commentlist {
+  padding: 0;
+}
+
+.woocommerce-tabs #reviews li.review,
+.woocommerce-tabs #reviews li.comment {
+  list-style: none;
+  margin-right: 0;
+  margin-bottom: 2.5rem;
+}
+
+.woocommerce-tabs #reviews li.review .avatar,
+.woocommerce-tabs #reviews li.comment .avatar {
+  max-height: 36px;
+  width: auto;
+  float: right;
+}
+
+.woocommerce-tabs #reviews li.review p.meta,
+.woocommerce-tabs #reviews li.comment p.meta {
+  margin-bottom: 0.5em;
+}
+
+.woocommerce-tabs #reviews p.stars {
+  margin-top: 0;
+}
+
+.woocommerce-tabs #reviews p.stars a {
+  position: relative;
+  height: 1em;
+  width: 1em;
+  text-indent: -999em;
+  display: inline-block;
+  text-decoration: none;
+  box-shadow: none;
+}
+
+.woocommerce-tabs #reviews p.stars a::before {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  font-family: "WooCommerce";
+  content: "\e021";
+  text-indent: 0;
+}
+
+.woocommerce-tabs #reviews p.stars a:hover ~ a::before {
+  content: "\e021";
+}
+
+.woocommerce-tabs #reviews p.stars:hover a::before {
+  content: "\e020";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a.active::before {
+  content: "\e020";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a.active ~ a::before {
+  content: "\e021";
+}
+
+.woocommerce-tabs #reviews p.stars.selected a:not(.active)::before {
+  content: "\e020";
+}
+
+/**
+ * Widgets
+ */
+.widget.woocommerce ul {
+  padding-left: 0;
+}
+
+.widget.woocommerce ul li {
+  list-style: none;
+}
+
+.widget .product_list_widget,
+.site-footer .widget .product_list_widget {
+  margin-bottom: 1.5rem;
+}
+
+.widget .product_list_widget a,
+.site-footer .widget .product_list_widget a {
+  display: block;
+  box-shadow: none;
+}
+
+.widget .product_list_widget a:hover,
+.site-footer .widget .product_list_widget a:hover {
+  box-shadow: none;
+}
+
+.widget .product_list_widget li,
+.site-footer .widget .product_list_widget li {
+  padding: 0.5rem 0;
+}
+
+.widget .product_list_widget li a.remove,
+.site-footer .widget .product_list_widget li a.remove {
+  float: left;
+  margin-top: 7px;
+  line-height: 20px;
+  color: #fff;
+  margin-right: 0.5rem;
+}
+
+.widget .product_list_widget img,
+.site-footer .widget .product_list_widget img {
+  display: none;
+}
+
+.widget_shopping_cart .buttons a {
+  display: inline-block;
+  margin: 0 0.5rem 0 0;
+}
+
+.widget_layered_nav .chosen:before {
+  content: "×";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  font-size: 16px;
+  text-align: center;
+  border-radius: 100%;
+  border: 1px solid black;
+  margin-right: 0.25rem;
+}
+
+.widget_price_filter .price_slider {
+  margin-bottom: 1rem;
+}
+
+.widget_price_filter .price_slider_amount {
+  text-align: right;
+  line-height: 2.4;
+  font-size: 0.8751em;
+}
+
+.widget_price_filter .price_slider_amount .button {
+  float: left;
+  padding: 0.4rem 1rem;
+}
+
+.widget_price_filter .ui-slider {
+  position: relative;
+  text-align: left;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.widget_price_filter .ui-slider .ui-slider-handle {
+  position: absolute;
+  z-index: 2;
+  width: 1em;
+  height: 1em;
+  background-color: #000;
+  border-radius: 1em;
+  cursor: ew-resize;
+  outline: none;
+  top: -0.3em;
+  margin-left: -0.5em;
+}
+
+.widget_price_filter .ui-slider .ui-slider-range {
+  position: absolute;
+  z-index: 1;
+  font-size: 0.7em;
+  display: block;
+  border: 0;
+  border-radius: 1em;
+  background-color: #000;
+}
+
+.widget_price_filter .price_slider_wrapper .ui-widget-content {
+  border-radius: 1em;
+  background-color: #666;
+  border: 0;
+}
+
+.widget_price_filter .ui-slider-horizontal {
+  height: 0.5em;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range {
+  top: 0;
+  height: 100%;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range-min {
+  left: -1px;
+}
+
+.widget_price_filter .ui-slider-horizontal .ui-slider-range-max {
+  right: -1px;
+}
+
+.widget_rating_filter li {
+  text-align: right;
+}
+
+.widget_rating_filter li .star-rating {
+  float: left;
+  margin-top: 0.3rem;
+}
+
+.widget_product_search form {
+  position: relative;
+}
+
+.widget_product_search .search-field {
+  padding-right: 100px;
+}
+
+.widget_product_search input[type="submit"] {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+/**
+ * Account section
+ */
+.woocommerce-account .woocommerce-MyAccount-navigation {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  margin: 0 0 2rem;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation ul {
+  margin: 0;
+  padding: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li {
+  list-style: none;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #ccc;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li:first-child {
+  padding-top: 0;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a {
+  box-shadow: none;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li a:hover {
+  color: #005177;
+  text-decoration: underline;
+}
+
+.woocommerce-account .woocommerce-MyAccount-navigation li.is-active a {
+  text-decoration: underline;
+}
+
+.woocommerce-account table.account-orders-table .button {
+  margin: 0 0.35rem 0.35rem 0;
+}
+
+/**
+ * Cart
+ */
+.woocommerce-cart-form img {
+  max-width: 42px;
+  height: auto;
+  display: block;
+}
+
+.woocommerce-cart-form dl.variation {
+  margin-top: 0;
+}
+
+.woocommerce-cart-form dl.variation p, .woocommerce-cart-form dl.variation:last-child {
+  margin-bottom: 0;
+}
+
+.woocommerce-cart-form .product-remove {
+  text-align: center;
+}
+
+.woocommerce-cart-form .actions .input-text {
+  width: 200px !important;
+  float: left;
+  margin-right: 0.25rem;
+}
+
+.woocommerce-cart-form .quantity input {
+  width: 4rem;
+}
+
+.cart_totals th,
+.cart_totals td {
+  vertical-align: top;
+}
+
+.cart_totals th {
+  padding-right: 1rem;
+}
+
+.cart_totals .woocommerce-shipping-destination {
+  margin-bottom: 0;
+}
+
+.shipping-calculator-button {
+  margin-top: 0.5rem;
+  display: inline-block;
+}
+
+.shipping-calculator-form {
+  margin: 1rem 0 0 0;
+}
+
+#shipping_method {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#shipping_method li {
+  margin-bottom: 0.5rem;
+}
+
+#shipping_method li input {
+  float: left;
+  margin-top: 0.17rem;
+}
+
+#shipping_method li label {
+  line-height: 1.5rem;
+}
+
+.checkout-button {
+  display: block;
+  padding: 1rem 2rem;
+  border: 2px solid #000;
+  text-align: center;
+  font-weight: 800;
+}
+
+.checkout-button:hover {
+  border-color: #999;
+}
+
+.checkout-button:after {
+  content: "→";
+  margin-left: 0.5rem;
+}
+
+/**
+ * Checkout
+ */
+#ship-to-different-address {
+  font-size: 1em;
+  display: inline-block;
+  margin: 1.41rem 0;
+}
+
+#ship-to-different-address label {
+  font-weight: 300;
+  cursor: pointer;
+}
+
+#ship-to-different-address label span {
+  position: relative;
+  display: block;
+  text-align: right;
+  padding-right: 45px;
+}
+
+#ship-to-different-address label span:before {
+  content: "";
+  display: block;
+  height: 16px;
+  width: 30px;
+  border: 2px solid #bbb;
+  background: #bbb;
+  border-radius: 13rem;
+  box-sizing: content-box;
+  transition: all ease-in-out 0.3s;
+  position: absolute;
+  top: 4px;
+  right: 0;
+}
+
+#ship-to-different-address label span:after {
+  content: "";
+  display: block;
+  width: 14px;
+  height: 14px;
+  background: white;
+  position: absolute;
+  top: 7px;
+  right: 17px;
+  border-radius: 13rem;
+  transition: all ease-in-out 0.3s;
+}
+
+#ship-to-different-address label input[type="checkbox"] {
+  display: none;
+}
+
+#ship-to-different-address label input[type="checkbox"]:checked + span:after {
+  right: 3px;
+}
+
+#ship-to-different-address label input[type="checkbox"]:checked + span:before {
+  border-color: #000;
+  background: #000;
+}
+
+.woocommerce-no-js form.woocommerce-form-login,
+.woocommerce-no-js form.woocommerce-form-coupon {
+  display: block !important;
+}
+
+.woocommerce-no-js .woocommerce-form-login-toggle,
+.woocommerce-no-js .woocommerce-form-coupon-toggle,
+.woocommerce-no-js .showcoupon {
+  display: none !important;
+}
+
+.woocommerce-terms-and-conditions {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.woocommerce-terms-and-conditions-link {
+  display: inline-block;
+}
+
+.woocommerce-terms-and-conditions-link:after {
+  content: "";
+  display: inline-block;
+  border-style: solid;
+  margin-bottom: 2px;
+  margin-left: 0.25rem;
+  border-width: 6px 6px 0 6px;
+  border-color: #111 transparent transparent transparent;
+}
+
+.woocommerce-terms-and-conditions-link.woocommerce-terms-and-conditions-link--open:after {
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent #111 transparent;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description {
+  background: royalblue;
+  color: #fff;
+  border-radius: 3px;
+  padding: 1rem;
+  margin: 0.5rem 0 0;
+  clear: both;
+  display: none;
+  position: relative;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description a {
+  color: #fff;
+  text-decoration: underline;
+  border: 0;
+  box-shadow: none;
+}
+
+.woocommerce-checkout .woocommerce-input-wrapper .description:before {
+  left: 50%;
+  top: 0%;
+  margin-top: -4px;
+  transform: translatex(-50%) rotate(180deg);
+  content: "";
+  position: absolute;
+  border-width: 4px 6px 0 6px;
+  border-style: solid;
+  border-color: royalblue transparent transparent transparent;
+  z-index: 100;
+  display: block;
+}
+
+.woocommerce-checkout .select2-choice,
+.woocommerce-checkout .select2-choice:hover {
+  box-shadow: none !important;
+}
+
+.woocommerce-checkout .select2-choice {
+  padding: 0.7rem 0 0.7rem 0.7rem;
+}
+
+.woocommerce-checkout .select2-container .select2-selection--single {
+  height: 48px;
+}
+
+.woocommerce-checkout .select2-container .select2-selection--single .select2-selection__rendered {
+  line-height: 48px;
+}
+
+.woocommerce-checkout .select2-container--default
+.select2-selection--single
+.select2-selection__arrow {
+  height: 46px;
+}
+
+.woocommerce-checkout .select2-container--focus .select2-selection {
+  border-color: black;
+}
+
+.woocommerce-checkout-review-order-table td {
+  padding: 1rem 0.5rem;
+}
+
+.woocommerce-checkout-review-order-table dl.variation {
+  margin: 0;
+}
+
+.woocommerce-checkout-review-order-table dl.variation p {
+  margin: 0;
+}
+
+.woocommerce-checkout-review-order ul {
+  margin: 2rem 0 1rem;
+  padding-left: 0;
+}
+
+.wc_payment_method {
+  list-style: none;
+}
+
+.wc_payment_method .payment_box {
+  padding: 1rem;
+  background: #eee;
+}
+
+.wc_payment_method .payment_box ul:last-of-type,
+.wc_payment_method .payment_box ol:last-of-type {
+  margin-bottom: 0;
+}
+
+.wc_payment_method .payment_box fieldset {
+  padding: 1.5rem;
+  padding-bottom: 0;
+  border: 0;
+  background: #f6f6f6;
+}
+
+.wc_payment_method .payment_box li {
+  list-style: none;
+}
+
+.wc_payment_method .payment_box p:first-child {
+  margin-top: 0;
+}
+
+.wc_payment_method .payment_box p:last-child {
+  margin-bottom: 0;
+}
+
+.wc_payment_method > label:first-of-type {
+  display: block;
+  margin: 1rem 0;
+}
+
+.wc_payment_method > label:first-of-type img {
+  max-height: 24px;
+  max-width: 200px;
+  float: right;
+}
+
+.wc_payment_method label {
+  cursor: pointer;
+}
+
+.wc_payment_method input.input-radio[name="payment_method"] {
+  display: none;
+}
+
+.wc_payment_method input.input-radio[name="payment_method"] + label:before {
+  content: "";
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid white;
+  box-shadow: 0 0 0 2px black;
+  background: white;
+  margin-left: 4px;
+  margin-right: 0.5rem;
+  border-radius: 100%;
+  transform: translateY(2px);
+}
+
+.wc_payment_method input.input-radio[name="payment_method"]:checked + label:before {
+  background: black;
+}
+
+.woocommerce-order-overview {
+  margin-bottom: 2rem;
+}
+
+.woocommerce-table--order-details {
+  margin-bottom: 2rem;
+}
+
+/**
+ * Layout stuff
+ */
+.woocommerce .content-area .site-main {
+  margin: calc(2 * 1rem) 1rem;
+}
+
+@media only screen and (max-width: 768px) {
+  .woocommerce table.shop_table_responsive tr,
+  .woocommerce-page table.shop_table_responsive tr {
+    margin: 0 0 1.5rem;
+  }
+  .woocommerce table.shop_table_responsive tr:first-child,
+  .woocommerce-page table.shop_table_responsive tr:first-child {
+    border-top: 1px solid;
+  }
+  .woocommerce table.shop_table_responsive tr:last-child,
+  .woocommerce-page table.shop_table_responsive tr:last-child {
+    margin-bottom: 0;
+  }
+  .woocommerce table.shop_table_responsive tr td,
+  .woocommerce-page table.shop_table_responsive tr td {
+    border-bottom-width: 0;
+  }
+  .woocommerce table.shop_table_responsive tr td:last-child,
+  .woocommerce-page table.shop_table_responsive tr td:last-child {
+    border-bottom-width: 1px;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  /**
+	* Tables
+	*/
+  .woocommerce table.shop_table tbody tr,
+  .woocommerce-page table.shop_table tbody tr {
+    font-size: 0.88889em;
+  }
+  /**
+	* Shop page
+	*/
+  .woocommerce-products-header__title.page-title {
+    font-size: 2.25em;
+  }
+  .woocommerce-pagination span.page-numbers,
+  .woocommerce-pagination a.page-numbers,
+  .woocommerce-pagination .next.page-numbers,
+  .woocommerce-pagination .prev.page-numbers {
+    padding: 1rem;
+  }
+  /**
+	* Account section
+	*/
+  .woocommerce-account .woocommerce-MyAccount-navigation {
+    float: none;
+    width: 100%;
+    margin-bottom: 1.5rem;
+  }
+  .woocommerce-account .woocommerce-MyAccount-navigation li {
+    display: inline-block;
+    margin: 0 1rem 0 0;
+    padding: 0;
+    border-bottom: 0;
+  }
+  .woocommerce-account .woocommerce-MyAccount-navigation li:last-child {
+    margin-right: 0;
+  }
+  .woocommerce-account .woocommerce-MyAccount-content {
+    float: none;
+    width: 100%;
+  }
+  /**
+	* Checkout
+	*/
+  #ship-to-different-address {
+    display: block;
+  }
+  /**
+	* Layout stuff
+	*/
+  .woocommerce .content-area {
+    margin: 0 calc(10% + 60px);
+  }
+  .woocommerce .content-area .site-main {
+    margin: 0;
+    max-width: calc(8 * (100vw / 12) - 28px);
+  }
+  .single-product .entry .entry-content,
+  .single-product .entry .entry-summary {
+    max-width: none;
+    margin: 0 0 3rem;
+    padding: 0;
+  }
+  .single-product .entry .entry-content > *,
+  .single-product .entry .entry-summary > * {
+    max-width: none;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .woocommerce .content-area .site-main {
+    max-width: calc(6 * (100vw / 12) - 28px);
+  }
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds very basic WooCommerce styles and support to the theme, based off of the styles and support baked into the WC plugin for Twenty Nineteen, as well as some visual tweaks for extensions like Name Your Price and One Page Checkout. 

This PR is not intended to be the final WooCommerce support. It is meant to clean up some more obvious visual issues with the plugin for the short-term; full support will need additional work and more in-depth testing. 

### How to test the changes in this Pull Request:

1. Follow the steps outlined here to create a product: pamTN9-aY-p2.
2. Publish and view the product; note visual issues like the tab styles not matching the styles, and weird font sizing.
3. Apply the PR; confirm that the visual issues are largely resolved. 
