### PR TITLE
Correct `$content_width` value for the theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -213,7 +213,7 @@ function newspack_content_width() {
 	// This variable is intended to be overruled from themes.
 	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', 640 );
+	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', 960 );
 }
 add_action( 'after_setup_theme', 'newspack_content_width', 0 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request just sets a higher `$content_width` value for the theme, which is used in embeds and for some content image sizing. 

While working on blocks, I noticed the current value was causing the default 'large' image sizes not to be available.

This might not be the final width (it will depend on how wide the content area of the theme ends up being) but it will make it easier to work with in the short-term. 

As an aside, the `$content_width` is coming from Twenty Nineteen, where [it's also incorrect based on the theme's actual width](https://core.trac.wordpress.org/ticket/46262).

### How to test the changes in this Pull Request:

1. Apply the patch.
2. Make sure the 'Large' image size is at least 960px wide (you can check under Settings > Media).
3. Add an image that's at least 960px wide to the editor.
4. Publish the post.
5. Make sure the image being loaded is 960px wide in the editor and on the front-end (as opposed to 640px, the original `$content_width` size).