### PR TITLE
Reorder existing header elements

### DIFF
--- a/header.php
+++ b/header.php
@@ -23,9 +23,41 @@
 
 		<header id="masthead" class="site-header">
 
+			<div class="top-nav-contain">
+				<?php if ( has_nav_menu( 'social' ) ) : ?>
+					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'social',
+								'menu_class'     => 'social-links-menu',
+								'link_before'    => '<span class="screen-reader-text">',
+								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .social-navigation -->
+				<?php endif; ?>
+			</div><!-- .site-menu-container -->
+
 			<div class="site-branding-container">
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 			</div><!-- .layout-wrap -->
+
+			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+					<?php
+					wp_nav_menu(
+						array(
+							'theme_location' => 'menu-1',
+							'menu_class'     => 'main-menu',
+							'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+						)
+					);
+					?>
+				</nav><!-- #site-navigation -->
+			<?php endif; ?>
 
 		</header><!-- #masthead -->
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -3,7 +3,7 @@
 .main-navigation {
 
 	margin-top: #{0.25 * $size__spacing-unit};
-
+	display: flex;
 
 	@include media(tablet) {
 		margin-left: $size__site-margins;

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -2,16 +2,12 @@
 
 .main-navigation {
 
-	display: block;
 	margin-top: #{0.25 * $size__spacing-unit};
-	width: 100%;
 
-	body.page & {
-		display: block;
-	}
 
-	> div {
-		display: inline;
+	@include media(tablet) {
+		margin-left: $size__site-margins;
+		margin-right: $size__site-margins;
 	}
 
 	/* Un-style buttons */

--- a/sass/navigation/_menu-top-navigation.scss
+++ b/sass/navigation/_menu-top-navigation.scss
@@ -1,0 +1,5 @@
+.top-nav-contain {
+	@include media(tablet) {
+		margin: 0 $size__site-margins;
+	}
+}

--- a/sass/navigation/_navigation.scss
+++ b/sass/navigation/_navigation.scss
@@ -7,6 +7,7 @@
 ## Menus
 --------------------------------------------------------------*/
 @import "menu-main-navigation";
+@import "menu-top-navigation";
 @import "menu-social-navigation";
 @import "menu-footer-navigation";
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -86,11 +86,6 @@
 		}
 	}
 
-	/* When there is no description set, make sure navigation appears below title. */
-	+ .main-navigation {
-		display: block;
-	}
-
 	&:not(:empty) + .site-description:not(:empty):before {
 		content: "\2014";
 		margin: 0 .2em;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -915,9 +915,6 @@ a:focus {
 .main-navigation {
   margin-top: 0.25rem;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -913,9 +913,11 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  display: block;
   margin-top: 0.25rem;
-  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles
@@ -931,12 +933,11 @@ a:focus {
 	 */
 }
 
-body.page .main-navigation {
-  display: block;
-}
-
-.main-navigation > div {
-  display: inline;
+@media only screen and (min-width: 768px) {
+  .main-navigation {
+    margin-right: calc(10% + 60px);
+    margin-left: calc(10% + 60px);
+  }
 }
 
 .main-navigation button {
@@ -1483,6 +1484,12 @@ body.page .main-navigation {
   }
 }
 
+@media only screen and (min-width: 768px) {
+  .top-nav-contain {
+    margin: 0 calc(10% + 60px);
+  }
+}
+
 /* Social menu */
 .social-navigation {
   margin-top: calc(1rem / 2);
@@ -2024,7 +2031,6 @@ body.page .main-navigation {
 .site-title {
   color: #111;
   margin: 0;
-  /* When there is no description set, make sure navigation appears below title. */
 }
 
 .site-title a {
@@ -2047,10 +2053,6 @@ body.page .main-navigation {
   .featured-image .site-title {
     display: inline-block;
   }
-}
-
-.site-title + .main-navigation {
-  display: block;
 }
 
 .site-title:not(:empty) + .site-description:not(:empty):before {

--- a/style.css
+++ b/style.css
@@ -913,9 +913,7 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  display: block;
   margin-top: 0.25rem;
-  width: 100%;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles
@@ -931,12 +929,11 @@ a:focus {
 	 */
 }
 
-body.page .main-navigation {
-  display: block;
-}
-
-.main-navigation > div {
-  display: inline;
+@media only screen and (min-width: 768px) {
+  .main-navigation {
+    margin-left: calc(10% + 60px);
+    margin-right: calc(10% + 60px);
+  }
 }
 
 .main-navigation button {
@@ -1480,6 +1477,12 @@ body.page .main-navigation {
   }
   to {
     opacity: 1;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .top-nav-contain {
+    margin: 0 calc(10% + 60px);
   }
 }
 
@@ -2030,7 +2033,6 @@ body.page .main-navigation {
 .site-title {
   color: #111;
   margin: 0;
-  /* When there is no description set, make sure navigation appears below title. */
 }
 
 .site-title a {
@@ -2053,10 +2055,6 @@ body.page .main-navigation {
   .featured-image .site-title {
     display: inline-block;
   }
-}
-
-.site-title + .main-navigation {
-  display: block;
 }
 
 .site-title:not(:empty) + .site-description:not(:empty):before {

--- a/style.css
+++ b/style.css
@@ -914,6 +914,7 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   margin-top: 0.25rem;
+  display: flex;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -24,35 +24,7 @@
 	if ( $description || is_customize_preview() ) :
 		?>
 			<p class="site-description">
-				<?php echo $description; ?>
+				<?php echo $description; /* WPCS: xss ok. */ ?>
 			</p>
-	<?php endif; ?>
-	<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
-		<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
-			<?php
-			wp_nav_menu(
-				array(
-					'theme_location' => 'menu-1',
-					'menu_class'     => 'main-menu',
-					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-				)
-			);
-			?>
-		</nav><!-- #site-navigation -->
-	<?php endif; ?>
-	<?php if ( has_nav_menu( 'social' ) ) : ?>
-		<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-			<?php
-			wp_nav_menu(
-				array(
-					'theme_location' => 'social',
-					'menu_class'     => 'social-links-menu',
-					'link_before'    => '<span class="screen-reader-text">',
-					'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-					'depth'          => 1,
-				)
-			);
-			?>
-		</nav><!-- .social-navigation -->
 	<?php endif; ?>
 </div><!-- .site-branding -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a starting point to reorder the header, in advance of adding additional menu spaces and making able to accommodate a few more flexible options. 

See #20.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add a 'primary' and 'social' menu, so both menus appear.
3. Confirm that the social menu is now above the site title, and the primary menu is still below.
4. Add a bunch of menu items to the primary menu, and also check it on a small-screen -- make sure the 'priority'/mobile menu functionality still works. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
