### PR TITLE
Re-add an automatically generated variation of the primary colour

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -146,7 +146,12 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'  => __( 'Primary', 'newspack' ),
 					'slug'  => 'primary',
-					'color' => 'default' === get_theme_mod( 'primary_color' ) ? $primary_color : get_theme_mod( 'primary_color_hex', $primary_color ),
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? $primary_color : get_theme_mod( 'primary_color_hex', $primary_color ),
+				),
+				array(
+					'name'  => __( 'Primary Variation', 'newspack' ),
+					'slug'  => 'primary-variation',
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? newspack_adjust_brightness( $primary_color, -40 ) : newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
 				),
 				array(
 					'name'  => __( 'Dark Gray', 'newspack' ),
@@ -255,7 +260,7 @@ function newspack_editor_customizer_styles() {
 
 	wp_enqueue_style( 'newspack-editor-customizer-styles', get_theme_file_uri( '/style-editor-customizer.css' ), false, '1.1', 'all' );
 
-	if ( 'custom' === get_theme_mod( 'primary_color' ) ) {
+	if ( 'custom' === get_theme_mod( 'theme_colors' ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 		wp_add_inline_style( 'newspack-editor-customizer-styles', newspack_custom_colors_css() );
@@ -269,14 +274,14 @@ add_action( 'enqueue_block_editor_assets', 'newspack_editor_customizer_styles' )
 function newspack_colors_css_wrap() {
 
 	// Only bother if we haven't customized the color.
-	if ( ( ! is_customize_preview() && 'default' === get_theme_mod( 'primary_color', 'default' ) ) || is_admin() ) {
+	if ( ( ! is_customize_preview() && 'default' === get_theme_mod( 'theme_colors', 'default' ) ) || is_admin() ) {
 		return;
 	}
 
 	require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 
 	$primary_color = newspack_get_primary_color();
-	if ( 'default' !== get_theme_mod( 'primary_color', 'default' ) ) {
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color = get_theme_mod( 'primary_color_hex', $primary_color );
 	}
 	?>
@@ -287,12 +292,6 @@ function newspack_colors_css_wrap() {
 	<?php
 }
 add_action( 'wp_head', 'newspack_colors_css_wrap' );
-
-/**
- * Default color filters.
- */
-require get_template_directory() . '/inc/color-filters.php';
-
 /**
  * SVG Icons class.
  */
@@ -307,6 +306,12 @@ require get_template_directory() . '/classes/class-newspack-walker-comment.php';
  * Enhance the theme by hooking into WordPress.
  */
 require get_template_directory() . '/inc/template-functions.php';
+
+/**
+ * Default color filters.
+ */
+require get_template_directory() . '/inc/color-filters.php';
+
 
 /**
  * SVG Icons related functions.

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -146,10 +146,10 @@ function newspack_custom_colors_css() {
 
 		/* Text selection colors */
 		::selection {
-			background-color: ' . newspack_adjust_brightness( $primary_color, -200 ) . '; /* base: #005177; */
+			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}
 		::-moz-selection {
-			background-color: ' . newspack_adjust_brightness( $primary_color, -200 ) . '; /* base: #005177; */
+			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}';
 
 	$editor_css = '

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -12,7 +12,7 @@ function newspack_custom_colors_css() {
 
 	$primary_color = newspack_get_primary_color();
 
-	if ( 'default' !== get_theme_mod( 'primary_color', 'default' ) ) {
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color = get_theme_mod( 'primary_color_hex', $primary_color );
 	}
 
@@ -116,17 +116,17 @@ function newspack_custom_colors_css() {
 		.post-navigation .nav-links a:hover,
 		.post-navigation .nav-links a:hover .post-title,
 		.author-bio .author-description .author-link:hover,
-		.entry .entry-content > .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
+		.entry .entry-content > .has-primary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color p,
 		.comment .comment-author .fn a:hover,
 		.comment-reply-link:hover,
 		.comment-navigation .nav-previous a:hover,
 		.comment-navigation .nav-next a:hover,
 		#cancel-comment-reply-link:hover,
 		.widget a:hover {
-			color: ' . $primary_color . '; /* base: #0073a8; */
+			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #0073a8; */
 		}
 
 		.main-navigation .sub-menu > li > a:hover,
@@ -137,19 +137,19 @@ function newspack_custom_colors_css() {
 		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
-		.entry .entry-content > .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
-			background-color: ' . $primary_color . '; /* base: #005177; */
+		.entry .entry-content > .has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
+			background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
 		}
 
 		/* Text selection colors */
 		::selection {
-			background-color: ' . $primary_color . '; /* base: #005177; */
+			background-color: ' . newspack_adjust_brightness( $primary_color, -200 ) . '; /* base: #005177; */
 		}
 		::-moz-selection {
-			background-color: ' . $primary_color . '; /* base: #005177; */
+			background-color: ' . newspack_adjust_brightness( $primary_color, -200 ) . '; /* base: #005177; */
 		}';
 
 	$editor_css = '
@@ -190,7 +190,7 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block a:hover,
 		.editor-block-list__layout .editor-block-list__block a:active,
 		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
-			color: ' . $primary_color . '; /* base: #005177; */
+			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -37,7 +37,7 @@ function newspack_customize_register( $wp_customize ) {
 	 * Primary color.
 	 */
 	$wp_customize->add_setting(
-		'primary_color',
+		'theme_colors',
 		array(
 			'default'           => 'default',
 			'transport'         => 'postMessage',
@@ -46,7 +46,7 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	$wp_customize->add_control(
-		'primary_color',
+		'theme_colors',
 		array(
 			'type'     => 'radio',
 			'label'    => __( 'Primary Color', 'newspack' ),

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -334,3 +334,32 @@ function newspack_add_mobile_parent_nav_menu_items( $sorted_menu_items, $args ) 
 	return $amended_menu_items;
 }
 add_filter( 'wp_nav_menu_objects', 'newspack_add_mobile_parent_nav_menu_items', 10, 2 );
+
+/**
+ * Adjust a hexidecimal colour value to lighten or darken it.
+ *
+ * @param  string $hex Hexidecimal value of the color to adjust.
+ * @param  string $steps Number of 'steps' to adjust the hexidecimal value's brightness.
+ * @return string Updated hexidecimal value.
+ */
+function newspack_adjust_brightness( $hex, $steps ) {
+
+	$steps = max( -255, min( 255, $steps ) );
+
+	$hex = str_replace( '#', '', $hex );
+	if ( 3 == strlen( $hex ) ) {
+		$hex = str_repeat( substr( $hex, 0, 1 ), 2 ) . str_repeat( substr( $hex, 1, 1 ), 2 ) . str_repeat( substr( $hex, 2, 1 ), 2 );
+	}
+
+	// Split into three parts: R, G and B
+	$color_parts = str_split( $hex, 2 );
+	$new_shade   = '#';
+
+	foreach ( $color_parts as $color ) {
+		$color      = hexdec( $color ); // Convert to decimal
+		$color      = max( 0, min( 255, $color + $steps ) ); // Adjust color
+		$new_shade .= str_pad( dechex( $color ), 2, '0', STR_PAD_LEFT ); // Make two char hex code
+	}
+
+	return $new_shade;
+}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -52,21 +52,22 @@ add_filter( 'woocommerce_enqueue_styles', 'newspack_dequeue_styles' );
 /**
  * Use theme's custom color for WooCommerce elements.
  */
-function newspack_woo_custom_colors_css( $css, $primary_color, $saturation ) {
+function newspack_woo_custom_colors_css( $css, $primary_color ) {
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {
 		return $css;
 	}
-	$lightness = absint( apply_filters( 'newspack_custom_colors_lightness', 33 ) );
-	$lightness = $lightness . '%';
 	$css      .= '
 		.onsale,
 		.woocommerce-info,
 		.woocommerce-store-notice {
-			background-color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
+			background-color: ' . $primary_color . ';
 		}
 		.woocommerce-tabs ul li.active a {
-			color: hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
-			box-shadow: 0 2px 0 hsl( ' . $primary_color . ', ' . $saturation . ', ' . $lightness . ' );
+			color:  ' . $primary_color . ';
+			box-shadow: 0 2px 0 ' . $primary_color . ';
+		}
+		.woocommerce-tabs ul li a:hover {
+			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 		}
 	';
 	return $css;

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -72,7 +72,7 @@ function newspack_woo_custom_colors_css( $css, $primary_color ) {
 	';
 	return $css;
 }
-add_filter( 'newspack_custom_colors_css', 'newspack_woo_custom_colors_css', 10, 3 );
+add_filter( 'newspack_custom_colors_css', 'newspack_woo_custom_colors_css', 10, 2 );
 
 
 /**

--- a/js/customize-controls.js
+++ b/js/customize-controls.js
@@ -11,7 +11,7 @@
 	wp.customize.bind( 'ready', function() {
 
 		// Only show the color hue control when there's a custom primary color.
-		wp.customize( 'primary_color', function( setting ) {
+		wp.customize( 'theme_colors', function( setting ) {
 			wp.customize.control( 'primary_color_hex', function( control ) {
 				var visibility = function() {
 					if ( 'custom' === setting.get() ) {

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -8,7 +8,7 @@
 
 (function( $ ) {
 	// Primary color.
-	wp.customize( 'primary_color', function( value ) {
+	wp.customize( 'theme_colors', function( value ) {
 		value.bind( function( to ) {
 			// Update custom color CSS.
 			var style = $( '#custom-theme-colors' ),

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -416,7 +416,7 @@
 				&.has-text-color p,
 				&.has-text-color a,
 				&.has-primary-color,
-				&.has-secondary-color,
+				&.has-primary-variation-color,
 				&.has-dark-gray-color,
 				&.has-light-gray-color,
 				&.has-white-color {
@@ -831,7 +831,7 @@
 
 	//! Custom background colors
 	.has-primary-background-color,
-	.has-secondary-background-color,
+	.has-primary-variation-background-color,
 	.has-dark-gray-background-color,
 	.has-light-gray-background-color {
 
@@ -871,8 +871,8 @@
 		background-color: $color__link;
 	}
 
-	.has-secondary-background-color,
-	.wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+	.has-primary-variation-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
 		background-color: $color__border-link-hover;
 	}
 
@@ -898,9 +898,9 @@
 		color: $color__link;
 	}
 
-	.has-secondary-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+	.has-primary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
 		color: $color__border-link-hover;
 	}
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -142,7 +142,7 @@ a:focus {
 }
 
 .has-primary-background-color,
-.has-secondary-background-color,
+.has-primary-variation-background-color,
 .has-dark-gray-background-color,
 .has-light-gray-background-color {
   color: #fff;
@@ -156,14 +156,14 @@ a:focus {
 .has-primary-background-color h5,
 .has-primary-background-color h6,
 .has-primary-background-color a,
-.has-secondary-background-color p,
-.has-secondary-background-color h1,
-.has-secondary-background-color h2,
-.has-secondary-background-color h3,
-.has-secondary-background-color h4,
-.has-secondary-background-color h5,
-.has-secondary-background-color h6,
-.has-secondary-background-color a,
+.has-primary-variation-background-color p,
+.has-primary-variation-background-color h1,
+.has-primary-variation-background-color h2,
+.has-primary-variation-background-color h3,
+.has-primary-variation-background-color h4,
+.has-primary-variation-background-color h5,
+.has-primary-variation-background-color h6,
+.has-primary-variation-background-color a,
 .has-dark-gray-background-color p,
 .has-dark-gray-background-color h1,
 .has-dark-gray-background-color h2,

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -152,7 +152,7 @@ a {
 
 // Use white text against these backgrounds by default.
 .has-primary-background-color,
-.has-secondary-background-color,
+.has-primary-variation-background-color,
 .has-dark-gray-background-color,
 .has-light-gray-background-color {
 	color: $color__background-body;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3680,7 +3680,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
@@ -4123,7 +4123,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .has-light-gray-background-color {
   color: #fff;
@@ -4137,14 +4137,14 @@ body.page .main-navigation {
 .entry .entry-content .has-primary-background-color h5,
 .entry .entry-content .has-primary-background-color h6,
 .entry .entry-content .has-primary-background-color a,
-.entry .entry-content .has-secondary-background-color p,
-.entry .entry-content .has-secondary-background-color h1,
-.entry .entry-content .has-secondary-background-color h2,
-.entry .entry-content .has-secondary-background-color h3,
-.entry .entry-content .has-secondary-background-color h4,
-.entry .entry-content .has-secondary-background-color h5,
-.entry .entry-content .has-secondary-background-color h6,
-.entry .entry-content .has-secondary-background-color a,
+.entry .entry-content .has-primary-variation-background-color p,
+.entry .entry-content .has-primary-variation-background-color h1,
+.entry .entry-content .has-primary-variation-background-color h2,
+.entry .entry-content .has-primary-variation-background-color h3,
+.entry .entry-content .has-primary-variation-background-color h4,
+.entry .entry-content .has-primary-variation-background-color h5,
+.entry .entry-content .has-primary-variation-background-color h6,
+.entry .entry-content .has-primary-variation-background-color a,
 .entry .entry-content .has-dark-gray-background-color p,
 .entry .entry-content .has-dark-gray-background-color h1,
 .entry .entry-content .has-dark-gray-background-color h2,
@@ -4184,8 +4184,8 @@ body.page .main-navigation {
   background-color: #0073aa;
 }
 
-.entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .has-primary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
   background-color: #005177;
 }
 
@@ -4210,9 +4210,9 @@ body.page .main-navigation {
   color: #0073aa;
 }
 
-.entry .entry-content .has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
   color: #005177;
 }
 

--- a/style.css
+++ b/style.css
@@ -3692,7 +3692,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
@@ -4135,7 +4135,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .has-primary-background-color,
-.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .has-dark-gray-background-color,
 .entry .entry-content .has-light-gray-background-color {
   color: #fff;
@@ -4149,14 +4149,14 @@ body.page .main-navigation {
 .entry .entry-content .has-primary-background-color h5,
 .entry .entry-content .has-primary-background-color h6,
 .entry .entry-content .has-primary-background-color a,
-.entry .entry-content .has-secondary-background-color p,
-.entry .entry-content .has-secondary-background-color h1,
-.entry .entry-content .has-secondary-background-color h2,
-.entry .entry-content .has-secondary-background-color h3,
-.entry .entry-content .has-secondary-background-color h4,
-.entry .entry-content .has-secondary-background-color h5,
-.entry .entry-content .has-secondary-background-color h6,
-.entry .entry-content .has-secondary-background-color a,
+.entry .entry-content .has-primary-variation-background-color p,
+.entry .entry-content .has-primary-variation-background-color h1,
+.entry .entry-content .has-primary-variation-background-color h2,
+.entry .entry-content .has-primary-variation-background-color h3,
+.entry .entry-content .has-primary-variation-background-color h4,
+.entry .entry-content .has-primary-variation-background-color h5,
+.entry .entry-content .has-primary-variation-background-color h6,
+.entry .entry-content .has-primary-variation-background-color a,
 .entry .entry-content .has-dark-gray-background-color p,
 .entry .entry-content .has-dark-gray-background-color h1,
 .entry .entry-content .has-dark-gray-background-color h2,
@@ -4196,8 +4196,8 @@ body.page .main-navigation {
   background-color: #0073aa;
 }
 
-.entry .entry-content .has-secondary-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+.entry .entry-content .has-primary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
   background-color: #005177;
 }
 
@@ -4222,9 +4222,9 @@ body.page .main-navigation {
   color: #0073aa;
 }
 
-.entry .entry-content .has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+.entry .entry-content .has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
   color: #005177;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR re-adds the darker shade of the theme's primary colour, but using the hexidecimal value rather than HSL. Changes include:

* Updates the name of the colour variation, and the customizer control to toggle default/custom colours, to make more generic for when additional custom colours are added.
* Adds a function that allows you to lighten/darken a hexadecimal colour value (originally done by manually adjusting the HSL values). 

Closes #22 

### How to test the changes in this Pull Request:

1. Apply PR.
2. Check the editor, to verify a darker version of the theme's primary blue colour is included, and can be successfully added as a background and foreground to blocks that support it (like the paragraph block). 
3. In the Customizer, change the primary colour and save and publish.
4. On the front-end, make sure the darker colour variation is applied -- one spot to check is to hover over the menu, it should switch from your custom colour to a darker shade. 
5. In the editor, make sure the darker colour variation reflects your new custom colour. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
