### PR TITLE
Add body class for the static front page

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -21,6 +21,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hfeed';
 	}
 
+	// Add class on front page.
+	if ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) {
+		$classes[] = 'newspack-front-page';
+	}
+
 	// Adds a class when in the Customizer.
 	if ( is_customize_preview() ) :
 		$classes[] = 'newspack-customizer';

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -224,7 +224,7 @@
 
 /* Hide page title on the homepage */
 
-.page.home.hide-homepage-title {
+.newpack-front-page.hide-homepage-title {
 	.entry-header {
 		display: none;
 	}

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2500,7 +2500,7 @@ body.page .main-navigation {
 }
 
 /* Hide page title on the homepage */
-.page.home.hide-homepage-title .entry-header {
+.newpack-front-page.hide-homepage-title .entry-header {
   display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -2506,7 +2506,7 @@ body.page .main-navigation {
 }
 
 /* Hide page title on the homepage */
-.page.home.hide-homepage-title .entry-header {
+.newpack-front-page.hide-homepage-title .entry-header {
   display: none;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add body class when the site has a static front page, in anticipation of having styles that will only be applied to that page.

It also updates existing styles to use this class. 

### How to test the changes in this Pull Request:

1. Apply PR.
2. In the Customizer, set the site to have a static front page if it doesn't already. 
3. Make sure the class `newpack-front-page` is added to the body.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
