### PR TITLE
Preliminary work to update the theme's width

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -5,12 +5,6 @@
 	margin: 32px 0;
 	max-width: 100%;
 
-	@include postContentMaxWidth();
-
-	@include media(tablet) {
-		margin: 32px auto;
-	}
-
 	> *:first-child {
 		margin-top: 0;
 	}
@@ -20,29 +14,23 @@
 	}
 
 	&.alignwide {
-		margin-left: auto;
-		margin-right: auto;
-		clear: both;
-
 		@include media(tablet) {
-			width: 100%;
-			max-width: 100%;
+			margin-right: -53%;
+			max-width: 1000%;
 		}
 	}
 
 	&.alignfull {
+		margin-left: calc(50% - 50vw);
+		margin-right: calc(50% - 50vw);
+		max-width: 100vw;
 		position: relative;
-		left: -#{$size__spacing-unit };
-		width: calc( 100% + (2 * #{$size__spacing-unit}));
-		max-width: calc( 100% + (2 * #{$size__spacing-unit}));
-		clear: both;
+		width: 100vw;
 
 		@include media(tablet) {
-			margin-top: calc(2 * #{$size__spacing-unit});
-			margin-bottom: calc(2 * #{$size__spacing-unit});
-			left: calc( -12.5% - 75px );
-			width: calc( 125% + 150px );
-			max-width: calc( 125% + 150px );
+			clear: both;
+			margin-left: calc(77% - 50vw);
+			margin-right: auto;
 		}
 	}
 
@@ -591,8 +579,6 @@
 			}
 
 			@include media(tablet) {
-				padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
-				padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
 
 				.wp-block-cover-image-text,
 				.wp-block-cover-text,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -16,7 +16,7 @@
 	&.alignwide {
 		@include media(tablet) {
 			margin-right: -53%;
-			max-width: 1000%;
+			max-width: 100vw;
 		}
 	}
 

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -9,3 +9,9 @@
 	overflow: hidden;
 }
 
+#main {
+	margin: auto;
+	width: $size__site-main;
+	max-width: 90%;
+}
+

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -6,30 +6,19 @@
 	margin: calc(3 * 1rem) 0;
 
 	@include media(tablet) {
-		margin: calc(3 * 1rem) $size__site-margins;
-		max-width: calc(6 * (100vw / 12));
+		max-width: $size__site-tablet-content;
 	}
 
 	@include media(desktop) {
-		margin: calc(3 * 1rem) 0;
-		max-width: 100%;
+		max-width: $size__site-desktop-content;
 	}
 
 	.nav-links {
-
-		margin: 0 $size__spacing-unit;
-		max-width: 100%;
 		display: flex;
 		flex-direction: column;
 
-		@include media(tablet) {
-			margin: 0;
-		}
-
 		@include media(desktop) {
 			flex-direction: row;
-			margin: 0 auto;
-			max-width: $size__site-desktop-content;
 		}
 
 		a {

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -4,22 +4,24 @@
 
 	.widget-area,
 	.site-info {
-		@include postContentMaxWidth();
-		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
+		margin: calc(2 * #{$size__spacing-unit}) auto;
+		max-width: 90%;
+		width: $size__site-main;
 
 		@include media(tablet) {
-			margin: calc(1.5 * #{$size__spacing-unit}) auto;
+			margin: calc(3 * #{$size__spacing-unit}) auto;
 		}
 	}
 
 	.widget-column {
 		display: flex;
 		flex-wrap: wrap;
+
 		.widget {
 			width: 100%;
 			@include media(desktop) {
 				margin-right: calc(3 * #{$size__spacing-unit});
-				width: calc(50% - (3 * #{$size__spacing-unit}));
+				width: calc(33% - (3 * #{$size__spacing-unit}));
 			}
 		}
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -28,18 +28,15 @@
 // Site branding
 
 .site-branding {
-
+	align-items: center;
+	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
-	align-items: center;
 	justify-content: space-between;
-
-	color: $color__text-light;
+	margin: auto;
+	max-width: 90%;
 	position: relative;
-
-	@include media(tablet) {
-		margin: 0 $size__site-margins;
-	}
+	width: $size__site-main;
 }
 
 // Site logo

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -1,10 +1,10 @@
 .archive .page-header,
 .search .page-header {
 
-	margin: $size__spacing-unit $size__spacing-unit calc(3 * #{$size__spacing-unit});
+	margin: $size__spacing-unit 0 calc(3 * #{$size__spacing-unit});
 
 	@include media(tablet) {
-		margin: 0 $size__site-margins $size__site-margins;
+		margin: 0 0 $size__site-margins;
 	}
 
 	.page-title {
@@ -35,13 +35,6 @@
 	display: block;
 	color: $color__text-main;
 	font-size: 1em;
-}
-
-.hfeed .entry .entry-header {
-
-	@include media(tablet) {
-		margin: calc(3 * #{$size__spacing-unit}) auto calc(#{ $size__spacing-unit } / 2);
-	}
 }
 
 /* 404 & Not found */

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -33,14 +33,8 @@
 	}
 
 	.entry-header {
-
-		margin: calc(3 * #{ $size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+		margin: calc(3 * #{ $size__spacing-unit}) 0 $size__spacing-unit;
 		position: relative;
-
-		@include media(tablet) {
-			margin: calc(3 * #{ $size__spacing-unit}) auto $size__spacing-unit;
-			@include postContentMaxWidth();
-		}
 	}
 
 	.entry-title {
@@ -97,10 +91,10 @@
 
 	.entry-footer {
 
-		margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit $size__spacing-unit;
+		margin: calc(2 * #{$size__spacing-unit}) 0 $size__spacing-unit;
 
 		@include media(tablet) {
-			margin: $size__spacing-unit auto calc(3 * #{$size__spacing-unit});
+			margin: $size__spacing-unit 0 calc(3 * #{$size__spacing-unit});
 			max-width: $size__site-tablet-content;
 		}
 
@@ -110,12 +104,7 @@
 	}
 
 	.post-thumbnail {
-
-		margin: $size__spacing-unit;
-
-		@include media(tablet) {
-			margin: $size__spacing-unit $size__site-margins;
-		}
+		margin: $size__spacing-unit 0;
 
 		&:focus {
 			outline: none;
@@ -134,13 +123,12 @@
 
 	.entry-content,
 	.entry-summary {
-		max-width: calc(100% - (2 * #{ $size__spacing-unit }));
-		margin: 0 $size__spacing-unit;
-
 		@include media(tablet) {
-			max-width: 80%;
-			margin: 0 10%;
-			padding: 0 60px;
+			max-width: $size__site-tablet-content;
+		}
+
+		@include media(desktop) {
+			max-width: $size__site-desktop-content;
 		}
 	}
 
@@ -220,6 +208,10 @@
 			}
 		}
 	}
+}
+
+.page.home .entry .entry-content {
+	max-width: 100%;
 }
 
 /* Hide page title on the homepage */

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -1,11 +1,11 @@
 // Responsive widths.
 
 $size__spacing-unit: 1rem;
-$size__site-main: 100%;
+$size__site-main: 1200px;
 $size__site-sidebar: 25%;
 $size__site-margins: calc(10% + 60px);
-$size__site-tablet-content: calc(8 * (100vw / 12) - 28px);
-$size__site-desktop-content: calc(6 * (100vw / 12) - 28px);
+$size__site-tablet-content: 65%;
+$size__site-desktop-content: 65%;
 
 // Responsive widths.
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3116,7 +3116,7 @@ body.page .main-navigation {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide {
     margin-left: -53%;
-    max-width: 1000%;
+    max-width: 100vw;
   }
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1150,17 +1150,6 @@ body.page .main-navigation {
   margin-left: calc( .25 * 1rem);
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: auto;
-  min-width: 100%;
-  /* Non-mobile position */
-  /* Nested sub-menu dashes */
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1173,21 +1162,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-    display: block;
-    margin-top: 0;
-    opacity: 1;
-    position: absolute;
-    right: 0;
-    left: auto;
-    top: auto;
-    bottom: auto;
-    height: auto;
-    min-width: -moz-max-content;
-    min-width: -webkit-max-content;
-    min-width: max-content;
-    transform: none;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1205,13 +1179,6 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-  right: 0;
-  width: 100%;
-  display: table;
-  position: absolute;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1220,12 +1187,6 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-    left: 0;
-    right: auto;
-    display: block;
-    width: max-content;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
     left: 0;
     right: auto;
@@ -1234,22 +1195,8 @@ body.page .main-navigation {
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
-  display: none;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  display: block;
-  margin-top: inherit;
-  position: relative;
-  width: 100%;
-  right: 0;
-  opacity: 1;
-  /* Non-mobile position */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
@@ -1263,29 +1210,14 @@ body.page .main-navigation {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-    float: none;
-    max-width: 100%;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
   }
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  counter-reset: submenu;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
-  content: "– " counters(submenu, "– ", none);
-  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
@@ -1575,36 +1507,24 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12));
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .post-navigation {
-    margin: calc(3 * 1rem) 0;
-    max-width: 100%;
+    max-width: 65%;
   }
 }
 
 .post-navigation .nav-links {
-  margin: 0 1rem;
-  max-width: 100%;
   display: flex;
   flex-direction: column;
-}
-
-@media only screen and (min-width: 768px) {
-  .post-navigation .nav-links {
-    margin: 0;
-  }
 }
 
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
-    margin: 0 auto;
-    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -1677,13 +1597,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .pagination .nav-links {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -1962,6 +1882,12 @@ body.page .main-navigation {
   overflow: hidden;
 }
 
+#main {
+  margin: auto;
+  width: 1200px;
+  max-width: 90%;
+}
+
 /* Content */
 /*--------------------------------------------------------------
 ## Header
@@ -1993,18 +1919,15 @@ body.page .main-navigation {
 }
 
 .site-branding {
+  align-items: center;
+  color: #767676;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
-  color: #767676;
+  margin: auto;
+  max-width: 90%;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    margin: 0 calc(10% + 60px);
-  }
+  width: 1200px;
 }
 
 .site-logo {
@@ -2189,13 +2112,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2291,26 +2214,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-header {
-  margin: calc(3 * 1rem) 1rem 1rem;
+  margin: calc(3 * 1rem) 0 1rem;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-header {
-    margin: calc(3 * 1rem) auto 1rem;
-  }
-}
-
-@media only screen and (min-width: 768px) and (min-width: 768px) {
-  .entry .entry-header {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) and (min-width: 1168px) {
-  .entry .entry-header {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
 }
 
 .entry .entry-title {
@@ -2367,30 +2272,24 @@ body.page .main-navigation {
 }
 
 .entry .entry-footer {
-  margin: calc(2 * 1rem) 1rem 1rem;
+  margin: calc(2 * 1rem) 0 1rem;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    margin: 1rem auto calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    margin: 1rem 0 calc(3 * 1rem);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 .entry .post-thumbnail {
-  margin: 1rem;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .post-thumbnail {
-    margin: 1rem calc(10% + 60px);
-  }
+  margin: 1rem 0;
 }
 
 .entry .post-thumbnail:focus {
@@ -2407,18 +2306,17 @@ body.page .main-navigation {
   width: 100%;
 }
 
-.entry .entry-content,
-.entry .entry-summary {
-  max-width: calc(100% - (2 * 1rem));
-  margin: 0 1rem;
-}
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
-    max-width: 80%;
-    margin: 0 10%;
-    padding: 0 60px;
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content,
+  .entry .entry-summary {
+    max-width: 65%;
   }
 }
 
@@ -2468,13 +2366,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(8 * (100vw / 12) - 28px) !important;
+    max-width: 65% !important;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12) - 28px) !important;
+    max-width: 65% !important;
   }
 }
 
@@ -2489,14 +2387,18 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
+}
+
+.page.home .entry .entry-content {
+  max-width: 100%;
 }
 
 /* Hide page title on the homepage */
@@ -2511,13 +2413,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2573,13 +2475,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comments-area {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .comments-area {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2962,13 +2864,13 @@ body.page .main-navigation {
 --------------------------------------------------------------*/
 .archive .page-header,
 .search .page-header {
-  margin: 1rem 1rem calc(3 * 1rem);
+  margin: 1rem 0 calc(3 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {
   .archive .page-header,
   .search .page-header {
-    margin: 0 calc(10% + 60px) calc(10% + 60px);
+    margin: 0 0 calc(10% + 60px);
   }
 }
 
@@ -3007,12 +2909,6 @@ body.page .main-navigation {
   font-size: 1em;
 }
 
-@media only screen and (min-width: 768px) {
-  .hfeed .entry .entry-header {
-    margin: calc(3 * 1rem) auto calc(1rem / 2);
-  }
-}
-
 /* 404 & Not found */
 .error-404.not-found .page-header,
 .error-404.not-found .page-content,
@@ -3047,27 +2943,15 @@ body.page .main-navigation {
 /* Site footer */
 #colophon .widget-area,
 #colophon .site-info {
-  margin: calc(2 * 1rem) 1rem;
+  margin: calc(2 * 1rem) auto;
+  max-width: 90%;
+  width: 1200px;
 }
 
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  #colophon .widget-area,
-  #colophon .site-info {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) {
-  #colophon .widget-area,
-  #colophon .site-info {
-    margin: calc(1.5 * 1rem) auto;
+    margin: calc(3 * 1rem) auto;
   }
 }
 
@@ -3083,7 +2967,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 1168px) {
   #colophon .widget-column .widget {
     margin-left: calc(3 * 1rem);
-    width: calc(50% - (3 * 1rem));
+    width: calc(33% - (3 * 1rem));
   }
 }
 
@@ -3218,27 +3102,6 @@ body.page .main-navigation {
   max-width: 100%;
 }
 
-@media only screen and (min-width: 768px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    margin: 32px auto;
-  }
-}
-
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > * > *:first-child {
   margin-top: 0;
@@ -3249,38 +3112,29 @@ body.page .main-navigation {
   margin-bottom: 0;
 }
 
-.entry .entry-content > *.alignwide,
-.entry .entry-summary > *.alignwide {
-  margin-right: auto;
-  margin-left: auto;
-  clear: both;
-}
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide {
-    width: 100%;
-    max-width: 100%;
+    margin-left: -53%;
+    max-width: 1000%;
   }
 }
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull {
+  margin-right: calc(50% - 50vw);
+  margin-left: calc(50% - 50vw);
+  max-width: 100vw;
   position: relative;
-  right: -1rem;
-  width: calc( 100% + (2 * 1rem));
-  max-width: calc( 100% + (2 * 1rem));
-  clear: both;
+  width: 100vw;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull {
-    margin-top: calc(2 * 1rem);
-    margin-bottom: calc(2 * 1rem);
-    right: calc( -12.5% - 75px);
-    width: calc( 125% + 150px);
-    max-width: calc( 125% + 150px);
+    clear: both;
+    margin-right: calc(77% - 50vw);
+    margin-left: auto;
   }
 }
 
@@ -3328,14 +3182,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3767,20 +3621,20 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
     margin: 0;
-    width: calc(8 * (100vw / 12) - 28px);
+    width: 65%;
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
@@ -3789,7 +3643,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    width: calc(6 * (100vw / 12) - 28px);
+    width: 65%;
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
@@ -3870,7 +3724,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3881,16 +3735,11 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
-    padding-right: calc(10% + 58px + (2 * 1rem));
-    padding-left: calc(10% + 58px + (2 * 1rem));
-  }
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover-image.alignfull h2,
@@ -3949,14 +3798,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3972,14 +3821,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
   .entry .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
   .entry .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -4276,14 +4125,14 @@ svg {
 @media only screen and (min-width: 768px) {
   .wp-caption.aligncenter {
     position: relative;
-    right: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    right: calc( 65% / 2);
     transform: translateX(50%);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .wp-caption.aligncenter {
-    right: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    right: calc( 65% / 2);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1575,36 +1575,24 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .post-navigation {
-    margin: calc(3 * 1rem) calc(10% + 60px);
-    max-width: calc(6 * (100vw / 12));
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .post-navigation {
-    margin: calc(3 * 1rem) 0;
-    max-width: 100%;
+    max-width: 65%;
   }
 }
 
 .post-navigation .nav-links {
-  margin: 0 1rem;
-  max-width: 100%;
   display: flex;
   flex-direction: column;
-}
-
-@media only screen and (min-width: 768px) {
-  .post-navigation .nav-links {
-    margin: 0;
-  }
 }
 
 @media only screen and (min-width: 1168px) {
   .post-navigation .nav-links {
     flex-direction: row;
-    margin: 0 auto;
-    max-width: calc(6 * (100vw / 12) - 28px);
   }
 }
 
@@ -1677,13 +1665,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .pagination .nav-links {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .pagination .nav-links {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -1968,6 +1956,12 @@ body.page .main-navigation {
   overflow: hidden;
 }
 
+#main {
+  margin: auto;
+  width: 1200px;
+  max-width: 90%;
+}
+
 /* Content */
 /*--------------------------------------------------------------
 ## Header
@@ -1999,18 +1993,15 @@ body.page .main-navigation {
 }
 
 .site-branding {
+  align-items: center;
+  color: #767676;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
-  color: #767676;
+  margin: auto;
+  max-width: 90%;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    margin: 0 calc(10% + 60px);
-  }
+  width: 1200px;
 }
 
 .site-logo {
@@ -2195,13 +2186,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .site-header.featured-image .site-featured-image .entry-header {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2297,26 +2288,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-header {
-  margin: calc(3 * 1rem) 1rem 1rem;
+  margin: calc(3 * 1rem) 0 1rem;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-header {
-    margin: calc(3 * 1rem) auto 1rem;
-  }
-}
-
-@media only screen and (min-width: 768px) and (min-width: 768px) {
-  .entry .entry-header {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) and (min-width: 1168px) {
-  .entry .entry-header {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
 }
 
 .entry .entry-title {
@@ -2373,30 +2346,24 @@ body.page .main-navigation {
 }
 
 .entry .entry-footer {
-  margin: calc(2 * 1rem) 1rem 1rem;
+  margin: calc(2 * 1rem) 0 1rem;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-footer {
-    margin: 1rem auto calc(3 * 1rem);
-    max-width: calc(8 * (100vw / 12) - 28px);
+    margin: 1rem 0 calc(3 * 1rem);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-footer {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 .entry .post-thumbnail {
-  margin: 1rem;
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .post-thumbnail {
-    margin: 1rem calc(10% + 60px);
-  }
+  margin: 1rem 0;
 }
 
 .entry .post-thumbnail:focus {
@@ -2413,18 +2380,17 @@ body.page .main-navigation {
   width: 100%;
 }
 
-.entry .entry-content,
-.entry .entry-summary {
-  max-width: calc(100% - (2 * 1rem));
-  margin: 0 1rem;
-}
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content,
   .entry .entry-summary {
-    max-width: 80%;
-    margin: 0 10%;
-    padding: 0 60px;
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content,
+  .entry .entry-summary {
+    max-width: 65%;
   }
 }
 
@@ -2474,13 +2440,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(8 * (100vw / 12) - 28px) !important;
+    max-width: 65% !important;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > iframe[style] {
-    max-width: calc(6 * (100vw / 12) - 28px) !important;
+    max-width: 65% !important;
   }
 }
 
@@ -2495,14 +2461,18 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-audio-shortcode {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
+}
+
+.page.home .entry .entry-content {
+  max-width: 100%;
 }
 
 /* Hide page title on the homepage */
@@ -2517,13 +2487,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .author-bio {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .author-bio {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2579,13 +2549,13 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .comments-area {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .comments-area {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -2968,13 +2938,13 @@ body.page .main-navigation {
 --------------------------------------------------------------*/
 .archive .page-header,
 .search .page-header {
-  margin: 1rem 1rem calc(3 * 1rem);
+  margin: 1rem 0 calc(3 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {
   .archive .page-header,
   .search .page-header {
-    margin: 0 calc(10% + 60px) calc(10% + 60px);
+    margin: 0 0 calc(10% + 60px);
   }
 }
 
@@ -3013,12 +2983,6 @@ body.page .main-navigation {
   font-size: 1em;
 }
 
-@media only screen and (min-width: 768px) {
-  .hfeed .entry .entry-header {
-    margin: calc(3 * 1rem) auto calc(1rem / 2);
-  }
-}
-
 /* 404 & Not found */
 .error-404.not-found .page-header,
 .error-404.not-found .page-content,
@@ -3053,27 +3017,15 @@ body.page .main-navigation {
 /* Site footer */
 #colophon .widget-area,
 #colophon .site-info {
-  margin: calc(2 * 1rem) 1rem;
+  margin: calc(2 * 1rem) auto;
+  max-width: 90%;
+  width: 1200px;
 }
 
 @media only screen and (min-width: 768px) {
   #colophon .widget-area,
   #colophon .site-info {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  #colophon .widget-area,
-  #colophon .site-info {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) {
-  #colophon .widget-area,
-  #colophon .site-info {
-    margin: calc(1.5 * 1rem) auto;
+    margin: calc(3 * 1rem) auto;
   }
 }
 
@@ -3089,7 +3041,7 @@ body.page .main-navigation {
 @media only screen and (min-width: 1168px) {
   #colophon .widget-column .widget {
     margin-right: calc(3 * 1rem);
-    width: calc(50% - (3 * 1rem));
+    width: calc(33% - (3 * 1rem));
   }
 }
 
@@ -3224,27 +3176,6 @@ body.page .main-navigation {
   max-width: 100%;
 }
 
-@media only screen and (min-width: 768px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    max-width: calc(8 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    max-width: calc(6 * (100vw / 12) - 28px);
-  }
-}
-
-@media only screen and (min-width: 768px) {
-  .entry .entry-content > *,
-  .entry .entry-summary > * {
-    margin: 32px auto;
-  }
-}
-
 .entry .entry-content > * > *:first-child,
 .entry .entry-summary > * > *:first-child {
   margin-top: 0;
@@ -3255,38 +3186,29 @@ body.page .main-navigation {
   margin-bottom: 0;
 }
 
-.entry .entry-content > *.alignwide,
-.entry .entry-summary > *.alignwide {
-  margin-left: auto;
-  margin-right: auto;
-  clear: both;
-}
-
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide {
-    width: 100%;
-    max-width: 100%;
+    margin-right: -53%;
+    max-width: 1000%;
   }
 }
 
 .entry .entry-content > *.alignfull,
 .entry .entry-summary > *.alignfull {
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  max-width: 100vw;
   position: relative;
-  left: -1rem;
-  width: calc( 100% + (2 * 1rem));
-  max-width: calc( 100% + (2 * 1rem));
-  clear: both;
+  width: 100vw;
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.alignfull,
   .entry .entry-summary > *.alignfull {
-    margin-top: calc(2 * 1rem);
-    margin-bottom: calc(2 * 1rem);
-    left: calc( -12.5% - 75px);
-    width: calc( 125% + 150px);
-    max-width: calc( 125% + 150px);
+    clear: both;
+    margin-left: calc(77% - 50vw);
+    margin-right: auto;
   }
 }
 
@@ -3340,14 +3262,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content > *.aligncenter,
   .entry .entry-summary > *.aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3779,20 +3701,20 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-image .aligncenter {
     margin: 0;
-    width: calc(8 * (100vw / 12) - 28px);
+    width: 65%;
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
@@ -3801,7 +3723,7 @@ body.page .main-navigation {
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-image .aligncenter {
-    width: calc(6 * (100vw / 12) - 28px);
+    width: 65%;
   }
   .entry .entry-content .wp-block-image .aligncenter img {
     margin: 0 auto;
@@ -3882,7 +3804,7 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3893,16 +3815,11 @@ body.page .main-navigation {
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover.alignfull h2 {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 768px) {
-  .entry .entry-content .wp-block-cover-image.alignfull,
-  .entry .entry-content .wp-block-cover.alignfull {
-    padding-left: calc(10% + 58px + (2 * 1rem));
-    padding-right: calc(10% + 58px + (2 * 1rem));
-  }
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
   .entry .entry-content .wp-block-cover-image.alignfull h2,
@@ -3961,14 +3878,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-wide,
   .entry .entry-content hr.is-style-wide {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -3984,14 +3901,14 @@ body.page .main-navigation {
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
   .entry .entry-content hr.is-style-dots {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-separator.is-style-dots,
   .entry .entry-content hr.is-style-dots {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
@@ -4288,14 +4205,14 @@ svg {
 @media only screen and (min-width: 768px) {
   .wp-caption.aligncenter {
     position: relative;
-    left: calc( calc(8 * (100vw / 12) - 28px) / 2);
+    left: calc( 65% / 2);
     transform: translateX(-50%);
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .wp-caption.aligncenter {
-    left: calc( calc(6 * (100vw / 12) - 28px) / 2);
+    left: calc( 65% / 2);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -3190,7 +3190,7 @@ body.page .main-navigation {
   .entry .entry-content > *.alignwide,
   .entry .entry-summary > *.alignwide {
     margin-right: -53%;
-    max-width: 1000%;
+    max-width: 100vw;
   }
 }
 

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -1191,13 +1191,13 @@ table.variations select {
 
 @media only screen and (min-width: 768px) {
   .woocommerce .content-area .site-main {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .woocommerce .content-area .site-main {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1191,13 +1191,13 @@ table.variations select {
 
 @media only screen and (min-width: 768px) {
   .woocommerce .content-area .site-main {
-    max-width: calc(8 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 
 @media only screen and (min-width: 1168px) {
   .woocommerce .content-area .site-main {
-    max-width: calc(6 * (100vw / 12) - 28px);
+    max-width: 65%;
   }
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR starts the process of fixing the theme's width to better match the in-progress mockups. It sets the header and footer width to 1200px, as well as the front page when set to a static page. It sets the content area of single posts to approximately 780px, and slightly offset. 

There's a number of things that still need to be done, like adding a sidebar, and deciding how to handle centring the content, and in what cases (like will it be always centred when there's no sidebar, or just for special features?). The editor styles will also need to be updated to match; these will all be handled in separate PRs.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Make sure the header and footer are 1200px wide and centred.
3. Make sure the content of single posts and pages is ~780px wide, and set to the left. 
4. Set a static front page; make sure the content area is 1200px in that case. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
