### PR TITLE
Remove author name, published date from entry footer

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -74,12 +74,6 @@ if ( ! function_exists( 'newspack_entry_footer' ) ) :
 		// Hide author, post date, category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
 
-			// Posted by
-			newspack_posted_by();
-
-			// Posted on
-			newspack_posted_on();
-
 			/* translators: used between list items, there is a space after the comma. */
 			$categories_list = get_the_category_list( __( ', ', 'newspack' ) );
 			if ( $categories_list ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Twenty Nineteen, the theme the Newspack theme is based on, repeats the author's name and publication date at the bottom of each post. They're only needed the one time, at the top, for the Newpack theme, so this PR removes the copies.

### How to test the changes in this Pull Request:

1. Check the bottom of a post; note the existence of the author name and publication date.
2. Apply the PR.
3. Confirm that they're both gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
