### PR TITLE
Add 'secondary' menu space to the header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -54,10 +54,10 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'menu-1' => __( 'Primary Menu', 'newspack' ),
-				'menu-2' => __( 'Secondary Menu', 'newspack' ),
-				'footer' => __( 'Footer Menu', 'newspack' ),
-				'social' => __( 'Social Links Menu', 'newspack' ),
+				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
+				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
+				'footer'         => __( 'Footer Menu', 'newspack' ),
+				'social'         => __( 'Social Links Menu', 'newspack' ),
 			)
 		);
 
@@ -223,7 +223,7 @@ function newspack_scripts() {
 
 	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 
-	if ( has_nav_menu( 'menu-1' ) ) {
+	if ( has_nav_menu( 'primary-menu' ) ) {
 		wp_enqueue_script( 'newspack-priority-menu', get_theme_file_uri( '/js/priority-menu.js' ), array(), '1.1', true );
 		wp_enqueue_script( 'newspack-touch-navigation', get_theme_file_uri( '/js/touch-keyboard-navigation.js' ), array(), '1.1', true );
 	}

--- a/functions.php
+++ b/functions.php
@@ -54,7 +54,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'menu-1' => __( 'Primary', 'newspack' ),
+				'menu-1' => __( 'Primary Menu', 'newspack' ),
+				'menu-2' => __( 'Secondary Menu', 'newspack' ),
 				'footer' => __( 'Footer Menu', 'newspack' ),
 				'social' => __( 'Social Links Menu', 'newspack' ),
 			)

--- a/header.php
+++ b/header.php
@@ -24,12 +24,12 @@
 		<header id="masthead" class="site-header">
 
 			<div class="top-nav-contain">
-				<?php if ( has_nav_menu( 'menu-2' ) ) : ?>
+				<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 					<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
 						<?php
 						wp_nav_menu(
 							array(
-								'theme_location' => 'menu-2',
+								'theme_location' => 'secondary-menu',
 								'menu_class'     => 'secondary-menu',
 								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 								'depth'          => 1,
@@ -59,12 +59,12 @@
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 			</div><!-- .layout-wrap -->
 
-			<?php if ( has_nav_menu( 'menu-1' ) ) : ?>
+			<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 					<?php
 					wp_nav_menu(
 						array(
-							'theme_location' => 'menu-1',
+							'theme_location' => 'primary-menu',
 							'menu_class'     => 'main-menu',
 							'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 						)

--- a/header.php
+++ b/header.php
@@ -32,6 +32,7 @@
 								'theme_location' => 'menu-2',
 								'menu_class'     => 'secondary-menu',
 								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								'depth'          => 1,
 							)
 						);
 						?>

--- a/header.php
+++ b/header.php
@@ -24,6 +24,19 @@
 		<header id="masthead" class="site-header">
 
 			<div class="top-nav-contain">
+				<?php if ( has_nav_menu( 'menu-2' ) ) : ?>
+					<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'menu-2',
+								'menu_class'     => 'secondary-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							)
+						);
+						?>
+					</nav>
+				<?php endif; ?>
 				<?php if ( has_nav_menu( 'social' ) ) : ?>
 					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
 						<?php

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -201,7 +201,7 @@ function newspack_get_discussion_data() {
  */
 function newspack_add_ellipses_to_nav( $nav_menu, $args ) {
 
-	if ( 'menu-1' === $args->theme_location ) :
+	if ( 'primary-menu' === $args->theme_location ) :
 
 		$nav_menu .= '<div class="main-menu-more">';
 		$nav_menu .= '<ul class="main-menu">';
@@ -262,7 +262,7 @@ add_filter( 'nav_menu_link_attributes', 'newspack_nav_menu_link_attributes', 10,
 function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 
 	// Only add class to 'top level' items on the 'primary' menu.
-	if ( ! isset( $args->theme_location ) || 'menu-1' !== $args->theme_location ) {
+	if ( ! isset( $args->theme_location ) || 'primary-menu' !== $args->theme_location ) {
 		return $output;
 	}
 
@@ -316,7 +316,7 @@ add_filter( 'walker_nav_menu_start_el', 'newspack_add_dropdown_icons', 10, 4 );
  */
 function newspack_add_mobile_parent_nav_menu_items( $sorted_menu_items, $args ) {
 	static $pseudo_id = 0;
-	if ( ! isset( $args->theme_location ) || 'menu-1' !== $args->theme_location ) {
+	if ( ! isset( $args->theme_location ) || 'primary-menu' !== $args->theme_location ) {
 		return $sorted_menu_items;
 	}
 

--- a/js/touch-keyboard-navigation.js
+++ b/js/touch-keyboard-navigation.js
@@ -329,7 +329,7 @@
 	 * Run our sub-menu function on selective refresh in the customizer
 	 */
 	document.addEventListener( 'customize-preview-menu-refreshed', function( e, params ) {
-		if ( 'menu-1' === params.wpNavMenuArgs.theme_location ) {
+		if ( 'primary-menu' === params.wpNavMenuArgs.theme_location ) {
 			toggleSubmenuDisplay();
 		}
 	});

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -1,14 +1,10 @@
 /** === Main menu === */
 
 .main-navigation {
-
-	margin-top: #{0.25 * $size__spacing-unit};
 	display: flex;
-
-	@include media(tablet) {
-		margin-left: $size__site-margins;
-		margin-right: $size__site-margins;
-	}
+	margin: #{0.25 * $size__spacing-unit} auto 0;
+	max-width: 90%;
+	width: $size__site-main;
 
 	/* Un-style buttons */
 	button {
@@ -44,7 +40,6 @@
 	}
 
 	.main-menu {
-
 		display: inline-block;
 		margin: 0;
 		padding: 0;

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -3,10 +3,6 @@
 .social-navigation {
 	text-align: left;
 
-	@include media(tablet) {
-		margin-left: auto; // bump social menu to the left on mobile - TODO maybe tie this into a class checking for other menus.
-	}
-
 	ul.social-links-menu {
 		display: flex;
 		margin: 0;

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -1,8 +1,11 @@
 /* Social menu */
 
 .social-navigation {
-	margin-top: calc(#{$size__spacing-unit} / 2 );
 	text-align: left;
+
+	@include media(tablet) {
+		margin-left: auto; // bump social menu to the left on mobile - TODO maybe tie this into a class checking for other menus.
+	}
 
 	ul.social-links-menu {
 		@include clearfix;
@@ -42,8 +45,8 @@
 
 				svg {
 					display: block;
-					width: 32px;
-					height: 32px;
+					width: 28px;
+					height: 28px;
 
 					// Prevent icons from jumping in Safari using hardware acceleration.
 					transform: translateZ(0);
@@ -54,13 +57,5 @@
 				}
 			}
 		}
-	}
-}
-
-.site-title + .social-navigation,
-.site-description + .social-navigation {
-
-	@include media(tablet) {
-		margin-top: calc(#{$size__spacing-unit} / 5 );
 	}
 }

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -40,8 +40,8 @@
 
 				svg {
 					display: block;
-					width: 28px;
-					height: 28px;
+					width: 32px;
+					height: 32px;
 
 					// Prevent icons from jumping in Safari using hardware acceleration.
 					transform: translateZ(0);

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -8,16 +8,11 @@
 	}
 
 	ul.social-links-menu {
-		@include clearfix;
-
-		display: inline-block;
+		display: flex;
 		margin: 0;
 		padding: 0;
 
 		li {
-			display: inline-block;
-			vertical-align: bottom;
-			vertical-align: -webkit-baseline-middle;
 			list-style: none;
 
 			&:nth-child(n+2) {

--- a/sass/navigation/_menu-top-navigation.scss
+++ b/sass/navigation/_menu-top-navigation.scss
@@ -1,5 +1,29 @@
 .top-nav-contain {
-	@include media(tablet) {
-		margin: 0 $size__site-margins;
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin: auto;
+	max-width: 90%;
+	width: $size__site-main;
+}
+
+.secondary-menu {
+	display: block;
+	font-family: $font__heading;
+	font-size: $font__size-sm;
+	margin: 0;
+	padding: 0;
+
+	li {
+		display: inline;
+		margin: 0;
+		padding: 0;
+	}
+
+	> li {
+		> a {
+			margin-right: #{0.5 * $size__spacing-unit};
+		}
 	}
 }

--- a/sass/navigation/_menu-top-navigation.scss
+++ b/sass/navigation/_menu-top-navigation.scss
@@ -1,22 +1,30 @@
 .top-nav-contain {
-	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin: auto;
 	max-width: 90%;
 	width: $size__site-main;
+
+	@include media(tablet) {
+		flex-wrap: nowrap;
+	}
 }
 
 .secondary-menu {
-	display: block;
+	display: flex;
+	flex-wrap: wrap;
 	font-family: $font__heading;
 	font-size: $font__size-sm;
+	list-style: none;
 	margin: 0;
-	padding: 0;
+	padding: 0 0 #{0.5 * $size__spacing-unit};
+
+	@include media(tablet) {
+		padding: 0;
+	}
 
 	li {
-		display: inline;
 		margin: 0;
 		padding: 0;
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -35,6 +35,7 @@
 	justify-content: space-between;
 	margin: auto;
 	max-width: 90%;
+	padding: $size__spacing-unit 0;
 	position: relative;
 	width: $size__site-main;
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -16,7 +16,7 @@
 
 	@include media(tablet) {
 		margin: 0;
-		padding: 3rem 0;
+		padding: 1rem 0 3rem;
 
 		&.featured-image {
 			min-height: 100vh;
@@ -38,6 +38,10 @@
 	padding: $size__spacing-unit 0;
 	position: relative;
 	width: $size__site-main;
+
+	@include media(tablet) {
+		padding: #{$size__spacing-unit * 2} 0;
+	}
 }
 
 // Site logo

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1154,17 +1154,6 @@ a:focus {
   /* Nested sub-menu dashes */
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: auto;
-  min-width: 100%;
-  /* Non-mobile position */
-  /* Nested sub-menu dashes */
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1177,21 +1166,6 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-    display: block;
-    margin-top: 0;
-    opacity: 1;
-    position: absolute;
-    right: 0;
-    left: auto;
-    top: auto;
-    bottom: auto;
-    height: auto;
-    min-width: -moz-max-content;
-    min-width: -webkit-max-content;
-    min-width: max-content;
-    transform: none;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1231,13 +1205,6 @@ a:focus {
   position: absolute;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-  right: 0;
-  width: 100%;
-  display: table;
-  position: absolute;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1252,22 +1219,12 @@ a:focus {
     display: block;
     width: max-content;
   }
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-    left: 0;
-    right: auto;
-    display: block;
-    width: max-content;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
     left: 0;
     right: auto;
     display: block;
     width: max-content;
   }
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
-  display: none;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
@@ -1288,16 +1245,6 @@ a:focus {
   /* Non-mobile position */
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  display: block;
-  margin-top: inherit;
-  position: relative;
-  width: 100%;
-  right: 0;
-  opacity: 1;
-  /* Non-mobile position */
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -1313,10 +1260,6 @@ a:focus {
     float: none;
     max-width: 100%;
   }
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-    float: none;
-    max-width: 100%;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
@@ -1327,19 +1270,8 @@ a:focus {
   counter-reset: submenu;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  counter-reset: submenu;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-weight: normal;
-  content: "– " counters(submenu, "– ", none);
-  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
@@ -1545,7 +1477,6 @@ a:focus {
 }
 
 .top-nav-contain {
-  align-items: center;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -1554,16 +1485,29 @@ a:focus {
   width: 1200px;
 }
 
+@media only screen and (min-width: 768px) {
+  .top-nav-contain {
+    flex-wrap: nowrap;
+  }
+}
+
 .secondary-menu {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
+  list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .secondary-menu {
+    padding: 0;
+  }
 }
 
 .secondary-menu li {
-  display: inline;
   margin: 0;
   padding: 0;
 }
@@ -1584,18 +1528,12 @@ a:focus {
 }
 
 .social-navigation ul.social-links-menu {
-  content: "";
-  display: table;
-  table-layout: fixed;
-  display: inline-block;
+  display: flex;
   margin: 0;
   padding: 0;
 }
 
 .social-navigation ul.social-links-menu li {
-  display: inline-block;
-  vertical-align: bottom;
-  vertical-align: -webkit-baseline-middle;
   list-style: none;
 }
 
@@ -2065,7 +2003,7 @@ a:focus {
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
-    padding: 3rem 0;
+    padding: 1rem 0 3rem;
   }
   .site-header.featured-image {
     min-height: 100vh;
@@ -2084,6 +2022,12 @@ a:focus {
   padding: 1rem 0;
   position: relative;
   width: 1200px;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-branding {
+    padding: 2rem 0;
+  }
 }
 
 .site-logo {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1562,8 +1562,8 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   transform: translateZ(0);
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1521,12 +1521,6 @@ a:focus {
   text-align: right;
 }
 
-@media only screen and (min-width: 768px) {
-  .social-navigation {
-    margin-right: auto;
-  }
-}
-
 .social-navigation ul.social-links-menu {
   display: flex;
   margin: 0;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -913,8 +913,10 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  margin-top: 0.25rem;
   display: flex;
+  margin: 0.25rem auto 0;
+  max-width: 90%;
+  width: 1200px;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles
@@ -928,13 +930,6 @@ a:focus {
   /**
 	 * Off-canvas touch device styles
 	 */
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation {
-    margin-right: calc(10% + 60px);
-    margin-left: calc(10% + 60px);
-  }
 }
 
 .main-navigation button {
@@ -1148,6 +1143,28 @@ a:focus {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1160,6 +1177,36 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1177,6 +1224,20 @@ a:focus {
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1185,6 +1246,18 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
     left: 0;
     right: auto;
@@ -1193,8 +1266,36 @@ a:focus {
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
+  display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
+  display: none;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
@@ -1208,14 +1309,44 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
+  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
+  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
@@ -1413,16 +1544,43 @@ a:focus {
   }
 }
 
-@media only screen and (min-width: 768px) {
-  .top-nav-contain {
-    margin: 0 calc(10% + 60px);
-  }
+.top-nav-contain {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: auto;
+  max-width: 90%;
+  width: 1200px;
+}
+
+.secondary-menu {
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+  margin: 0;
+  padding: 0;
+}
+
+.secondary-menu li {
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.secondary-menu > li > a {
+  margin-left: 0.5rem;
 }
 
 /* Social menu */
 .social-navigation {
-  margin-top: calc(1rem / 2);
   text-align: right;
+}
+
+@media only screen and (min-width: 768px) {
+  .social-navigation {
+    margin-right: auto;
+  }
 }
 
 .social-navigation ul.social-links-menu {
@@ -1466,20 +1624,13 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   transform: translateZ(0);
 }
 
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {
   transform: rotate(45deg);
-}
-
-@media only screen and (min-width: 768px) {
-  .site-title + .social-navigation,
-  .site-description + .social-navigation {
-    margin-top: calc(1rem / 5);
-  }
 }
 
 /** === Footer menu === */
@@ -1930,6 +2081,7 @@ a:focus {
   justify-content: space-between;
   margin: auto;
   max-width: 90%;
+  padding: 1rem 0;
   position: relative;
   width: 1200px;
 }

--- a/style.css
+++ b/style.css
@@ -1521,12 +1521,6 @@ a:focus {
   text-align: left;
 }
 
-@media only screen and (min-width: 768px) {
-  .social-navigation {
-    margin-left: auto;
-  }
-}
-
 .social-navigation ul.social-links-menu {
   display: flex;
   margin: 0;

--- a/style.css
+++ b/style.css
@@ -1477,7 +1477,6 @@ a:focus {
 }
 
 .top-nav-contain {
-  align-items: center;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
@@ -1486,16 +1485,29 @@ a:focus {
   width: 1200px;
 }
 
+@media only screen and (min-width: 768px) {
+  .top-nav-contain {
+    flex-wrap: nowrap;
+  }
+}
+
 .secondary-menu {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
+  list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .secondary-menu {
+    padding: 0;
+  }
 }
 
 .secondary-menu li {
-  display: inline;
   margin: 0;
   padding: 0;
 }
@@ -1516,18 +1528,12 @@ a:focus {
 }
 
 .social-navigation ul.social-links-menu {
-  content: "";
-  display: table;
-  table-layout: fixed;
-  display: inline-block;
+  display: flex;
   margin: 0;
   padding: 0;
 }
 
 .social-navigation ul.social-links-menu li {
-  display: inline-block;
-  vertical-align: bottom;
-  vertical-align: -webkit-baseline-middle;
   list-style: none;
 }
 
@@ -2003,7 +2009,7 @@ a:focus {
 @media only screen and (min-width: 768px) {
   .site-header {
     margin: 0;
-    padding: 3rem 0;
+    padding: 1rem 0 3rem;
   }
   .site-header.featured-image {
     min-height: 100vh;
@@ -2022,6 +2028,12 @@ a:focus {
   padding: 1rem 0;
   position: relative;
   width: 1200px;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-branding {
+    padding: 2rem 0;
+  }
 }
 
 .site-logo {

--- a/style.css
+++ b/style.css
@@ -1562,8 +1562,8 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   transform: translateZ(0);
 }
 

--- a/style.css
+++ b/style.css
@@ -913,8 +913,10 @@ a:focus {
 --------------------------------------------------------------*/
 /** === Main menu === */
 .main-navigation {
-  margin-top: 0.25rem;
   display: flex;
+  margin: 0.25rem auto 0;
+  max-width: 90%;
+  width: 1200px;
   /* Un-style buttons */
   /*
 	 * Sub-menu styles
@@ -928,13 +930,6 @@ a:focus {
   /**
 	 * Off-canvas touch device styles
 	 */
-}
-
-@media only screen and (min-width: 768px) {
-  .main-navigation {
-    margin-left: calc(10% + 60px);
-    margin-right: calc(10% + 60px);
-  }
 }
 
 .main-navigation button {
@@ -1481,16 +1476,43 @@ a:focus {
   }
 }
 
-@media only screen and (min-width: 768px) {
-  .top-nav-contain {
-    margin: 0 calc(10% + 60px);
-  }
+.top-nav-contain {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: auto;
+  max-width: 90%;
+  width: 1200px;
+}
+
+.secondary-menu {
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+  margin: 0;
+  padding: 0;
+}
+
+.secondary-menu li {
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.secondary-menu > li > a {
+  margin-right: 0.5rem;
 }
 
 /* Social menu */
 .social-navigation {
-  margin-top: calc(1rem / 2);
   text-align: left;
+}
+
+@media only screen and (min-width: 768px) {
+  .social-navigation {
+    margin-left: auto;
+  }
 }
 
 .social-navigation ul.social-links-menu {
@@ -1534,20 +1556,13 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   transform: translateZ(0);
 }
 
 .social-navigation ul.social-links-menu li a svg#ui-icon-link {
   transform: rotate(-45deg);
-}
-
-@media only screen and (min-width: 768px) {
-  .site-title + .social-navigation,
-  .site-description + .social-navigation {
-    margin-top: calc(1rem / 5);
-  }
 }
 
 /** === Footer menu === */
@@ -2004,6 +2019,7 @@ a:focus {
   justify-content: space-between;
   margin: auto;
   max-width: 90%;
+  padding: 1rem 0;
   position: relative;
   width: 1200px;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the secondary menu space outlined in #20. 

It adds a one-level menu that will sit to the left of the social menu when added. 

It does not:

1. Do anything 'special' on mobile -- the links currently all remain visible, though around the tablet breakpoint this menu and the social menu will become stacked. 
2. Add more than one level to the menu.

Mobile improvements will definitely be handled in a future PR; adding the ability to have more than one level of menu can also be added pretty painlessly, if it's deemed necessary. Either of these should use the styles and functionality already built out for the primary menu, to reduce duplication of code, so it will need to be reworked a bit. 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add a menu to the 'Secondary Menu' space. 
3. Test with and without a social menu, and with a short and longer menu, to make sure there is no major breakage. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?