### PR TITLE
Add second custom color option

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -137,7 +137,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
-		$primary_color = newspack_get_primary_color();
+		$primary_color   = newspack_get_primary_color();
 		$secondary_color = newspack_get_secondary_color();
 
 		// Editor color palette.
@@ -147,22 +147,30 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'  => __( 'Primary', 'newspack' ),
 					'slug'  => 'primary',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? $primary_color : get_theme_mod( 'primary_color_hex', $primary_color ),
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
+						$primary_color :
+						get_theme_mod( 'primary_color_hex', $primary_color ),
 				),
 				array(
 					'name'  => __( 'Primary Variation', 'newspack' ),
 					'slug'  => 'primary-variation',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? newspack_adjust_brightness( $primary_color, -40 ) : newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
+						newspack_adjust_brightness( $primary_color, -40 ) :
+						newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
 				),
 				array(
 					'name'  => __( 'Secondary', 'newspack' ),
 					'slug'  => 'secondary',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? $secondary_color : get_theme_mod( 'secondary_color_hex', $secondary_color ),
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
+						$secondary_color :
+						get_theme_mod( 'secondary_color_hex', $secondary_color ),
 				),
 				array(
 					'name'  => __( 'Secondary Variation', 'newspack' ),
 					'slug'  => 'secondary-variation',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? newspack_adjust_brightness( $secondary_color, -40 ) : newspack_adjust_brightness( get_theme_mod( 'secondary_color_hex', $secondary_color ), -40 ),
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
+						newspack_adjust_brightness( $secondary_color, -40 ) :
+						newspack_adjust_brightness( get_theme_mod( 'secondary_color_hex', $secondary_color ), -40 ),
 				),
 				array(
 					'name'  => __( 'White', 'newspack' ),

--- a/functions.php
+++ b/functions.php
@@ -138,6 +138,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		);
 
 		$primary_color = newspack_get_primary_color();
+		$secondary_color = newspack_get_secondary_color();
 
 		// Editor color palette.
 		add_theme_support(
@@ -154,14 +155,14 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? newspack_adjust_brightness( $primary_color, -40 ) : newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
 				),
 				array(
-					'name'  => __( 'Dark Gray', 'newspack' ),
-					'slug'  => 'dark-gray',
-					'color' => '#111',
+					'name'  => __( 'Secondary', 'newspack' ),
+					'slug'  => 'secondary',
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? $secondary_color : get_theme_mod( 'secondary_color_hex', $secondary_color ),
 				),
 				array(
-					'name'  => __( 'Light Gray', 'newspack' ),
-					'slug'  => 'light-gray',
-					'color' => '#767676',
+					'name'  => __( 'Secondary Variation', 'newspack' ),
+					'slug'  => 'secondary-variation',
+					'color' => 'default' === get_theme_mod( 'theme_colors' ) ? newspack_adjust_brightness( $secondary_color, -40 ) : newspack_adjust_brightness( get_theme_mod( 'secondary_color_hex', $secondary_color ), -40 ),
 				),
 				array(
 					'name'  => __( 'White', 'newspack' ),

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -10,6 +10,7 @@
  */
 
 define( 'NEWSPACK_DEFAULT_PRIMARY', '#0073a8' ); // Hex
+define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
 /**
  * The default color used for the primary color throughout this theme
@@ -21,10 +22,30 @@ function newspack_get_primary_color() {
 }
 
 /**
- * Tests the current default hue against NEWSPACK_DEFAULT_HEX.
+ * The default color used for the secondary color throughout this theme
+ *
+ * @return string the default hexidecimal color.
+ */
+function newspack_get_secondary_color() {
+	return apply_filters( 'newspack_secondary_color', NEWSPACK_DEFAULT_SECONDARY );
+}
+
+/**
+ * Tests the current default hue against NEWSPACK_DEFAULT_PRIMARY.
  *
  * @return bool
  */
 function newspack_has_custom_primary_color() {
 	return newspack_get_primary_color() !== NEWSPACK_DEFAULT_PRIMARY;
 }
+
+/**
+ * Tests the current default hue against NEWSPACK_DEFAULT_SECONDARY.
+ *
+ * @return bool
+ */
+function newspack_has_custom_secondary_color() {
+	return newspack_get_secondary_color() !== NEWSPACK_DEFAULT_SECONDARY;
+}
+
+

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -24,7 +24,7 @@ function newspack_get_primary_color() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string NEWSPACK_DEFAULT_PRIMARY Default hexidecimal value.
+	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
 	 */
 	return apply_filters( 'newspack_primary_color', NEWSPACK_DEFAULT_PRIMARY );
 }
@@ -42,7 +42,7 @@ function newspack_get_secondary_color() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string NEWSPACK_DEFAULT_SECONDARY Default hexidecimal value.
+	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
 	 */
 	return apply_filters( 'newspack_secondary_color', NEWSPACK_DEFAULT_SECONDARY );
 }

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -8,7 +8,6 @@
 /**
  * Define default color filters.
  */
-
 define( 'NEWSPACK_DEFAULT_PRIMARY', '#0073a8' ); // Hex
 define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
@@ -18,6 +17,15 @@ define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
  * @return string the default hexidecimal color.
  */
 function newspack_get_primary_color() {
+	/**
+	 * Default primary color.
+	 *
+	 * Sets the default primary color for the theme's custom colors.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string NEWSPACK_DEFAULT_PRIMARY Default hexidecimal value.
+	 */
 	return apply_filters( 'newspack_primary_color', NEWSPACK_DEFAULT_PRIMARY );
 }
 
@@ -27,6 +35,15 @@ function newspack_get_primary_color() {
  * @return string the default hexidecimal color.
  */
 function newspack_get_secondary_color() {
+	/**
+	 * Default secondary color.
+	 *
+	 * Sets the default secondary color for the theme's custom colors.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string NEWSPACK_DEFAULT_SECONDARY Default hexidecimal value.
+	 */
 	return apply_filters( 'newspack_secondary_color', NEWSPACK_DEFAULT_SECONDARY );
 }
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -11,25 +11,17 @@
 function newspack_custom_colors_css() {
 
 	$primary_color = newspack_get_primary_color();
+	$secondary_color = newspack_get_secondary_color();
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color = get_theme_mod( 'primary_color_hex', $primary_color );
+		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 	}
 
 
 	$theme_css = '
-		/*
-		 * Set background for:
-		 * - featured image :before
-		 * - featured image :before
-		 * - post thumbmail :before
-		 * - post thumbmail :before
-		 * - Submenu
-		 * - Sticky Post
-		 * - buttons
-		 * - WP Block Button
-		 * - Blocks
-		 */
+		/* Set primary background color */
+
 		.main-navigation .sub-menu,
 		.sticky-post,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
@@ -43,21 +35,8 @@ function newspack_custom_colors_css() {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		/*
-		 * Set Color for:
-		 * - all links
-		 * - main navigation links
-		 * - Post navigation links
-		 * - Post entry meta hover
-		 * - Post entry header more-link hover
-		 * - main navigation svg
-		 * - comment navigation
-		 * - Comment edit link hover
-		 * - Site Footer Link hover
-		 * - Widget links
-		 */
-		a,
-		a:visited,
+		/* Set primary color */
+
 		.main-navigation .main-menu > li,
 		.main-navigation ul.main-menu > li > a,
 		.post-navigation .post-title,
@@ -68,7 +47,7 @@ function newspack_custom_colors_css() {
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		#colophon .site-info a:hover,
-		.widget a,
+		.widget a, .widget a:visited,
 		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.entry .entry-content > .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
@@ -77,11 +56,8 @@ function newspack_custom_colors_css() {
 			color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		/*
-		 * Set border color for:
-		 * wp block quote
-		 * :focus
-		 */
+		/* Set primary border color */
+
 		blockquote,
 		.entry .entry-content blockquote,
 		.entry .entry-content .wp-block-quote:not(.is-large),
@@ -109,8 +85,44 @@ function newspack_custom_colors_css() {
 			box-shadow: 0 0 0 2px ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		/* Hover colors */
-		a:hover, a:active,
+		/* Set secondary background color */
+
+		.entry .entry-content > .has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
+			background-color:' . $secondary_color . '; /* base: #666 */
+		}
+
+		/* Set secondary color */
+
+		a, a:visited,
+		.entry .entry-content > .has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
+			color:' . $secondary_color . '; /* base: #666 */
+		}
+
+		/* Set primary variation background color */
+
+		.main-navigation .sub-menu > li > a:hover,
+		.main-navigation .sub-menu > li > a:focus,
+		.main-navigation .sub-menu > li > a:hover:after,
+		.main-navigation .sub-menu > li > a:focus:after,
+		.main-navigation .sub-menu > li > .menu-item-link-return:hover,
+		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
+		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
+		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
+		.entry .entry-content > .has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
+			background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
+		}
+
+		/* Set primary variation color */
+
 		.main-navigation .main-menu > li > a:hover,
 		.main-navigation .main-menu > li > a:hover + svg,
 		.post-navigation .nav-links a:hover,
@@ -129,22 +141,27 @@ function newspack_custom_colors_css() {
 			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #0073a8; */
 		}
 
-		.main-navigation .sub-menu > li > a:hover,
-		.main-navigation .sub-menu > li > a:focus,
-		.main-navigation .sub-menu > li > a:hover:after,
-		.main-navigation .sub-menu > li > a:focus:after,
-		.main-navigation .sub-menu > li > .menu-item-link-return:hover,
-		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
-		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
-		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
-		.entry .entry-content > .has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
-			background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
+		/* Set secondary variation background color */
+
+		.entry .entry-content > .has-secondary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-secondary-variation-ackground-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-variation-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color {
+			background-color:' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #666 */
+		}
+
+		/* Set secondary variation color */
+
+		a:hover, a:active,
+		.entry .entry-content > .has-secondary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p {
+			color:' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #666 */
 		}
 
 		/* Text selection colors */
+
 		::selection {
 			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -40,7 +40,6 @@ function newspack_customize_register( $wp_customize ) {
 		'theme_colors',
 		array(
 			'default'           => 'default',
-			'transport'         => 'postMessage',
 			'sanitize_callback' => 'newspack_sanitize_color_option',
 		)
 	);
@@ -64,7 +63,6 @@ function newspack_customize_register( $wp_customize ) {
 		'primary_color_hex',
 		array(
 			'default'           => newspack_get_primary_color(),
-			'transport'         => 'postMessage',
 			'sanitize_callback' => 'sanitize_hex_color',
 		)
 	);
@@ -74,7 +72,27 @@ function newspack_customize_register( $wp_customize ) {
 			$wp_customize,
 			'primary_color_hex',
 			array(
-				'description' => __( 'Apply a custom color for buttons, links, featured images, etc.', 'newspack' ),
+				'description' => __( 'Apply a primary custom color.', 'newspack' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
+	// Add secondary color hexidecimal setting and control.
+	$wp_customize->add_setting(
+		'secondary_color_hex',
+		array(
+			'default'           => newspack_get_secondary_color(),
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'secondary_color_hex',
+			array(
+				'description' => __( 'Apply a secondary custom color.', 'newspack' ),
 				'section'     => 'colors',
 			)
 		)

--- a/js/customize-controls.js
+++ b/js/customize-controls.js
@@ -24,6 +24,18 @@
 				visibility();
 				setting.bind( visibility );
 			});
+			wp.customize.control( 'secondary_color_hex', function( control ) {
+				var visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+
+				visibility();
+				setting.bind( visibility );
+			});
 		});
 	});
 

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -7,43 +7,6 @@
  */
 
 (function( $ ) {
-	// Primary color.
-	wp.customize( 'theme_colors', function( value ) {
-		value.bind( function( to ) {
-			// Update custom color CSS.
-			var style = $( '#custom-theme-colors' ),
-				primary = style.data( 'primary' ),
-				css = style.html(),
-				color;
-
-			if ( 'custom' === to ) {
-				// If a custom primary color is selected, use the currently set primary_color_hex
-				color = wp.customize.get().primary_color_hex;
-			} else {
-				// If the "default" option is selected, get the default primary_color_hex
-				color = _NewspackThemePreviewData.default_hex;
-			}
-
-			// Replace previous hex value with new hex value.
-			css = css.split( primary ).join( color );
-			style.html( css ).data( 'primary', color );
-		});
-	});
-
-	// Primary color hex.
-	wp.customize( 'primary_color_hex', function( value ) {
-		value.bind( function( to ) {
-			// Update custom color CSS.
-			var style = $( '#custom-theme-colors' ),
-				primary = style.data( 'primary' ),
-				css = style.html();
-
-			// Replace previous primary hex value with new primary hex value.
-			css = css.split( primary ).join( to );
-			style.html( css ).data( 'primary', to );
-		});
-	});
-
 	// Hide Front Page Title
 	wp.customize( 'hide_front_page_title', function( value ) {
 		value.bind( function( to ) {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -405,8 +405,8 @@
 				&.has-text-color a,
 				&.has-primary-color,
 				&.has-primary-variation-color,
-				&.has-dark-gray-color,
-				&.has-light-gray-color,
+				&.has-secondary-color,
+				&.has-secondary-variation-color,
 				&.has-white-color {
 					color: inherit;
 				}
@@ -818,8 +818,8 @@
 	//! Custom background colors
 	.has-primary-background-color,
 	.has-primary-variation-background-color,
-	.has-dark-gray-background-color,
-	.has-light-gray-background-color {
+	.has-secondary-background-color,
+	.has-secondary-variation-background-color {
 
 		// Use white text against these backgrounds by default.
 		color: $color__background-body;
@@ -862,14 +862,14 @@
 		background-color: $color__border-link-hover;
 	}
 
-	.has-dark-gray-background-color,
-	.wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
-		background-color: $color__text-main;
+	.has-secondary-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+		background-color: $color__secondary;
 	}
 
-	.has-light-gray-background-color,
-	.wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
-		background-color: $color__text-light;
+	.has-secondary-variation-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-secondary-variation-background-color {
+		background-color: $color__secondary-variation;
 	}
 
 	.has-white-background-color,
@@ -890,16 +890,16 @@
 		color: $color__border-link-hover;
 	}
 
-	.has-dark-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
-		color: $color__text-main;
+	.has-secondary-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+		color: $color__link;
 	}
 
-	.has-light-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
-		color: $color__text-light;
+	.has-secondary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+		color: $color__border-link-hover;
 	}
 
 	.has-white-color,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -366,7 +366,7 @@
 		}
 
 		&.is-style-solid-color {
-			background-color: $color__link;
+			background-color: $color__primary;
 			padding-left: 0;
 			padding-right: 0;
 
@@ -854,12 +854,12 @@
 
 	.has-primary-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-		background-color: $color__link;
+		background-color: $color__primary;
 	}
 
 	.has-primary-variation-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
-		background-color: $color__border-link-hover;
+		background-color: $color__primary-variation;
 	}
 
 	.has-secondary-background-color,
@@ -881,25 +881,25 @@
 	.has-primary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-		color: $color__link;
+		color: $color__primary;
 	}
 
 	.has-primary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
-		color: $color__border-link-hover;
+		color: $color__primary-variation;
 	}
 
 	.has-secondary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
-		color: $color__link;
+		color: $color__secondary;
 	}
 
 	.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
-		color: $color__border-link-hover;
+		color: $color__secondary-variation;
 	}
 
 	.has-white-color,

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -71,7 +71,7 @@ figure {
 }
 
 blockquote {
-	border-left: 2px solid $color__link;
+	border-left: 2px solid $color__primary;
 	margin-left: 0;
 	padding: 0 0 0 $size__spacing-unit;
 

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -25,8 +25,8 @@ textarea {
 	border-radius: 0;
 
 	&:focus {
-		border-color: $color__link;
-		outline: thin solid rgba( $color__link, 0.15 );
+		border-color: $color__primary;
+		outline: thin solid rgba( $color__primary, 0.15 );
 		outline-offset: -4px;
 	}
 }

--- a/sass/media/_galleries.scss
+++ b/sass/media/_galleries.scss
@@ -46,7 +46,7 @@
 	box-shadow: 0 0 0 0 transparent;
 
 	&:focus {
-		box-shadow: 0 0 0 2px rgba( $color__link, 1 );
+		box-shadow: 0 0 0 2px rgba( $color__primary, 1 );
 	}
 }
 

--- a/sass/mixins/_mixins-master.scss
+++ b/sass/mixins/_mixins-master.scss
@@ -31,14 +31,14 @@
 @mixin filter-duotone {
 
 	&:before {
-		background: $color__link;
+		background: $color__primary;
 		mix-blend-mode: screen;
 		opacity: 0.1;
 		z-index: 2;
 	}
 
 	&:after {
-		background: $color__link;
+		background: $color__primary;
 		mix-blend-mode: multiply;
 		opacity: .8;
 		z-index: 3;

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -51,14 +51,14 @@
 
 		> li {
 
-			color: $color__link;
+			color: $color__primary;
 			display: inline;
 			position: relative;
 
 			> a {
 
 				font-weight: 700;
-				color: $color__link;
+				color: $color__primary;
 				margin-right: #{0.5 * $size__spacing-unit};
 
 				+ svg {
@@ -67,7 +67,7 @@
 
 				&:hover,
 				&:hover + svg {
-					color: $color__link-hover;
+					color: $color__primary-variation;
 				}
 			}
 
@@ -137,7 +137,7 @@
 
 	.sub-menu {
 
-		background-color: $color__link;
+		background-color: $color__primary;
 		color: $color__background-body;
 		list-style: none;
 		padding-left: 0;
@@ -205,10 +205,10 @@
 
 				&:hover,
 				&:focus {
-					background: $color__link-hover;
+					background: $color__primary-variation;
 
 					&:after {
-						background: $color__link-hover;
+						background: $color__primary-variation;
 					}
 				}
 			}

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -41,7 +41,7 @@
 			}
 
 			&:hover {
-				color: $color__link-hover;
+				color: $color__primary-variation;
 			}
 		}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -34,7 +34,7 @@
 
 			&:hover {
 				text-decoration: none;
-				color: $color__link;
+				color: $color__primary-variation;
 			}
 		}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -210,7 +210,7 @@
 				color: inherit;
 
 				&:hover {
-					color: $color__link-hover;
+					color: $color__primary-variation;
 				}
 			}
 		}
@@ -220,7 +220,7 @@
 			display: block;
 			height: 18px;
 			position: absolute;
-			background: lighten( $color__link, 8% );
+			background: lighten( $color__primary, 8% );
 			right: calc(100% - #{$size__spacing-unit * 2.5});
 			top: -3px;
 			width: 18px;
@@ -253,7 +253,7 @@
 			}
 
 			&:hover {
-				color: $color__link-hover;
+				color: $color__primary-variation;
 				text-decoration: none;
 			}
 		}
@@ -285,7 +285,7 @@
 			z-index: 1;
 
 			&:hover {
-				color: $color__link;
+				color: $color__primary;
 			}
 		}
 	}
@@ -325,7 +325,7 @@
 	font-weight: 500;
 
 	&:hover {
-		color: $color__link-hover;
+		color: $color__primary-variation;
 	}
 }
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -73,7 +73,7 @@
 
 			&:hover {
 				text-decoration: none;
-				color: $color__link;
+				color: $color__primary-variation;
 			}
 		}
 
@@ -150,7 +150,7 @@
 			}
 
 			&:hover {
-				color: $color__link;
+				color: $color__primary-variation;
 				text-decoration: none;
 			}
 		}
@@ -252,7 +252,7 @@
 			display: inline-block;
 
 			&:hover {
-				color: $color__link-hover;
+				color: $color__primary-variation;
 				text-decoration: none;
 			}
 		}

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -7,10 +7,10 @@
 	}
 
 	a {
-		color: $color__link;
+		color: $color__primary;
 
 		&:hover {
-			color: $color__link-hover;
+			color: $color__primary-variation;
 		}
 	}
 }

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -1,14 +1,20 @@
 
+// Custom Colors - defaults
+$color__primary: #0073aa;
+$color__primary-variation: darken( $color__primary, 10% );
+$color__secondary: #666;
+$color__secondary-variation: darken( $color__secondary, 10% );
+
 // Backgrounds
 $color__background-body: #fff;
 $color__background-input: #fff;
 $color__background-screen: #f1f1f1;
 $color__background-hr: #ccc;
-$color__background-button: #0073aa;
+$color__background-button: $color__primary;
 $color__background-button-hover: #111;
 $color__background-pre: #eee;
 $color__background-ins: #fff9c0;
-$color__background_selection: mix( $color__background-body, $color__background-button, 75% ); // lighten( salmon, 22.5% ); // lighten( #0999d4, 48% );
+$color__background_selection: mix( $color__background-body, $color__primary, 75% ); // lighten( salmon, 22.5% ); // lighten( #0999d4, 48% );
 
 // Text
 $color__text-main: #111;
@@ -19,14 +25,14 @@ $color__text-input: #666;
 $color__text-input-focus: #111;
 
 // Links
-$color__link: #0073aa;
-$color__link-visited: #0073aa;
-$color__link-hover: darken( $color__link, 10% );
+$color__link: $color__secondary;
+$color__link-visited: $color__secondary;
+$color__link-hover: $color__secondary-variation;
 
 // Borders
 $color__border: #ccc;
 $color__border-link: #0073aa;
-$color__border-link-hover: darken( $color__link, 10% );
+$color__border-link-hover: $color__primary-variation;
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;
 $color__border-button-focus: #aaa #bbb #bbb;

--- a/style-editor.css
+++ b/style-editor.css
@@ -127,11 +127,11 @@ h6 {
 
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
+  color: #666;
 }
 
 a:hover, a:active {
-  color: #005177;
+  color: #4d4d4d;
   outline: 0;
   text-decoration: none;
 }
@@ -143,8 +143,8 @@ a:focus {
 
 .has-primary-background-color,
 .has-primary-variation-background-color,
-.has-dark-gray-background-color,
-.has-light-gray-background-color {
+.has-secondary-background-color,
+.has-secondary-variation-background-color {
   color: #fff;
 }
 
@@ -164,22 +164,22 @@ a:focus {
 .has-primary-variation-background-color h5,
 .has-primary-variation-background-color h6,
 .has-primary-variation-background-color a,
-.has-dark-gray-background-color p,
-.has-dark-gray-background-color h1,
-.has-dark-gray-background-color h2,
-.has-dark-gray-background-color h3,
-.has-dark-gray-background-color h4,
-.has-dark-gray-background-color h5,
-.has-dark-gray-background-color h6,
-.has-dark-gray-background-color a,
-.has-light-gray-background-color p,
-.has-light-gray-background-color h1,
-.has-light-gray-background-color h2,
-.has-light-gray-background-color h3,
-.has-light-gray-background-color h4,
-.has-light-gray-background-color h5,
-.has-light-gray-background-color h6,
-.has-light-gray-background-color a {
+.has-secondary-background-color p,
+.has-secondary-background-color h1,
+.has-secondary-background-color h2,
+.has-secondary-background-color h3,
+.has-secondary-background-color h4,
+.has-secondary-background-color h5,
+.has-secondary-background-color h6,
+.has-secondary-background-color a,
+.has-secondary-variation-background-color p,
+.has-secondary-variation-background-color h1,
+.has-secondary-variation-background-color h2,
+.has-secondary-variation-background-color h3,
+.has-secondary-variation-background-color h4,
+.has-secondary-variation-background-color h5,
+.has-secondary-variation-background-color h6,
+.has-secondary-variation-background-color a {
   color: #fff;
 }
 
@@ -373,7 +373,7 @@ figcaption,
 /** === Blockquote === */
 .wp-block-quote:not(.is-large):not(.is-style-large) {
   border-width: 2px;
-  border-color: #0073aa;
+  border-color: #666;
 }
 
 .wp-block-quote.is-large, .wp-block-quote.is-style-large {
@@ -438,7 +438,7 @@ figcaption,
 }
 
 .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
-  background-color: #0073aa;
+  background-color: #666;
 }
 
 .wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
@@ -526,11 +526,11 @@ figcaption,
 
 .wp-block-file .wp-block-file__textlink {
   text-decoration: underline;
-  color: #0073aa;
+  color: #666;
 }
 
 .wp-block-file .wp-block-file__textlink:hover {
-  color: #005177;
+  color: #4d4d4d;
   text-decoration: none;
 }
 
@@ -539,7 +539,7 @@ figcaption,
   line-height: 1.8;
   font-size: 0.88889em;
   font-weight: bold;
-  background-color: #0073aa;
+  background-color: #666;
   border-radius: 5px;
 }
 
@@ -714,7 +714,7 @@ ul.wp-block-archives li ul,
 }
 
 .wp-block-freeform blockquote {
-  border-left: 2px solid #0073aa;
+  border-left: 2px solid #666;
 }
 
 .wp-block-freeform blockquote cite {

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -153,8 +153,8 @@ a {
 // Use white text against these backgrounds by default.
 .has-primary-background-color,
 .has-primary-variation-background-color,
-.has-dark-gray-background-color,
-.has-light-gray-background-color {
+.has-secondary-background-color,
+.has-secondary-variation-background-color {
 	color: $color__background-body;
 
 	p,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -671,7 +671,7 @@ a {
 
 a:hover,
 a:active {
-  color: #005177;
+  color: #4d4d4d;
   outline: 0;
   text-decoration: none;
 }
@@ -894,11 +894,11 @@ a {
 }
 
 a:visited {
-  color: #0073aa;
+  color: #666;
 }
 
 a:hover, a:active {
-  color: #005177;
+  color: #4d4d4d;
   outline: 0;
   text-decoration: none;
 }
@@ -991,7 +991,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1116,13 +1116,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #4d4d4d;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #4d4d4d;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1618,7 +1618,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -2518,7 +2518,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #4d4d4d;
   text-decoration: none;
 }
 
@@ -2748,7 +2748,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2791,7 +2791,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #4d4d4d;
   text-decoration: none;
 }
 
@@ -2863,7 +2863,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .discussion-avatar-list {
@@ -3071,7 +3071,7 @@ a:focus {
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .widget_archive ul,
@@ -4097,7 +4097,7 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #666;
+  background-color: #0073aa;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
@@ -4123,7 +4123,7 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #666;
+  color: #0073aa;
 }
 
 .entry .entry-content .has-primary-variation-color,
@@ -4141,7 +4141,7 @@ a:focus {
 .entry .entry-content .has-secondary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -666,7 +666,7 @@ body {
 
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
+  color: #666;
 }
 
 a:hover,
@@ -743,7 +743,7 @@ figure {
 }
 
 blockquote {
-  border-right: 2px solid #0073aa;
+  border-right: 2px solid #666;
   margin-right: 0;
   padding: 0 1rem 0 0;
 }
@@ -863,8 +863,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #666;
+  outline: thin solid rgba(102, 102, 102, 0.15);
   outline-offset: -4px;
 }
 
@@ -890,7 +890,7 @@ form p {
 --------------------------------------------------------------*/
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
+  color: #666;
 }
 
 a:visited {
@@ -974,14 +974,14 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #666;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
   font-weight: 700;
-  color: #0073aa;
+  color: #666;
   margin-left: 0.5rem;
 }
 
@@ -1052,7 +1052,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #666;
   color: #fff;
   list-style: none;
   padding-right: 0;
@@ -1148,6 +1148,17 @@ a:focus {
   margin-left: calc( .25 * 1rem);
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1160,6 +1171,21 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1177,6 +1203,13 @@ a:focus {
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1185,6 +1218,12 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
     left: 0;
     right: auto;
@@ -1193,8 +1232,22 @@ a:focus {
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
+  display: none;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
@@ -1208,14 +1261,29 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
   }
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
+  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
@@ -2255,7 +2323,7 @@ a:focus {
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
-  color: #0073aa;
+  color: #666;
 }
 
 .entry .entry-meta .svg-icon,
@@ -2336,7 +2404,7 @@ a:focus {
 }
 
 .entry .entry-content .more-link:hover {
-  color: #0073aa;
+  color: #666;
   text-decoration: none;
 }
 
@@ -2688,7 +2756,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #7a7a7a;
   left: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2755,7 +2823,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #666;
 }
 
 .comment .comment-content {
@@ -2980,7 +3048,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #0073aa;
+  color: #666;
 }
 
 #colophon .site-info .imprint,
@@ -2999,7 +3067,7 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #666;
 }
 
 .widget a:hover {
@@ -3491,7 +3559,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #666;
   padding-right: 0;
   padding-left: 0;
 }
@@ -3533,7 +3601,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
@@ -3559,7 +3627,7 @@ a:focus {
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
-  border-color: #0073aa;
+  border-color: #666;
   padding-top: 0;
   padding-bottom: 0;
 }
@@ -3972,8 +4040,8 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-primary-variation-background-color,
-.entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color {
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-secondary-variation-background-color {
   color: #fff;
 }
 
@@ -3993,22 +4061,22 @@ a:focus {
 .entry .entry-content .has-primary-variation-background-color h5,
 .entry .entry-content .has-primary-variation-background-color h6,
 .entry .entry-content .has-primary-variation-background-color a,
-.entry .entry-content .has-dark-gray-background-color p,
-.entry .entry-content .has-dark-gray-background-color h1,
-.entry .entry-content .has-dark-gray-background-color h2,
-.entry .entry-content .has-dark-gray-background-color h3,
-.entry .entry-content .has-dark-gray-background-color h4,
-.entry .entry-content .has-dark-gray-background-color h5,
-.entry .entry-content .has-dark-gray-background-color h6,
-.entry .entry-content .has-dark-gray-background-color a,
-.entry .entry-content .has-light-gray-background-color p,
-.entry .entry-content .has-light-gray-background-color h1,
-.entry .entry-content .has-light-gray-background-color h2,
-.entry .entry-content .has-light-gray-background-color h3,
-.entry .entry-content .has-light-gray-background-color h4,
-.entry .entry-content .has-light-gray-background-color h5,
-.entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a {
+.entry .entry-content .has-secondary-background-color p,
+.entry .entry-content .has-secondary-background-color h1,
+.entry .entry-content .has-secondary-background-color h2,
+.entry .entry-content .has-secondary-background-color h3,
+.entry .entry-content .has-secondary-background-color h4,
+.entry .entry-content .has-secondary-background-color h5,
+.entry .entry-content .has-secondary-background-color h6,
+.entry .entry-content .has-secondary-background-color a,
+.entry .entry-content .has-secondary-variation-background-color p,
+.entry .entry-content .has-secondary-variation-background-color h1,
+.entry .entry-content .has-secondary-variation-background-color h2,
+.entry .entry-content .has-secondary-variation-background-color h3,
+.entry .entry-content .has-secondary-variation-background-color h4,
+.entry .entry-content .has-secondary-variation-background-color h5,
+.entry .entry-content .has-secondary-variation-background-color h6,
+.entry .entry-content .has-secondary-variation-background-color a {
   color: #fff;
 }
 
@@ -4029,7 +4097,7 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #666;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
@@ -4037,14 +4105,14 @@ a:focus {
   background-color: #005177;
 }
 
-.entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
-  background-color: #111;
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+  background-color: #666;
 }
 
-.entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
-  background-color: #767676;
+.entry .entry-content .has-secondary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-variation-background-color {
+  background-color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-background-color,
@@ -4055,7 +4123,7 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #666;
 }
 
 .entry .entry-content .has-primary-variation-color,
@@ -4064,16 +4132,16 @@ a:focus {
   color: #005177;
 }
 
-.entry .entry-content .has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
-  color: #111;
+.entry .entry-content .has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+  color: #666;
 }
 
-.entry .entry-content .has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
-  color: #767676;
+.entry .entry-content .has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+  color: #005177;
 }
 
 .entry .entry-content .has-white-color,
@@ -4254,5 +4322,5 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #666666;
 }

--- a/style.css
+++ b/style.css
@@ -743,7 +743,7 @@ figure {
 }
 
 blockquote {
-  border-left: 2px solid #666;
+  border-left: 2px solid #0073aa;
   margin-left: 0;
   padding: 0 0 0 1rem;
 }
@@ -863,8 +863,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #666;
-  outline: thin solid rgba(102, 102, 102, 0.15);
+  border-color: #0073aa;
+  outline: thin solid rgba(0, 115, 170, 0.15);
   outline-offset: -4px;
 }
 
@@ -974,14 +974,14 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #666;
+  color: #0073aa;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
   font-weight: 700;
-  color: #666;
+  color: #0073aa;
   margin-right: 0.5rem;
 }
 
@@ -991,7 +991,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #4d4d4d;
+  color: #005177;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1052,7 +1052,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #666;
+  background-color: #0073aa;
   color: #fff;
   list-style: none;
   padding-left: 0;
@@ -1116,13 +1116,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #4d4d4d;
+  background: #005177;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #4d4d4d;
+  background: #005177;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1618,7 +1618,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #4d4d4d;
+  color: #005177;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -2329,7 +2329,7 @@ a:focus {
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
-  color: #666;
+  color: #005177;
 }
 
 .entry .entry-meta .svg-icon,
@@ -2410,7 +2410,7 @@ a:focus {
 }
 
 .entry .entry-content .more-link:hover {
-  color: #666;
+  color: #005177;
   text-decoration: none;
 }
 
@@ -2524,7 +2524,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #4d4d4d;
+  color: #005177;
   text-decoration: none;
 }
 
@@ -2754,7 +2754,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #4d4d4d;
+  color: #005177;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2762,7 +2762,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #7a7a7a;
+  background: #008fd3;
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2797,7 +2797,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #4d4d4d;
+  color: #005177;
   text-decoration: none;
 }
 
@@ -2829,7 +2829,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #666;
+  color: #0073aa;
 }
 
 .comment .comment-content {
@@ -2869,7 +2869,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #4d4d4d;
+  color: #005177;
 }
 
 .discussion-avatar-list {
@@ -3054,7 +3054,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #666;
+  color: #005177;
 }
 
 #colophon .site-info .imprint,
@@ -3073,11 +3073,11 @@ a:focus {
 }
 
 .widget a {
-  color: #666;
+  color: #0073aa;
 }
 
 .widget a:hover {
-  color: #4d4d4d;
+  color: #005177;
 }
 
 .widget_archive ul,
@@ -3571,7 +3571,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #666;
+  background-color: #0073aa;
   padding-left: 0;
   padding-right: 0;
 }
@@ -4109,7 +4109,7 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #666;
+  background-color: #0073aa;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
@@ -4135,7 +4135,7 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #666;
+  color: #0073aa;
 }
 
 .entry .entry-content .has-primary-variation-color,
@@ -4153,7 +4153,7 @@ a:focus {
 .entry .entry-content .has-secondary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,
@@ -4334,5 +4334,5 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #666666;
+  box-shadow: 0 0 0 2px #0073aa;
 }

--- a/style.css
+++ b/style.css
@@ -666,12 +666,12 @@ body {
 
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
+  color: #666;
 }
 
 a:hover,
 a:active {
-  color: #005177;
+  color: #4d4d4d;
   outline: 0;
   text-decoration: none;
 }
@@ -743,7 +743,7 @@ figure {
 }
 
 blockquote {
-  border-left: 2px solid #0073aa;
+  border-left: 2px solid #666;
   margin-left: 0;
   padding: 0 0 0 1rem;
 }
@@ -863,8 +863,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #666;
+  outline: thin solid rgba(102, 102, 102, 0.15);
   outline-offset: -4px;
 }
 
@@ -890,15 +890,15 @@ form p {
 --------------------------------------------------------------*/
 a {
   transition: color 110ms ease-in-out;
-  color: #0073aa;
+  color: #666;
 }
 
 a:visited {
-  color: #0073aa;
+  color: #666;
 }
 
 a:hover, a:active {
-  color: #005177;
+  color: #4d4d4d;
   outline: 0;
   text-decoration: none;
 }
@@ -974,14 +974,14 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #666;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
   font-weight: 700;
-  color: #0073aa;
+  color: #666;
   margin-right: 0.5rem;
 }
 
@@ -991,7 +991,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1052,7 +1052,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #666;
   color: #fff;
   list-style: none;
   padding-left: 0;
@@ -1116,13 +1116,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #4d4d4d;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #4d4d4d;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1618,7 +1618,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -2329,7 +2329,7 @@ a:focus {
 .entry .entry-meta a:hover,
 .entry .entry-footer a:hover {
   text-decoration: none;
-  color: #0073aa;
+  color: #666;
 }
 
 .entry .entry-meta .svg-icon,
@@ -2410,7 +2410,7 @@ a:focus {
 }
 
 .entry .entry-content .more-link:hover {
-  color: #0073aa;
+  color: #666;
   text-decoration: none;
 }
 
@@ -2524,7 +2524,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #4d4d4d;
   text-decoration: none;
 }
 
@@ -2754,7 +2754,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2762,7 +2762,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #7a7a7a;
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2797,7 +2797,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #4d4d4d;
   text-decoration: none;
 }
 
@@ -2829,7 +2829,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #666;
 }
 
 .comment .comment-content {
@@ -2869,7 +2869,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .discussion-avatar-list {
@@ -3054,7 +3054,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #0073aa;
+  color: #666;
 }
 
 #colophon .site-info .imprint,
@@ -3073,11 +3073,11 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #666;
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #4d4d4d;
 }
 
 .widget_archive ul,
@@ -3571,7 +3571,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #666;
   padding-left: 0;
   padding-right: 0;
 }
@@ -3613,7 +3613,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
   color: inherit;
 }
 
@@ -3639,7 +3639,7 @@ a:focus {
 
 .entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
   border-width: 2px;
-  border-color: #0073aa;
+  border-color: #666;
   padding-top: 0;
   padding-bottom: 0;
 }
@@ -4052,8 +4052,8 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .has-primary-variation-background-color,
-.entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .has-light-gray-background-color {
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-secondary-variation-background-color {
   color: #fff;
 }
 
@@ -4073,22 +4073,22 @@ a:focus {
 .entry .entry-content .has-primary-variation-background-color h5,
 .entry .entry-content .has-primary-variation-background-color h6,
 .entry .entry-content .has-primary-variation-background-color a,
-.entry .entry-content .has-dark-gray-background-color p,
-.entry .entry-content .has-dark-gray-background-color h1,
-.entry .entry-content .has-dark-gray-background-color h2,
-.entry .entry-content .has-dark-gray-background-color h3,
-.entry .entry-content .has-dark-gray-background-color h4,
-.entry .entry-content .has-dark-gray-background-color h5,
-.entry .entry-content .has-dark-gray-background-color h6,
-.entry .entry-content .has-dark-gray-background-color a,
-.entry .entry-content .has-light-gray-background-color p,
-.entry .entry-content .has-light-gray-background-color h1,
-.entry .entry-content .has-light-gray-background-color h2,
-.entry .entry-content .has-light-gray-background-color h3,
-.entry .entry-content .has-light-gray-background-color h4,
-.entry .entry-content .has-light-gray-background-color h5,
-.entry .entry-content .has-light-gray-background-color h6,
-.entry .entry-content .has-light-gray-background-color a {
+.entry .entry-content .has-secondary-background-color p,
+.entry .entry-content .has-secondary-background-color h1,
+.entry .entry-content .has-secondary-background-color h2,
+.entry .entry-content .has-secondary-background-color h3,
+.entry .entry-content .has-secondary-background-color h4,
+.entry .entry-content .has-secondary-background-color h5,
+.entry .entry-content .has-secondary-background-color h6,
+.entry .entry-content .has-secondary-background-color a,
+.entry .entry-content .has-secondary-variation-background-color p,
+.entry .entry-content .has-secondary-variation-background-color h1,
+.entry .entry-content .has-secondary-variation-background-color h2,
+.entry .entry-content .has-secondary-variation-background-color h3,
+.entry .entry-content .has-secondary-variation-background-color h4,
+.entry .entry-content .has-secondary-variation-background-color h5,
+.entry .entry-content .has-secondary-variation-background-color h6,
+.entry .entry-content .has-secondary-variation-background-color a {
   color: #fff;
 }
 
@@ -4109,7 +4109,7 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #666;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
@@ -4117,14 +4117,14 @@ a:focus {
   background-color: #005177;
 }
 
-.entry .entry-content .has-dark-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
-  background-color: #111;
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+  background-color: #666;
 }
 
-.entry .entry-content .has-light-gray-background-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
-  background-color: #767676;
+.entry .entry-content .has-secondary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-variation-background-color {
+  background-color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-background-color,
@@ -4135,7 +4135,7 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #666;
 }
 
 .entry .entry-content .has-primary-variation-color,
@@ -4144,16 +4144,16 @@ a:focus {
   color: #005177;
 }
 
-.entry .entry-content .has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color p {
-  color: #111;
+.entry .entry-content .has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+  color: #666;
 }
 
-.entry .entry-content .has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color p {
-  color: #767676;
+.entry .entry-content .has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+  color: #005177;
 }
 
 .entry .entry-content .has-white-color,
@@ -4334,5 +4334,5 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #666666;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The secondary colour has only been added to the content links so far (which alone, needed a lot of variables to be changed). We still need to finalize exactly where it should be applied otherwise in the theme, and added there in a future PR. 

This PR also:

* Cleans up comments in color-patterns.php, to reference the colour being applied rather than what it's being applied to. 
* Removes theme's Dark Grey and Light Grey from the editor colour palette; we will want to have some default colours that are always there, but we'll need to figure out what they should be once the default colour palettes are finalized. As is, with a default secondary grey colour, you end up with a lot of different greys. 
* Removes the `postMessage` transport from the Customizer colour options, and the JavaScript preview. Unfortunately, incorporating multiple colours makes previewing like this more complex -- it's something to revisit in the future, once the colour behaviour is finalized, but is not a breaking issue (the Customizer will just do a full refresh when the colour is changed, rather than previewing without). 

See #24.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that there is a mid-range and dark grey added to the editor as colour options.
3. In the Customizer, confirm that there is an option for a second custom colour. 
4. Change the colour; confirm it changes links in the content body, and the colour options in the editor. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
