### PR TITLE
Add tertiary menu space to the theme header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -56,6 +56,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			array(
 				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
 				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
+				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
 				'footer'         => __( 'Footer Menu', 'newspack' ),
 				'social'         => __( 'Social Links Menu', 'newspack' ),
 			)

--- a/header.php
+++ b/header.php
@@ -57,7 +57,22 @@
 
 			<div class="site-branding-container">
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
-			</div><!-- .layout-wrap -->
+
+				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
+					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'tertiary-menu',
+								'menu_class'     => 'tertiary-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav>
+				<?php endif; ?>
+			</div><!-- .site-branding-container -->
 
 			<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
 				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -1,0 +1,26 @@
+/** === Tertiary menu === */
+
+.tertiary-menu {
+	display: flex;
+	flex-wrap: wrap;
+	font-family: $font__heading;
+	font-size: $font__size-sm;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 #{0.5 * $size__spacing-unit};
+
+	@include media(tablet) {
+		padding: 0;
+	}
+
+	li {
+		margin: 0;
+		padding: 0;
+	}
+
+	> li {
+		> a {
+			margin-right: #{0.5 * $size__spacing-unit};
+		}
+	}
+}

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -1,19 +1,19 @@
 /** === Tertiary menu === */
 
 .tertiary-menu {
-	display: flex;
-	flex-wrap: wrap;
 	font-family: $font__heading;
 	font-size: $font__size-sm;
 	list-style: none;
 	margin: 0;
-	padding: 0 0 #{0.5 * $size__spacing-unit};
+	padding: 0;
 
 	@include media(tablet) {
 		padding: 0;
+		text-align: right;
 	}
 
 	li {
+		display: inline;
 		margin: 0;
 		padding: 0;
 	}

--- a/sass/navigation/_navigation.scss
+++ b/sass/navigation/_navigation.scss
@@ -8,6 +8,7 @@
 --------------------------------------------------------------*/
 @import "menu-main-navigation";
 @import "menu-top-navigation";
+@import "menu-tertiary-navigation";
 @import "menu-social-navigation";
 @import "menu-footer-navigation";
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -36,7 +36,9 @@
 	max-width: 90%;
 	padding: $size__spacing-unit 0;
 	width: $size__site-main;
+
 	@include media(tablet) {
+		flex-wrap: nowrap;
 		padding: #{$size__spacing-unit * 2} 0;
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -27,21 +27,27 @@
 
 // Site branding
 
-.site-branding {
+.site-branding-container {
 	align-items: center;
-	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin: auto;
 	max-width: 90%;
 	padding: $size__spacing-unit 0;
-	position: relative;
 	width: $size__site-main;
-
 	@include media(tablet) {
 		padding: #{$size__spacing-unit * 2} 0;
 	}
+}
+
+.site-branding {
+	align-items: center;
+	color: $color__text-light;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	position: relative;
 }
 
 // Site logo

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1516,6 +1516,32 @@ a:focus {
   margin-left: 0.5rem;
 }
 
+/** === Tertiary menu === */
+.tertiary-menu {
+  display: flex;
+  flex-wrap: wrap;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .tertiary-menu {
+    padding: 0;
+  }
+}
+
+.tertiary-menu li {
+  margin: 0;
+  padding: 0;
+}
+
+.tertiary-menu > li > a {
+  margin-left: 0.5rem;
+}
+
 /* Social menu */
 .social-navigation {
   text-align: right;
@@ -2005,23 +2031,30 @@ a:focus {
   }
 }
 
-.site-branding {
+.site-branding-container {
   align-items: center;
-  color: #767676;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   margin: auto;
   max-width: 90%;
   padding: 1rem 0;
-  position: relative;
   width: 1200px;
 }
 
 @media only screen and (min-width: 768px) {
-  .site-branding {
+  .site-branding-container {
     padding: 2rem 0;
   }
+}
+
+.site-branding {
+  align-items: center;
+  color: #767676;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  position: relative;
 }
 
 .site-logo {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2044,6 +2044,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .site-branding-container {
+    flex-wrap: nowrap;
     padding: 2rem 0;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1516,6 +1516,32 @@ a:focus {
   margin-right: 0.5rem;
 }
 
+/** === Tertiary menu === */
+.tertiary-menu {
+  display: flex;
+  flex-wrap: wrap;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 0.88889em;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .tertiary-menu {
+    padding: 0;
+  }
+}
+
+.tertiary-menu li {
+  margin: 0;
+  padding: 0;
+}
+
+.tertiary-menu > li > a {
+  margin-right: 0.5rem;
+}
+
 /* Social menu */
 .social-navigation {
   text-align: left;
@@ -2011,23 +2037,30 @@ a:focus {
   }
 }
 
-.site-branding {
+.site-branding-container {
   align-items: center;
-  color: #767676;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   margin: auto;
   max-width: 90%;
   padding: 1rem 0;
-  position: relative;
   width: 1200px;
 }
 
 @media only screen and (min-width: 768px) {
-  .site-branding {
+  .site-branding-container {
     padding: 2rem 0;
   }
+}
+
+.site-branding {
+  align-items: center;
+  color: #767676;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  position: relative;
 }
 
 .site-logo {

--- a/style.css
+++ b/style.css
@@ -1518,22 +1518,22 @@ a:focus {
 
 /** === Tertiary menu === */
 .tertiary-menu {
-  display: flex;
-  flex-wrap: wrap;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
   list-style: none;
   margin: 0;
-  padding: 0 0 0.5rem;
+  padding: 0;
 }
 
 @media only screen and (min-width: 768px) {
   .tertiary-menu {
     padding: 0;
+    text-align: right;
   }
 }
 
 .tertiary-menu li {
+  display: inline;
   margin: 0;
   padding: 0;
 }
@@ -2050,6 +2050,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .site-branding-container {
+    flex-wrap: nowrap;
     padding: 2rem 0;
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a simple tertiary menu space to the theme header. Like the secondary menu, this menu is currently set to only show one level of links, and does not have any mobile styles outside of some graceful degradation on smaller screens. 

See #20.

### How to test the changes in this Pull Request:

1. Apply the patch.
2. Confirm that there's a space to add a tertiary menu to the header.
3. Confirm that the menu sits to the right of the site branding (site title, or logo, depending on how you have your site set up). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
