### PR TITLE
Update the theme font faces and sizes

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -798,6 +798,14 @@
 		}
 	}
 
+	//! Newspack Block
+
+	.wp-block-newspack-blocks-homepage-articles {
+		.article-meta {
+			font-family: $font__heading;
+		}
+	}
+
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -210,6 +210,16 @@
 	}
 }
 
+/* Single Post */
+
+.single-post .entry-title {
+	font-size: $font__size-xxxl;
+
+	@include media(desktop) {
+		font-size: $font__size-xxxxl;
+	}
+}
+
 .page.home .entry .entry-content {
 	max-width: 100%;
 }

--- a/sass/variables-site/_fonts.scss
+++ b/sass/variables-site/_fonts.scss
@@ -1,22 +1,23 @@
 // Font and typographic variables
 
-$font__body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+$font__body: Georgia, Garamond, "Times New Roman", serif;
 $font__heading: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 
 $font__code: Menlo, monaco, Consolas, Lucida Console, monospace;
 $font__pre: "Courier 10 Pitch", Courier, monospace;
 
-$font__size_base: 22px;
+$font__size_base: 20px;
 $font__size-ratio: 1.125;
 
 $font__size-xxs:   1em / (1.5 * $font__size-ratio);
 $font__size-xs:    1em / (1.25 * $font__size-ratio);
 $font__size-sm:    1em / (1 * $font__size-ratio);
 $font__size-md:    1em * (1 * $font__size-ratio);
-$font__size-lg:    1em * (1.5 * $font__size-ratio);
-$font__size-xl:    1em * (2 * $font__size-ratio);
-$font__size-xxl:   1em * (2.5 * $font__size-ratio);
-$font__size-xxxl:  1em * (3 * $font__size-ratio);
+$font__size-lg:    1em * (1.25 * $font__size-ratio);
+$font__size-xl:    1em * (1.5 * $font__size-ratio);
+$font__size-xxl:   1em * (2 * $font__size-ratio);
+$font__size-xxxl:  1em * (2.5 * $font__size-ratio);
+$font__size-xxxxl: 1em * (2.75 * $font__size-ratio);
 
 $font__line-height-body: 1.6;
 $font__line-height-pre: 1.6;

--- a/style-editor.css
+++ b/style-editor.css
@@ -69,14 +69,14 @@ body .wp-block[data-align="full"] {
 
 /** === Base Typography === */
 body {
-  font-size: 22px;
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-size: 20px;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   line-height: 1.6;
   color: #111;
 }
 
 p {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 h1,
@@ -90,27 +90,27 @@ h6 {
 }
 
 h1 {
-  font-size: 2.25em;
+  font-size: 1.6875em;
 }
 
 @media only screen and (min-width: 768px) {
   h1 {
-    font-size: 2.8125em;
-  }
-}
-
-h2 {
-  font-size: 1.6875em;
-}
-
-@media only screen and (min-width: 768px) {
-  h2 {
     font-size: 2.25em;
   }
 }
 
+h2 {
+  font-size: 1.40625em;
+}
+
+@media only screen and (min-width: 768px) {
+  h2 {
+    font-size: 1.6875em;
+  }
+}
+
 h3 {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 h4 {
@@ -208,7 +208,7 @@ figcaption,
 
 /** === Post Title === */
 .editor-post-title__block:before {
-  width: 2.8125em;
+  width: 2.25em;
   margin-top: 0;
   margin-bottom: 0;
   margin-left: 1em;
@@ -218,14 +218,14 @@ figcaption,
 
 .editor-post-title__block .editor-post-title__input {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 2.8125em;
+  font-size: 2.25em;
   font-weight: 700;
 }
 
 /** === Default Appender === */
 .editor-default-block-appender .editor-default-block-appender__content {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-size: 22px;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+  font-size: 20px;
 }
 
 /** === Heading === */
@@ -236,7 +236,7 @@ figcaption,
 /** === Paragraph === */
 .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 3.375em;
+  font-size: 2.8125em;
   line-height: 1;
   font-weight: bold;
   margin: 0 0.25em 0 0;
@@ -251,7 +251,7 @@ figcaption,
 .wp-block-cover h2,
 .wp-block-cover .wp-block-cover-text {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-weight: bold;
   line-height: 1.4;
   padding-left: 1rem;
@@ -279,7 +279,7 @@ figcaption,
   }
   .wp-block-cover h2,
   .wp-block-cover .wp-block-cover-text {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -377,13 +377,13 @@ figcaption,
 }
 
 .wp-block-quote.is-large, .wp-block-quote.is-style-large {
-  margin-top: 2.8125em;
-  margin-bottom: 2.8125em;
+  margin-top: 2.25em;
+  margin-bottom: 2.25em;
 }
 
 .wp-block-quote.is-large p,
 .wp-block-quote.is-style-large p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
@@ -450,7 +450,7 @@ figcaption,
 .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
 .wp-block[data-type="core/pullquote"][data-align="right"] p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-style: italic;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -467,7 +467,7 @@ figcaption,
   .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
   .wp-block[data-type="core/pullquote"][data-align="right"] blockquote > .editor-rich-text p,
   .wp-block[data-type="core/pullquote"][data-align="right"] p {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -571,13 +571,13 @@ figcaption,
 }
 
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
-  width: 2.25em;
+  width: 1.6875em;
   margin-left: 0;
 }
 
 .wp-block-separator.is-style-dots:before {
   color: #767676;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   letter-spacing: calc(2 * 1rem);
   padding-left: calc(2 * 1rem);
 }
@@ -609,7 +609,7 @@ ul.wp-block-archives li,
 .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.125);
+  font-size: calc(20px * 1.125);
   font-weight: bold;
   line-height: 1.2;
   padding-bottom: 0.75rem;
@@ -644,7 +644,7 @@ ul.wp-block-archives li ul,
 }
 
 .wp-block-categories ul ul > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -4055,6 +4055,10 @@ a:focus {
   font-size: 0.71111em;
 }
 
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -393,14 +393,14 @@ template {
 
 /* Typography */
 html {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #111;
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: 400;
   font-size: 1em;
   line-height: 1.6;
@@ -414,7 +414,7 @@ select,
 optgroup,
 textarea {
   color: #111;
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: 400;
   line-height: 1.6;
   text-rendering: optimizeLegibility;
@@ -473,7 +473,7 @@ h6 {
 }
 
 .page-title {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
 }
 
 .site-branding,
@@ -485,12 +485,12 @@ h6 {
 }
 
 h1 {
-  font-size: 2.25em;
+  font-size: 1.6875em;
 }
 
 @media only screen and (min-width: 768px) {
   h1 {
-    font-size: 2.8125em;
+    font-size: 2.25em;
   }
 }
 
@@ -499,7 +499,7 @@ h1 {
 .error-404 .page-title,
 .has-larger-font-size,
 h2 {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 @media only screen and (min-width: 768px) {
@@ -508,7 +508,7 @@ h2 {
   .error-404 .page-title,
   .has-larger-font-size,
   h2 {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -516,7 +516,7 @@ h2 {
 .has-large-font-size,
 .comments-title,
 h3 {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 .site-title,
@@ -1122,7 +1122,7 @@ a:focus {
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: normal;
   text-align: right;
 }
@@ -1275,14 +1275,14 @@ a:focus {
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -1378,7 +1378,7 @@ a:focus {
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -2486,6 +2486,17 @@ a:focus {
   }
 }
 
+/* Single Post */
+.single-post .entry-title {
+  font-size: 2.8125em;
+}
+
+@media only screen and (min-width: 1168px) {
+  .single-post .entry-title {
+    font-size: 3.09375em;
+  }
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }
@@ -2640,7 +2651,7 @@ a:focus {
 
 #respond > small {
   display: block;
-  font-size: 22px;
+  font-size: 20px;
   position: absolute;
   right: calc(1rem + 100%);
   top: calc(-3.5 * 1rem);
@@ -2697,7 +2708,7 @@ a:focus {
 .comment-list .pingback .comment-body a:not(.comment-edit-link),
 .comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
-  font-size: 19.55556px;
+  font-size: 17.77778px;
   line-height: 1.5;
   padding-left: 0.5rem;
   display: block;
@@ -3118,7 +3129,7 @@ a:focus {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.125);
+  font-size: calc(20px * 1.125);
   font-weight: 700;
   line-height: 1.2;
   margin-top: 0.5rem;
@@ -3144,7 +3155,7 @@ a:focus {
 .widget_recent_comments ul ul > li > a::before,
 .widget_recent_entries ul ul > li > a::before,
 .widget_rss ul ul > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -3435,7 +3446,7 @@ a:focus {
 .entry .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.125);
+  font-size: calc(20px * 1.125);
   font-weight: bold;
   line-height: 1.2;
   padding-bottom: 0.75rem;
@@ -3474,7 +3485,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-categories ul > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -3505,14 +3516,14 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-verse {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-size: 22px;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+  font-size: 20px;
   line-height: 1.8;
 }
 
 .entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 3.375em;
+  font-size: 2.8125em;
   line-height: 1;
   font-weight: bold;
   margin: 0 0 0 0.25em;
@@ -3534,7 +3545,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-style: italic;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -3547,7 +3558,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote p {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -3594,7 +3605,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
@@ -3602,7 +3613,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -3675,7 +3686,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   line-height: 1.4;
   font-style: italic;
 }
@@ -3696,7 +3707,7 @@ a:focus {
     padding: 1rem 0;
   }
   .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
-    font-size: 1.6875em;
+    font-size: 1.40625em;
   }
 }
 
@@ -3773,7 +3784,7 @@ a:focus {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-weight: bold;
   line-height: 1.25;
   padding: 0;
@@ -3787,7 +3798,7 @@ a:focus {
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
-    font-size: 2.25em;
+    font-size: 1.6875em;
     max-width: 100%;
   }
 }
@@ -3924,7 +3935,7 @@ a:focus {
 .entry .entry-content .wp-block-separator.is-style-dots:before,
 .entry .entry-content hr.is-style-dots:before {
   color: #767676;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   letter-spacing: 0.88889em;
   padding-right: 0.88889em;
 }
@@ -3956,7 +3967,7 @@ a:focus {
   border-radius: 5px;
   background: #0073aa;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 22px;
+  font-size: 20px;
   line-height: 1.2;
   text-decoration: none;
   font-weight: bold;
@@ -3968,7 +3979,7 @@ a:focus {
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-file .wp-block-file__button {
-    font-size: 22px;
+    font-size: 20px;
     padding: 0.875rem 1.5rem;
   }
 }
@@ -4053,11 +4064,11 @@ a:focus {
 }
 
 .entry .entry-content .has-large-font-size {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 .entry .entry-content .has-huge-font-size {
-  font-size: 2.25em;
+  font-size: 1.6875em;
 }
 
 .entry .entry-content .has-primary-background-color,

--- a/style.css
+++ b/style.css
@@ -4067,6 +4067,10 @@ a:focus {
   font-size: 0.71111em;
 }
 
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/style.css
+++ b/style.css
@@ -393,14 +393,14 @@ template {
 
 /* Typography */
 html {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #111;
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: 400;
   font-size: 1em;
   line-height: 1.6;
@@ -414,7 +414,7 @@ select,
 optgroup,
 textarea {
   color: #111;
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: 400;
   line-height: 1.6;
   text-rendering: optimizeLegibility;
@@ -473,7 +473,7 @@ h6 {
 }
 
 .page-title {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
 }
 
 .site-branding,
@@ -485,12 +485,12 @@ h6 {
 }
 
 h1 {
-  font-size: 2.25em;
+  font-size: 1.6875em;
 }
 
 @media only screen and (min-width: 768px) {
   h1 {
-    font-size: 2.8125em;
+    font-size: 2.25em;
   }
 }
 
@@ -499,7 +499,7 @@ h1 {
 .error-404 .page-title,
 .has-larger-font-size,
 h2 {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 @media only screen and (min-width: 768px) {
@@ -508,7 +508,7 @@ h2 {
   .error-404 .page-title,
   .has-larger-font-size,
   h2 {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -516,7 +516,7 @@ h2 {
 .has-large-font-size,
 .comments-title,
 h3 {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 .site-title,
@@ -1122,7 +1122,7 @@ a:focus {
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
   width: 100%;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: normal;
   text-align: left;
 }
@@ -1275,14 +1275,14 @@ a:focus {
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -1378,7 +1378,7 @@ a:focus {
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
 .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -2492,6 +2492,17 @@ a:focus {
   }
 }
 
+/* Single Post */
+.single-post .entry-title {
+  font-size: 2.8125em;
+}
+
+@media only screen and (min-width: 1168px) {
+  .single-post .entry-title {
+    font-size: 3.09375em;
+  }
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }
@@ -2646,7 +2657,7 @@ a:focus {
 
 #respond > small {
   display: block;
-  font-size: 22px;
+  font-size: 20px;
   position: absolute;
   left: calc(1rem + 100%);
   top: calc(-3.5 * 1rem);
@@ -2703,7 +2714,7 @@ a:focus {
 .comment-list .pingback .comment-body a:not(.comment-edit-link),
 .comment-list .trackback .comment-body a:not(.comment-edit-link) {
   font-weight: bold;
-  font-size: 19.55556px;
+  font-size: 17.77778px;
   line-height: 1.5;
   padding-right: 0.5rem;
   display: block;
@@ -3124,7 +3135,7 @@ a:focus {
 .widget_rss ul li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.125);
+  font-size: calc(20px * 1.125);
   font-weight: 700;
   line-height: 1.2;
   margin-top: 0.5rem;
@@ -3150,7 +3161,7 @@ a:focus {
 .widget_recent_comments ul ul > li > a::before,
 .widget_recent_entries ul ul > li > a::before,
 .widget_rss ul ul > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -3447,7 +3458,7 @@ a:focus {
 .entry .entry-content .wp-block-latest-posts li {
   color: #767676;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: calc(22px * 1.125);
+  font-size: calc(20px * 1.125);
   font-weight: bold;
   line-height: 1.2;
   padding-bottom: 0.75rem;
@@ -3486,7 +3497,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-categories ul > li > a::before {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
   font-weight: normal;
   content: "– " counters(submenu, "– ", none);
   counter-increment: submenu;
@@ -3517,14 +3528,14 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-verse {
-  font-family: "Baskerville Old Face", Garamond, "Times New Roman", serif;
-  font-size: 22px;
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+  font-size: 20px;
   line-height: 1.8;
 }
 
 .entry .entry-content .has-drop-cap:not(:focus):first-letter {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 3.375em;
+  font-size: 2.8125em;
   line-height: 1;
   font-weight: bold;
   margin: 0 0.25em 0 0;
@@ -3546,7 +3557,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-style: italic;
   line-height: 1.3;
   margin-bottom: 0.5em;
@@ -3559,7 +3570,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote p {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -3606,7 +3617,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   line-height: 1.3;
   margin-bottom: 0.5em;
   margin-top: 0.5em;
@@ -3614,7 +3625,7 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
-    font-size: 2.25em;
+    font-size: 1.6875em;
   }
 }
 
@@ -3687,7 +3698,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   line-height: 1.4;
   font-style: italic;
 }
@@ -3708,7 +3719,7 @@ a:focus {
     padding: 1rem 0;
   }
   .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
-    font-size: 1.6875em;
+    font-size: 1.40625em;
   }
 }
 
@@ -3785,7 +3796,7 @@ a:focus {
 .entry .entry-content .wp-block-cover .wp-block-cover-text,
 .entry .entry-content .wp-block-cover h2 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   font-weight: bold;
   line-height: 1.25;
   padding: 0;
@@ -3799,7 +3810,7 @@ a:focus {
   .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
   .entry .entry-content .wp-block-cover .wp-block-cover-text,
   .entry .entry-content .wp-block-cover h2 {
-    font-size: 2.25em;
+    font-size: 1.6875em;
     max-width: 100%;
   }
 }
@@ -3936,7 +3947,7 @@ a:focus {
 .entry .entry-content .wp-block-separator.is-style-dots:before,
 .entry .entry-content hr.is-style-dots:before {
   color: #767676;
-  font-size: 1.6875em;
+  font-size: 1.40625em;
   letter-spacing: 0.88889em;
   padding-left: 0.88889em;
 }
@@ -3968,7 +3979,7 @@ a:focus {
   border-radius: 5px;
   background: #0073aa;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-size: 22px;
+  font-size: 20px;
   line-height: 1.2;
   text-decoration: none;
   font-weight: bold;
@@ -3980,7 +3991,7 @@ a:focus {
 
 @media only screen and (min-width: 1168px) {
   .entry .entry-content .wp-block-file .wp-block-file__button {
-    font-size: 22px;
+    font-size: 20px;
     padding: 0.875rem 1.5rem;
   }
 }
@@ -4065,11 +4076,11 @@ a:focus {
 }
 
 .entry .entry-content .has-large-font-size {
-  font-size: 1.6875em;
+  font-size: 1.40625em;
 }
 
 .entry .entry-content .has-huge-font-size {
-  font-size: 2.25em;
+  font-size: 1.6875em;
 }
 
 .entry .entry-content .has-primary-background-color,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This looks like a lot, but it's just a couple font updates to the theme:

* Swapping out Bakerville for Georgia in the theme's body font. 
* Adjusting the font sizes throughout -- reduce the size of the base and the headers, and add an additional larger font size for post titles.
* Add font family to Newspack block article meta (the class will probably need to be updated if/when the block is broken into multiple blocks.

### How to test the changes in this Pull Request:

Probably the quickest thing to check would be:

1. Apply the PR.
2. Confirm that the body font has changed to Georgia.
3. Confirm that the headers and body is a bit smaller (the quickest thing to check is the widget title size, since it's pretty noticeable). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
