### PR TITLE
Fix full and wide aligned blocks on the static front page

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -102,6 +102,7 @@
  */
 .entry .entry-content,
 .entry .entry-summary {
+
 	.entry-content,
 	.entry-summary,
 	.entry {
@@ -118,6 +119,7 @@
 }
 
 .entry .entry-content {
+
 	//! Paragraphs
 	p.has-background {
 		padding: 20px 30px;
@@ -125,6 +127,7 @@
 
 	//! Audio
 	.wp-block-audio {
+
 		width: 100%;
 
 		audio {
@@ -133,6 +136,7 @@
 
 		&.alignleft audio,
 		&.alignright audio {
+
 			max-width: (0.33 * $mobile_width);
 
 			@include media(tablet) {
@@ -147,6 +151,7 @@
 
 	//! Video
 	.wp-block-video {
+
 		video {
 			width: 100%;
 		}
@@ -154,6 +159,7 @@
 
 	//! Button
 	.wp-block-button {
+
 		.wp-block-button__link {
 			@include button-transition;
 			border: none;
@@ -163,7 +169,7 @@
 			box-sizing: border-box;
 			font-weight: bold;
 			text-decoration: none;
-			padding: ($size__spacing-unit * 0.76) $size__spacing-unit;
+			padding: ($size__spacing-unit * .76) $size__spacing-unit;
 			outline: none;
 			outline: none;
 
@@ -232,7 +238,7 @@
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
-			padding-bottom: (0.75 * $size__spacing-unit);
+			padding-bottom: ( .75 * $size__spacing-unit );
 
 			&.menu-item-has-children,
 			&:last-child {
@@ -247,6 +253,7 @@
 
 	.wp-block-archives,
 	.wp-block-categories {
+
 		&.aligncenter {
 			text-align: center;
 		}
@@ -254,8 +261,9 @@
 
 	//! Latest categories
 	.wp-block-categories {
+
 		ul {
-			padding-top: (0.75 * $size__spacing-unit);
+			padding-top: ( .75 * $size__spacing-unit );
 		}
 
 		li ul {
@@ -274,13 +282,13 @@
 			margin-bottom: (2 * $size__spacing-unit);
 			a {
 				&:after {
-					content: "";
+					content: '';
 				}
 			}
 			&:last-child {
 				margin-bottom: auto;
 				a:after {
-					content: "";
+					content: '';
 				}
 			}
 		}
@@ -320,8 +328,8 @@
 		blockquote {
 			color: $color__text-main;
 			border: none;
-			margin-top: calc(4 * #{$size__spacing-unit});
-			margin-bottom: calc(4.33 * #{$size__spacing-unit});
+			margin-top: calc(4 * #{ $size__spacing-unit});
+			margin-bottom: calc(4.33 * #{ $size__spacing-unit});
 			margin-right: 0;
 			padding-left: 0;
 		}
@@ -427,20 +435,17 @@
 
 			&.alignright,
 			&.alignleft {
+
 				@include media(tablet) {
-					padding: $size__spacing-unit
-						calc(2 * #{$size__spacing-unit});
+					padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
 				}
 			}
 
 			&.alignfull {
+
 				@include media(tablet) {
-					padding-left: calc(
-						10% + 58px + (2 * #{$size__spacing-unit})
-					);
-					padding-right: calc(
-						10% + 58px + (2 * #{$size__spacing-unit})
-					);
+					padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+					padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
 				}
 			}
 		}
@@ -448,6 +453,7 @@
 
 	//! Blockquote
 	.wp-block-quote {
+
 		&:not(.is-large),
 		&:not(.is-style-large) {
 			border-width: 2px;
@@ -504,11 +510,13 @@
 
 	//! Image
 	.wp-block-image {
+
 		img {
 			display: block;
 		}
 
 		.aligncenter {
+
 			@include media(tablet) {
 				margin: 0;
 
@@ -518,6 +526,7 @@
 			}
 
 			@include media(desktop) {
+
 				img {
 					margin: 0 auto;
 				}
@@ -571,6 +580,7 @@
 		}
 
 		&.alignfull {
+
 			.wp-block-cover-image-text,
 			.wp-block-cover-text,
 			h2 {
@@ -578,6 +588,7 @@
 			}
 
 			@include media(tablet) {
+
 				.wp-block-cover-image-text,
 				.wp-block-cover-text,
 				h2 {
@@ -616,7 +627,7 @@
 		font-size: $font__size-xs;
 		line-height: $font__line-height-pre;
 		margin: 0;
-		padding: ($size__spacing-unit * 0.5);
+		padding: ( $size__spacing-unit * .5 );
 		text-align: center;
 	}
 
@@ -654,6 +665,7 @@
 		 * is followed by an H1, or H2 */
 		& + h1,
 		& + h2 {
+
 			&:before {
 				display: none;
 			}
@@ -667,6 +679,7 @@
 
 	//! Table
 	.wp-block-table {
+
 		th,
 		td {
 			border-color: $color__text-light;
@@ -688,15 +701,14 @@
 			line-height: $font__line-height-heading;
 			text-decoration: none;
 			font-weight: bold;
-			padding: ($size__spacing-unit * 0.75) $size__spacing-unit;
+			padding: ($size__spacing-unit * .75) $size__spacing-unit;
 			color: #fff;
 			margin-left: 0;
 			margin-top: calc(0.75 * #{$size__spacing-unit});
 
 			@include media(desktop) {
 				font-size: $font__size-base;
-				padding: ($size__spacing-unit * 0.875)
-					($size__spacing-unit * 1.5);
+				padding: ($size__spacing-unit * .875) ($size__spacing-unit * 1.5);
 			}
 
 			&:hover {
@@ -719,12 +731,13 @@
 		code {
 			font-size: $font__size-md;
 			white-space: pre-wrap;
-			word-break: break-word;
+    	                word-break: break-word;
 		}
 	}
 
 	//! Columns
 	.wp-block-columns {
+
 		&.alignfull {
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;
@@ -736,6 +749,7 @@
 
 		@include media(tablet) {
 			.wp-block-column > * {
+
 				&:first-child {
 					margin-top: 0;
 				}
@@ -745,7 +759,7 @@
 				}
 			}
 
-			&[class*="has-"] > * {
+			&[class*='has-'] > * {
 				margin-right: $size__spacing-unit;
 
 				&:last-child {
@@ -763,6 +777,7 @@
 
 	//! Latest Comments
 	.wp-block-latest-comments {
+
 		.wp-block-latest-comments__comment-meta {
 			font-family: $font__heading;
 			font-weight: bold;
@@ -779,15 +794,18 @@
 		}
 
 		&.has-avatars {
+
 		}
 
 		&.has-dates {
+
 			.wp-block-latest-comments__comment-date {
 				font-size: $font__size-xs;
 			}
 		}
 
 		&.has-excerpts {
+
 		}
 	}
 
@@ -821,6 +839,7 @@
 	.has-primary-variation-background-color,
 	.has-secondary-background-color,
 	.has-secondary-variation-background-color {
+
 		// Use white text against these backgrounds by default.
 		color: $color__background-body;
 
@@ -874,7 +893,7 @@
 
 	.has-white-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-white-background-color {
-		background-color: #fff;
+		background-color: #FFF;
 	}
 
 	//! Custom foreground colors
@@ -885,11 +904,8 @@
 	}
 
 	.has-primary-variation-color,
-	.wp-block-pullquote.is-style-solid-color
-		blockquote.has-primary-variation-color,
-	.wp-block-pullquote.is-style-solid-color
-		blockquote.has-primary-variation-color
-		p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
 		color: $color__primary-variation;
 	}
 
@@ -900,16 +916,13 @@
 	}
 
 	.has-secondary-variation-color,
-	.wp-block-pullquote.is-style-solid-color
-		blockquote.has-secondary-variation-color,
-	.wp-block-pullquote.is-style-solid-color
-		blockquote.has-secondary-variation-color
-		p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
 		color: $color__secondary-variation;
 	}
 
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-		color: #fff;
+		color: #FFF;
 	}
 }

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -77,6 +77,24 @@
 	}
 }
 
+// Wide and full widths need adjustment for the homepage
+.newspack-front-page {
+	.entry .entry-content > * {
+		&.alignwide {
+			@include media(tablet) {
+				margin-left: calc(25% - 25vw);
+				margin-right: calc(25% - 25vw);
+			}
+		}
+		&.alignfull {
+			@include media(tablet) {
+				margin-left: calc(50% - 50vw);
+				margin-right: calc(50% - 50vw);
+			}
+		}
+	}
+}
+
 /*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
@@ -84,7 +102,6 @@
  */
 .entry .entry-content,
 .entry .entry-summary {
-
 	.entry-content,
 	.entry-summary,
 	.entry {
@@ -101,7 +118,6 @@
 }
 
 .entry .entry-content {
-
 	//! Paragraphs
 	p.has-background {
 		padding: 20px 30px;
@@ -109,7 +125,6 @@
 
 	//! Audio
 	.wp-block-audio {
-
 		width: 100%;
 
 		audio {
@@ -118,7 +133,6 @@
 
 		&.alignleft audio,
 		&.alignright audio {
-
 			max-width: (0.33 * $mobile_width);
 
 			@include media(tablet) {
@@ -133,7 +147,6 @@
 
 	//! Video
 	.wp-block-video {
-
 		video {
 			width: 100%;
 		}
@@ -141,7 +154,6 @@
 
 	//! Button
 	.wp-block-button {
-
 		.wp-block-button__link {
 			@include button-transition;
 			border: none;
@@ -151,7 +163,7 @@
 			box-sizing: border-box;
 			font-weight: bold;
 			text-decoration: none;
-			padding: ($size__spacing-unit * .76) $size__spacing-unit;
+			padding: ($size__spacing-unit * 0.76) $size__spacing-unit;
 			outline: none;
 			outline: none;
 
@@ -220,7 +232,7 @@
 			font-size: calc(#{$font__size_base} * #{$font__size-ratio});
 			font-weight: bold;
 			line-height: $font__line-height-heading;
-			padding-bottom: ( .75 * $size__spacing-unit );
+			padding-bottom: (0.75 * $size__spacing-unit);
 
 			&.menu-item-has-children,
 			&:last-child {
@@ -235,7 +247,6 @@
 
 	.wp-block-archives,
 	.wp-block-categories {
-
 		&.aligncenter {
 			text-align: center;
 		}
@@ -243,9 +254,8 @@
 
 	//! Latest categories
 	.wp-block-categories {
-
 		ul {
-			padding-top: ( .75 * $size__spacing-unit );
+			padding-top: (0.75 * $size__spacing-unit);
 		}
 
 		li ul {
@@ -264,13 +274,13 @@
 			margin-bottom: (2 * $size__spacing-unit);
 			a {
 				&:after {
-					content: '';
+					content: "";
 				}
 			}
 			&:last-child {
 				margin-bottom: auto;
 				a:after {
-					content: '';
+					content: "";
 				}
 			}
 		}
@@ -310,8 +320,8 @@
 		blockquote {
 			color: $color__text-main;
 			border: none;
-			margin-top: calc(4 * #{ $size__spacing-unit});
-			margin-bottom: calc(4.33 * #{ $size__spacing-unit});
+			margin-top: calc(4 * #{$size__spacing-unit});
+			margin-bottom: calc(4.33 * #{$size__spacing-unit});
 			margin-right: 0;
 			padding-left: 0;
 		}
@@ -417,17 +427,20 @@
 
 			&.alignright,
 			&.alignleft {
-
 				@include media(tablet) {
-					padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
+					padding: $size__spacing-unit
+						calc(2 * #{$size__spacing-unit});
 				}
 			}
 
 			&.alignfull {
-
 				@include media(tablet) {
-					padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
-					padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
+					padding-left: calc(
+						10% + 58px + (2 * #{$size__spacing-unit})
+					);
+					padding-right: calc(
+						10% + 58px + (2 * #{$size__spacing-unit})
+					);
 				}
 			}
 		}
@@ -435,7 +448,6 @@
 
 	//! Blockquote
 	.wp-block-quote {
-
 		&:not(.is-large),
 		&:not(.is-style-large) {
 			border-width: 2px;
@@ -492,13 +504,11 @@
 
 	//! Image
 	.wp-block-image {
-
 		img {
 			display: block;
 		}
 
 		.aligncenter {
-
 			@include media(tablet) {
 				margin: 0;
 
@@ -508,7 +518,6 @@
 			}
 
 			@include media(desktop) {
-
 				img {
 					margin: 0 auto;
 				}
@@ -562,7 +571,6 @@
 		}
 
 		&.alignfull {
-
 			.wp-block-cover-image-text,
 			.wp-block-cover-text,
 			h2 {
@@ -570,7 +578,6 @@
 			}
 
 			@include media(tablet) {
-
 				.wp-block-cover-image-text,
 				.wp-block-cover-text,
 				h2 {
@@ -609,7 +616,7 @@
 		font-size: $font__size-xs;
 		line-height: $font__line-height-pre;
 		margin: 0;
-		padding: ( $size__spacing-unit * .5 );
+		padding: ($size__spacing-unit * 0.5);
 		text-align: center;
 	}
 
@@ -647,7 +654,6 @@
 		 * is followed by an H1, or H2 */
 		& + h1,
 		& + h2 {
-
 			&:before {
 				display: none;
 			}
@@ -661,7 +667,6 @@
 
 	//! Table
 	.wp-block-table {
-
 		th,
 		td {
 			border-color: $color__text-light;
@@ -683,14 +688,15 @@
 			line-height: $font__line-height-heading;
 			text-decoration: none;
 			font-weight: bold;
-			padding: ($size__spacing-unit * .75) $size__spacing-unit;
+			padding: ($size__spacing-unit * 0.75) $size__spacing-unit;
 			color: #fff;
 			margin-left: 0;
 			margin-top: calc(0.75 * #{$size__spacing-unit});
 
 			@include media(desktop) {
 				font-size: $font__size-base;
-				padding: ($size__spacing-unit * .875) ($size__spacing-unit * 1.5);
+				padding: ($size__spacing-unit * 0.875)
+					($size__spacing-unit * 1.5);
 			}
 
 			&:hover {
@@ -713,13 +719,12 @@
 		code {
 			font-size: $font__size-md;
 			white-space: pre-wrap;
-    	                word-break: break-word;
+			word-break: break-word;
 		}
 	}
 
 	//! Columns
 	.wp-block-columns {
-
 		&.alignfull {
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;
@@ -731,7 +736,6 @@
 
 		@include media(tablet) {
 			.wp-block-column > * {
-
 				&:first-child {
 					margin-top: 0;
 				}
@@ -741,7 +745,7 @@
 				}
 			}
 
-			&[class*='has-'] > * {
+			&[class*="has-"] > * {
 				margin-right: $size__spacing-unit;
 
 				&:last-child {
@@ -759,7 +763,6 @@
 
 	//! Latest Comments
 	.wp-block-latest-comments {
-
 		.wp-block-latest-comments__comment-meta {
 			font-family: $font__heading;
 			font-weight: bold;
@@ -776,18 +779,15 @@
 		}
 
 		&.has-avatars {
-
 		}
 
 		&.has-dates {
-
 			.wp-block-latest-comments__comment-date {
 				font-size: $font__size-xs;
 			}
 		}
 
 		&.has-excerpts {
-
 		}
 	}
 
@@ -821,7 +821,6 @@
 	.has-primary-variation-background-color,
 	.has-secondary-background-color,
 	.has-secondary-variation-background-color {
-
 		// Use white text against these backgrounds by default.
 		color: $color__background-body;
 
@@ -875,7 +874,7 @@
 
 	.has-white-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-white-background-color {
-		background-color: #FFF;
+		background-color: #fff;
 	}
 
 	//! Custom foreground colors
@@ -886,8 +885,11 @@
 	}
 
 	.has-primary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
+	.wp-block-pullquote.is-style-solid-color
+		blockquote.has-primary-variation-color,
+	.wp-block-pullquote.is-style-solid-color
+		blockquote.has-primary-variation-color
+		p {
 		color: $color__primary-variation;
 	}
 
@@ -898,13 +900,16 @@
 	}
 
 	.has-secondary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+	.wp-block-pullquote.is-style-solid-color
+		blockquote.has-secondary-variation-color,
+	.wp-block-pullquote.is-style-solid-color
+		blockquote.has-secondary-variation-color
+		p {
 		color: $color__secondary-variation;
 	}
 
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-		color: #FFF;
+		color: #fff;
 	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1518,22 +1518,22 @@ a:focus {
 
 /** === Tertiary menu === */
 .tertiary-menu {
-  display: flex;
-  flex-wrap: wrap;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
   list-style: none;
   margin: 0;
-  padding: 0 0 0.5rem;
+  padding: 0;
 }
 
 @media only screen and (min-width: 768px) {
   .tertiary-menu {
     padding: 0;
+    text-align: left;
   }
 }
 
 .tertiary-menu li {
+  display: inline;
   margin: 0;
   padding: 0;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3236,7 +3236,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: "";
+  content: '';
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
@@ -3244,7 +3244,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: "";
+  content: '';
 }
 
 .entry .entry-content .wp-block-preformatted {
@@ -3391,8 +3391,8 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-right: calc( 10% + 58px + (2 * 1rem));
-    padding-left: calc( 10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + (2 * 1rem));
   }
 }
 
@@ -3714,10 +3714,10 @@ a:focus {
   .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns[class*="has-"] > * {
+  .entry .entry-content .wp-block-columns[class*='has-'] > * {
     margin-left: 1rem;
   }
-  .entry .entry-content .wp-block-columns[class*="has-"] > *:last-child {
+  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-left: 0;
   }
   .entry .entry-content .wp-block-columns.alignfull,
@@ -3845,7 +3845,7 @@ a:focus {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #fff;
+  background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
@@ -3855,11 +3855,8 @@ a:focus {
 }
 
 .entry .entry-content .has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-primary-variation-color
-p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
   color: #005177;
 }
 
@@ -3870,17 +3867,14 @@ p {
 }
 
 .entry .entry-content .has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-secondary-variation-color
-p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
   color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #fff;
+  color: #FFF;
 }
 
 /* Media */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3025,6 +3025,20 @@ a:focus {
   }
 }
 
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignwide {
+    margin-right: calc(25% - 25vw);
+    margin-left: calc(25% - 25vw);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignfull {
+    margin-right: calc(50% - 50vw);
+    margin-left: calc(50% - 50vw);
+  }
+}
+
 /*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
@@ -3222,7 +3236,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: '';
+  content: "";
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
@@ -3230,7 +3244,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: '';
+  content: "";
 }
 
 .entry .entry-content .wp-block-preformatted {
@@ -3377,8 +3391,8 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-right: calc(10% + 58px + (2 * 1rem));
-    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc( 10% + 58px + (2 * 1rem));
+    padding-left: calc( 10% + 58px + (2 * 1rem));
   }
 }
 
@@ -3700,10 +3714,10 @@ a:focus {
   .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns[class*='has-'] > * {
+  .entry .entry-content .wp-block-columns[class*="has-"] > * {
     margin-left: 1rem;
   }
-  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+  .entry .entry-content .wp-block-columns[class*="has-"] > *:last-child {
     margin-left: 0;
   }
   .entry .entry-content .wp-block-columns.alignfull,
@@ -3831,7 +3845,7 @@ a:focus {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #FFF;
+  background-color: #fff;
 }
 
 .entry .entry-content .has-primary-color,
@@ -3841,8 +3855,11 @@ a:focus {
 }
 
 .entry .entry-content .has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-primary-variation-color
+p {
   color: #005177;
 }
 
@@ -3853,14 +3870,17 @@ a:focus {
 }
 
 .entry .entry-content .has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-secondary-variation-color
+p {
   color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #FFF;
+  color: #fff;
 }
 
 /* Media */

--- a/style.css
+++ b/style.css
@@ -3037,6 +3037,20 @@ a:focus {
   }
 }
 
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignwide {
+    margin-left: calc(25% - 25vw);
+    margin-right: calc(25% - 25vw);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignfull {
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+  }
+}
+
 /*
  * Unset nested content selector styles
  * - Prevents layout styles from cascading too deeply
@@ -3234,7 +3248,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: '';
+  content: "";
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
@@ -3242,7 +3256,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: '';
+  content: "";
 }
 
 .entry .entry-content .wp-block-preformatted {
@@ -3389,8 +3403,8 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-left: calc(10% + 58px + (2 * 1rem));
-    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc( 10% + 58px + (2 * 1rem));
+    padding-right: calc( 10% + 58px + (2 * 1rem));
   }
 }
 
@@ -3712,10 +3726,10 @@ a:focus {
   .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns[class*='has-'] > * {
+  .entry .entry-content .wp-block-columns[class*="has-"] > * {
     margin-right: 1rem;
   }
-  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+  .entry .entry-content .wp-block-columns[class*="has-"] > *:last-child {
     margin-right: 0;
   }
   .entry .entry-content .wp-block-columns.alignfull,
@@ -3843,7 +3857,7 @@ a:focus {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #FFF;
+  background-color: #fff;
 }
 
 .entry .entry-content .has-primary-color,
@@ -3853,8 +3867,11 @@ a:focus {
 }
 
 .entry .entry-content .has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-primary-variation-color
+p {
   color: #005177;
 }
 
@@ -3865,14 +3882,17 @@ a:focus {
 }
 
 .entry .entry-content .has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color
+blockquote.has-secondary-variation-color
+p {
   color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #FFF;
+  color: #fff;
 }
 
 /* Media */

--- a/style.css
+++ b/style.css
@@ -3248,7 +3248,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li a:after {
-  content: "";
+  content: '';
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
@@ -3256,7 +3256,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
-  content: "";
+  content: '';
 }
 
 .entry .entry-content .wp-block-preformatted {
@@ -3403,8 +3403,8 @@ a:focus {
 
 @media only screen and (min-width: 768px) {
   .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
-    padding-left: calc( 10% + 58px + (2 * 1rem));
-    padding-right: calc( 10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + (2 * 1rem));
+    padding-right: calc(10% + 58px + (2 * 1rem));
   }
 }
 
@@ -3726,10 +3726,10 @@ a:focus {
   .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
     margin-bottom: 0;
   }
-  .entry .entry-content .wp-block-columns[class*="has-"] > * {
+  .entry .entry-content .wp-block-columns[class*='has-'] > * {
     margin-right: 1rem;
   }
-  .entry .entry-content .wp-block-columns[class*="has-"] > *:last-child {
+  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-right: 0;
   }
   .entry .entry-content .wp-block-columns.alignfull,
@@ -3857,7 +3857,7 @@ a:focus {
 
 .entry .entry-content .has-white-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
-  background-color: #fff;
+  background-color: #FFF;
 }
 
 .entry .entry-content .has-primary-color,
@@ -3867,11 +3867,8 @@ a:focus {
 }
 
 .entry .entry-content .has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-primary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-primary-variation-color
-p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
   color: #005177;
 }
 
@@ -3882,17 +3879,14 @@ p {
 }
 
 .entry .entry-content .has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-secondary-variation-color,
-.entry .entry-content .wp-block-pullquote.is-style-solid-color
-blockquote.has-secondary-variation-color
-p {
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
   color: #4d4d4d;
 }
 
 .entry .entry-content .has-white-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
-  color: #fff;
+  color: #FFF;
 }
 
 /* Media */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The static front page template in the theme has a different width than the rest of the templates, and because of this, the full and wide alignment styles don't look great.

This PR makes sure they're aligned and sized correctly.

(There's some extra RTL styles in this PR that catches style-rtl.css up with the style.css from previous commits; sometimes the build script doesn't regenerate the RTL styles and needs to be re-run -- unfortunately, I didn't catch it when it happened last time!). 

### How to test the changes in this Pull Request:

1. On a test site, add a full and wide aligned block on the front page. 
2. Publish and view on the front-end. Both are likely pushed too far to the right, and hanging out of view.
3. Apply the PR.
4. Confirm that they now appear to be aligned correctly, and aren't cut off on the right. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
