### PR TITLE
Custom Fonts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -345,6 +345,28 @@ function newspack_colors_css_wrap() {
 add_action( 'wp_head', 'newspack_colors_css_wrap' );
 
 /**
+ * Display custom color CSS in customizer and on frontend.
+ */
+function newspack_typography_css_wrap() {
+
+	if ( is_admin() ) {
+		return;
+	}
+
+	require_once get_parent_theme_file_path( '/inc/typography.php' );
+
+	?>
+	<?php echo newspack_custom_typography_link( 'custom_font_import_code' ); ?>
+	<?php echo newspack_custom_typography_link( 'custom_font_import_code_alternate' ); ?>
+
+	<style type="text/css" id="custom-typography">
+		<?php echo newspack_custom_typography_css(); ?>
+	</style>
+	<?php
+}
+add_action( 'wp_head', 'newspack_typography_css_wrap' );
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';

--- a/functions.php
+++ b/functions.php
@@ -355,14 +355,21 @@ function newspack_typography_css_wrap() {
 
 	require_once get_parent_theme_file_path( '/inc/typography.php' );
 
-	?>
-	<?php echo newspack_custom_typography_link( 'custom_font_import_code' ); ?>
-	<?php echo newspack_custom_typography_link( 'custom_font_import_code_alternate' ); ?>
+	$allowed_html = array(
+		'link'  => array(
+			'href' => true,
+			'rel'  => true,
+		),
+		'style' => array(
+			'type' => true,
+			'id'   => true,
+		),
+	);
 
-	<style type="text/css" id="custom-typography">
-		<?php echo newspack_custom_typography_css(); ?>
-	</style>
-	<?php
+	echo wp_kses( newspack_custom_typography_link( 'custom_font_import_code' ), $allowed_html );
+	echo wp_kses( newspack_custom_typography_link( 'custom_font_import_code_alternate' ), $allowed_html );
+	echo wp_kses( newspack_custom_typography_css(), $allowed_html );
+
 }
 add_action( 'wp_head', 'newspack_typography_css_wrap' );
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -230,7 +230,7 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'font_body_stack',
 		array(
-			'label'   => __( 'Header font fallback stack', 'newspack' ),
+			'label'   => __( 'Body font fallback stack', 'newspack' ),
 			'default' => 'serif',
 			'section' => 'newspack_typography',
 			'type'    => 'select',

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -210,6 +210,10 @@ function newspack_customize_typography_register( $wp_customize ) {
 
 	$font_stacks = newspack_get_font_stacks_as_select_choices();
 
+	foreach ( $font_stacks as $key => &$stack ) {
+		$stack = wp_kses( $stack, null );
+	}
+
 	$wp_customize->add_control(
 		'font_header_stack',
 		array(

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -168,12 +168,14 @@ function newspack_customize_typography_register( $wp_customize ) {
 		'font_body_stack',
 		array(
 			'sanitize_callback' => 'newspack_sanitize_font_stack',
+			'default'           => 'serif',
 		)
 	);
 	$wp_customize->add_setting(
 		'font_header_stack',
 		array(
 			'sanitize_callback' => 'newspack_sanitize_font_stack',
+			'default'           => 'serif',
 		)
 	);
 
@@ -211,7 +213,6 @@ function newspack_customize_typography_register( $wp_customize ) {
 		'font_header_stack',
 		array(
 			'label'   => __( 'Header font fallback stack', 'newspack' ),
-			'default' => 'serif',
 			'section' => 'newspack_typography',
 			'type'    => 'select',
 			'choices' => $font_stacks,
@@ -231,7 +232,6 @@ function newspack_customize_typography_register( $wp_customize ) {
 		'font_body_stack',
 		array(
 			'label'   => __( 'Body font fallback stack', 'newspack' ),
-			'default' => 'serif',
 			'section' => 'newspack_typography',
 			'type'    => 'select',
 			'choices' => $font_stacks,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -128,16 +128,15 @@ add_action( 'customize_register', 'newspack_customize_register' );
  *
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
-
 function newspack_customize_typography_register( $wp_customize ) {
 
 	require_once get_parent_theme_file_path( '/inc/typography.php' );
 
 	$wp_customize->add_section(
-		'newspack_typography' ,
+		'newspack_typography',
 		array(
-		    'title'      => __( 'Typography', 'newspack' ),
-		    'priority'   => 50,
+			'title'    => __( 'Typography', 'newspack' ),
+			'priority' => 50,
 		)
 	);
 
@@ -150,81 +149,81 @@ function newspack_customize_typography_register( $wp_customize ) {
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'custom_font_import_code',
-	        array(
-	            'label'       => __( 'Font import code', 'newspack' ),
-	            'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.'),
-	            'section'     => 'newspack_typography',
-	            'type'        => 'text',
-	        )
-	    )
+			$wp_customize,
+			'custom_font_import_code',
+			array(
+				'label'       => __( 'Font import code', 'newspack' ),
+				'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.' ),
+				'section'     => 'newspack_typography',
+				'type'        => 'text',
+			)
+		)
 	);
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'custom_font_import_code_alternate',
-	        array(
-	            'label'       => __( 'Font import code (alternate)', 'newspack' ),
-	            'section'     => 'newspack_typography',
-	            'type'        => 'text',
-	        )
-	    )
+			$wp_customize,
+			'custom_font_import_code_alternate',
+			array(
+				'label'   => __( 'Font import code (alternate)', 'newspack' ),
+				'section' => 'newspack_typography',
+				'type'    => 'text',
+			)
+		)
 	);
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'font_header',
-	        array(
-	            'label'    => __( 'Header font', 'newspack' ),
-	            'section'  => 'newspack_typography',
-	            'type'     => 'text',
-	        )
-	    )
+			$wp_customize,
+			'font_header',
+			array(
+				'label'   => __( 'Header font', 'newspack' ),
+				'section' => 'newspack_typography',
+				'type'    => 'text',
+			)
+		)
 	);
 
 	$font_stacks = newspack_get_font_stacks_as_select_choices();
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'font_header_stack',
-	        array(
-	            'label'    => __( 'Header font fallback stack', 'newspack' ),
-	            'default'  => 'serif',
-	            'section'  => 'newspack_typography',
-	            'type'     => 'select',
-	            'choices'  => $font_stacks
-	        )
-	    )
+			$wp_customize,
+			'font_header_stack',
+			array(
+				'label'   => __( 'Header font fallback stack', 'newspack' ),
+				'default' => 'serif',
+				'section' => 'newspack_typography',
+				'type'    => 'select',
+				'choices' => $font_stacks,
+			)
+		)
 	);
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'font_body',
-	        array(
-	            'label'    => __( 'Body font family', 'newspack' ),
-	            'section'  => 'newspack_typography',
-	            'type'     => 'text',
-	        )
-	    )
+			$wp_customize,
+			'font_body',
+			array(
+				'label'   => __( 'Body font family', 'newspack' ),
+				'section' => 'newspack_typography',
+				'type'    => 'text',
+			)
+		)
 	);
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
-	        $wp_customize,
-	        'font_body_stack',
-	        array(
-	            'label'    => __( 'Header font fallback stack', 'newspack' ),
-	            'default'  => 'serif',
-	            'section'  => 'newspack_typography',
-	            'type'     => 'select',
-	            'choices'  => $font_stacks
-	        )
-	    )
+			$wp_customize,
+			'font_body_stack',
+			array(
+				'label'   => __( 'Header font fallback stack', 'newspack' ),
+				'default' => 'serif',
+				'section' => 'newspack_typography',
+				'type'    => 'select',
+				'choices' => $font_stacks,
+			)
+		)
 	);
 }
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -178,81 +178,63 @@ function newspack_customize_typography_register( $wp_customize ) {
 	);
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'custom_font_import_code',
-			array(
-				'label'       => __( 'Font import code', 'newspack' ),
-				'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.' ),
-				'section'     => 'newspack_typography',
-				'type'        => 'text',
-			)
+		'custom_font_import_code',
+		array(
+			'label'       => __( 'Font import code', 'newspack' ),
+			'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.' ),
+			'section'     => 'newspack_typography',
+			'type'        => 'text',
 		)
 	);
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'custom_font_import_code_alternate',
-			array(
-				'label'   => __( 'Font import code (alternate)', 'newspack' ),
-				'section' => 'newspack_typography',
-				'type'    => 'text',
-			)
+		'custom_font_import_code_alternate',
+		array(
+			'label'   => __( 'Font import code (alternate)', 'newspack' ),
+			'section' => 'newspack_typography',
+			'type'    => 'text',
 		)
 	);
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'font_header',
-			array(
-				'label'   => __( 'Header font', 'newspack' ),
-				'section' => 'newspack_typography',
-				'type'    => 'text',
-			)
+		'font_header',
+		array(
+			'label'   => __( 'Header font', 'newspack' ),
+			'section' => 'newspack_typography',
+			'type'    => 'text',
 		)
 	);
 
 	$font_stacks = newspack_get_font_stacks_as_select_choices();
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'font_header_stack',
-			array(
-				'label'   => __( 'Header font fallback stack', 'newspack' ),
-				'default' => 'serif',
-				'section' => 'newspack_typography',
-				'type'    => 'select',
-				'choices' => $font_stacks,
-			)
+		'font_header_stack',
+		array(
+			'label'   => __( 'Header font fallback stack', 'newspack' ),
+			'default' => 'serif',
+			'section' => 'newspack_typography',
+			'type'    => 'select',
+			'choices' => $font_stacks,
 		)
 	);
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'font_body',
-			array(
-				'label'   => __( 'Body font family', 'newspack' ),
-				'section' => 'newspack_typography',
-				'type'    => 'text',
-			)
+		'font_body',
+		array(
+			'label'   => __( 'Body font family', 'newspack' ),
+			'section' => 'newspack_typography',
+			'type'    => 'text',
 		)
 	);
 
 	$wp_customize->add_control(
-		new WP_Customize_Control(
-			$wp_customize,
-			'font_body_stack',
-			array(
-				'label'   => __( 'Header font fallback stack', 'newspack' ),
-				'default' => 'serif',
-				'section' => 'newspack_typography',
-				'type'    => 'select',
-				'choices' => $font_stacks,
-			)
+		'font_body_stack',
+		array(
+			'label'   => __( 'Header font fallback stack', 'newspack' ),
+			'default' => 'serif',
+			'section' => 'newspack_typography',
+			'type'    => 'select',
+			'choices' => $font_stacks,
 		)
 	);
 }

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -140,12 +140,42 @@ function newspack_customize_typography_register( $wp_customize ) {
 		)
 	);
 
-	$wp_customize->add_setting( 'custom_font_import_code' );
-	$wp_customize->add_setting( 'custom_font_import_code_alternate' );
-	$wp_customize->add_setting( 'font_body' );
-	$wp_customize->add_setting( 'font_header' );
-	$wp_customize->add_setting( 'font_body_stack' );
-	$wp_customize->add_setting( 'font_header_stack' );
+	$wp_customize->add_setting(
+		'custom_font_import_code',
+		array(
+			'sanitize_callback' => 'newspack_sanitize_font_provider_url',
+		)
+	);
+	$wp_customize->add_setting(
+		'custom_font_import_code_alternate',
+		array(
+			'sanitize_callback' => 'newspack_sanitize_font_provider_url',
+		)
+	);
+	$wp_customize->add_setting(
+		'font_body',
+		array(
+			'sanitize_callback' => 'wp_filter_nohtml_kses',
+		)
+	);
+	$wp_customize->add_setting(
+		'font_header',
+		array(
+			'sanitize_callback' => 'wp_filter_nohtml_kses',
+		)
+	);
+	$wp_customize->add_setting(
+		'font_body_stack',
+		array(
+			'sanitize_callback' => 'newspack_sanitize_font_stack',
+		)
+	);
+	$wp_customize->add_setting(
+		'font_header_stack',
+		array(
+			'sanitize_callback' => 'newspack_sanitize_font_stack',
+		)
+	);
 
 	$wp_customize->add_control(
 		new WP_Customize_Control(
@@ -303,4 +333,45 @@ function newspack_sanitize_checkbox( $input ) {
 	} else {
 		return false;
 	}
+}
+
+/**
+ * Sanitize font provider embed URL.
+ *
+ * @param string $code Font provider embed code.
+ *
+ * @return string Return a valid font provider URL if found or false if not.
+ */
+function newspack_sanitize_font_provider_url( $code ) {
+	$font_service_urls = array(
+		'google'     => 'fonts.googleapis.com',
+		'fonts'      => 'fast.fonts.net',
+		'typekit'    => 'use.typekit.net',
+		'typography' => 'cloud.typography.com',
+	);
+
+	$regex = '/\/\/[^\("\') \n]+/i';
+	preg_match( $regex, $code, $matches );
+	$url = isset( $matches[0] ) ? $matches[0] : null;
+
+	$url_info = wp_parse_url( $url );
+	if ( isset( $url_info['host'] ) && in_array( $url_info['host'], array_values( $font_service_urls ) ) ) {
+		return $url;
+	}
+	return null;
+}
+
+/**
+ * Sanitize font stack ID.
+ *
+ * @param string $stack_id Font stack ID.
+ *
+ * @return string Return a valid font stack ID or null.
+ */
+function newspack_sanitize_font_stack( $stack_id ) {
+	$stacks = newspack_get_font_stacks();
+	if ( in_array( $stack_id, array_keys( $stacks ) ) ) {
+		return $stack_id;
+	}
+	return null;
 }

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -182,8 +182,8 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'custom_font_import_code',
 		array(
-			'label'       => __( 'Font import code', 'newspack' ),
-			'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.' ),
+			'label'       => __( 'Font Provider Import Code or URL', 'newspack' ),
+			'description' => __( 'Example: &lt;link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet"&gt; or https://fonts.googleapis.com/css?family=Open+Sans' ),
 			'section'     => 'newspack_typography',
 			'type'        => 'text',
 		)
@@ -192,7 +192,7 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'custom_font_import_code_alternate',
 		array(
-			'label'   => __( 'Font import code (alternate)', 'newspack' ),
+			'label'   => __( 'Secondary Font Provider Import Code or URL', 'newspack' ),
 			'section' => 'newspack_typography',
 			'type'    => 'text',
 		)
@@ -201,9 +201,10 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'font_header',
 		array(
-			'label'   => __( 'Header font', 'newspack' ),
-			'section' => 'newspack_typography',
-			'type'    => 'text',
+			'label'       => __( 'Header Font', 'newspack' ),
+			'description' => __( 'Example: Open Sans' ),
+			'section'     => 'newspack_typography',
+			'type'        => 'text',
 		)
 	);
 
@@ -212,7 +213,7 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'font_header_stack',
 		array(
-			'label'   => __( 'Header font fallback stack', 'newspack' ),
+			'label'   => __( 'Header Font Fallback Stack', 'newspack' ),
 			'section' => 'newspack_typography',
 			'type'    => 'select',
 			'choices' => $font_stacks,
@@ -222,7 +223,7 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'font_body',
 		array(
-			'label'   => __( 'Body font family', 'newspack' ),
+			'label'   => __( 'Body Font', 'newspack' ),
 			'section' => 'newspack_typography',
 			'type'    => 'text',
 		)
@@ -231,7 +232,7 @@ function newspack_customize_typography_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'font_body_stack',
 		array(
-			'label'   => __( 'Body font fallback stack', 'newspack' ),
+			'label'   => __( 'Body Font Fallback Stack', 'newspack' ),
 			'section' => 'newspack_typography',
 			'type'    => 'select',
 			'choices' => $font_stacks,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -124,6 +124,113 @@ function newspack_customize_register( $wp_customize ) {
 add_action( 'customize_register', 'newspack_customize_register' );
 
 /**
+ * Add custom font support in the Customizer
+ *
+ * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ */
+
+function newspack_customize_typography_register( $wp_customize ) {
+
+	require_once get_parent_theme_file_path( '/inc/typography.php' );
+
+	$wp_customize->add_section(
+		'newspack_typography' ,
+		array(
+		    'title'      => __( 'Typography', 'newspack' ),
+		    'priority'   => 50,
+		)
+	);
+
+	$wp_customize->add_setting( 'custom_font_import_code' );
+	$wp_customize->add_setting( 'custom_font_import_code_alternate' );
+	$wp_customize->add_setting( 'font_body' );
+	$wp_customize->add_setting( 'font_header' );
+	$wp_customize->add_setting( 'font_body_stack' );
+	$wp_customize->add_setting( 'font_header_stack' );
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'custom_font_import_code',
+	        array(
+	            'label'       => __( 'Font import code', 'newspack' ),
+	            'description' => __( 'Paste the import tag provided by the font service. Supported services are Fonts.com, Typekit, Google Fonts, and Typography.com.'),
+	            'section'     => 'newspack_typography',
+	            'type'        => 'text',
+	        )
+	    )
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'custom_font_import_code_alternate',
+	        array(
+	            'label'       => __( 'Font import code (alternate)', 'newspack' ),
+	            'section'     => 'newspack_typography',
+	            'type'        => 'text',
+	        )
+	    )
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'font_header',
+	        array(
+	            'label'    => __( 'Header font', 'newspack' ),
+	            'section'  => 'newspack_typography',
+	            'type'     => 'text',
+	        )
+	    )
+	);
+
+	$font_stacks = newspack_get_font_stacks_as_select_choices();
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'font_header_stack',
+	        array(
+	            'label'    => __( 'Header font fallback stack', 'newspack' ),
+	            'default'  => 'serif',
+	            'section'  => 'newspack_typography',
+	            'type'     => 'select',
+	            'choices'  => $font_stacks
+	        )
+	    )
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'font_body',
+	        array(
+	            'label'    => __( 'Body font family', 'newspack' ),
+	            'section'  => 'newspack_typography',
+	            'type'     => 'text',
+	        )
+	    )
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Control(
+	        $wp_customize,
+	        'font_body_stack',
+	        array(
+	            'label'    => __( 'Header font fallback stack', 'newspack' ),
+	            'default'  => 'serif',
+	            'section'  => 'newspack_typography',
+	            'type'     => 'select',
+	            'choices'  => $font_stacks
+	        )
+	    )
+	);
+}
+
+add_action( 'customize_register', 'newspack_customize_typography_register' );
+
+/**
  * Render the site title for the selective refresh partial.
  *
  * @return void

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -17,8 +17,10 @@ function newspack_custom_typography_css() {
 	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
 	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack' ) );
 
-	$theme_css = "
+	$css_blocks = array();
 
+	if ( get_theme_mod( 'font_header' ) ) {
+		$css_blocks[] = "
 		/* _headings.scssc */
 		.author-description .author-link,
 		.comment-metadata,
@@ -107,8 +109,10 @@ function newspack_custom_typography_css() {
 
 		{
 			font-family: $font_header;
-		}
-
+		}";
+	}
+	if ( get_theme_mod( 'font_body' ) ) {
+		$css_blocks[] = "
 		/* _typography.scss */
 		body,
 		button,
@@ -123,7 +127,13 @@ function newspack_custom_typography_css() {
 		{
 			font-family: $font_body;
 		}
-	";
+		";
+	}
+	if ( count( $css_blocks ) > 0 ) {
+		$theme_css = "<style type='text/css' id='custom-typography'>\n" . implode( '', $css_blocks ) . "\n</style>";
+	} else {
+		$theme_css = '';
+	}
 
 	/**
 	 * Filters Newspack Theme custom colors CSS.
@@ -147,7 +157,7 @@ function newspack_custom_typography_link( $theme_mod ) {
 	if ( $font_code ) {
 		return "<link rel='stylesheet' href='$font_code'>";
 	}
-	return null;
+	return '';
 }
 
 /**

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -10,8 +10,8 @@
  */
 function newspack_custom_typography_css() {
 
-	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
-	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack' ) );
+	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack', 'serif' ) );
+	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack', 'serif' ) );
 
 	$css_blocks = array();
 

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -17,7 +17,7 @@ function newspack_custom_typography_css() {
 
 	if ( get_theme_mod( 'font_header' ) ) {
 		$css_blocks[] = "
-		/* _headings.scssc */
+		/* _headings.scss */
 		.author-description .author-link,
 		.comment-metadata,
 		.comment-reply-link,

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -172,8 +172,8 @@ function newspack_get_font_stacks() {
 				'serif',
 			),
 		),
-		'san_serif' => array(
-			'name'  => __( 'San Serif' ),
+		'sans_serif' => array(
+			'name'  => __( 'Sans Serif' ),
 			'fonts' => array(
 				'Arial',
 				'Helvetica Neue',

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Newspack Theme: Typography
+ *
+ * @package Newspack
+ */
+
+/**
+ * Generate the CSS for custom typography.
+ */
+function newspack_custom_typography_css() {
+
+	if ( function_exists( 'register_block_type' ) && is_admin() ) {
+		$theme_css = $editor_css;
+	}
+
+	$font_body = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
+	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack' ) );
+
+	$theme_css = "
+
+		/* _headings.scssc */
+		.author-description .author-link,
+		.comment-metadata,
+		.comment-reply-link,
+		.comments-title,
+		.comment-author .fn,
+		.discussion-meta-info,
+		.entry-meta,
+		.entry-footer,
+		.main-navigation,
+		.no-comments,
+		.not-found .page-title,
+		.error-404 .page-title,
+		.post-navigation .post-title,
+		.page-links,
+		.page-description,
+		.pagination .nav-links,
+		.sticky-post,
+		.site-title,
+		.site-info,
+		#cancel-comment-reply-link,
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+
+		/* _tables.scss */
+		table,
+
+		/* _buttons.scss */
+		.button,
+		button,
+		input[type=\"button\"],
+		input[type=\"reset\"],
+		input[type=\"submit\"],
+
+		/* _captions.scss */
+		.wp-caption-text,
+		.gallery-caption,
+
+		/* _infinite_scroll.scss */
+		.site-main #infinite-handle span button,
+		.site-main #infinite-handle span button:hover,
+		.site-main #infinite-handle span button:focus,
+
+		/* _menu-main-navigation.scss */
+		.main-navigation button,
+
+		/* _menu-tertiary-navigation.scss */
+		.tertiary-menu,
+
+		/* _menu-top-navigation.scss */
+		.secondary-menu,
+
+		/* _next_previous.scss */
+		.comment-navigation .nav-previous,
+		.comment-navigation .nav-next,
+
+		/* _comments.scss */
+		.comment-list .pingback .comment-body,
+		.comment-list .trackback .comment-body,
+
+		.comment-list .pingback .comment-body .comment-edit-link,
+		.comment-list .trackback .comment-body .comment-edit-link,
+
+
+		.comment-form label,
+		.comment-form .comment-notes,
+
+		/* _widgets.scss */
+		.widget_archive ul li,
+		.widget_categories ul li,
+		.widget_meta ul li,
+		.widget_nav_menu ul li,
+		.widget_pages ul li,
+		.widget_recent_comments ul li,
+		.widget_recent_entries ul li,
+		.widget_rss ul li,
+
+		.widget_tag_cloud .tagcloud,
+
+		/* _copy.scss */
+		blockquote cite
+
+		{
+			font-family: $font_header;
+		}
+
+		/* _typography.scss */
+		body,
+		button,
+		input,
+		select,
+		optgroup,
+		textarea,
+
+		/* _blocks.scss */
+		.entry .entry-content .wp-block-verse,
+		.page-title
+		{
+			font-family: $font_body;
+		}
+	";
+
+	/**
+	 * Filters Newspack Theme custom colors CSS.
+	 *
+	 * @since Newspack Theme 1.0
+	 *
+	 * @param string $css           Base theme colors CSS.
+	 * @param int    $primary_color The user's selected color hex.
+	 * @param string $saturation    Filtered theme color saturation level.
+	 */
+	return apply_filters( 'newspack_custom_typography_css', $theme_css, $font_header, $font_body );
+}
+
+/**
+ * Generate link elements for custom typography stylesheets.
+ */
+function newspack_custom_typography_link( $theme_mod ) {
+
+	$font_code = get_theme_mod( $theme_mod );
+
+	$regex = '/\/\/[^\" \n]+/i';
+	preg_match_all( $regex, $font_code, $matches );
+
+	$provider_url = isset( $matches, $matches[0], $matches[0][0] ) ? $matches[0][0] : null;
+
+	if ( newspack_verify_url_for_service( $provider_url) ) {
+		return "<link rel='stylesheet' href='$provider_url'>";
+	}
+
+	return null;
+
+}
+
+/**
+ * Check that provider URL looks like a match for the specified provider.
+ */
+function newspack_verify_url_for_service( $url ) {
+	$newspack_service_hosts = array(
+		'google' => 'fonts.googleapis.com',
+		'fonts' => 'fast.fonts.net',
+		'typekit' => 'use.typekit.net',
+		'typography' => 'cloud.typography.com',
+	);
+	$url_info = parse_url( $url );
+	return ( isset( $url_info['host'] ) && in_array( $url_info['host'], array_values( $newspack_service_hosts ) ) );
+}
+
+/**
+ * Fallback font stacks
+ */
+function newspack_get_font_stacks() {
+	return array(
+		'serif' => array(
+			'name' => __( 'Serif' ),
+			'fonts' => array(
+				'TimesNewRoman',
+				'Times New Roman',
+				'Times',
+				'Baskerville',
+				'Georgia',
+				'serif',
+			)
+		),
+		'san_serif' => array(
+			'name' => __( 'San Serif' ),
+			'fonts' => array(
+				'Arial',
+				'Helvetica Neue',
+				'Helvetica',
+				'sans-serif',
+			),
+		),
+	);
+}
+
+/**
+ * Prepare fallback font stacks for use in a Select element
+ */
+function newspack_get_font_stacks_as_select_choices() {
+	$stacks = array();
+	foreach ( newspack_get_font_stacks() as $key => $value ) {
+		$stacks[ $key ] = $value[ 'name' ];
+	}
+	return $stacks;
+}
+
+/**
+ * Prepare a font-family definition with a primary font and fallbacks.
+ */
+function newspack_font_stack( $primary_font, $fallback_id ) {
+	$stacks = newspack_get_font_stacks();
+	$fonts = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ][ "fonts" ] : array();
+	array_unshift( $fonts, $primary_font );
+	return implode( ',', $fonts );
+}

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -131,16 +131,7 @@ function newspack_custom_typography_css() {
 		$theme_css = '';
 	}
 
-	/**
-	 * Filters Newspack Theme custom colors CSS.
-	 *
-	 * @since Newspack Theme 1.0
-	 *
-	 * @param string $css           Base theme colors CSS.
-	 * @param int    $primary_color The user's selected color hex.
-	 * @param string $saturation    Filtered theme color saturation level.
-	 */
-	return apply_filters( 'newspack_custom_typography_css', $theme_css, $font_header, $font_body );
+	return $theme_css;
 }
 
 /**

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -161,23 +161,28 @@ function newspack_custom_typography_link( $theme_mod ) {
  */
 function newspack_get_font_stacks() {
 	return array(
-		'serif'     => array(
+		'serif'      => array(
 			'name'  => __( 'Serif' ),
 			'fonts' => array(
-				'TimesNewRoman',
-				'Times New Roman',
-				'Times',
-				'Baskerville',
 				'Georgia',
+				'Garamond',
+				'Times New Roman',
 				'serif',
 			),
 		),
 		'sans_serif' => array(
 			'name'  => __( 'Sans Serif' ),
 			'fonts' => array(
-				'Arial',
+				'-apple-system',
+				'BlinkMacSystemFont',
+				'Segoe UI',
+				'Roboto',
+				'Oxygen',
+				'Ubuntu',
+				'Cantarell',
+				'Fira Sans',
+				'Droid Sans',
 				'Helvetica Neue',
-				'Helvetica',
 				'sans-serif',
 			),
 		),

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -14,7 +14,7 @@ function newspack_custom_typography_css() {
 		$theme_css = $editor_css;
 	}
 
-	$font_body = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
+	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
 	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack' ) );
 
 	$theme_css = "
@@ -149,7 +149,7 @@ function newspack_custom_typography_link( $theme_mod ) {
 
 	$provider_url = isset( $matches, $matches[0], $matches[0][0] ) ? $matches[0][0] : null;
 
-	if ( newspack_verify_url_for_service( $provider_url) ) {
+	if ( newspack_verify_url_for_service( $provider_url ) ) {
 		return "<link rel='stylesheet' href='$provider_url'>";
 	}
 
@@ -162,12 +162,13 @@ function newspack_custom_typography_link( $theme_mod ) {
  */
 function newspack_verify_url_for_service( $url ) {
 	$newspack_service_hosts = array(
-		'google' => 'fonts.googleapis.com',
-		'fonts' => 'fast.fonts.net',
-		'typekit' => 'use.typekit.net',
+		'google'     => 'fonts.googleapis.com',
+		'fonts'      => 'fast.fonts.net',
+		'typekit'    => 'use.typekit.net',
 		'typography' => 'cloud.typography.com',
 	);
-	$url_info = parse_url( $url );
+
+	$url_info = wp_parse_url( $url );
 	return ( isset( $url_info['host'] ) && in_array( $url_info['host'], array_values( $newspack_service_hosts ) ) );
 }
 
@@ -176,8 +177,8 @@ function newspack_verify_url_for_service( $url ) {
  */
 function newspack_get_font_stacks() {
 	return array(
-		'serif' => array(
-			'name' => __( 'Serif' ),
+		'serif'     => array(
+			'name'  => __( 'Serif' ),
 			'fonts' => array(
 				'TimesNewRoman',
 				'Times New Roman',
@@ -185,10 +186,10 @@ function newspack_get_font_stacks() {
 				'Baskerville',
 				'Georgia',
 				'serif',
-			)
+			),
 		),
 		'san_serif' => array(
-			'name' => __( 'San Serif' ),
+			'name'  => __( 'San Serif' ),
 			'fonts' => array(
 				'Arial',
 				'Helvetica Neue',
@@ -205,7 +206,7 @@ function newspack_get_font_stacks() {
 function newspack_get_font_stacks_as_select_choices() {
 	$stacks = array();
 	foreach ( newspack_get_font_stacks() as $key => $value ) {
-		$stacks[ $key ] = $value[ 'name' ];
+		$stacks[ $key ] = $value['name'];
 	}
 	return $stacks;
 }
@@ -215,7 +216,7 @@ function newspack_get_font_stacks_as_select_choices() {
  */
 function newspack_font_stack( $primary_font, $fallback_id ) {
 	$stacks = newspack_get_font_stacks();
-	$fonts = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ][ "fonts" ] : array();
+	$fonts  = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : array();
 	array_unshift( $fonts, $primary_font );
 	return implode( ',', $fonts );
 }

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -190,7 +190,7 @@ function newspack_get_font_stacks() {
 function newspack_get_font_stacks_as_select_choices() {
 	$stacks = array();
 	foreach ( newspack_get_font_stacks() as $key => $value ) {
-		$stacks[ $key ] = $value['name'];
+		$stacks[ $key ] = wp_kses( $value['name'], null );
 	}
 	return $stacks;
 }

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -144,32 +144,10 @@ function newspack_custom_typography_link( $theme_mod ) {
 
 	$font_code = get_theme_mod( $theme_mod );
 
-	$regex = '/\/\/[^\" \n]+/i';
-	preg_match_all( $regex, $font_code, $matches );
-
-	$provider_url = isset( $matches, $matches[0], $matches[0][0] ) ? $matches[0][0] : null;
-
-	if ( newspack_verify_url_for_service( $provider_url ) ) {
-		return "<link rel='stylesheet' href='$provider_url'>";
+	if ( $font_code ) {
+		return "<link rel='stylesheet' href='$font_code'>";
 	}
-
 	return null;
-
-}
-
-/**
- * Check that provider URL looks like a match for the specified provider.
- */
-function newspack_verify_url_for_service( $url ) {
-	$newspack_service_hosts = array(
-		'google'     => 'fonts.googleapis.com',
-		'fonts'      => 'fast.fonts.net',
-		'typekit'    => 'use.typekit.net',
-		'typography' => 'cloud.typography.com',
-	);
-
-	$url_info = wp_parse_url( $url );
-	return ( isset( $url_info['host'] ) && in_array( $url_info['host'], array_values( $newspack_service_hosts ) ) );
 }
 
 /**
@@ -218,5 +196,8 @@ function newspack_font_stack( $primary_font, $fallback_id ) {
 	$stacks = newspack_get_font_stacks();
 	$fonts  = isset( $stacks[ $fallback_id ] ) ? $stacks[ $fallback_id ]['fonts'] : array();
 	array_unshift( $fonts, $primary_font );
+	foreach ( $fonts as &$font ) {
+		$font = '"' . $font . '"';
+	}
 	return implode( ',', $fonts );
 }

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -10,10 +10,6 @@
  */
 function newspack_custom_typography_css() {
 
-	if ( function_exists( 'register_block_type' ) && is_admin() ) {
-		$theme_css = $editor_css;
-	}
-
 	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack' ) );
 	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack' ) );
 

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -151,7 +151,7 @@ function newspack_custom_typography_link( $theme_mod ) {
 	$font_code = get_theme_mod( $theme_mod );
 
 	if ( $font_code ) {
-		return "<link rel='stylesheet' href='$font_code'>";
+		return "<link rel='stylesheet' href='" . esc_url( $font_code ) . "'>";
 	}
 	return '';
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces support for custom fonts from [Google Fonts](https://fonts.google.com/), [Hoefler & Co.](https://www.typography.com/), [Typekit](https://fonts.adobe.com/?ref=tk.com), and [Fonts.com](https://www.fonts.com/). There is a new `Typography` section in the Customizer where all new fields are found. There are two font families which can be set: **Header** and **Body**, which correspond to the theme's Sass variables `$font__heading` and `$font__body`. There is also a "fallback stack" select for each which specifies the websafe stack to fall back to. For the moment there are only two fallback options (serif & san-serif), but we could expand to include everything here: https://www.cssfontstack.com/. If the Header Font is set to "My Custom Font" and Header font fallback stack is "San Serif," the full output should look like this:

`font-family: My Custom Font, Arial,Helvetica Neue,Helvetica,sans-serif`

There are two text fields for import code, which is provided by the services. Here are examples from all four services:

`<link type="text/css" rel="stylesheet" href="//fast.fonts.net/cssapi/06088785-3e45-466c-87e4-110b94b1a190.css"/>`
`<link href="https://fonts.googleapis.com/css?family=Varela+Round&display=swap" rel="stylesheet">`
`<link rel="stylesheet" href="https://use.typekit.net/jiw3zxe.css">`
`<link type="text/css" rel="stylesheet" href="//fast.fonts.net/cssapi/06088785-3e45-466c-87e4-110b94b1a190.css"/>`

I opted for two to accommodate situations where header and body come from different services, but this is arguably bad practice, and we might consider limiting to just one service.

To sanitize the input, the theme extracts the URL from the embed code, verifies that it is from one of the four supported services, and then reconstructs the import tag (following AMP convention listed [here](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts)). Because of this approach,  pasting in just the URL (e.g. `https://fonts.googleapis.com/css?family=Noto+Sans+HK|Roboto+Condensed&display=swap`) will work just as well as the full `link` code. Similarly, `@import` style code should also work since the URL is in the code, e.g. 

```
<style>
@import url('https://fonts.googleapis.com/css?family=Noto+Sans+HK|Roboto+Condensed&display=swap');
</style>
```

This PR should be completely AMP compatible. 

### How to test the changes in this Pull Request:

Google Fonts is the easiest to test with since  no account is required. Go to https://fonts.google.com/, choose two fonts and click the + icons next to each. Grab the embed code, and past into the first `Font Import Code` field. Set `Header Font` and `Body Font` to the full font names as listed in Google Fonts (e.g. `Noto Sans HK`, `Roboto Condensed`). You should see the fonts immediately in the customizer preview. 

I have access to accounts for the other three services, so I can help set up font sets for testing. Just get in touch with me when you begin testing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
