### PR TITLE
Fix widths in editor styles

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -276,8 +276,19 @@ function newspack_editor_customizer_styles() {
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 		wp_add_inline_style( 'newspack-editor-customizer-styles', newspack_custom_colors_css() );
 	}
+
+	// Add a class to style the static front page differently in the editor.
+	// A hacky work around for: https://github.com/WordPress/gutenberg/issues/10640
+	$frontpage_id = get_option( 'page_on_front' );
+	global $post;
+	$page_id = $post->ID;
+
+	if ( $frontpage_id == $page_id ) {
+		wp_enqueue_script( 'newspack-editor-classes', get_theme_file_uri( '/js/homepage-editor-class.js' ), array(), '1.0', true );
+	}
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_editor_customizer_styles' );
+
 
 /**
  * Display custom color CSS in customizer and on frontend.

--- a/js/homepage-editor-class.js
+++ b/js/homepage-editor-class.js
@@ -1,0 +1,13 @@
+/**
+ * File homepage-editor-class.js
+ *
+ * A hacky work around for: https://github.com/WordPress/gutenberg/issues/10640
+ *
+ * Adds a class to the editor when it's on the static front page, so it can be made wider.
+ */
+
+(function($) {
+	wp.domReady(function() {
+		$(".editor-writing-flow").addClass("newspack-static-front-page");
+	});
+})(jQuery);

--- a/style-editor.css
+++ b/style-editor.css
@@ -51,11 +51,21 @@ body .wp-block[data-align="full"] {
 
 @media only screen and (min-width: 768px) {
   .wp-block {
-    width: 780px;
+    width: 866px;
   }
 }
 
 .wp-block .wp-block {
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .newspack-static-front-page .wp-block {
+    width: 1286px;
+  }
+}
+
+.newspack-static-front-page .wp-block .wp-block {
   width: 100%;
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -28,8 +28,7 @@ body .wp-block[data-align="full"] {
   body .editor-post-title__block,
   body .editor-default-block-appender,
   body .editor-block-list__block {
-    margin-left: auto;
-    margin-right: auto;
+    margin-left: 0;
   }
   body .wp-block[data-align="wide"] {
     width: 100%;
@@ -47,19 +46,12 @@ body .wp-block[data-align="full"] {
 
 /** === Content Width === */
 .wp-block {
-  width: calc(100vw - (2 * 1rem));
   max-width: 100%;
 }
 
 @media only screen and (min-width: 768px) {
   .wp-block {
-    width: calc(8 * (100vw / 12));
-  }
-}
-
-@media only screen and (min-width: 1168px) {
-  .wp-block {
-    width: calc(6 * (100vw / 12 ));
+    width: 780px;
   }
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -20,10 +20,10 @@ body .wp-block[data-align="full"] {
   }
 }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1168px) {
   body .editor-writing-flow {
-    max-width: 80%;
-    margin: 0 10%;
+    max-width: 1322px;
+    margin: 0 auto;
   }
   body .editor-post-title__block,
   body .editor-default-block-appender,
@@ -51,7 +51,7 @@ body .wp-block[data-align="full"] {
 
 @media only screen and (min-width: 768px) {
   .wp-block {
-    width: 866px;
+    width: 810px;
   }
 }
 
@@ -61,7 +61,7 @@ body .wp-block[data-align="full"] {
 
 @media only screen and (min-width: 768px) {
   .newspack-static-front-page .wp-block {
-    width: 1286px;
+    width: 1230px;
   }
 }
 

--- a/style-editor.css
+++ b/style-editor.css
@@ -10,37 +10,13 @@ Newspack Theme Editor Styles
 /* Nested sub-menu padding: 10 levels deep */
 /** === Editor Frame === */
 body .wp-block[data-align="full"] {
-  width: 100%;
-}
-
-@media only screen and (min-width: 600px) {
-  body .wp-block[data-align="full"] {
-    width: calc( 100% + 90px);
-    max-width: calc( 100% + 90px);
-  }
+  max-width: 100vw;
+  width: auto;
 }
 
 @media only screen and (min-width: 1168px) {
-  body .editor-writing-flow {
-    max-width: 1322px;
-    margin: 0 auto;
-  }
-  body .editor-post-title__block,
-  body .editor-default-block-appender,
-  body .editor-block-list__block {
-    margin-left: 0;
-  }
   body .wp-block[data-align="wide"] {
-    width: 100%;
-  }
-  body .wp-block[data-align="full"] {
-    position: relative;
-    left: calc( -12.5% - 14px);
-    width: calc( 125% + 116px);
-    max-width: calc( 125% + 115px);
-  }
-  body .wp-block[data-align="right"] {
-    max-width: 125%;
+    width: 1230px;
   }
 }
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -23,11 +23,11 @@ body {
 		}
 	}
 
-	@include media(tablet) {
+	@include media(desktop) {
 
 		.editor-writing-flow {
-			max-width: 80%;
-			margin: 0 10%;
+			max-width: 1322px;
+			margin: 0 auto;
 		}
 
 		.editor-post-title__block,
@@ -59,7 +59,7 @@ body {
 	max-width: 100%;
 
 	@include media(tablet) {
-		width: 866px; // 780px + ( 43px x 2 ) for padding
+		width: 810px; // 780px + 30px to offset padding
 	}
 
 	// Only the top level blocks need specific widths, therefore override for every nested block.
@@ -70,7 +70,7 @@ body {
 
 .newspack-static-front-page .wp-block {
 	@include media(tablet) {
-		width: 1286px; // 1200px + ( 43px x 2 ) for padding
+		width: 1230px; // 1200px + 30px to offset padding
 	}
 
 	// Only the top level blocks need specific widths, therefore override for every nested block.

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -33,8 +33,7 @@ body {
 		.editor-post-title__block,
 		.editor-default-block-appender,
 		.editor-block-list__block {
-			margin-left: auto;
-			margin-right: auto;
+			margin-left: 0;
 		}
 
 		.wp-block[data-align="wide"] {
@@ -57,15 +56,10 @@ body {
 /** === Content Width === */
 
 .wp-block {
-	width: calc(100vw - (2 * #{$size__spacing-unit}));
 	max-width: 100%;
 
 	@include media(tablet) {
-		width: calc(8 * (100vw / 12));
-	}
-
-	@include media(desktop) {
-		width: calc(6 * (100vw / 12 ));
+		width: 780px;
 	}
 
 	// Only the top level blocks need specific widths, therefore override for every nested block.

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -12,43 +12,14 @@ Newspack Theme Editor Styles
 body {
 
 	.wp-block[data-align="full"] {
-		width: 100%;
-	}
-
-	@include media(mobile) {
-
-		.wp-block[data-align="full"] {
-			width: calc( 100% + 90px );
-			max-width: calc( 100% + 90px );
-		}
+		max-width: 100vw;
+		width: auto;
 	}
 
 	@include media(desktop) {
 
-		.editor-writing-flow {
-			max-width: 1322px;
-			margin: 0 auto;
-		}
-
-		.editor-post-title__block,
-		.editor-default-block-appender,
-		.editor-block-list__block {
-			margin-left: 0;
-		}
-
 		.wp-block[data-align="wide"] {
-			width: 100%;
-		}
-
-		.wp-block[data-align="full"] {
-			position: relative;
-			left: calc( -12.5% - 14px );
-			width: calc( 125% + 116px );
-			max-width: calc( 125% + 115px ); // Subtract 1px here to avoid the rounding errors that happen due to the usage of percentages.
-		}
-
-		.wp-block[data-align="right"] {
-			max-width: 125%;
+			width: 1230px;
 		}
 	}
 }

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -59,7 +59,18 @@ body {
 	max-width: 100%;
 
 	@include media(tablet) {
-		width: 780px;
+		width: 866px; // 780px + ( 43px x 2 ) for padding
+	}
+
+	// Only the top level blocks need specific widths, therefore override for every nested block.
+	.wp-block {
+		width: 100%;
+	}
+}
+
+.newspack-static-front-page .wp-block {
+	@include media(tablet) {
+		width: 1286px; // 1200px + ( 43px x 2 ) for padding
 	}
 
 	// Only the top level blocks need specific widths, therefore override for every nested block.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is meant to correct the content width in the editor, so for standard posts and pages, it should be about 780px, and for the static home page, it should be around 1200px.

Since Gutenberg doesn't include body classes in the editor outside of whether it's a post or page, the approach for adding a class to the homepage is a bit hacky; I'm definitely open to other ways to tackle that!

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Set up the site with a static homepage, and verify the content width is about 1200px.
3. Check a single post in the editor, and verify the content width is about 780px.
4. Check a regular page in the editor, and verify the content width is about 780px.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
