### PR TITLE
Add default theme styles for the article blocks

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -178,7 +178,6 @@ function newspack_custom_colors_css() {
 		 * - pullquote (solid color)
 		 * - buttons
 		 */
-		.editor-block-list__layout .editor-block-list__block a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
@@ -203,6 +202,12 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
+		}
+
+		/* Set secondary color */
+
+		.editor-block-list__layout .editor-block-list__block  a {
+			color:' . $secondary_color . '; /* base: #666 */
 		}
 
 		/* Hover colors */

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -183,7 +183,8 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink,
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .article-section-title {
 			color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -52,7 +52,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content > .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
+		.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
 			color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -812,8 +812,20 @@
 	//! Newspack Block
 
 	.wp-block-newspack-blocks-homepage-articles {
+
+		.article-section-title {
+			border-bottom: 4px solid #ddd;
+			color: $color__primary;
+			display: inline-block;
+			text-transform: uppercase;
+		}
+
 		.article-meta {
 			font-family: $font__heading;
+		}
+
+		.author-name .author {
+			font-weight: bold;
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -760,7 +760,8 @@
 			}
 
 			&[class*='has-'] > * {
-				margin-right: $size__spacing-unit;
+				margin-left: 0;
+				margin-right: calc(2 * #{$size__spacing-unit});
 
 				&:last-child {
 					margin-right: 0;
@@ -806,26 +807,6 @@
 
 		&.has-excerpts {
 
-		}
-	}
-
-	//! Newspack Block
-
-	.wp-block-newspack-blocks-homepage-articles {
-
-		.article-section-title {
-			border-bottom: 4px solid #ddd;
-			color: $color__primary;
-			display: inline-block;
-			text-transform: uppercase;
-		}
-
-		.article-meta {
-			font-family: $font__heading;
-		}
-
-		.author-name .author {
-			font-weight: bold;
 		}
 	}
 

--- a/sass/blocks/_newspack-blocks.scss
+++ b/sass/blocks/_newspack-blocks.scss
@@ -1,0 +1,29 @@
+/* !Newspack Block styles */
+
+.entry .entry-content {
+
+	/* !Homepage article blocks */
+	.wp-block-newspack-blocks-homepage-articles {
+
+		.article-section-title {
+			border-bottom: 4px solid #ddd;
+			color: $color__primary;
+			display: inline-block;
+			text-transform: uppercase;
+
+			span {
+				border-bottom: 4px solid #666;
+				display: inline-block;
+				margin-bottom: -4px;
+			}
+		}
+
+		.article-meta {
+			font-family: $font__heading;
+		}
+
+		.author-name .author {
+			font-weight: bold;
+		}
+	}
+}

--- a/sass/blocks/_newspack-blocks.scss
+++ b/sass/blocks/_newspack-blocks.scss
@@ -8,7 +8,6 @@
 		.article-section-title {
 			border-bottom: 4px solid #ddd;
 			color: $color__primary;
-			font-family: $font__heading;
 			display: inline-block;
 			margin-bottom: calc( #{$size__spacing-unit} / 2 );
 			text-transform: uppercase;
@@ -18,14 +17,6 @@
 				display: inline-block;
 				margin-bottom: -4px;
 			}
-		}
-
-		.article-meta {
-			font-family: $font__heading;
-		}
-
-		.author-name .author {
-			font-weight: bold;
 		}
 	}
 }

--- a/sass/blocks/_newspack-blocks.scss
+++ b/sass/blocks/_newspack-blocks.scss
@@ -8,7 +8,9 @@
 		.article-section-title {
 			border-bottom: 4px solid #ddd;
 			color: $color__primary;
+			font-family: $font__heading;
 			display: inline-block;
+			margin-bottom: calc( #{$size__spacing-unit} / 2 );
 			text-transform: uppercase;
 
 			span {

--- a/style-editor.css
+++ b/style-editor.css
@@ -695,6 +695,38 @@ ul.wp-block-archives li ul,
   font-size: 0.71111em;
 }
 
+/** === Newspack Block === */
+.wp-block-newspack-blocks-homepage-articles .article-section-title {
+  border-bottom: 4px solid #ddd;
+  color: #0073aa;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  display: inline-block;
+  position: relative;
+  text-transform: uppercase;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-section-title:after {
+  border-bottom: 4px solid #666;
+  bottom: -4px;
+  content: '';
+  display: inline-block;
+  left: 0;
+  position: absolute;
+  width: 100px;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-title a {
+  color: inherit;
+}
+
+.wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.wp-block-newspack-blocks-homepage-articles .author-name .author {
+  font-weight: bold;
+}
+
 /** === Classic Editor === */
 /* Properly center-align captions in the classic-editor block */
 .wp-caption dd {

--- a/style-editor.css
+++ b/style-editor.css
@@ -699,7 +699,6 @@ ul.wp-block-archives li ul,
 .wp-block-newspack-blocks-homepage-articles .article-section-title {
   border-bottom: 4px solid #ddd;
   color: #0073aa;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   display: inline-block;
   position: relative;
   text-transform: uppercase;
@@ -717,14 +716,6 @@ ul.wp-block-archives li ul,
 
 .wp-block-newspack-blocks-homepage-articles .article-title a {
   color: inherit;
-}
-
-.wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.wp-block-newspack-blocks-homepage-articles .author-name .author {
-  font-weight: bold;
 }
 
 /** === Classic Editor === */

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -709,7 +709,6 @@ ul.wp-block-archives,
 	.article-section-title {
 		border-bottom: 4px solid #ddd;
 		color: $color__primary;
-		font-family: $font__heading;
 		display: inline-block;
 		position: relative;
 		text-transform: uppercase;
@@ -727,14 +726,6 @@ ul.wp-block-archives,
 
 	.article-title a {
 		color: inherit;
-	}
-
-	.article-meta {
-		font-family: $font__heading;
-	}
-
-	.author-name .author {
-		font-weight: bold;
 	}
 }
 

--- a/style-editor.scss
+++ b/style-editor.scss
@@ -661,23 +661,23 @@ ul.wp-block-archives,
 
 /** === Latest Posts grid view === */
 .wp-block-latest-posts.is-grid {
-		li {
-			border-top: 2px solid $color__border;
-			padding-top: (1 * $size__spacing-unit);
-			margin-bottom: (2 * $size__spacing-unit);
-			a {
-				&:after {
-					content: '';
-				}
+	li {
+		border-top: 2px solid $color__border;
+		padding-top: (1 * $size__spacing-unit);
+		margin-bottom: (2 * $size__spacing-unit);
+		a {
+			&:after {
+				content: '';
 			}
-			&:last-child {
-				margin-bottom: auto;
-				a:after {
-					content: '';
-				}
+		}
+		&:last-child {
+			margin-bottom: auto;
+			a:after {
+				content: '';
 			}
 		}
 	}
+}
 
 /** === Latest Comments === */
 
@@ -700,6 +700,41 @@ ul.wp-block-archives,
 
 	.wp-block-latest-comments__comment-date {
 		font-size: $font__size-xs;
+	}
+}
+
+/** === Newspack Block === */
+.wp-block-newspack-blocks-homepage-articles {
+
+	.article-section-title {
+		border-bottom: 4px solid #ddd;
+		color: $color__primary;
+		font-family: $font__heading;
+		display: inline-block;
+		position: relative;
+		text-transform: uppercase;
+
+		&:after {
+			border-bottom: 4px solid #666;
+			bottom: -4px;
+			content: '';
+			display: inline-block;
+			left: 0;
+			position: absolute;
+			width: 100px;
+		}
+	}
+
+	.article-title a {
+		color: inherit;
+	}
+
+	.article-meta {
+		font-family: $font__heading;
+	}
+
+	.author-name .author {
+		font-weight: bold;
 	}
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3774,8 +3774,19 @@ a:focus {
   font-size: 0.71111em;
 }
 
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
+  border-bottom: 4px solid #ddd;
+  color: #0073aa;
+  display: inline-block;
+  text-transform: uppercase;
+}
+
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
+  font-weight: bold;
 }
 
 .entry .entry-content .has-small-font-size {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -49,6 +49,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Posts and pages
 	## Comments
 # Blocks
+	## Newpack blocks
 # Media
 	## Captions
 	## Galleries
@@ -1154,6 +1155,17 @@ a:focus {
   /* Nested sub-menu dashes */
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1166,6 +1178,21 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1205,6 +1232,13 @@ a:focus {
   position: absolute;
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1213,6 +1247,12 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
     left: 0;
     right: auto;
@@ -1231,8 +1271,22 @@ a:focus {
   display: none;
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
+  display: none;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
   display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
@@ -1260,6 +1314,10 @@ a:focus {
     float: none;
     max-width: 100%;
   }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
@@ -1270,8 +1328,19 @@ a:focus {
   counter-reset: submenu;
 }
 
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
@@ -3743,7 +3812,8 @@ a:focus {
     margin-bottom: 0;
   }
   .entry .entry-content .wp-block-columns[class*='has-'] > * {
-    margin-left: 1rem;
+    margin-right: 0;
+    margin-left: calc(2 * 1rem);
   }
   .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-left: 0;
@@ -3772,21 +3842,6 @@ a:focus {
 
 .entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
-  border-bottom: 4px solid #ddd;
-  color: #0073aa;
-  display: inline-block;
-  text-transform: uppercase;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
-  font-weight: bold;
 }
 
 .entry .entry-content .has-small-font-size {
@@ -3937,6 +3992,32 @@ a:focus {
   .single.has-sidebar .entry .entry-summary > *.alignfull {
     margin-right: 0;
   }
+}
+
+/* !Newspack Block styles */
+.entry .entry-content {
+  /* !Homepage article blocks */
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
+  border-bottom: 4px solid #ddd;
+  color: #0073aa;
+  display: inline-block;
+  text-transform: uppercase;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title span {
+  border-bottom: 4px solid #666;
+  display: inline-block;
+  margin-bottom: -4px;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
+  font-weight: bold;
 }
 
 /* Media */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -1155,17 +1155,6 @@ a:focus {
   /* Nested sub-menu dashes */
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-  display: block;
-  right: 0;
-  margin-top: 0;
-  opacity: 1;
-  width: auto;
-  min-width: 100%;
-  /* Non-mobile position */
-  /* Nested sub-menu dashes */
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
   display: block;
   right: 0;
@@ -1178,21 +1167,6 @@ a:focus {
 }
 
 @media only screen and (min-width: 768px) {
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
-    display: block;
-    margin-top: 0;
-    opacity: 1;
-    position: absolute;
-    right: 0;
-    left: auto;
-    top: auto;
-    bottom: auto;
-    height: auto;
-    min-width: -moz-max-content;
-    min-width: -webkit-max-content;
-    min-width: max-content;
-    transform: none;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
     display: block;
     margin-top: 0;
@@ -1232,13 +1206,6 @@ a:focus {
   position: absolute;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-  right: 0;
-  width: 100%;
-  display: table;
-  position: absolute;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
   right: 0;
   width: 100%;
@@ -1253,22 +1220,12 @@ a:focus {
     display: block;
     width: max-content;
   }
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
-    left: 0;
-    right: auto;
-    display: block;
-    width: max-content;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
     left: 0;
     right: auto;
     display: block;
     width: max-content;
   }
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
-  display: none;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
@@ -1289,16 +1246,6 @@ a:focus {
   /* Non-mobile position */
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  display: block;
-  margin-top: inherit;
-  position: relative;
-  width: 100%;
-  right: 0;
-  opacity: 1;
-  /* Non-mobile position */
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   display: block;
   margin-top: inherit;
@@ -1314,10 +1261,6 @@ a:focus {
     float: none;
     max-width: 100%;
   }
-  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-    float: none;
-    max-width: 100%;
-  }
   .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
     float: none;
     max-width: 100%;
@@ -1328,19 +1271,8 @@ a:focus {
   counter-reset: submenu;
 }
 
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
-  counter-reset: submenu;
-}
-
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
   counter-reset: submenu;
-}
-
-.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
-  font-family: Georgia, Garamond, "Times New Roman", serif;
-  font-weight: normal;
-  content: "– " counters(submenu, "– ", none);
-  counter-increment: submenu;
 }
 
 .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
@@ -4002,7 +3934,9 @@ a:focus {
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
   border-bottom: 4px solid #ddd;
   color: #0073aa;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   display: inline-block;
+  margin-bottom: calc( 1rem / 2);
   text-transform: uppercase;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3934,7 +3934,6 @@ a:focus {
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
   border-bottom: 4px solid #ddd;
   color: #0073aa;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   display: inline-block;
   margin-bottom: calc( 1rem / 2);
   text-transform: uppercase;
@@ -3944,14 +3943,6 @@ a:focus {
   border-bottom: 4px solid #666;
   display: inline-block;
   margin-bottom: -4px;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
-  font-weight: bold;
 }
 
 /* Media */

--- a/style.css
+++ b/style.css
@@ -3946,7 +3946,9 @@ a:focus {
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
   border-bottom: 4px solid #ddd;
   color: #0073aa;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   display: inline-block;
+  margin-bottom: calc( 1rem / 2);
   text-transform: uppercase;
 }
 

--- a/style.css
+++ b/style.css
@@ -3946,7 +3946,6 @@ a:focus {
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
   border-bottom: 4px solid #ddd;
   color: #0073aa;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   display: inline-block;
   margin-bottom: calc( 1rem / 2);
   text-transform: uppercase;
@@ -3956,14 +3955,6 @@ a:focus {
   border-bottom: 4px solid #666;
   display: inline-block;
   margin-bottom: -4px;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
-  font-weight: bold;
 }
 
 /* Media */

--- a/style.css
+++ b/style.css
@@ -49,6 +49,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Posts and pages
 	## Comments
 # Blocks
+	## Newpack blocks
 # Media
 	## Captions
 	## Galleries
@@ -3755,7 +3756,8 @@ a:focus {
     margin-bottom: 0;
   }
   .entry .entry-content .wp-block-columns[class*='has-'] > * {
-    margin-right: 1rem;
+    margin-left: 0;
+    margin-right: calc(2 * 1rem);
   }
   .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
     margin-right: 0;
@@ -3784,21 +3786,6 @@ a:focus {
 
 .entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
   font-size: 0.71111em;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
-  border-bottom: 4px solid #ddd;
-  color: #0073aa;
-  display: inline-block;
-  text-transform: uppercase;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
-  font-weight: bold;
 }
 
 .entry .entry-content .has-small-font-size {
@@ -3949,6 +3936,32 @@ a:focus {
   .single.has-sidebar .entry .entry-summary > *.alignfull {
     margin-left: 0;
   }
+}
+
+/* !Newspack Block styles */
+.entry .entry-content {
+  /* !Homepage article blocks */
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
+  border-bottom: 4px solid #ddd;
+  color: #0073aa;
+  display: inline-block;
+  text-transform: uppercase;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title span {
+  border-bottom: 4px solid #666;
+  display: inline-block;
+  margin-bottom: -4px;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
+  font-weight: bold;
 }
 
 /* Media */

--- a/style.css
+++ b/style.css
@@ -3786,8 +3786,19 @@ a:focus {
   font-size: 0.71111em;
 }
 
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
+  border-bottom: 4px solid #ddd;
+  color: #0073aa;
+  display: inline-block;
+  text-transform: uppercase;
+}
+
 .entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .author-name .author {
+  font-weight: bold;
 }
 
 .entry .entry-content .has-small-font-size {

--- a/style.scss
+++ b/style.scss
@@ -49,6 +49,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Posts and pages
 	## Comments
 # Blocks
+	## Newpack blocks
 # Media
 	## Captions
 	## Galleries
@@ -103,6 +104,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /* Blocks */
 
 @import "sass/blocks/blocks";
+@import "sass/blocks/newspack-blocks";
 
 /* Media */
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some default styles for the Newspack article blocks, mostly around giving the section headers a distinct look. 

### How to test the changes in this Pull Request:

1. Add the homepage article blocks to a page, including the section header.
2. Apply the PR.
3. Confirm that the block section headers are blue (or using your primary accent colour), all-caps, and with a border underneath.
4. Confirm that the blocks look the same in the editor (note that the border detail won't be exactly the same; see the discussion in this block PR here for more info: https://github.com/Automattic/newspack-blocks/pull/30#pullrequestreview-245499130

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
