### PR TITLE
Generally scale down elements in the header

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -85,8 +85,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 1200,
-				'width'       => 900,
+				'height'      => 400,
+				'width'       => 800,
 				'flex-width'  => true,
 				'flex-height' => true,
 				'header-text' => array( 'site-title' ),

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -13,7 +13,6 @@
 		padding: 0;
 		margin: 0;
 		font-family: $font__heading;
-		font-weight: 700;
 		line-height: $font__line-height-heading;
 		text-decoration: none;
 		background: transparent;
@@ -52,7 +51,6 @@
 
 			> a {
 
-				font-weight: 700;
 				color: $color__primary;
 				margin-right: #{0.5 * $size__spacing-unit};
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -52,6 +52,7 @@
 			> a {
 
 				color: $color__primary;
+				font-weight: 700;
 				margin-right: #{0.5 * $size__spacing-unit};
 
 				+ svg {
@@ -93,13 +94,12 @@
 
 					/* Priority+ Menu */
 					&.main-menu-more-toggle {
-
 						position: relative;
 						height: 24px;
 						line-height: $font__line-height-heading;
 						width: 24px;
 						padding: 0;
-						margin-left: #{0.5 * $size__spacing-unit};
+						margin: #{0.25 * $size__spacing-unit} 0 0 #{0.5 * $size__spacing-unit};
 
 						svg {
 							height: 24px;

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -20,6 +20,7 @@
 				display: block;
 				color: $color__text-main;
 				margin-bottom: -1px;
+				padding: 0 0.25em;
 				transition: opacity $link_transition ease-in-out;
 
 				&:hover,
@@ -36,8 +37,8 @@
 
 				svg {
 					display: block;
-					width: 32px;
-					height: 32px;
+					width: 24px;
+					height: 24px;
 
 					// Prevent icons from jumping in Safari using hardware acceleration.
 					transform: translateZ(0);

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -12,7 +12,7 @@
 			list-style: none;
 
 			&:nth-child(n+2) {
-				margin-left: 0.1em;
+				margin-left: 0.5em;
 			}
 
 			a {
@@ -20,7 +20,6 @@
 				display: block;
 				color: $color__text-main;
 				margin-bottom: -1px;
-				padding: 0 0.25em;
 				transition: opacity $link_transition ease-in-out;
 
 				&:hover,

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -23,4 +23,8 @@
 			margin-right: #{0.5 * $size__spacing-unit};
 		}
 	}
+
+	a, a:visited {
+		color: $color__text-light;
+	}
 }

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -4,7 +4,7 @@
 	font-family: $font__heading;
 	font-size: $font__size-sm;
 	list-style: none;
-	margin: 0;
+	margin: 0.5em 0;
 	padding: 0;
 
 	@include media(tablet) {
@@ -16,15 +16,29 @@
 		display: inline;
 		margin: 0;
 		padding: 0;
-	}
 
-	> li {
-		> a {
-			margin-right: #{0.5 * $size__spacing-unit};
+		&:nth-child(n+2) {
+			margin-left: ($size__spacing-unit * 0.5);
 		}
 	}
 
-	a, a:visited {
-		color: $color__text-light;
+	a {
+		background-color: lighten($color__text-light, 45%);
+		@include button-transition;
+		border-radius: 5px;
+		display: inline-block;
+		font-size: $font__size-sm;
+		font-weight: 700;
+		padding: ($size__spacing-unit * 0.5) ($size__spacing-unit * 0.75);
+	}
+
+	a,
+	a:visited {
+		color: $color__text-main;
+	}
+
+	a:hover {
+		background-color: $color__text-main;
+		color: #fff;
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -28,7 +28,7 @@
 }
 
 .site-branding {
-	align-items: center;
+	align-items: baseline;
 	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
@@ -72,16 +72,14 @@
 		}
 	}
 
-	&:not(:empty) + .site-description:not(:empty):before {
-		content: "\2014";
-		margin: 0 .2em;
+	&:not(:empty) + .site-description:not(:empty) {
+		margin-left: 0.5em;
 	}
 }
 
 // Site description
 
 .site-description {
-
 	color: $color__text-light;
 	flex: 1 1 auto;
 	font-weight: normal;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -28,27 +28,41 @@
 }
 
 .site-branding {
-	align-items: baseline;
+	align-items: center;
 	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
 	position: relative;
+
+	@include media(tablet) {
+		flex-basis: 60%;
+	}
 }
 
 // Site logo
 
 .site-logo {
+	line-height: 1;
+	margin: 0 $size__spacing-unit 0 0;
+	max-width: 80%;
 
-	/* margin-bottom: calc(.66 * #{$size__spacing-unit}); */
-	width: 100%;
+	@include media(mobile) {
+		max-width: 60%;
+	}
+
+	@include media(tablet) {
+		max-width: 40%;
+	}
 
 	.custom-logo-link {
 		box-sizing: content-box;
 		overflow: hidden;
 
 		.custom-logo {
+			height: auto;
 			min-height: inherit;
+			max-height: 150px;
+			width: auto;
 		}
 	}
 }
@@ -57,7 +71,10 @@
 
 .site-title {
 	color: $color__text-main;
-	margin: 0;
+	font-weight: 700;
+	margin: 0 $size__spacing-unit 0 0;
+	position: relative;
+	top: 2px;
 
 	a {
 		color: $color__text-main;
@@ -70,10 +87,6 @@
 		&:hover {
 			color: $color__text-hover;
 		}
-	}
-
-	&:not(:empty) + .site-description:not(:empty) {
-		margin-left: 0.5em;
 	}
 }
 

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -27,7 +27,6 @@ h6 {
 	font-family: $font__heading;
 }
 
-.main-navigation,
 .page-description,
 .author-description .author-link,
 .not-found .page-title,
@@ -45,6 +44,12 @@ h4,
 h5,
 h6 {
 	font-weight: 700;
+	line-height: $font__line-height-heading;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+.main-navigation {
 	line-height: $font__line-height-heading;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
@@ -91,7 +96,6 @@ h3 {
 
 .site-title,
 .site-description,
-.main-navigation,
 .nav-links,
 .page-title,
 .page-description,
@@ -103,6 +107,7 @@ h4 {
 	font-size: $font__size-md;
 }
 
+.main-navigation,
 .pagination .nav-links,
 .comment-content,
 h5 {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -449,7 +449,6 @@ h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.main-navigation,
 .page-description,
 .author-description .author-link,
 .not-found .page-title,
@@ -467,6 +466,12 @@ h4,
 h5,
 h6 {
   font-weight: 700;
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.main-navigation {
   line-height: 1.2;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -521,7 +526,6 @@ h3 {
 
 .site-title,
 .site-description,
-.main-navigation,
 .nav-links,
 .page-title,
 .page-description,
@@ -533,6 +537,7 @@ h4 {
   font-size: 1.125em;
 }
 
+.main-navigation,
 .pagination .nav-links,
 .comment-content,
 h5 {
@@ -938,7 +943,6 @@ a:focus {
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-weight: 700;
   line-height: 1.2;
   text-decoration: none;
   background: transparent;
@@ -975,7 +979,6 @@ a:focus {
 }
 
 .main-navigation .main-menu > li > a {
-  font-weight: 700;
   color: #0073aa;
   margin-left: 0.5rem;
 }
@@ -1542,6 +1545,10 @@ a:focus {
   margin-left: 0.5rem;
 }
 
+.tertiary-menu a {
+  color: #767676;
+}
+
 /* Social menu */
 .social-navigation {
   text-align: right;
@@ -1566,6 +1573,7 @@ a:focus {
   display: block;
   color: #111;
   margin-bottom: -1px;
+  padding: 0 0.25em;
   transition: opacity 110ms ease-in-out;
 }
 
@@ -1582,8 +1590,8 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   transform: translateZ(0);
 }
 
@@ -2030,7 +2038,7 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
+  align-items: baseline;
   color: #767676;
   display: flex;
   flex-wrap: wrap;
@@ -2069,9 +2077,8 @@ a:focus {
   color: #4a4a4a;
 }
 
-.site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
+.site-title:not(:empty) + .site-description:not(:empty) {
+  margin-right: 0.5em;
 }
 
 .site-description {

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -980,6 +980,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a {
   color: #0073aa;
+  font-weight: 700;
   margin-left: 0.5rem;
 }
 
@@ -1025,7 +1026,7 @@ a:focus {
   line-height: 1.2;
   width: 24px;
   padding: 0;
-  margin-right: 0.5rem;
+  margin: 0.25rem 0.5rem 0 0;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle svg {
@@ -1524,7 +1525,7 @@ a:focus {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
   list-style: none;
-  margin: 0;
+  margin: 0.5em 0;
   padding: 0;
 }
 
@@ -1541,12 +1542,28 @@ a:focus {
   padding: 0;
 }
 
-.tertiary-menu > li > a {
-  margin-left: 0.5rem;
+.tertiary-menu li:nth-child(n+2) {
+  margin-right: 0.5rem;
 }
 
 .tertiary-menu a {
-  color: #767676;
+  background-color: #e9e9e9;
+  transition: background 150ms ease-in-out;
+  border-radius: 5px;
+  display: inline-block;
+  font-size: 0.88889em;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+}
+
+.tertiary-menu a,
+.tertiary-menu a:visited {
+  color: #111;
+}
+
+.tertiary-menu a:hover {
+  background-color: #111;
+  color: #fff;
 }
 
 /* Social menu */
@@ -1565,7 +1582,7 @@ a:focus {
 }
 
 .social-navigation ul.social-links-menu li:nth-child(n+2) {
-  margin-right: 0.1em;
+  margin-right: 0.5em;
 }
 
 .social-navigation ul.social-links-menu li a {
@@ -1573,7 +1590,6 @@ a:focus {
   display: block;
   color: #111;
   margin-bottom: -1px;
-  padding: 0 0.25em;
   transition: opacity 110ms ease-in-out;
 }
 
@@ -2038,17 +2054,38 @@ a:focus {
 }
 
 .site-branding {
-  align-items: baseline;
+  align-items: center;
   color: #767676;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   position: relative;
 }
 
+@media only screen and (min-width: 768px) {
+  .site-branding {
+    flex-basis: 60%;
+  }
+}
+
 .site-logo {
-  /* margin-bottom: calc(.66 * 1rem); */
-  width: 100%;
+  line-height: 1;
+  height: auto;
+  margin: 0 0 0 1rem;
+  max-width: 80%;
+  max-height: 20px;
+  width: auto;
+}
+
+@media only screen and (min-width: 600px) {
+  .site-logo {
+    max-width: 60%;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .site-logo {
+    max-width: 40%;
+  }
 }
 
 .site-logo .custom-logo-link {
@@ -2062,7 +2099,10 @@ a:focus {
 
 .site-title {
   color: #111;
-  margin: 0;
+  font-weight: 700;
+  margin: 0 0 0 1rem;
+  position: relative;
+  top: 2px;
 }
 
 .site-title a {
@@ -2075,10 +2115,6 @@ a:focus {
 
 .site-title a:hover {
   color: #4a4a4a;
-}
-
-.site-title:not(:empty) + .site-description:not(:empty) {
-  margin-right: 0.5em;
 }
 
 .site-description {

--- a/style.css
+++ b/style.css
@@ -449,7 +449,6 @@ h6 {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
-.main-navigation,
 .page-description,
 .author-description .author-link,
 .not-found .page-title,
@@ -467,6 +466,12 @@ h4,
 h5,
 h6 {
   font-weight: 700;
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.main-navigation {
   line-height: 1.2;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -521,7 +526,6 @@ h3 {
 
 .site-title,
 .site-description,
-.main-navigation,
 .nav-links,
 .page-title,
 .page-description,
@@ -533,6 +537,7 @@ h4 {
   font-size: 1.125em;
 }
 
+.main-navigation,
 .pagination .nav-links,
 .comment-content,
 h5 {
@@ -938,7 +943,6 @@ a:focus {
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  font-weight: 700;
   line-height: 1.2;
   text-decoration: none;
   background: transparent;
@@ -975,7 +979,6 @@ a:focus {
 }
 
 .main-navigation .main-menu > li > a {
-  font-weight: 700;
   color: #0073aa;
   margin-right: 0.5rem;
 }
@@ -1542,6 +1545,10 @@ a:focus {
   margin-right: 0.5rem;
 }
 
+.tertiary-menu a, .tertiary-menu a:visited {
+  color: #767676;
+}
+
 /* Social menu */
 .social-navigation {
   text-align: left;
@@ -1566,6 +1573,7 @@ a:focus {
   display: block;
   color: #111;
   margin-bottom: -1px;
+  padding: 0 0.25em;
   transition: opacity 110ms ease-in-out;
 }
 
@@ -1582,8 +1590,8 @@ a:focus {
 
 .social-navigation ul.social-links-menu li a svg {
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   transform: translateZ(0);
 }
 
@@ -2036,7 +2044,7 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
+  align-items: baseline;
   color: #767676;
   display: flex;
   flex-wrap: wrap;
@@ -2075,9 +2083,8 @@ a:focus {
   color: #4a4a4a;
 }
 
-.site-title:not(:empty) + .site-description:not(:empty):before {
-  content: "\2014";
-  margin: 0 .2em;
+.site-title:not(:empty) + .site-description:not(:empty) {
+  margin-left: 0.5em;
 }
 
 .site-description {

--- a/style.css
+++ b/style.css
@@ -980,6 +980,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a {
   color: #0073aa;
+  font-weight: 700;
   margin-right: 0.5rem;
 }
 
@@ -1025,7 +1026,7 @@ a:focus {
   line-height: 1.2;
   width: 24px;
   padding: 0;
-  margin-left: 0.5rem;
+  margin: 0.25rem 0 0 0.5rem;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle svg {
@@ -1524,7 +1525,7 @@ a:focus {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
   list-style: none;
-  margin: 0;
+  margin: 0.5em 0;
   padding: 0;
 }
 
@@ -1541,12 +1542,28 @@ a:focus {
   padding: 0;
 }
 
-.tertiary-menu > li > a {
-  margin-right: 0.5rem;
+.tertiary-menu li:nth-child(n+2) {
+  margin-left: 0.5rem;
 }
 
-.tertiary-menu a, .tertiary-menu a:visited {
-  color: #767676;
+.tertiary-menu a {
+  background-color: #e9e9e9;
+  transition: background 150ms ease-in-out;
+  border-radius: 5px;
+  display: inline-block;
+  font-size: 0.88889em;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+}
+
+.tertiary-menu a,
+.tertiary-menu a:visited {
+  color: #111;
+}
+
+.tertiary-menu a:hover {
+  background-color: #111;
+  color: #fff;
 }
 
 /* Social menu */
@@ -1565,7 +1582,7 @@ a:focus {
 }
 
 .social-navigation ul.social-links-menu li:nth-child(n+2) {
-  margin-left: 0.1em;
+  margin-left: 0.5em;
 }
 
 .social-navigation ul.social-links-menu li a {
@@ -1573,7 +1590,6 @@ a:focus {
   display: block;
   color: #111;
   margin-bottom: -1px;
-  padding: 0 0.25em;
   transition: opacity 110ms ease-in-out;
 }
 
@@ -2044,17 +2060,35 @@ a:focus {
 }
 
 .site-branding {
-  align-items: baseline;
+  align-items: center;
   color: #767676;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   position: relative;
 }
 
+@media only screen and (min-width: 768px) {
+  .site-branding {
+    flex-basis: 60%;
+  }
+}
+
 .site-logo {
-  /* margin-bottom: calc(.66 * 1rem); */
-  width: 100%;
+  line-height: 1;
+  margin: 0 1rem 0 0;
+  max-width: 80%;
+}
+
+@media only screen and (min-width: 600px) {
+  .site-logo {
+    max-width: 60%;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .site-logo {
+    max-width: 40%;
+  }
 }
 
 .site-logo .custom-logo-link {
@@ -2063,12 +2097,18 @@ a:focus {
 }
 
 .site-logo .custom-logo-link .custom-logo {
+  height: auto;
   min-height: inherit;
+  max-height: 150px;
+  width: auto;
 }
 
 .site-title {
   color: #111;
-  margin: 0;
+  font-weight: 700;
+  margin: 0 1rem 0 0;
+  position: relative;
+  top: 2px;
 }
 
 .site-title a {
@@ -2081,10 +2121,6 @@ a:focus {
 
 .site-title a:hover {
   color: #4a4a4a;
-}
-
-.site-title:not(:empty) + .site-description:not(:empty) {
-  margin-left: 0.5em;
 }
 
 .site-description {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces some more general polish to the theme header. The big changes include:

1. Setting a smaller size for the logo, and styles for it to make sure it's not gigantic. 
2. Scale down the menus -- specifically the primary menu (the one that runs along the bottom of the header) and the social menu. 
3. Style the tertiary menu (the one that sits to the right of the site title, description and logo) to look like buttons.

As before, this isn't the final styles for the header, but it's slowly getting there!

See #20.

### How to test the changes in this Pull Request:

1. In the Customizer, populate all the menu locations (primary, secondary [ideally with a mid-length menu], tertiary [ideally with a shorter menu -- 1-2 links], and social). 
2. Add a logo (and optionally hide the Site Title; it's very unlikely a publication will need to show both).
3. Save and Publish the changes and review.
4. Apply the PR. 
5. Confirm that things look correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?