### PR TITLE
Add RTL styles for style packs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:style-editor-customizer": "node-sass style-editor-customizer.scss style-editor-customizer.css --output-style expanded && postcss -r style-editor-customizer.css",
     "build:style-woocommerce": "node-sass sass/plugins/woocommerce.scss woocommerce.css --output-style expanded && postcss -r woocommerce.css",
     "build:rtl": "rtlcss style.css style-rtl.css",
+    "build:rtl-style-1": "rtlcss styles/style-1.css styles/style-1-rtl.css",
     "build:rtl-woocommerce": "rtlcss woocommerce.css woocommerce-rtl.css",
     "build:print": "node-sass print.scss print.css --output-style expanded && postcss -r print.css",
     "build": "run-p \"build:*\"",

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -1,0 +1,4065 @@
+@charset "UTF-8";
+/* Mixins */
+/* If we add the border using a regular CSS border, it won't look good on non-retina devices,
+ * since its edges can look jagged due to lack of antialiasing. In this case, we are several
+ * layers of box-shadow to add the border visually, which will render the border smoother. */
+/* Calculates maximum width for post content */
+/* Nested sub-menu padding: 10 levels deep */
+/* Normalize */
+/*! normalize.css v8.0.0 | MIT License | github.com/necolas/normalize.css */
+/* Document
+	 ========================================================================== */
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+html {
+  line-height: 1.15;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+}
+
+/* Sections
+	 ========================================================================== */
+/**
+ * Remove the margin in all browsers.
+ */
+body {
+  margin: 0;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+	 ========================================================================== */
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+  box-sizing: content-box;
+  /* 1 */
+  height: 0;
+  /* 1 */
+  overflow: visible;
+  /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+pre {
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/* Text-level semantics
+	 ========================================================================== */
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+abbr[title] {
+  border-bottom: none;
+  /* 1 */
+  text-decoration: underline;
+  /* 2 */
+  text-decoration: underline dotted;
+  /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+code,
+kbd,
+samp {
+  font-family: monospace, monospace;
+  /* 1 */
+  font-size: 1em;
+  /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+	 ========================================================================== */
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+img {
+  border-style: none;
+}
+
+/* Forms
+	 ========================================================================== */
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  line-height: 1.15;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+button,
+input {
+  /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+button,
+select {
+  /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *		`fieldset` elements in all browsers.
+ */
+legend {
+  box-sizing: border-box;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  display: table;
+  /* 1 */
+  max-width: 100%;
+  /* 1 */
+  padding: 0;
+  /* 3 */
+  white-space: normal;
+  /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/* Interactive
+	 ========================================================================== */
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+summary {
+  display: list-item;
+}
+
+/* Misc
+	 ========================================================================== */
+/**
+ * Add the correct display in IE 10+.
+ */
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+[hidden] {
+  display: none;
+}
+
+/* Typography */
+html {
+  font-size: 20px;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: #111;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 400;
+  font-size: 1em;
+  line-height: 1.6;
+  margin: 0;
+  text-rendering: optimizeLegibility;
+}
+
+button,
+input,
+select,
+optgroup,
+textarea {
+  color: #111;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 400;
+  line-height: 1.6;
+  text-rendering: optimizeLegibility;
+}
+
+.author-description .author-link,
+.comment-metadata,
+.comment-reply-link,
+.comments-title,
+.comment-author .fn,
+.discussion-meta-info,
+.entry-meta,
+.entry-footer,
+.main-navigation,
+.no-comments,
+.not-found .page-title,
+.error-404 .page-title,
+.post-navigation .post-title,
+.page-links,
+.page-description,
+.pagination .nav-links,
+.sticky-post,
+.site-title,
+.site-info,
+#cancel-comment-reply-link,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
+.main-navigation,
+.page-description,
+.author-description .author-link,
+.not-found .page-title,
+.error-404 .page-title,
+.post-navigation .post-title,
+.pagination .nav-links,
+.comments-title,
+.comment-author .fn,
+.no-comments,
+.site-title,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.page-title {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
+.site-branding,
+.main-navigation ul.main-menu > li,
+.social-navigation,
+.author-description .author-bio,
+.nav-links {
+  line-height: 1.25;
+}
+
+h1 {
+  font-size: 1.6875em;
+}
+
+@media only screen and (min-width: 768px) {
+  h1 {
+    font-size: 2.25em;
+  }
+}
+
+.entry-title,
+.not-found .page-title,
+.error-404 .page-title,
+.has-larger-font-size,
+h2 {
+  font-size: 1.40625em;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-title,
+  .not-found .page-title,
+  .error-404 .page-title,
+  .has-larger-font-size,
+  h2 {
+    font-size: 1.6875em;
+  }
+}
+
+.has-regular-font-size,
+.has-large-font-size,
+.comments-title,
+h3 {
+  font-size: 1.40625em;
+}
+
+.site-title,
+.site-description,
+.main-navigation,
+.nav-links,
+.page-title,
+.page-description,
+.comment-author .fn,
+.no-comments,
+h2.author-title,
+p.author-bio,
+h4 {
+  font-size: 1.125em;
+}
+
+.pagination .nav-links,
+.comment-content,
+h5 {
+  font-size: 0.88889em;
+}
+
+.entry-meta,
+.entry-footer,
+.discussion-meta-info,
+.site-info,
+.has-small-font-size,
+.comment-reply-link,
+.comment-metadata,
+.comment-notes,
+.sticky-post,
+#cancel-comment-reply-link,
+img:after,
+h6 {
+  font-size: 0.71111em;
+}
+
+.site-title,
+.page-title {
+  font-weight: normal;
+}
+
+.page-description,
+.page-links a {
+  font-weight: bold;
+}
+
+.post-navigation .post-title,
+.entry-title,
+.not-found .page-title,
+.error-404 .page-title,
+.comments-title,
+blockquote {
+  hyphens: auto;
+  word-break: break-word;
+}
+
+/* Do not hyphenate entry title on tablet view and bigger. */
+@media only screen and (min-width: 768px) {
+  .entry-title {
+    hyphens: none;
+  }
+}
+
+p {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+dfn,
+cite,
+em,
+i {
+  font-style: italic;
+}
+
+blockquote cite {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.71111em;
+  font-style: normal;
+}
+
+pre {
+  font-size: 0.88889em;
+  font-family: "Courier 10 Pitch", Courier, monospace;
+  line-height: 1.6;
+  overflow: auto;
+}
+
+code,
+kbd,
+tt,
+var {
+  font-size: 0.88889em;
+  font-family: Menlo, monaco, Consolas, Lucida Console, monospace;
+}
+
+abbr, acronym {
+  border-bottom: 1px dotted #666;
+  cursor: help;
+}
+
+mark,
+ins {
+  background: #fff9c0;
+  text-decoration: none;
+}
+
+big {
+  font-size: 125%;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+a:focus {
+  text-decoration: underline;
+}
+
+/* Elements */
+html {
+  box-sizing: border-box;
+}
+
+::-moz-selection {
+  background-color: #bfdcea;
+}
+
+::selection {
+  background-color: #bfdcea;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  background-color: #eee;
+}
+
+a {
+  transition: color 110ms ease-in-out;
+  color: #666;
+}
+
+a:hover,
+a:active {
+  color: #4d4d4d;
+  outline: 0;
+  text-decoration: none;
+}
+
+a:focus {
+  outline: thin;
+  outline-style: dotted;
+  text-decoration: underline;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  clear: both;
+  margin: 1rem 0;
+}
+
+hr {
+  background-color: #767676;
+  border: 0;
+  height: 2px;
+}
+
+ul,
+ol {
+  padding-right: 1rem;
+}
+
+ul {
+  list-style: disc;
+}
+
+ul ul {
+  list-style-type: circle;
+}
+
+ol {
+  list-style: decimal;
+}
+
+li {
+  line-height: 1.6;
+}
+
+li > ul,
+li > ol {
+  padding-right: 2rem;
+}
+
+dt {
+  font-weight: bold;
+}
+
+dd {
+  margin: 0 1rem 1rem;
+}
+
+img {
+  height: auto;
+  max-width: 100%;
+  position: relative;
+}
+
+figure {
+  margin: 0;
+}
+
+blockquote {
+  border-right: 2px solid #0073aa;
+  margin-right: 0;
+  padding: 0 1rem 0 0;
+}
+
+blockquote > p {
+  margin: 0 0 1rem;
+}
+
+blockquote cite {
+  color: #767676;
+}
+
+table {
+  margin: 0 0 1rem;
+  border-collapse: collapse;
+  width: 100%;
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
+table td,
+table th {
+  padding: 0.5em;
+  border: 1px solid #767676;
+  word-break: break-all;
+}
+
+/* Forms */
+.button,
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  transition: background 150ms ease-in-out;
+  background: #0073aa;
+  border: none;
+  border-radius: 5px;
+  box-sizing: border-box;
+  color: #eee;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.88889em;
+  font-weight: 700;
+  line-height: 1.2;
+  outline: none;
+  padding: 0.76rem 1rem;
+  text-decoration: none;
+  vertical-align: bottom;
+}
+
+.button:hover,
+button:hover,
+input[type="button"]:hover,
+input[type="reset"]:hover,
+input[type="submit"]:hover {
+  background: #111;
+  cursor: pointer;
+}
+
+.button:visited,
+button:visited,
+input[type="button"]:visited,
+input[type="reset"]:visited,
+input[type="submit"]:visited {
+  color: #eee;
+  text-decoration: none;
+}
+
+.button:focus,
+button:focus,
+input[type="button"]:focus,
+input[type="reset"]:focus,
+input[type="submit"]:focus {
+  background: #111;
+  outline: thin dotted;
+  outline-offset: -4px;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="search"],
+input[type="number"],
+input[type="tel"],
+input[type="range"],
+input[type="date"],
+input[type="month"],
+input[type="week"],
+input[type="time"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="color"],
+textarea {
+  -webkit-backface-visibility: hidden;
+  background: #fff;
+  border: solid 1px #ccc;
+  box-sizing: border-box;
+  outline: none;
+  padding: 0.36rem 0.66rem;
+  -webkit-appearance: none;
+  outline-offset: 0;
+  border-radius: 0;
+}
+
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="search"]:focus,
+input[type="number"]:focus,
+input[type="tel"]:focus,
+input[type="range"]:focus,
+input[type="date"]:focus,
+input[type="month"]:focus,
+input[type="week"]:focus,
+input[type="time"]:focus,
+input[type="datetime"]:focus,
+input[type="datetime-local"]:focus,
+input[type="color"]:focus,
+textarea:focus {
+  border-color: #0073aa;
+  outline: thin solid rgba(0, 115, 170, 0.15);
+  outline-offset: -4px;
+}
+
+input[type="search"]::-webkit-search-decoration {
+  display: none;
+}
+
+textarea {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  resize: vertical;
+}
+
+form p {
+  margin: 1rem 0;
+}
+
+/* Navigation */
+/*--------------------------------------------------------------
+## Links
+--------------------------------------------------------------*/
+a {
+  transition: color 110ms ease-in-out;
+  color: #666;
+}
+
+a:visited {
+  color: #666;
+}
+
+a:hover, a:active {
+  color: #4d4d4d;
+  outline: 0;
+  text-decoration: none;
+}
+
+a:focus {
+  outline: thin dotted;
+  text-decoration: underline;
+}
+
+/*--------------------------------------------------------------
+## Menus
+--------------------------------------------------------------*/
+/** === Main menu === */
+.main-navigation {
+  display: flex;
+  margin: 0.25rem auto 0;
+  max-width: 90%;
+  width: 1200px;
+  /* Un-style buttons */
+  /*
+	 * Sub-menu styles
+	 *
+	 * :focus-within needs its own selector so other similar
+	 * selectors don’t get ignored if a browser doesn’t recognize it
+	 */
+  /**
+	 * Fade-in animation for top-level submenus
+	 */
+  /**
+	 * Off-canvas touch device styles
+	 */
+}
+
+.main-navigation button {
+  display: inline-block;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 250ms ease-in-out, transform 150ms ease;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.main-navigation button:hover, .main-navigation button:focus {
+  background: transparent;
+}
+
+.main-navigation button:focus {
+  outline: 1px solid transparent;
+  outline-offset: -4px;
+}
+
+.main-navigation button:active {
+  transform: scale(0.99);
+}
+
+.main-navigation .main-menu {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+}
+
+.main-navigation .main-menu > li {
+  color: #0073aa;
+  display: inline;
+  position: relative;
+}
+
+.main-navigation .main-menu > li > a {
+  font-weight: 700;
+  color: #0073aa;
+  margin-left: 0.5rem;
+}
+
+.main-navigation .main-menu > li > a + svg {
+  margin-left: 0.5rem;
+}
+
+.main-navigation .main-menu > li > a:hover,
+.main-navigation .main-menu > li > a:hover + svg {
+  color: #005177;
+}
+
+.main-navigation .main-menu > li.menu-item-has-children {
+  display: inline-block;
+  position: inherit;
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu > li.menu-item-has-children {
+    position: relative;
+  }
+}
+
+.main-navigation .main-menu > li.menu-item-has-children > a {
+  margin-left: 0.125rem;
+}
+
+.main-navigation .main-menu > li.menu-item-has-children > a:after,
+.main-navigation .main-menu > li.menu-item-has-children .menu-item-has-children > a:after {
+  content: "";
+  display: none;
+}
+
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
+  display: inline-block;
+  margin-left: 0.25rem;
+  /* Priority+ Menu */
+}
+
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle {
+  position: relative;
+  height: 24px;
+  line-height: 1.2;
+  width: 24px;
+  padding: 0;
+  margin-right: 0.5rem;
+}
+
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand.main-menu-more-toggle svg {
+  height: 24px;
+  width: 24px;
+  top: -0.125rem;
+  vertical-align: text-bottom;
+}
+
+.wp-customizer-unloading .main-navigation .main-menu > li.menu-item-has-children .submenu-expand, .main-navigation .main-menu > li.menu-item-has-children .submenu-expand.is-empty {
+  display: none;
+}
+
+.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
+  position: relative;
+  top: 0.2rem;
+}
+
+.main-navigation .main-menu > li:last-child > a,
+.main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+  margin-left: 0;
+}
+
+.main-navigation .sub-menu {
+  background-color: #0073aa;
+  color: #eee;
+  list-style: none;
+  padding-right: 0;
+  position: absolute;
+  opacity: 0;
+  right: -9999px;
+  z-index: 99999;
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .sub-menu {
+    width: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+  }
+}
+
+.main-navigation .sub-menu > li {
+  display: block;
+  float: none;
+  position: relative;
+}
+
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
+  display: inline-block;
+  position: absolute;
+  width: calc( 24px + 1rem);
+  left: 0;
+  top: calc( .125 * 1rem);
+  bottom: 0;
+  color: white;
+  line-height: 1;
+  padding: calc( .5 * 1rem);
+}
+
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand svg {
+  top: 0;
+}
+
+.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand {
+  margin-left: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .sub-menu > li.menu-item-has-children .menu-item-has-children > a:after {
+    content: "\203a";
+  }
+}
+
+.main-navigation .sub-menu > li > a,
+.main-navigation .sub-menu > li > .menu-item-link-return {
+  color: #eee;
+  display: block;
+  line-height: 1.2;
+  text-shadow: none;
+  padding: calc( .5 * 1rem) 1rem calc( .5 * 1rem) calc( 24px + 1rem);
+  white-space: nowrap;
+}
+
+.main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus {
+  background: #005177;
+}
+
+.main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
+.main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
+  background: #005177;
+}
+
+.main-navigation .sub-menu > li > .menu-item-link-return {
+  width: 100%;
+  font-size: 20px;
+  font-weight: normal;
+  text-align: right;
+}
+
+.main-navigation .sub-menu > li > a:empty {
+  display: none;
+}
+
+.main-navigation .sub-menu > li.mobile-parent-nav-menu-item {
+  display: none;
+  font-size: 0.88889em;
+  font-weight: normal;
+}
+
+.main-navigation .sub-menu > li.mobile-parent-nav-menu-item svg {
+  position: relative;
+  top: 0.2rem;
+  margin-left: calc( .25 * 1rem);
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+    display: block;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: block;
+    width: max-content;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .submenu-expand {
+  display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .submenu-expand {
+  display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas)[focus-within] > .sub-menu .sub-menu > li > a::before {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu .sub-menu > li > a::before {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+  display: block;
+  right: 0;
+  margin-top: 0;
+  opacity: 1;
+  width: auto;
+  min-width: 100%;
+  /* Non-mobile position */
+  /* Nested sub-menu dashes */
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+    display: block;
+    float: none;
+    margin-top: 0;
+    opacity: 1;
+    position: absolute;
+    right: 0;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    height: auto;
+    min-width: -moz-max-content;
+    min-width: -webkit-max-content;
+    min-width: max-content;
+    transform: none;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu.hidden-links {
+  right: 0;
+  width: 100%;
+  display: table;
+  position: absolute;
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu.hidden-links,
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu.hidden-links,
+  .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu.hidden-links {
+    left: 0;
+    right: auto;
+    display: table;
+    width: max-content;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .submenu-expand,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .submenu-expand,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .submenu-expand {
+  display: none;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
+  display: block;
+  margin-top: inherit;
+  position: relative;
+  width: 100%;
+  right: 0;
+  opacity: 1;
+  /* Non-mobile position */
+}
+
+@media only screen and (min-width: 768px) {
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
+  .main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
+    float: none;
+    max-width: 100%;
+  }
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu {
+  counter-reset: submenu;
+}
+
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu .sub-menu > li > a::before,
+.main-navigation .main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu .sub-menu > li > a::before {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.main-navigation .main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
+  animation: fade_in 0.1s forwards;
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .submenu-expand .svg-icon {
+  transform: rotate(-270deg);
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .sub-menu {
+  opacity: 0;
+  position: absolute;
+  z-index: 0;
+  transform: translateX(100%);
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:hover,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li:focus,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:hover,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu li > a:focus {
+  background-color: transparent;
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > a,
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu > li > .menu-item-link-return {
+  white-space: inherit;
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  display: table;
+  margin-top: 0;
+  opacity: 1;
+  padding-right: 0;
+  /* Mobile position */
+  right: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  position: fixed;
+  z-index: 100000;
+  /* Make sure appears above mobile admin bar */
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  transform: translateX(-100%);
+  animation: slide_in_right 0.3s forwards;
+  /* Prevent menu from being blocked by admin bar */
+}
+
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true > .mobile-parent-nav-menu-item {
+  display: block;
+}
+
+.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+  top: 46px;
+  height: calc( 100vh - 46px);
+  /* WP core breakpoint */
+}
+
+.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
+  top: 0;
+}
+
+@media only screen and (min-width: 782px) {
+  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
+    top: 32px;
+    height: calc( 100vh - 32px);
+  }
+  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
+    top: 0;
+  }
+}
+
+.main-navigation .main-menu-more:nth-child(n+3) {
+  display: none;
+}
+
+/* Menu animation */
+@keyframes slide_in_right {
+  100% {
+    transform: translateX(0%);
+  }
+}
+
+@keyframes fade_in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.top-nav-contain {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: auto;
+  max-width: 90%;
+  width: 1200px;
+}
+
+@media only screen and (min-width: 768px) {
+  .top-nav-contain {
+    flex-wrap: nowrap;
+  }
+}
+
+.secondary-menu {
+  display: flex;
+  flex-wrap: wrap;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.88889em;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.5rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .secondary-menu {
+    padding: 0;
+  }
+}
+
+.secondary-menu li {
+  margin: 0;
+  padding: 0;
+}
+
+.secondary-menu > li > a {
+  margin-left: 0.5rem;
+}
+
+/** === Tertiary menu === */
+.tertiary-menu {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.88889em;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .tertiary-menu {
+    padding: 0;
+    text-align: left;
+  }
+}
+
+.tertiary-menu li {
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.tertiary-menu > li > a {
+  margin-left: 0.5rem;
+}
+
+/* Social menu */
+.social-navigation {
+  text-align: right;
+}
+
+.social-navigation ul.social-links-menu {
+  display: flex;
+  margin: 0;
+  padding: 0;
+}
+
+.social-navigation ul.social-links-menu li {
+  list-style: none;
+}
+
+.social-navigation ul.social-links-menu li:nth-child(n+2) {
+  margin-right: 0.1em;
+}
+
+.social-navigation ul.social-links-menu li a {
+  border-bottom: 1px solid transparent;
+  display: block;
+  color: #111;
+  margin-bottom: -1px;
+  transition: opacity 110ms ease-in-out;
+}
+
+.social-navigation ul.social-links-menu li a:hover, .social-navigation ul.social-links-menu li a:active {
+  color: #111;
+  opacity: 0.6;
+}
+
+.social-navigation ul.social-links-menu li a:focus {
+  color: #111;
+  opacity: 1;
+  border-bottom: 1px solid #111;
+}
+
+.social-navigation ul.social-links-menu li a svg {
+  display: block;
+  width: 32px;
+  height: 32px;
+  transform: translateZ(0);
+}
+
+.social-navigation ul.social-links-menu li a svg#ui-icon-link {
+  transform: rotate(45deg);
+}
+
+/** === Footer menu === */
+.footer-navigation {
+  display: inline;
+}
+
+.footer-navigation > div {
+  display: inline;
+}
+
+.footer-navigation .footer-menu {
+  display: inline;
+  padding-right: 0;
+}
+
+.footer-navigation .footer-menu li {
+  display: inline;
+  margin-left: 1rem;
+}
+
+/*--------------------------------------------------------------
+## Next / Previous
+--------------------------------------------------------------*/
+/* Next/Previous navigation */
+.post-navigation {
+  margin: calc(3 * 1rem) 0;
+}
+
+.post-navigation .nav-links {
+  display: flex;
+  flex-direction: column;
+}
+
+@media only screen and (min-width: 1168px) {
+  .post-navigation .nav-links {
+    flex-direction: row;
+  }
+}
+
+.post-navigation .nav-links a .meta-nav {
+  color: #767676;
+  user-select: none;
+}
+
+.post-navigation .nav-links a .meta-nav:before, .post-navigation .nav-links a .meta-nav:after {
+  display: none;
+  content: "—";
+  width: 2em;
+  color: #767676;
+  height: 1em;
+}
+
+.post-navigation .nav-links a .post-title {
+  hyphens: auto;
+}
+
+.post-navigation .nav-links a:hover {
+  color: #005177;
+}
+
+@media only screen and (min-width: 1168px) {
+  .post-navigation .nav-links .nav-previous,
+  .post-navigation .nav-links .nav-next {
+    min-width: calc(50% - 2 * 1rem);
+  }
+}
+
+.post-navigation .nav-links .nav-previous {
+  order: 2;
+}
+
+@media only screen and (min-width: 1168px) {
+  .post-navigation .nav-links .nav-previous {
+    order: 1;
+  }
+}
+
+.post-navigation .nav-links .nav-previous + .nav-next {
+  margin-bottom: 1rem;
+}
+
+.post-navigation .nav-links .nav-previous .meta-nav:before {
+  display: inline;
+}
+
+.post-navigation .nav-links .nav-next {
+  order: 1;
+}
+
+@media only screen and (min-width: 1168px) {
+  .post-navigation .nav-links .nav-next {
+    order: 2;
+    padding-right: 1rem;
+  }
+}
+
+.post-navigation .nav-links .nav-next .meta-nav:after {
+  display: inline;
+}
+
+.pagination .nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0 calc(.5 * 1rem);
+}
+
+.pagination .nav-links > * {
+  padding: calc(.5 * 1rem);
+}
+
+.pagination .nav-links > *.dots, .pagination .nav-links > *.prev {
+  padding-right: 0;
+}
+
+.pagination .nav-links > *.dots, .pagination .nav-links > *.next {
+  padding-left: 0;
+}
+
+.pagination .nav-links a:focus {
+  text-decoration: underline;
+  outline-offset: -1px;
+}
+
+.pagination .nav-links a:focus.prev, .pagination .nav-links a:focus.next {
+  text-decoration: none;
+}
+
+.pagination .nav-links a:focus.prev .nav-prev-text,
+.pagination .nav-links a:focus.prev .nav-next-text, .pagination .nav-links a:focus.next .nav-prev-text,
+.pagination .nav-links a:focus.next .nav-next-text {
+  text-decoration: underline;
+}
+
+.pagination .nav-links .nav-next-text,
+.pagination .nav-links .nav-prev-text {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .pagination .nav-links {
+    margin-right: 0 auto;
+    padding: 0;
+  }
+  .pagination .nav-links .prev > *,
+  .pagination .nav-links .next > * {
+    display: inline-block;
+    vertical-align: text-bottom;
+  }
+  .pagination .nav-links > * {
+    padding: 1rem;
+  }
+}
+
+.comment-navigation .nav-links {
+  display: flex;
+  flex-direction: row;
+}
+
+.comment-navigation .nav-previous,
+.comment-navigation .nav-next {
+  min-width: 50%;
+  width: 100%;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: bold;
+}
+
+.comment-navigation .nav-previous .secondary-text,
+.comment-navigation .nav-next .secondary-text {
+  display: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .comment-navigation .nav-previous .secondary-text,
+  .comment-navigation .nav-next .secondary-text {
+    display: inline;
+  }
+}
+
+.comment-navigation .nav-previous svg,
+.comment-navigation .nav-next svg {
+  vertical-align: middle;
+  position: relative;
+  margin: 0 -0.35em;
+  top: -1px;
+}
+
+.comment-navigation .nav-next {
+  text-align: left;
+}
+
+/*--------------------------------------------------------------
+## Infinite Scroll
+--------------------------------------------------------------*/
+/* Infinite scroll */
+/* Globally hidden elements when Infinite Scroll is supported and in use. */
+.infinite-scroll .pagination,
+.infinite-scroll .posts-navigation,
+.infinite-scroll.neverending .site-footer {
+  /* Theme Footer (when set to scrolling) */
+  display: none;
+}
+
+/* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before. */
+.infinity-end.neverending .site-footer {
+  display: block;
+}
+
+.infinite-loader {
+  margin: calc(3 * 1rem) auto;
+}
+
+.infinite-loader .spinner {
+  margin: 0 auto;
+  right: inherit !important;
+}
+
+.site-main #infinite-handle {
+  margin: calc(2 * 1rem) auto;
+}
+
+.site-main #infinite-handle span {
+  background: transparent;
+  display: block;
+  font-size: 0.88889em;
+  text-align: center;
+}
+
+.site-main #infinite-handle span button,
+.site-main #infinite-handle span button:hover,
+.site-main #infinite-handle span button:focus {
+  transition: background 150ms ease-in-out;
+  background: #0073aa;
+  border: none;
+  border-radius: 5px;
+  box-sizing: border-box;
+  color: #eee;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 700;
+  line-height: 1.2;
+  outline: none;
+  padding: 0.76rem 1rem;
+  text-decoration: none;
+  vertical-align: bottom;
+}
+
+.site-main #infinite-handle span button:hover,
+.site-main #infinite-handle span button:hover:hover,
+.site-main #infinite-handle span button:focus:hover {
+  background: #111;
+  cursor: pointer;
+}
+
+.site-main #infinite-handle span button:visited,
+.site-main #infinite-handle span button:hover:visited,
+.site-main #infinite-handle span button:focus:visited {
+  color: #eee;
+  text-decoration: none;
+}
+
+.site-main #infinite-handle span button:focus,
+.site-main #infinite-handle span button:hover:focus,
+.site-main #infinite-handle span button:focus:focus {
+  background: #111;
+  outline: thin dotted;
+  outline-offset: -4px;
+}
+
+.site-main .infinite-wrap .entry:first-of-type {
+  margin-top: calc(6 * 1rem);
+}
+
+/* Accessibility */
+/* Text meant only for screen readers. */
+.screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}
+
+.screen-reader-text:focus {
+  background-color: #f1f1f1;
+  border-radius: 3px;
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+  clip: auto !important;
+  clip-path: none;
+  color: #21759b;
+  display: block;
+  font-size: 14px;
+  font-size: 0.875rem;
+  font-weight: bold;
+  height: auto;
+  right: 5px;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  text-decoration: none;
+  top: 5px;
+  width: auto;
+  z-index: 100000;
+  /* Above WP toolbar. */
+}
+
+/* Do not show the outline on the skip link target. */
+#content[tabindex="-1"]:focus {
+  outline: 0;
+}
+
+/* Alignments */
+.alignleft {
+  float: left;
+  margin-right: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignleft {
+    margin-right: calc(2 * 1rem);
+  }
+}
+
+.alignright {
+  float: right;
+  margin-left: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .alignright {
+    margin-left: calc(2 * 1rem);
+  }
+}
+
+.aligncenter {
+  clear: both;
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+/* Clearings */
+.clear:before,
+.clear:after,
+.entry-content:before,
+.entry-content:after,
+.comment-content:before,
+.comment-content:after,
+.site-header:before,
+.site-header:after,
+.site-content:before,
+.site-content:after,
+.site-footer:before,
+.site-footer:after {
+  content: "";
+  display: table;
+  table-layout: fixed;
+}
+
+.clear:after,
+.entry-content:after,
+.comment-content:after,
+.site-header:after,
+.site-content:after,
+.site-footer:after {
+  clear: both;
+}
+
+/* Layout */
+/** === Layout === */
+#page {
+  overflow: hidden;
+  width: 100%;
+}
+
+.site-content {
+  overflow: hidden;
+}
+
+#main {
+  margin: auto;
+  max-width: 90%;
+  width: 1200px;
+}
+
+.single #main {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+@media only screen and (min-width: 768px) {
+  body:not(.newspack-front-page):not(.has-sidebar) .main-content {
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  body:not(.newspack-front-page):not(.has-sidebar) .main-content {
+    max-width: 65%;
+  }
+}
+
+/* Content */
+/*--------------------------------------------------------------
+## Header
+--------------------------------------------------------------*/
+.site-header {
+  padding: 1em;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-header {
+    margin: 0;
+    padding: 1rem 0 3rem;
+  }
+}
+
+.site-branding-container {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: auto;
+  max-width: 90%;
+  padding: 1rem 0;
+  width: 1200px;
+}
+
+@media only screen and (min-width: 768px) {
+  .site-branding-container {
+    flex-wrap: nowrap;
+    padding: 2rem 0;
+  }
+}
+
+.site-branding {
+  align-items: center;
+  color: #767676;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  position: relative;
+}
+
+.site-logo {
+  /* margin-bottom: calc(.66 * 1rem); */
+  width: 100%;
+}
+
+.site-logo .custom-logo-link {
+  box-sizing: content-box;
+  overflow: hidden;
+}
+
+.site-logo .custom-logo-link .custom-logo {
+  min-height: inherit;
+}
+
+.site-title {
+  color: #111;
+  margin: 0;
+}
+
+.site-title a {
+  color: #111;
+}
+
+.site-title a:link, .site-title a:visited {
+  color: #111;
+}
+
+.site-title a:hover {
+  color: #4a4a4a;
+}
+
+.site-title:not(:empty) + .site-description:not(:empty):before {
+  content: "\2014";
+  margin: 0 .2em;
+}
+
+.site-description {
+  color: #767676;
+  flex: 1 1 auto;
+  font-weight: normal;
+  font-size: 0.88889em;
+  margin: 7px 0 0;
+}
+
+/*--------------------------------------------------------------
+## Posts and pages
+--------------------------------------------------------------*/
+.sticky {
+  display: block;
+}
+
+.sticky-post {
+  background: #0073aa;
+  color: #fff;
+  display: inline-block;
+  font-weight: bold;
+  line-height: 1;
+  padding: .25rem;
+  position: absolute;
+  text-transform: uppercase;
+  top: -1rem;
+  z-index: 1;
+}
+
+.updated:not(.published) {
+  display: none;
+}
+
+.page-links {
+  clear: both;
+  margin: 0 0 calc(1.5 * 1rem);
+}
+
+.entry {
+  margin-top: calc(6 * 1rem);
+}
+
+.entry:first-of-type {
+  margin-top: 0;
+}
+
+.entry-header {
+  margin: calc(3 * 1rem) 0 1rem;
+  position: relative;
+}
+
+.entry-title {
+  margin: 0;
+}
+
+.entry-title a {
+  color: inherit;
+}
+
+.entry-title a:hover {
+  color: #4a4a4a;
+}
+
+.entry-meta,
+.entry-footer {
+  color: #767676;
+  font-weight: 500;
+}
+
+.entry-meta > span,
+.entry-footer > span {
+  margin-left: 1rem;
+  display: inline-block;
+}
+
+.entry-meta > span:last-child,
+.entry-footer > span:last-child {
+  margin-left: 0;
+}
+
+.entry-meta a,
+.entry-footer a {
+  transition: color 110ms ease-in-out;
+  color: inherit;
+}
+
+.entry-meta a:visited,
+.entry-footer a:visited {
+  color: inherit;
+}
+
+.entry-meta a:hover,
+.entry-footer a:hover {
+  text-decoration: none;
+  color: #005177;
+}
+
+.entry-meta .svg-icon,
+.entry-footer .svg-icon {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 0.5em;
+}
+
+.entry-meta {
+  margin: 1rem 0;
+}
+
+.entry-footer {
+  margin: calc(2 * 1rem) 0 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry-footer {
+    margin: 1rem 0 calc(3 * 1rem);
+  }
+}
+
+.post-thumbnail {
+  margin: 1rem 0;
+}
+
+.post-thumbnail:focus {
+  outline: none;
+}
+
+.post-thumbnail .post-thumbnail-inner {
+  display: block;
+}
+
+.post-thumbnail .post-thumbnail-inner img {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.entry-content p {
+  word-wrap: break-word;
+}
+
+.entry-content .more-link {
+  transition: color 110ms ease-in-out;
+  display: inline;
+  color: inherit;
+}
+
+.entry-content .more-link:after {
+  content: "\02192";
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
+.entry-content .more-link:hover {
+  color: #005177;
+  text-decoration: none;
+}
+
+.entry-content a {
+  text-decoration: underline;
+}
+
+.entry-content a.button, .entry-content a:hover {
+  text-decoration: none;
+}
+
+.entry-content a.button {
+  display: inline-block;
+}
+
+.entry-content a.button:hover {
+  background: #111;
+  color: #eee;
+  cursor: pointer;
+}
+
+.entry-content > iframe[style] {
+  margin: 32px 0 !important;
+  max-width: 100% !important;
+}
+
+.entry-content .page-links a {
+  margin: calc(0.5 * 1rem);
+  text-decoration: none;
+}
+
+.entry-content .wp-audio-shortcode {
+  max-width: calc(100vw - (2 * 1rem));
+}
+
+/* Single Post */
+.single-post .entry-header {
+  width: 100%;
+}
+
+.single-post .entry-title {
+  font-size: 2.8125em;
+}
+
+@media only screen and (min-width: 1168px) {
+  .single-post .entry-title {
+    font-size: 3.09375em;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .single-post .main-content {
+    flex-basis: calc( 65% - 24px);
+  }
+  .single-post #secondary {
+    flex-basis: calc( 35% - 24px);
+  }
+}
+
+.page.home .entry .entry-content {
+  max-width: 100%;
+}
+
+/* Hide page title on the homepage */
+.newspack-front-page.hide-homepage-title .entry-header {
+  display: none;
+}
+
+/* Author description */
+.author-bio {
+  margin: calc(2 * 1rem) 1rem 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .author-bio {
+    margin: calc(3 * 1rem) auto;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .author-bio {
+    margin: calc(3 * 1rem) auto;
+  }
+}
+
+.author-bio .author-title {
+  display: inline;
+}
+
+.author-bio .author-description {
+  display: inline;
+  color: #767676;
+  font-size: 1.125em;
+  line-height: 1.2;
+}
+
+.author-bio .author-description .author-link {
+  display: inline-block;
+}
+
+.author-bio .author-description .author-link:hover {
+  color: #005177;
+  text-decoration: none;
+}
+
+/*--------------------------------------------------------------
+## Comments
+--------------------------------------------------------------*/
+.comment-content a {
+  word-wrap: break-word;
+}
+
+.bypostauthor {
+  display: block;
+}
+
+.comments-area {
+  margin: calc(2 * 1rem) 1rem;
+  /* Add extra margin when the comments section is located immediately after the
+	 * post itself (this happens on pages).
+	 */
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area {
+    margin: calc(3 * 1rem) auto;
+  }
+}
+
+.comments-area > * {
+  margin-top: calc(2 * 1rem);
+  margin-bottom: calc(2 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area > * {
+    margin-top: calc(3 * 1rem);
+    margin-bottom: calc(3 * 1rem);
+  }
+}
+
+.entry + .comments-area {
+  margin-top: calc(3 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap {
+    align-items: baseline;
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.comments-area .comments-title-wrap .comments-title {
+  margin: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .comments-title {
+    flex: 1 0 calc(3 * (100vw / 12));
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comments-area .comments-title-wrap .discussion-meta {
+    flex: 0 0 calc(2 * (100vw / 12));
+    margin-right: 1rem;
+  }
+}
+
+#comment {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+#respond {
+  position: relative;
+}
+
+#respond .comment-user-avatar {
+  margin: 1rem 0 -1rem;
+}
+
+#respond .comment .comment-form {
+  padding-right: 0;
+}
+
+#respond > small {
+  display: block;
+  font-size: 20px;
+  position: absolute;
+  right: calc(1rem + 100%);
+  top: calc(-3.5 * 1rem);
+  width: calc(100vw / 12);
+}
+
+#comments > .comments-title:last-child {
+  display: none;
+}
+
+.comment-form-flex {
+  display: flex;
+  flex-direction: column;
+}
+
+.comment-form-flex .comments-title {
+  display: none;
+  margin: 0;
+  order: 1;
+}
+
+.comment-form-flex #respond {
+  order: 2;
+}
+
+.comment-form-flex #respond + .comments-title {
+  display: block;
+}
+
+.comment-list {
+  list-style: none;
+  padding: 0;
+}
+
+.comment-list .children {
+  margin: 0;
+  padding: 0 1rem 0 0;
+}
+
+.comment-list > .comment:first-child {
+  margin-top: 0;
+}
+
+.comment-list .pingback .comment-body,
+.comment-list .trackback .comment-body {
+  color: #767676;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.71111em;
+  font-weight: 500;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.comment-list .pingback .comment-body a:not(.comment-edit-link),
+.comment-list .trackback .comment-body a:not(.comment-edit-link) {
+  font-weight: bold;
+  font-size: 17.77778px;
+  line-height: 1.5;
+  padding-left: 0.5rem;
+  display: block;
+}
+
+.comment-list .pingback .comment-body .comment-edit-link,
+.comment-list .trackback .comment-body .comment-edit-link {
+  color: #767676;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 500;
+}
+
+#respond + .comment-reply {
+  display: none;
+}
+
+.comment-reply .comment-reply-link {
+  display: inline-block;
+}
+
+.comment {
+  list-style: none;
+  position: relative;
+}
+
+@media only screen and (min-width: 768px) {
+  .comment {
+    padding-right: calc(.5 * (1rem + calc(100vw / 12 )));
+  }
+  .comment.depth-1,
+  .comment .children {
+    padding-right: 0;
+  }
+  .comment.depth-1 {
+    margin-right: calc(3.25 * 1rem);
+  }
+}
+
+.comment .comment-body {
+  margin: calc(2 * 1rem) 0 0;
+}
+
+.comment .comment-meta {
+  position: relative;
+}
+
+.comment .comment-author .avatar {
+  float: right;
+  margin-left: 1rem;
+  position: relative;
+}
+
+@media only screen and (min-width: 768px) {
+  .comment .comment-author .avatar {
+    float: inherit;
+    margin-left: inherit;
+    position: absolute;
+    top: 0;
+    left: calc(100% + 1rem);
+  }
+}
+
+.comment .comment-author .fn {
+  position: relative;
+  display: block;
+}
+
+.comment .comment-author .fn a {
+  color: inherit;
+}
+
+.comment .comment-author .fn a:hover {
+  color: #005177;
+}
+
+.comment .comment-author .post-author-badge {
+  border-radius: 100%;
+  display: block;
+  height: 18px;
+  position: absolute;
+  background: #008fd3;
+  left: calc(100% - 2.5rem);
+  top: -3px;
+  width: 18px;
+}
+
+@media only screen and (min-width: 768px) {
+  .comment .comment-author .post-author-badge {
+    left: calc(100% + 0.75rem);
+  }
+}
+
+.comment .comment-author .post-author-badge svg {
+  width: inherit;
+  height: inherit;
+  display: block;
+  fill: white;
+  transform: scale(0.875);
+}
+
+.comment .comment-metadata > a,
+.comment .comment-metadata .comment-edit-link {
+  display: inline;
+  font-weight: 500;
+  color: #767676;
+  vertical-align: baseline;
+}
+
+.comment .comment-metadata > a time,
+.comment .comment-metadata .comment-edit-link time {
+  vertical-align: baseline;
+}
+
+.comment .comment-metadata > a:hover,
+.comment .comment-metadata .comment-edit-link:hover {
+  color: #005177;
+  text-decoration: none;
+}
+
+.comment .comment-metadata > * {
+  display: inline-block;
+}
+
+.comment .comment-metadata .edit-link-sep {
+  color: #767676;
+  margin: 0 0.2em;
+  vertical-align: baseline;
+}
+
+.comment .comment-metadata .edit-link {
+  color: #767676;
+}
+
+.comment .comment-metadata .edit-link svg {
+  transform: scale(0.8);
+  vertical-align: baseline;
+  margin-left: 0.1em;
+}
+
+.comment .comment-metadata .comment-edit-link {
+  position: relative;
+  padding-right: 1rem;
+  margin-right: -1rem;
+  z-index: 1;
+}
+
+.comment .comment-metadata .comment-edit-link:hover {
+  color: #0073aa;
+}
+
+.comment .comment-content {
+  margin: 1rem 0;
+}
+
+@media only screen and (min-width: 1168px) {
+  .comment .comment-content {
+    padding-left: 1rem;
+  }
+}
+
+.comment .comment-content > *:first-child {
+  margin-top: 0;
+}
+
+.comment .comment-content > *:last-child {
+  margin-bottom: 0;
+}
+
+.comment .comment-content blockquote {
+  margin-right: 0;
+}
+
+.comment .comment-content a {
+  text-decoration: underline;
+}
+
+.comment .comment-content a:hover {
+  text-decoration: none;
+}
+
+.comment-reply-link,
+#cancel-comment-reply-link {
+  font-weight: 500;
+}
+
+.comment-reply-link:hover,
+#cancel-comment-reply-link:hover {
+  color: #005177;
+}
+
+.discussion-avatar-list {
+  content: "";
+  display: table;
+  table-layout: fixed;
+  margin: 0;
+  padding: 0;
+}
+
+.discussion-avatar-list li {
+  position: relative;
+  list-style: none;
+  margin: 0 0 0 -8px;
+  padding: 0;
+  float: right;
+}
+
+.discussion-avatar-list .comment-user-avatar img {
+  height: calc(1.5 * 1rem);
+  width: calc(1.5 * 1rem);
+}
+
+.discussion-meta .discussion-meta-info {
+  margin: 0;
+}
+
+.discussion-meta .discussion-meta-info .svg-icon {
+  vertical-align: middle;
+  fill: currentColor;
+  transform: scale(0.6) scaleX(-1) translateY(-0.1em);
+  margin-right: -0.25rem;
+}
+
+.comment-form .comment-notes,
+.comment-form label {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.71111em;
+  color: #767676;
+}
+
+@media only screen and (min-width: 768px) {
+  .comment-form .comment-form-author,
+  .comment-form .comment-form-email {
+    width: calc(50% - 0.5rem);
+    float: right;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .comment-form .comment-form-email {
+    margin-right: 1rem;
+  }
+}
+
+.comment-form input[name="author"],
+.comment-form input[name="email"],
+.comment-form input[name="url"] {
+  display: block;
+  width: 100%;
+}
+
+/*--------------------------------------------------------------
+## Archives
+--------------------------------------------------------------*/
+.archive .page-header,
+.search .page-header {
+  margin: 1rem 0 calc(3 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .archive .page-header,
+  .search .page-header {
+    margin: 0 0 calc(10% + 60px);
+  }
+}
+
+.archive .page-header .page-title,
+.search .page-header .page-title {
+  color: #767676;
+  display: inline;
+  letter-spacing: normal;
+}
+
+.archive .page-header .page-title:before,
+.search .page-header .page-title:before {
+  display: none;
+}
+
+.archive .page-header .search-term,
+.archive .page-header .page-description,
+.search .page-header .search-term,
+.search .page-header .page-description {
+  display: inherit;
+  clear: both;
+}
+
+.archive .page-header .search-term:after,
+.archive .page-header .page-description:after,
+.search .page-header .search-term:after,
+.search .page-header .page-description:after {
+  content: ".";
+  font-weight: bold;
+  color: #767676;
+}
+
+.archive .page-header .page-description {
+  display: block;
+  color: #111;
+  font-size: 1em;
+}
+
+/* 404 & Not found */
+.error-404.not-found .page-header,
+.error-404.not-found .page-content,
+.no-results.not-found .page-header,
+.no-results.not-found .page-content {
+  margin: calc(3 * 1rem) 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .error-404.not-found .page-header,
+  .error-404.not-found .page-content,
+  .no-results.not-found .page-header,
+  .no-results.not-found .page-content {
+    margin: calc(3 * 1rem) calc(10% + 60px) calc(1rem / 2);
+  }
+}
+
+.error-404.not-found .search-submit,
+.no-results.not-found .search-submit {
+  vertical-align: middle;
+  margin: 1rem 0;
+}
+
+.error-404.not-found .search-field,
+.no-results.not-found .search-field {
+  width: 100%;
+}
+
+/*--------------------------------------------------------------
+## Footer
+--------------------------------------------------------------*/
+/* Site footer */
+#colophon .widget-area,
+#colophon .site-info {
+  margin: calc(2 * 1rem) auto;
+  max-width: 90%;
+  width: 1200px;
+}
+
+@media only screen and (min-width: 768px) {
+  #colophon .widget-area,
+  #colophon .site-info {
+    margin: calc(3 * 1rem) auto;
+  }
+}
+
+#colophon .widget-column {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+#colophon .widget-column .widget {
+  width: 100%;
+}
+
+@media only screen and (min-width: 1168px) {
+  #colophon .widget-column .widget {
+    margin-left: calc(3 * 1rem);
+    width: calc(33% - (3 * 1rem));
+  }
+}
+
+#colophon .site-info {
+  color: #767676;
+}
+
+#colophon .site-info a {
+  color: inherit;
+}
+
+#colophon .site-info a:hover {
+  text-decoration: none;
+  color: #005177;
+}
+
+#colophon .site-info .imprint,
+#colophon .site-info .privacy-policy-link {
+  margin-left: 1rem;
+}
+
+/* Widgets */
+.widget {
+  margin: 0 0 1rem;
+  /* Make sure select elements fit in widgets. */
+}
+
+.widget select {
+  max-width: 100%;
+}
+
+.widget a {
+  color: #0073aa;
+}
+
+.widget a:hover {
+  color: #005177;
+}
+
+.widget_archive ul,
+.widget_categories ul,
+.widget_meta ul,
+.widget_nav_menu ul,
+.widget_pages ul,
+.widget_recent_comments ul,
+.widget_recent_entries ul,
+.widget_rss ul {
+  padding: 0;
+  list-style: none;
+}
+
+.widget_archive ul li,
+.widget_categories ul li,
+.widget_meta ul li,
+.widget_nav_menu ul li,
+.widget_pages ul li,
+.widget_recent_comments ul li,
+.widget_recent_entries ul li,
+.widget_rss ul li {
+  color: #767676;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: calc(20px * 1.125);
+  font-weight: 700;
+  line-height: 1.2;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.widget_archive ul ul,
+.widget_categories ul ul,
+.widget_meta ul ul,
+.widget_nav_menu ul ul,
+.widget_pages ul ul,
+.widget_recent_comments ul ul,
+.widget_recent_entries ul ul,
+.widget_rss ul ul {
+  counter-reset: submenu;
+}
+
+.widget_archive ul ul > li > a::before,
+.widget_categories ul ul > li > a::before,
+.widget_meta ul ul > li > a::before,
+.widget_nav_menu ul ul > li > a::before,
+.widget_pages ul ul > li > a::before,
+.widget_recent_comments ul ul > li > a::before,
+.widget_recent_entries ul ul > li > a::before,
+.widget_rss ul ul > li > a::before {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.widget_tag_cloud .tagcloud {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: 700;
+}
+
+.widget_search .search-field {
+  width: 100%;
+}
+
+@media only screen and (min-width: 600px) {
+  .widget_search .search-field {
+    width: auto;
+  }
+}
+
+.widget_search .search-submit {
+  display: block;
+  margin-top: 1rem;
+}
+
+.widget_calendar .calendar_wrap {
+  text-align: center;
+}
+
+.widget_calendar .calendar_wrap table td,
+.widget_calendar .calendar_wrap table th {
+  border: none;
+}
+
+.widget_calendar .calendar_wrap a {
+  text-decoration: underline;
+}
+
+/* Blocks */
+/* !Block styles */
+.entry .entry-content > *,
+.entry .entry-summary > * {
+  margin: 32px 0;
+  max-width: 100%;
+}
+
+.entry .entry-content > * > *:first-child,
+.entry .entry-summary > * > *:first-child {
+  margin-top: 0;
+}
+
+.entry .entry-content > * > *:last-child,
+.entry .entry-summary > * > *:last-child {
+  margin-bottom: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignwide,
+  .entry .entry-summary > *.alignwide {
+    margin-left: -53%;
+    max-width: 100vw;
+  }
+}
+
+.entry .entry-content > *.alignfull,
+.entry .entry-summary > *.alignfull {
+  margin-right: calc(50% - 50vw);
+  margin-left: calc(50% - 50vw);
+  max-width: 100vw;
+  position: relative;
+  width: 100vw;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignfull,
+  .entry .entry-summary > *.alignfull {
+    clear: both;
+    margin-right: calc(77% - 50vw);
+    margin-left: auto;
+  }
+}
+
+.entry .entry-content > *.alignleft,
+.entry .entry-summary > *.alignleft {
+  float: left;
+  max-width: calc(5 * (100vw / 12));
+  margin-top: 0;
+  margin-right: 0;
+  margin-right: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignleft,
+  .entry .entry-summary > *.alignleft {
+    max-width: calc(4 * (100vw / 12));
+    margin-right: calc(2 * 1rem);
+  }
+}
+
+.entry .entry-content > *.alignright,
+.entry .entry-summary > *.alignright {
+  float: right;
+  max-width: calc(5 * (100vw / 12));
+  margin-top: 0;
+  margin-left: 0;
+  margin-left: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.alignright,
+  .entry .entry-summary > *.alignright {
+    max-width: calc(4 * (100vw / 12));
+    margin-left: 0;
+    margin-left: calc(2 * 1rem);
+  }
+}
+
+.entry .entry-content > *.aligncenter,
+.entry .entry-summary > *.aligncenter {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content > *.aligncenter,
+  .entry .entry-summary > *.aligncenter {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignwide {
+    margin-right: calc(25% - 25vw);
+    margin-left: calc(25% - 25vw);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .newspack-front-page .entry .entry-content > *.alignfull {
+    margin-right: calc(50% - 50vw);
+    margin-left: calc(50% - 50vw);
+  }
+}
+
+/*
+ * Unset nested content selector styles
+ * - Prevents layout styles from cascading too deeply
+ * - helps with plugin compatibility
+ */
+.entry .entry-content .entry-content,
+.entry .entry-content .entry-summary,
+.entry .entry-content .entry,
+.entry .entry-summary .entry-content,
+.entry .entry-summary .entry-summary,
+.entry .entry-summary .entry {
+  margin: inherit;
+  max-width: inherit;
+  padding: inherit;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .entry-content,
+  .entry .entry-content .entry-summary,
+  .entry .entry-content .entry,
+  .entry .entry-summary .entry-content,
+  .entry .entry-summary .entry-summary,
+  .entry .entry-summary .entry {
+    margin: inherit;
+    max-width: inherit;
+    padding: inherit;
+  }
+}
+
+.entry .entry-content p.has-background {
+  padding: 20px 30px;
+}
+
+.entry .entry-content .wp-block-audio {
+  width: 100%;
+}
+
+.entry .entry-content .wp-block-audio audio {
+  width: 100%;
+}
+
+.entry .entry-content .wp-block-audio.alignleft audio,
+.entry .entry-content .wp-block-audio.alignright audio {
+  max-width: 198px;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
+    max-width: 384px;
+  }
+}
+
+@media only screen and (min-width: 1379px) {
+  .entry .entry-content .wp-block-audio.alignleft audio,
+  .entry .entry-content .wp-block-audio.alignright audio {
+    max-width: 385.44px;
+  }
+}
+
+.entry .entry-content .wp-block-video video {
+  width: 100%;
+}
+
+.entry .entry-content .wp-block-button .wp-block-button__link {
+  transition: background 150ms ease-in-out;
+  border: none;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.88889em;
+  line-height: 1.2;
+  box-sizing: border-box;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 0.76rem 1rem;
+  outline: none;
+  outline: none;
+}
+
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
+  background-color: #0073aa;
+}
+
+.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
+  color: white;
+}
+
+.entry .entry-content .wp-block-button .wp-block-button__link:hover {
+  color: white;
+  background: #111;
+  cursor: pointer;
+}
+
+.entry .entry-content .wp-block-button .wp-block-button__link:focus {
+  color: white;
+  background: #111;
+  outline: thin dotted;
+  outline-offset: -4px;
+}
+
+.entry .entry-content .wp-block-button:not(.is-style-squared) .wp-block-button__link {
+  border-radius: 5px;
+}
+
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus,
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active {
+  transition: all 150ms ease-in-out;
+  border-width: 2px;
+  border-style: solid;
+}
+
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-background),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-background) {
+  background: transparent;
+}
+
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
+  color: #0073aa;
+  border-color: currentColor;
+}
+
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover {
+  color: white;
+  border-color: #111;
+}
+
+.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:hover:not(.has-background) {
+  color: #111;
+}
+
+.entry .entry-content .wp-block-archives,
+.entry .entry-content .wp-block-categories,
+.entry .entry-content .wp-block-latest-posts {
+  padding: 0;
+  list-style: none;
+}
+
+.entry .entry-content .wp-block-archives li,
+.entry .entry-content .wp-block-categories li,
+.entry .entry-content .wp-block-latest-posts li {
+  color: #767676;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: calc(20px * 1.125);
+  font-weight: bold;
+  line-height: 1.2;
+  padding-bottom: 0.75rem;
+}
+
+.entry .entry-content .wp-block-archives li.menu-item-has-children, .entry .entry-content .wp-block-archives li:last-child,
+.entry .entry-content .wp-block-categories li.menu-item-has-children,
+.entry .entry-content .wp-block-categories li:last-child,
+.entry .entry-content .wp-block-latest-posts li.menu-item-has-children,
+.entry .entry-content .wp-block-latest-posts li:last-child {
+  padding-bottom: 0;
+}
+
+.entry .entry-content .wp-block-archives li a,
+.entry .entry-content .wp-block-categories li a,
+.entry .entry-content .wp-block-latest-posts li a {
+  text-decoration: none;
+}
+
+.entry .entry-content .wp-block-archives.aligncenter,
+.entry .entry-content .wp-block-categories.aligncenter {
+  text-align: center;
+}
+
+.entry .entry-content .wp-block-categories ul {
+  padding-top: 0.75rem;
+}
+
+.entry .entry-content .wp-block-categories li ul {
+  list-style: none;
+  padding-right: 0;
+}
+
+.entry .entry-content .wp-block-categories ul {
+  counter-reset: submenu;
+}
+
+.entry .entry-content .wp-block-categories ul > li > a::before {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: normal;
+  content: "– " counters(submenu, "– ", none);
+  counter-increment: submenu;
+}
+
+.entry .entry-content .wp-block-latest-posts.is-grid li {
+  border-top: 2px solid #ccc;
+  padding-top: 1rem;
+  margin-bottom: 2rem;
+}
+
+.entry .entry-content .wp-block-latest-posts.is-grid li a:after {
+  content: '';
+}
+
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child {
+  margin-bottom: auto;
+}
+
+.entry .entry-content .wp-block-latest-posts.is-grid li:last-child a:after {
+  content: '';
+}
+
+.entry .entry-content .wp-block-preformatted {
+  font-size: 0.71111em;
+  line-height: 1.8;
+  padding: 1rem;
+}
+
+.entry .entry-content .wp-block-verse {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 20px;
+  line-height: 1.8;
+}
+
+.entry .entry-content .has-drop-cap:not(:focus):first-letter {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 2.8125em;
+  line-height: 1;
+  font-weight: bold;
+  margin: 0 0 0 0.25em;
+}
+
+.entry .entry-content .wp-block-pullquote {
+  border-color: transparent;
+  border-width: 2px;
+  padding: 1rem;
+}
+
+.entry .entry-content .wp-block-pullquote blockquote {
+  color: #111;
+  border: none;
+  margin-top: calc(4 * 1rem);
+  margin-bottom: calc(4.33 * 1rem);
+  margin-left: 0;
+  padding-right: 0;
+}
+
+.entry .entry-content .wp-block-pullquote p {
+  font-size: 1.40625em;
+  font-style: italic;
+  line-height: 1.3;
+  margin-bottom: 0.5em;
+  margin-top: 0.5em;
+}
+
+.entry .entry-content .wp-block-pullquote p em {
+  font-style: normal;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote p {
+    font-size: 1.6875em;
+  }
+}
+
+.entry .entry-content .wp-block-pullquote cite {
+  display: inline-block;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  line-height: 1.6;
+  text-transform: none;
+  color: #767676;
+  /*
+			 * This requires a rem-based font size calculation instead of our normal em-based one,
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+			 */
+  font-size: calc(1rem / (1.25 * 1.125));
+}
+
+.entry .entry-content .wp-block-pullquote.alignleft, .entry .entry-content .wp-block-pullquote.alignright {
+  width: 100%;
+  padding: 0;
+}
+
+.entry .entry-content .wp-block-pullquote.alignleft blockquote, .entry .entry-content .wp-block-pullquote.alignright blockquote {
+  margin: 1rem 0;
+  padding: 0;
+  text-align: right;
+  max-width: 100%;
+}
+
+.entry .entry-content .wp-block-pullquote.alignleft blockquote p:first-child, .entry .entry-content .wp-block-pullquote.alignright blockquote p:first-child {
+  margin-top: 0;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color {
+  background-color: #0073aa;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color {
+    padding-right: 10%;
+    padding-left: 10%;
+  }
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+  font-size: 1.40625em;
+  line-height: 1.3;
+  margin-bottom: 0.5em;
+  margin-top: 0.5em;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color p {
+    font-size: 1.6875em;
+  }
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color a {
+  color: #eee;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color cite {
+  color: inherit;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+  max-width: 100%;
+  color: #eee;
+  padding-right: 0;
+  margin-right: 1rem;
+  margin-left: 1rem;
+}
+
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color p,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-text-color a, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color, .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+  color: inherit;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignright, .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignleft {
+    padding: 1rem calc(2 * 1rem);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-pullquote.is-style-solid-color.alignfull {
+    padding-right: calc(10% + 58px + (2 * 1rem));
+    padding-left: calc(10% + 58px + (2 * 1rem));
+  }
+}
+
+.entry .entry-content .wp-block-quote:not(.is-large), .entry .entry-content .wp-block-quote:not(.is-style-large) {
+  border-width: 2px;
+  border-color: #666;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.entry .entry-content .wp-block-quote p {
+  font-size: 1em;
+  font-style: normal;
+  line-height: 1.8;
+}
+
+.entry .entry-content .wp-block-quote cite {
+  /*
+			 * This requires a rem-based font size calculation instead of our normal em-based one,
+			 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+			 */
+  font-size: calc(1rem / (1.25 * 1.125));
+}
+
+.entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+  margin: 1rem 0;
+  padding: 0;
+  border-right: none;
+}
+
+.entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+  font-size: 1.40625em;
+  line-height: 1.4;
+  font-style: italic;
+}
+
+.entry .entry-content .wp-block-quote.is-large cite,
+.entry .entry-content .wp-block-quote.is-large footer, .entry .entry-content .wp-block-quote.is-style-large cite,
+.entry .entry-content .wp-block-quote.is-style-large footer {
+  /*
+				 * This requires a rem-based font size calculation instead of our normal em-based one,
+				 * because the cite tag sometimes gets wrapped in a p tag. This is equivalent to $font-size_xs.
+				 */
+  font-size: calc(1rem / (1.25 * 1.125));
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-quote.is-large, .entry .entry-content .wp-block-quote.is-style-large {
+    margin: 1rem 0;
+    padding: 1rem 0;
+  }
+  .entry .entry-content .wp-block-quote.is-large p, .entry .entry-content .wp-block-quote.is-style-large p {
+    font-size: 1.40625em;
+  }
+}
+
+.entry .entry-content .wp-block-image img {
+  display: block;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-image .aligncenter {
+    margin: 0;
+  }
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-image .aligncenter img {
+    margin: 0 auto;
+  }
+}
+
+.entry .entry-content .wp-block-image.alignfull img {
+  width: 100vw;
+  max-width: 100vw;
+}
+
+.entry .entry-content .wp-block-image.alignwide {
+  max-width: 100vw;
+}
+
+.entry .entry-content .wp-block-cover-image,
+.entry .entry-content .wp-block-cover {
+  position: relative;
+  min-height: 430px;
+  padding: 1rem;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image,
+  .entry .entry-content .wp-block-cover {
+    padding: 1rem 10%;
+  }
+}
+
+.entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+.entry .entry-content .wp-block-cover-image h2,
+.entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+.entry .entry-content .wp-block-cover .wp-block-cover-text,
+.entry .entry-content .wp-block-cover h2 {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 1.40625em;
+  font-weight: bold;
+  line-height: 1.25;
+  padding: 0;
+  color: #fff;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image h2,
+  .entry .entry-content .wp-block-cover .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover h2 {
+    font-size: 1.6875em;
+    max-width: 100%;
+  }
+}
+
+.entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+.entry .entry-content .wp-block-cover.alignleft,
+.entry .entry-content .wp-block-cover.alignright {
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignleft, .entry .entry-content .wp-block-cover-image.alignright,
+  .entry .entry-content .wp-block-cover.alignleft,
+  .entry .entry-content .wp-block-cover.alignright {
+    padding: 1rem calc(2 * 1rem);
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover-image.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover-image.alignfull h2,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-image-text,
+  .entry .entry-content .wp-block-cover.alignfull .wp-block-cover-text,
+  .entry .entry-content .wp-block-cover.alignfull h2 {
+    padding: 0;
+  }
+}
+
+.entry .entry-content .wp-block-cover-image.alignwide,
+.entry .entry-content .wp-block-cover.alignwide {
+  width: auto;
+}
+
+.entry .entry-content .wp-block-gallery {
+  list-style-type: none;
+  padding-right: 0;
+}
+
+.entry .entry-content .wp-block-gallery .blocks-gallery-image:last-child,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item:last-child {
+  margin-bottom: 16px;
+}
+
+.entry .entry-content .wp-block-gallery figcaption a {
+  color: #fff;
+}
+
+.entry .entry-content .wp-block-audio figcaption,
+.entry .entry-content .wp-block-video figcaption,
+.entry .entry-content .wp-block-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-image figcaption,
+.entry .entry-content .wp-block-gallery .blocks-gallery-item figcaption {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.71111em;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.entry .entry-content .wp-block-separator,
+.entry .entry-content hr {
+  background-color: #767676;
+  border: 0;
+  height: 2px;
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+  max-width: 2.25em;
+  text-align: right;
+  /* Remove duplicate rule-line when a separator
+		 * is followed by an H1, or H2 */
+}
+
+.entry .entry-content .wp-block-separator.is-style-wide,
+.entry .entry-content hr.is-style-wide {
+  max-width: 100%;
+}
+
+.entry .entry-content .wp-block-separator.is-style-dots,
+.entry .entry-content hr.is-style-dots {
+  max-width: 100%;
+  background-color: inherit;
+  border: inherit;
+  height: inherit;
+  text-align: center;
+}
+
+.entry .entry-content .wp-block-separator.is-style-dots:before,
+.entry .entry-content hr.is-style-dots:before {
+  color: #767676;
+  font-size: 1.40625em;
+  letter-spacing: 0.88889em;
+  padding-right: 0.88889em;
+}
+
+.entry .entry-content .wp-block-separator + h1:before,
+.entry .entry-content .wp-block-separator + h2:before,
+.entry .entry-content hr + h1:before,
+.entry .entry-content hr + h2:before {
+  display: none;
+}
+
+.entry .entry-content .wp-block-embed-twitter {
+  word-break: break-word;
+}
+
+.entry .entry-content .wp-block-table th,
+.entry .entry-content .wp-block-table td {
+  border-color: #767676;
+}
+
+.entry .entry-content .wp-block-file {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
+.entry .entry-content .wp-block-file .wp-block-file__button {
+  display: table;
+  transition: background 150ms ease-in-out;
+  border: none;
+  border-radius: 5px;
+  background: #0073aa;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 20px;
+  line-height: 1.2;
+  text-decoration: none;
+  font-weight: bold;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  margin-right: 0;
+  margin-top: calc(0.75 * 1rem);
+}
+
+@media only screen and (min-width: 1168px) {
+  .entry .entry-content .wp-block-file .wp-block-file__button {
+    font-size: 20px;
+    padding: 0.875rem 1.5rem;
+  }
+}
+
+.entry .entry-content .wp-block-file .wp-block-file__button:hover {
+  background: #111;
+  cursor: pointer;
+}
+
+.entry .entry-content .wp-block-file .wp-block-file__button:focus {
+  background: #111;
+  outline: thin dotted;
+  outline-offset: -4px;
+}
+
+.entry .entry-content .wp-block-code {
+  border-radius: 0;
+}
+
+.entry .entry-content .wp-block-code code {
+  font-size: 1.125em;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.entry .entry-content .wp-block-columns.alignfull {
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+
+@media only screen and (min-width: 600px) {
+  .entry .entry-content .wp-block-columns {
+    flex-wrap: nowrap;
+  }
+}
+
+@media only screen and (min-width: 768px) {
+  .entry .entry-content .wp-block-columns .wp-block-column > *:first-child {
+    margin-top: 0;
+  }
+  .entry .entry-content .wp-block-columns .wp-block-column > *:last-child {
+    margin-bottom: 0;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > * {
+    margin-left: 1rem;
+  }
+  .entry .entry-content .wp-block-columns[class*='has-'] > *:last-child {
+    margin-left: 0;
+  }
+  .entry .entry-content .wp-block-columns.alignfull,
+  .entry .entry-content .wp-block-columns.alignfull .wp-block-column {
+    padding-right: calc(2 * 1rem);
+    padding-left: calc(2 * 1rem);
+  }
+}
+
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta {
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-weight: bold;
+}
+
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-meta .wp-block-latest-comments__comment-date {
+  font-weight: normal;
+}
+
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-date,
+.entry .entry-content .wp-block-latest-comments .wp-block-latest-comments__comment-excerpt p {
+  font-size: inherit;
+}
+
+.entry .entry-content .wp-block-latest-comments.has-dates .wp-block-latest-comments__comment-date {
+  font-size: 0.71111em;
+}
+
+.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
+.entry .entry-content .has-small-font-size {
+  font-size: 0.88889em;
+}
+
+.entry .entry-content .has-normal-font-size {
+  font-size: 1.125em;
+}
+
+.entry .entry-content .has-large-font-size {
+  font-size: 1.40625em;
+}
+
+.entry .entry-content .has-huge-font-size {
+  font-size: 1.6875em;
+}
+
+.entry .entry-content .has-primary-background-color,
+.entry .entry-content .has-primary-variation-background-color,
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-secondary-variation-background-color {
+  color: #eee;
+}
+
+.entry .entry-content .has-primary-background-color p,
+.entry .entry-content .has-primary-background-color h1,
+.entry .entry-content .has-primary-background-color h2,
+.entry .entry-content .has-primary-background-color h3,
+.entry .entry-content .has-primary-background-color h4,
+.entry .entry-content .has-primary-background-color h5,
+.entry .entry-content .has-primary-background-color h6,
+.entry .entry-content .has-primary-background-color a,
+.entry .entry-content .has-primary-variation-background-color p,
+.entry .entry-content .has-primary-variation-background-color h1,
+.entry .entry-content .has-primary-variation-background-color h2,
+.entry .entry-content .has-primary-variation-background-color h3,
+.entry .entry-content .has-primary-variation-background-color h4,
+.entry .entry-content .has-primary-variation-background-color h5,
+.entry .entry-content .has-primary-variation-background-color h6,
+.entry .entry-content .has-primary-variation-background-color a,
+.entry .entry-content .has-secondary-background-color p,
+.entry .entry-content .has-secondary-background-color h1,
+.entry .entry-content .has-secondary-background-color h2,
+.entry .entry-content .has-secondary-background-color h3,
+.entry .entry-content .has-secondary-background-color h4,
+.entry .entry-content .has-secondary-background-color h5,
+.entry .entry-content .has-secondary-background-color h6,
+.entry .entry-content .has-secondary-background-color a,
+.entry .entry-content .has-secondary-variation-background-color p,
+.entry .entry-content .has-secondary-variation-background-color h1,
+.entry .entry-content .has-secondary-variation-background-color h2,
+.entry .entry-content .has-secondary-variation-background-color h3,
+.entry .entry-content .has-secondary-variation-background-color h4,
+.entry .entry-content .has-secondary-variation-background-color h5,
+.entry .entry-content .has-secondary-variation-background-color h6,
+.entry .entry-content .has-secondary-variation-background-color a {
+  color: #eee;
+}
+
+.entry .entry-content .has-white-background-color {
+  color: #111;
+}
+
+.entry .entry-content .has-white-background-color p,
+.entry .entry-content .has-white-background-color h1,
+.entry .entry-content .has-white-background-color h2,
+.entry .entry-content .has-white-background-color h3,
+.entry .entry-content .has-white-background-color h4,
+.entry .entry-content .has-white-background-color h5,
+.entry .entry-content .has-white-background-color h6,
+.entry .entry-content .has-white-background-color a {
+  color: #111;
+}
+
+.entry .entry-content .has-primary-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
+  background-color: #0073aa;
+}
+
+.entry .entry-content .has-primary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
+  background-color: #005177;
+}
+
+.entry .entry-content .has-secondary-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+  background-color: #666;
+}
+
+.entry .entry-content .has-secondary-variation-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-variation-background-color {
+  background-color: #4d4d4d;
+}
+
+.entry .entry-content .has-white-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-white-background-color {
+  background-color: #FFF;
+}
+
+.entry .entry-content .has-primary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+  color: #0073aa;
+}
+
+.entry .entry-content .has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
+  color: #005177;
+}
+
+.entry .entry-content .has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+  color: #666;
+}
+
+.entry .entry-content .has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+  color: #4d4d4d;
+}
+
+.entry .entry-content .has-white-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+  color: #FFF;
+}
+
+@media only screen and (min-width: 768px) {
+  .single.has-sidebar .entry .entry-content > *.alignwide,
+  .single.has-sidebar .entry .entry-summary > *.alignwide {
+    margin-left: 0;
+    max-width: 100%;
+  }
+}
+
+.single.has-sidebar .entry .entry-content > *.alignfull,
+.single.has-sidebar .entry .entry-summary > *.alignfull {
+  margin-right: 0;
+  margin-left: 0;
+  max-width: 100%;
+  width: 100%;
+}
+
+@media only screen and (min-width: 768px) {
+  .single.has-sidebar .entry .entry-content > *.alignfull,
+  .single.has-sidebar .entry .entry-summary > *.alignfull {
+    margin-right: 0;
+  }
+}
+
+/* Media */
+.page-content .wp-smiley,
+.entry-content .wp-smiley,
+.comment-content .wp-smiley {
+  border: none;
+  margin-bottom: 0;
+  margin-top: 0;
+  padding: 0;
+}
+
+embed,
+iframe,
+object {
+  max-width: 100%;
+}
+
+.custom-logo-link {
+  display: inline-block;
+}
+
+.avatar {
+  border-radius: 100%;
+  display: block;
+  height: calc(2.25 * 1rem);
+  min-height: inherit;
+  width: calc(2.25 * 1rem);
+}
+
+svg {
+  transition: fill 120ms ease-in-out;
+  fill: currentColor;
+}
+
+/*--------------------------------------------------------------
+## Captions
+--------------------------------------------------------------*/
+.wp-caption {
+  margin-bottom: calc(1.5 * 1rem);
+}
+
+@media only screen and (min-width: 768px) {
+  .wp-caption.aligncenter {
+    position: relative;
+    right: calc( 65% / 2);
+    transform: translateX(50%);
+  }
+}
+
+@media only screen and (min-width: 1168px) {
+  .wp-caption.aligncenter {
+    right: calc( 65% / 2);
+  }
+}
+
+.wp-caption img[class*="wp-image-"] {
+  display: block;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.wp-caption-text {
+  color: #767676;
+  font-size: 0.71111em;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+/*--------------------------------------------------------------
+## Galleries
+--------------------------------------------------------------*/
+.gallery {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  margin-bottom: calc(1.5 * 1rem);
+}
+
+.gallery-item {
+  display: inline-block;
+  margin-left: 16px;
+  margin-bottom: 16px;
+  text-align: center;
+  vertical-align: top;
+  width: 100%;
+}
+
+.gallery-columns-2 .gallery-item {
+  max-width: calc((100% - 16px * 1) / 2);
+}
+
+.gallery-columns-2 .gallery-item:nth-of-type(2n+2) {
+  margin-left: 0;
+}
+
+.gallery-columns-3 .gallery-item {
+  max-width: calc((100% - 16px * 2) / 3);
+}
+
+.gallery-columns-3 .gallery-item:nth-of-type(3n+3) {
+  margin-left: 0;
+}
+
+.gallery-columns-4 .gallery-item {
+  max-width: calc((100% - 16px * 3) / 4);
+}
+
+.gallery-columns-4 .gallery-item:nth-of-type(4n+4) {
+  margin-left: 0;
+}
+
+.gallery-columns-5 .gallery-item {
+  max-width: calc((100% - 16px * 4) / 5);
+}
+
+.gallery-columns-5 .gallery-item:nth-of-type(5n+5) {
+  margin-left: 0;
+}
+
+.gallery-columns-6 .gallery-item {
+  max-width: calc((100% - 16px * 5) / 6);
+}
+
+.gallery-columns-6 .gallery-item:nth-of-type(6n+6) {
+  margin-left: 0;
+}
+
+.gallery-columns-7 .gallery-item {
+  max-width: calc((100% - 16px * 6) / 7);
+}
+
+.gallery-columns-7 .gallery-item:nth-of-type(7n+7) {
+  margin-left: 0;
+}
+
+.gallery-columns-8 .gallery-item {
+  max-width: calc((100% - 16px * 7) / 8);
+}
+
+.gallery-columns-8 .gallery-item:nth-of-type(8n+8) {
+  margin-left: 0;
+}
+
+.gallery-columns-9 .gallery-item {
+  max-width: calc((100% - 16px * 8) / 9);
+}
+
+.gallery-columns-9 .gallery-item:nth-of-type(9n+9) {
+  margin-left: 0;
+}
+
+.gallery-item:last-of-type {
+  padding-left: 0;
+}
+
+.gallery-caption {
+  display: block;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 0.71111em;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0.5rem;
+}
+
+.gallery-item > div > a {
+  display: block;
+  line-height: 0;
+  box-shadow: 0 0 0 0 transparent;
+}
+
+.gallery-item > div > a:focus {
+  box-shadow: 0 0 0 2px #0073aa;
+}
+
+/* Style pack-specific overrides */
+#colophon .widget-title,
+.article-section-title {
+  border-bottom: 4px solid;
+  font-family: "IBM Plex Serif", Georgia, serif;
+  font-size: 1em;
+}
+
+.wp-block-newspack-blocks-homepage-articles:not(.is-grid) article:not(:last-of-type) {
+  border-bottom: 2px solid #e1e1e1;
+  padding-bottom: 1em;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Rather than layering RTL styles on top of the existing style.css, the Newspack theme follow's Twenty Nineteen's approach and generates a completely separate stylesheet (which is much easier for managing changes and making sure things aren't missed!).

This PR adds a line in the build process for generating an RTL stylesheet for Style 1, and adds the initial styles.

Closes #48.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customizer > Style Pack, and switch to Style 1.
3. View the RTL version of the styles. The easiest way to do this is installing and activating RTL Tester (https://wordpress.org/plugins/rtl-tester/), and click 'Switch to RTL' in the admin toolbar.
4. Confirm that the site still looks like style pack 1 (light grey background, all fonts serif). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
