### PR TITLE
Fix PHP Warning

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -297,7 +297,7 @@ add_action( 'enqueue_block_editor_assets', 'newspack_editor_customizer_styles' )
 function newspack_is_static_front_page() {
 	global $post;
 	$page_on_front = intval( get_option( 'page_on_front' ) );
-	return intval( $post->ID ) === $page_on_front;
+	return isset( $post->ID ) && intval( $post->ID ) === $page_on_front;
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a regression that introduced a PHP Warning that appears on any admin page that doesn't have a `$post` object (i.e. anything but the editor).

### How to test the changes in this Pull Request:

1. On `master` navigate to any plugin page (`/admin.php?page=newspack-components-demo` if you have `newspack-plugin` installed.
2. Observe error similar to `Notice: Trying to get property 'ID' of non-object in /srv/www/repos/newspack-theme/functions.php on line 300`
3. Switch to `fix/warning-on-non-editor-admin-screens`.
4. Observe the error goes away.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
