### PR TITLE
Allow Clearing Font Provider URL Fields

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -330,6 +330,9 @@ function newspack_sanitize_checkbox( $input ) {
  * @return string Return a valid font provider URL if found or false if not.
  */
 function newspack_sanitize_font_provider_url( $code ) {
+	if ( trim( $code ) === '' ) {
+		return '';
+	}
 	$font_service_urls = array(
 		'google'     => 'fonts.googleapis.com',
 		'fonts'      => 'fast.fonts.net',

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -330,7 +330,7 @@ function newspack_sanitize_checkbox( $input ) {
  * @return string Return a valid font provider URL if found or false if not.
  */
 function newspack_sanitize_font_provider_url( $code ) {
-	if ( trim( $code ) === '' ) {
+	if ( '' === trim( $code ) ) {
 		return '';
 	}
 	$font_service_urls = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow users to clear the `Font Provider Import Code or URL` and `Secondary Font Provider Import Code or URL` fields in the Customizer. Previously clearing these fields and Publishing threw an Invalid Value error, thus making it impossible to unset these fields.

Closes #53.

### How to test the changes in this Pull Request:

1. In Customizer, paste in a valid Font Provider URL for the primary and secondary URL fields (you can use the code given in the example). 
2. Publish.
3. Delete the contents of both fields and publish again. This should occur with no error.
4. Finally, try populating the fields with invalid input (e.g. "NOTAFONTURL"). This _should_ continue to give an error as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
