### PR TITLE
Fix issue with style pack preview overriding custom colours and fonts

### DIFF
--- a/classes/class-newspack-style-packs-core.php
+++ b/classes/class-newspack-style-packs-core.php
@@ -54,6 +54,7 @@ class Newspack_Style_Packs_Core {
 					'body_class_format'  => 'style-pack-%s',
 					'styles_directory'   => 'styles',
 					'js_directory'       => 'js',
+					'default_css_id'     => '',
 					'style_thumbs'       => array(),
 					'style_descriptions' => array(),
 					'default_headers'    => array(),
@@ -277,6 +278,7 @@ class Newspack_Style_Packs_Core {
 			'preview_style'     => $this->get_preview_style(),
 			'styles'            => $style_pack_stylesheets,
 			'fonts'             => $style_pack_fonts,
+			'default_css_id'    => $this->config['default_css_id'],
 		);
 		wp_localize_script( 'style-packs-customizer', 'stylePacksData', $style_packs_data );
 	}

--- a/inc/style-packs.php
+++ b/inc/style-packs.php
@@ -12,6 +12,8 @@ new Newspack_Style_Packs_Core(
 		'styles_directory'   => 'styles',
 		// JavaScript directory
 		'js_directory'       => 'js',
+		// Default style.css ID
+		'default_css_id'     => 'newspack-style-css',
 		// Style declarations
 		'styles'             => array(
 			'default' => esc_html__( 'Default Style', 'newspack' ),

--- a/js/src/style-packs-customizer.js
+++ b/js/src/style-packs-customizer.js
@@ -56,12 +56,21 @@
 
 		if ( styleData ) {
 			link = createLink( styleData.id, styleData.uri );
-			document.head.appendChild( link );
+			if ( '' !== stylePacksData.default_css_id ) {
+				document.getElementById( stylePacksData.default_css_id ).insertAdjacentElement( "afterend", link );
+			} else {
+				document.head.appendChild( link );
+			}
+
 		}
 
 		_.each( config.fonts[style], function( uri, id ) {
 			var link = createLink( id, uri );
-			document.head.appendChild( link );
+			if ( '' !== stylePacksData.default_css_id ) {
+				document.getElementById( stylePacksData.default_css_id ).insertAdjacentElement( "afterend", link );
+			} else {
+				document.head.appendChild( link );
+			}
 		});
 	}
 
@@ -78,10 +87,18 @@
 		var style = config.preview_style,
 			data  = config.styles[style];
 		_.each(config.fonts[style], function( uri, id ) {
-			document.head.appendChild( createLink( id, uri ) );
+			if ( '' !== stylePacksData.default_css_id ) {
+				document.getElementById( stylePacksData.default_css_id ).insertAdjacentElement( "afterend", createLink( id, uri ) );
+			} else {
+				document.head.appendChild( createLink( id, uri ) );
+			}
 		} );
 		if ( data ) {
-			document.head.appendChild( createLink( data.id, data.uri ) );
+			if ( '' !== stylePacksData.default_css_id ) {
+				document.getElementById( stylePacksData.default_css_id ).insertAdjacentElement( "afterend", createLink( data.id, data.uri ) );
+			} else {
+				document.head.appendChild( createLink( data.id, data.uri ) );
+			}
 		}
 	}
 } )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The custom colours and typography styles get over-riden in the Customizer preview by the Style pack styles. This is because, in the preview, they are appended as the last item in the `<head>`, so they are the last styles loaded.

I thought I could rework how the style pack preview works to remove the JavaScript all together, but it's turning out to be a little trickier than I thought. So instead I created an optional value that could be set for the style pack settings -- the main CSS file's ID -- and if populated, used it to insert the style pack preview styles right after the theme's default style.css. That way, the custom font and colour styles come after it, and successfully override the values. 

If the value is left empty, the styles are added to the bottom of the `<head>` in the preview. 

Closes #52.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Typography, and set a custom font.
2. Navigate to Customizer > Style Packs, and pick Style Pack 1. (If you've already changed the style pack and changed back to the default at any point, you'll still get this issue). 
3. Save and Publish.
4. Return to the Customizer; confirm that your fonts are not previewing. 
5. Apply the PR.
6. Refresh the Customizer. Confirm that the correct font is now displaying. Try changing the style packs/fonts again, and confirm they continue to be correct. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
