### PR TITLE
Remove Newspack-block specific styles from theme's default styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -809,14 +809,6 @@
 		}
 	}
 
-	//! Newspack Block
-
-	.wp-block-newspack-blocks-homepage-articles {
-		.article-meta {
-			font-family: $font__heading;
-		}
-	}
-
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -17,6 +17,7 @@
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
+.use-header-font,
 h1,
 h2,
 h3,

--- a/sass/typography/_typography.scss
+++ b/sass/typography/_typography.scss
@@ -27,6 +27,10 @@ textarea {
 	text-rendering: optimizeLegibility;
 }
 
+.use-body-font {
+	font-family: $font__body;
+}
+
 @import "headings";
 
 @import "copy";

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -3810,10 +3810,6 @@ a:focus {
   font-size: 0.71111em;
 }
 
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -420,6 +420,10 @@ textarea {
   text-rendering: optimizeLegibility;
 }
 
+.use-body-font {
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+}
+
 .author-description .author-link,
 .comment-metadata,
 .comment-reply-link,
@@ -439,6 +443,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
+.use-heading-font,
 h1,
 h2,
 h3,

--- a/style.css
+++ b/style.css
@@ -3822,10 +3822,6 @@ a:focus {
   font-size: 0.71111em;
 }
 
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-}
-
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/style.css
+++ b/style.css
@@ -420,6 +420,10 @@ textarea {
   text-rendering: optimizeLegibility;
 }
 
+.use-body-font {
+  font-family: Georgia, Garamond, "Times New Roman", serif;
+}
+
 .author-description .author-link,
 .comment-metadata,
 .comment-reply-link,
@@ -439,6 +443,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
+.use-header-font,
 h1,
 h2,
 h3,

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -3757,10 +3757,6 @@ a:focus {
   font-size: 0.71111em;
 }
 
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: "IBM Plex Serif", Georgia, serif;
-}
-
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -367,6 +367,10 @@ textarea {
   text-rendering: optimizeLegibility;
 }
 
+.use-body-font {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
 .author-description .author-link,
 .comment-metadata,
 .comment-reply-link,
@@ -386,6 +390,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
+.use-heading-font,
 h1,
 h2,
 h3,

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -3769,10 +3769,6 @@ a:focus {
   font-size: 0.71111em;
 }
 
-.entry .entry-content .wp-block-newspack-blocks-homepage-articles .article-meta {
-  font-family: "IBM Plex Serif", Georgia, serif;
-}
-
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -367,6 +367,10 @@ textarea {
   text-rendering: optimizeLegibility;
 }
 
+.use-body-font {
+  font-family: "IBM Plex Serif", Georgia, serif;
+}
+
 .author-description .author-link,
 .comment-metadata,
 .comment-reply-link,
@@ -386,6 +390,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
+.use-header-font,
 h1,
 h2,
 h3,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes Newspack block-specific styles from the theme, with the goal of keeping styles in the theme generic enough that they don't call out our custom blocks, and instead, aim to use semantic markup or more general classes.

It also adds the classes `.use-body-font` and `.use-header-font`, to make them available for use in our blocks as needed.

Related: #58.

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Confirm that the post meta in the article blocks (the author name and published date) are now using a serif font, instead of a sans-serif font.
3. Can also be tested with https://github.com/Automattic/newspack-blocks/pull/34, a PR that adds the `.use-header-font` to the article meta (author name and date), to confirm the heading font is applied again. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
