### PR TITLE
Try out an approach for customizing headers

### DIFF
--- a/header.php
+++ b/header.php
@@ -38,7 +38,7 @@
 						?>
 					</nav>
 				<?php endif; ?>
-				<?php if ( has_nav_menu( 'social' ) ) : ?>
+				<?php if ( has_nav_menu( 'social' ) && 'default' === get_theme_mod( 'header_layout', 'default' ) ) : ?>
 					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
 						<?php
 						wp_nav_menu(
@@ -56,6 +56,22 @@
 			</div><!-- .site-menu-container -->
 
 			<div class="site-branding-container">
+				<?php if ( has_nav_menu( 'social' ) && 'centered' === get_theme_mod( 'header_layout', 'default' ) ) : ?>
+					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'social',
+								'menu_class'     => 'social-links-menu',
+								'link_before'    => '<span class="screen-reader-text">',
+								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .social-navigation -->
+				<?php endif; ?>
+
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
 				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
@@ -74,19 +90,21 @@
 				<?php endif; ?>
 			</div><!-- .site-branding-container -->
 
-			<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
-				<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
-					<?php
-					wp_nav_menu(
-						array(
-							'theme_location' => 'primary-menu',
-							'menu_class'     => 'main-menu',
-							'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-						)
-					);
-					?>
-				</nav><!-- #site-navigation -->
-			<?php endif; ?>
+			<div class="bottom-nav-contain">
+				<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'primary-menu',
+								'menu_class'     => 'main-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							)
+						);
+						?>
+					</nav><!-- #site-navigation -->
+				<?php endif; ?>
+			</div><!-- .bottom-nav-container -->
 
 		</header><!-- #masthead -->
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -18,6 +18,9 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 	}
 
+	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
+	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+
 
 	$theme_css = '
 		/* Set primary background color */
@@ -168,6 +171,25 @@ function newspack_custom_colors_css() {
 		::-moz-selection {
 			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}';
+
+	if ( 'solid' === get_theme_mod( 'header_layout', 'default' ) ) {
+		$theme_css .= '
+			.site-header {
+				background-color: ' . $primary_color . ';
+			}
+
+			.site-header,
+			.site-header a, .site-header a:visited,
+			.site-description {
+				color: ' . $primary_color_contrast . ';
+			}
+
+			.main-navigation .main-menu > li,
+			.main-navigation ul.main-menu > li > a {
+				color: inherit;
+			}
+		';
+	}
 
 	$editor_css = '
 		/*

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -34,6 +34,31 @@ function newspack_customize_register( $wp_customize ) {
 	}
 
 	/**
+	 * Header laypit
+	 */
+	$wp_customize->add_setting(
+		'header_layout',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_header_layout_option',
+		)
+	);
+
+	$wp_customize->add_control(
+		'header_layout',
+		array(
+			'type'    => 'select',
+			'label'   => esc_html__( 'Header Layout', 'newspack' ),
+			'choices' => array(
+				'default'  => esc_html__( 'Default Layout', 'newspack' ),
+				'centered' => esc_html__( 'Centered Layout', 'newspack' ),
+				'solid'    => esc_html__( 'Solid Background', 'newspack' ),
+			),
+			'section' => 'title_tagline',
+		)
+	);
+
+	/**
 	 * Primary color.
 	 */
 	$wp_customize->add_setting(
@@ -298,6 +323,27 @@ function newspack_sanitize_color_option( $choice ) {
 	$valid = array(
 		'default',
 		'custom',
+	);
+
+	if ( in_array( $choice, $valid, true ) ) {
+		return $choice;
+	}
+
+	return 'default';
+}
+
+/**
+ * Sanitize header layout choice.
+ *
+ * @param string $choice Sanitized dropdown value.
+ *
+ * @return string
+ */
+function newspack_sanitize_header_layout_option( $choice ) {
+	$valid = array(
+		'default',
+		'centered',
+		'solid',
 	);
 
 	if ( in_array( $choice, $valid, true ) ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -41,6 +41,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
+	// Adds a class to reflect the header layout
+	$header_layout_class = get_theme_mod( 'header_layout', 'default' ) . '-header-layout';
+	$classes[]           = esc_attr( $header_layout_class );
+
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );
@@ -373,3 +378,50 @@ function newspack_adjust_brightness( $hex, $steps ) {
 
 	return $new_shade;
 }
+
+/**
+ * Pick either white or black, whatever has sufficient contrast with the color being passed to it.
+ *
+ * @param  string $hex Hexidecimal value of the color to adjust.
+ * @return string Either black or white hexidecimal values.
+ *
+ * @ref https://stackoverflow.com/questions/1331591/given-a-background-color-black-or-white-text
+ */
+function newspack_get_color_contrast( $hex ) {
+
+	// hex RGB
+	$r1 = hexdec( substr( $hex, 1, 2 ) );
+	$g1 = hexdec( substr( $hex, 3, 2 ) );
+	$b1 = hexdec( substr( $hex, 5, 2 ) );
+
+	// Black RGB
+	$black_color    = '#000';
+	$r2_black_color = hexdec( substr( $black_color, 1, 2 ) );
+	$g2_black_color = hexdec( substr( $black_color, 3, 2 ) );
+	$b2_black_color = hexdec( substr( $black_color, 5, 2 ) );
+
+	// Calc contrast ratio
+	$l1 = 0.2126 * pow( $r1 / 255, 2.2 ) +
+		0.7152 * pow( $g1 / 255, 2.2 ) +
+		0.0722 * pow( $b1 / 255, 2.2 );
+
+	$l2 = 0.2126 * pow( $r2_black_color / 255, 2.2 ) +
+		0.7152 * pow( $g2_black_color / 255, 2.2 ) +
+		0.0722 * pow( $b2_black_color / 255, 2.2 );
+
+	$contrast_ratio = 0;
+	if ( $l1 > $l2 ) {
+		$contrast_ratio = (int) ( ( $l1 + 0.05 ) / ( $l2 + 0.05 ) );
+	} else {
+		$contrast_ratio = (int) ( ( $l2 + 0.05 ) / ( $l1 + 0.05 ) );
+	}
+
+	if ( $contrast_ratio > 5 ) {
+		// If contrast is more than 5, return black color
+		return '#000';
+	} else {
+		// if not, return white color.
+		return '#fff';
+	}
+}
+

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -2,8 +2,10 @@
 
 .main-navigation {
 	display: flex;
-	margin: #{0.25 * $size__spacing-unit} auto 0;
+	font-size: $font__size-sm;
+	margin: 0 auto;
 	max-width: 90%;
+	padding: 0 0 #{0.25 * $size__spacing-unit} 0;
 	width: $size__site-main;
 
 	/* Un-style buttons */
@@ -491,5 +493,27 @@
 	}
 	to {
 		opacity: 1;
+	}
+}
+
+.centered-header-layout {
+	.main-navigation {
+		border-bottom: 1px solid lighten( $color__text-main, 80% );
+		border-top: 1px solid lighten( $color__text-main, 80% );
+		justify-content: center;
+		padding: #{0.25 * $size__spacing-unit} 0 #{0.5 * $size__spacing-unit};
+	}
+}
+
+.solid-header-layout {
+	.bottom-nav-contain {
+		background-color: $color__background-body;
+	}
+
+	.main-navigation .main-menu > li {
+		color: $color__text-main;
+		> a {
+			color: $color__text-main;
+		}
 	}
 }

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -42,3 +42,10 @@
 		color: #fff;
 	}
 }
+
+.solid-header-layout {
+	.tertiary-menu a {
+		background: transparent;
+		padding: 0;
+	}
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -28,15 +28,8 @@
 }
 
 .site-branding {
-	align-items: center;
 	color: $color__text-light;
-	display: flex;
-	flex-wrap: wrap;
 	position: relative;
-
-	@include media(tablet) {
-		flex-basis: 60%;
-	}
 }
 
 // Site logo
@@ -94,8 +87,37 @@
 
 .site-description {
 	color: $color__text-light;
-	flex: 1 1 auto;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	margin: 7px 0 0;
+}
+
+.default-header-layout,
+.solid-header-layout {
+	.site-branding {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+
+		@include media(tablet) {
+			flex-basis: 60%;
+		}
+	}
+
+	.site-description {
+		flex: 1 1 auto;
+	}
+}
+
+.centered-header-layout {
+	.site-branding {
+		flex-grow: 1;
+		text-align: center;
+	}
+}
+
+.solid-header-layout {
+	.site-header {
+		padding-bottom: 0;
+	}
 }

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -918,8 +918,10 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: flex;
-  margin: 0.25rem auto 0;
+  font-size: 0.88889em;
+  margin: 0 auto;
   max-width: 90%;
+  padding: 0 0 0.25rem 0;
   width: 1200px;
   /* Un-style buttons */
   /*
@@ -1479,6 +1481,25 @@ a:focus {
   }
 }
 
+.centered-header-layout .main-navigation {
+  border-bottom: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  justify-content: center;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.solid-header-layout .bottom-nav-contain {
+  background-color: #fff;
+}
+
+.solid-header-layout .main-navigation .main-menu > li {
+  color: #111;
+}
+
+.solid-header-layout .main-navigation .main-menu > li > a {
+  color: #111;
+}
+
 .top-nav-contain {
   display: flex;
   flex-wrap: wrap;
@@ -1563,6 +1584,11 @@ a:focus {
 .tertiary-menu a:hover {
   background-color: #111;
   color: #fff;
+}
+
+.solid-header-layout .tertiary-menu a {
+  background: transparent;
+  padding: 0;
 }
 
 /* Social menu */
@@ -2053,17 +2079,8 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
   color: #767676;
-  display: flex;
-  flex-wrap: wrap;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    flex-basis: 60%;
-  }
 }
 
 .site-logo {
@@ -2118,10 +2135,37 @@ a:focus {
 
 .site-description {
   color: #767676;
-  flex: 1 1 auto;
   font-weight: normal;
   font-size: 0.88889em;
   margin: 7px 0 0;
+}
+
+.default-header-layout .site-branding,
+.solid-header-layout .site-branding {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media only screen and (min-width: 768px) {
+  .default-header-layout .site-branding,
+  .solid-header-layout .site-branding {
+    flex-basis: 60%;
+  }
+}
+
+.default-header-layout .site-description,
+.solid-header-layout .site-description {
+  flex: 1 1 auto;
+}
+
+.centered-header-layout .site-branding {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.solid-header-layout .site-header {
+  padding-bottom: 0;
 }
 
 /*--------------------------------------------------------------

--- a/style.css
+++ b/style.css
@@ -918,8 +918,10 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: flex;
-  margin: 0.25rem auto 0;
+  font-size: 0.88889em;
+  margin: 0 auto;
   max-width: 90%;
+  padding: 0 0 0.25rem 0;
   width: 1200px;
   /* Un-style buttons */
   /*
@@ -1479,6 +1481,25 @@ a:focus {
   }
 }
 
+.centered-header-layout .main-navigation {
+  border-bottom: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  justify-content: center;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.solid-header-layout .bottom-nav-contain {
+  background-color: #fff;
+}
+
+.solid-header-layout .main-navigation .main-menu > li {
+  color: #111;
+}
+
+.solid-header-layout .main-navigation .main-menu > li > a {
+  color: #111;
+}
+
 .top-nav-contain {
   display: flex;
   flex-wrap: wrap;
@@ -1563,6 +1584,11 @@ a:focus {
 .tertiary-menu a:hover {
   background-color: #111;
   color: #fff;
+}
+
+.solid-header-layout .tertiary-menu a {
+  background: transparent;
+  padding: 0;
 }
 
 /* Social menu */
@@ -2059,17 +2085,8 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
   color: #767676;
-  display: flex;
-  flex-wrap: wrap;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    flex-basis: 60%;
-  }
 }
 
 .site-logo {
@@ -2124,10 +2141,37 @@ a:focus {
 
 .site-description {
   color: #767676;
-  flex: 1 1 auto;
   font-weight: normal;
   font-size: 0.88889em;
   margin: 7px 0 0;
+}
+
+.default-header-layout .site-branding,
+.solid-header-layout .site-branding {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media only screen and (min-width: 768px) {
+  .default-header-layout .site-branding,
+  .solid-header-layout .site-branding {
+    flex-basis: 60%;
+  }
+}
+
+.default-header-layout .site-description,
+.solid-header-layout .site-description {
+  flex: 1 1 auto;
+}
+
+.centered-header-layout .site-branding {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.solid-header-layout .site-header {
+  padding-bottom: 0;
 }
 
 /*--------------------------------------------------------------

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -865,8 +865,10 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: flex;
-  margin: 0.25rem auto 0;
+  font-size: 0.88889em;
+  margin: 0 auto;
   max-width: 90%;
+  padding: 0 0 0.25rem 0;
   width: 1200px;
   /* Un-style buttons */
   /*
@@ -1426,6 +1428,25 @@ a:focus {
   }
 }
 
+.centered-header-layout .main-navigation {
+  border-bottom: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  justify-content: center;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.solid-header-layout .bottom-nav-contain {
+  background-color: #eee;
+}
+
+.solid-header-layout .main-navigation .main-menu > li {
+  color: #111;
+}
+
+.solid-header-layout .main-navigation .main-menu > li > a {
+  color: #111;
+}
+
 .top-nav-contain {
   display: flex;
   flex-wrap: wrap;
@@ -1510,6 +1531,11 @@ a:focus {
 .tertiary-menu a:hover {
   background-color: #111;
   color: #fff;
+}
+
+.solid-header-layout .tertiary-menu a {
+  background: transparent;
+  padding: 0;
 }
 
 /* Social menu */
@@ -2000,17 +2026,8 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
   color: #767676;
-  display: flex;
-  flex-wrap: wrap;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    flex-basis: 60%;
-  }
 }
 
 .site-logo {
@@ -2065,10 +2082,37 @@ a:focus {
 
 .site-description {
   color: #767676;
-  flex: 1 1 auto;
   font-weight: normal;
   font-size: 0.88889em;
   margin: 7px 0 0;
+}
+
+.default-header-layout .site-branding,
+.solid-header-layout .site-branding {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media only screen and (min-width: 768px) {
+  .default-header-layout .site-branding,
+  .solid-header-layout .site-branding {
+    flex-basis: 60%;
+  }
+}
+
+.default-header-layout .site-description,
+.solid-header-layout .site-description {
+  flex: 1 1 auto;
+}
+
+.centered-header-layout .site-branding {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.solid-header-layout .site-header {
+  padding-bottom: 0;
 }
 
 /*--------------------------------------------------------------

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -865,8 +865,10 @@ a:focus {
 /** === Main menu === */
 .main-navigation {
   display: flex;
-  margin: 0.25rem auto 0;
+  font-size: 0.88889em;
+  margin: 0 auto;
   max-width: 90%;
+  padding: 0 0 0.25rem 0;
   width: 1200px;
   /* Un-style buttons */
   /*
@@ -1426,6 +1428,25 @@ a:focus {
   }
 }
 
+.centered-header-layout .main-navigation {
+  border-bottom: 1px solid #dddddd;
+  border-top: 1px solid #dddddd;
+  justify-content: center;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.solid-header-layout .bottom-nav-contain {
+  background-color: #eee;
+}
+
+.solid-header-layout .main-navigation .main-menu > li {
+  color: #111;
+}
+
+.solid-header-layout .main-navigation .main-menu > li > a {
+  color: #111;
+}
+
 .top-nav-contain {
   display: flex;
   flex-wrap: wrap;
@@ -1510,6 +1531,11 @@ a:focus {
 .tertiary-menu a:hover {
   background-color: #111;
   color: #fff;
+}
+
+.solid-header-layout .tertiary-menu a {
+  background: transparent;
+  padding: 0;
 }
 
 /* Social menu */
@@ -2006,17 +2032,8 @@ a:focus {
 }
 
 .site-branding {
-  align-items: center;
   color: #767676;
-  display: flex;
-  flex-wrap: wrap;
   position: relative;
-}
-
-@media only screen and (min-width: 768px) {
-  .site-branding {
-    flex-basis: 60%;
-  }
 }
 
 .site-logo {
@@ -2071,10 +2088,37 @@ a:focus {
 
 .site-description {
   color: #767676;
-  flex: 1 1 auto;
   font-weight: normal;
   font-size: 0.88889em;
   margin: 7px 0 0;
+}
+
+.default-header-layout .site-branding,
+.solid-header-layout .site-branding {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media only screen and (min-width: 768px) {
+  .default-header-layout .site-branding,
+  .solid-header-layout .site-branding {
+    flex-basis: 60%;
+  }
+}
+
+.default-header-layout .site-description,
+.solid-header-layout .site-description {
+  flex: 1 1 auto;
+}
+
+.centered-header-layout .site-branding {
+  flex-grow: 1;
+  text-align: center;
+}
+
+.solid-header-layout .site-header {
+  padding-bottom: 0;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

I suggested this as one way to allow different headers layouts in the theme prior to full-page editing: 
This PR adds a 'Header Layout' dropdown to the Site Identity section of the customizer, and has two options on top of the default: one to centre the logo, and one to use the primary colour as a background. These aren't finalized, more of a way to test how easy it would be to change layout and how colours are assigned. 

I had originally considered including the headers as part of the style packs, but it seems like it would make more sense to keep it independent; I'm interested to know if this seems like a logical approach, and if there are any concerns about it. 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customizer > Site Identity, and try switching between different header options (note that #52 will cause issues with the 'Solid' option). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
