### PR TITLE
Fix hide site title preview in Customizer

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -73,7 +73,6 @@
 	color: $color__text-main;
 	font-weight: 700;
 	margin: 0 $size__spacing-unit 0 0;
-	position: relative;
 	top: 2px;
 
 	a {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -72,8 +72,7 @@
 .site-title {
 	color: $color__text-main;
 	font-weight: 700;
-	margin: 0 $size__spacing-unit 0 0;
-	top: 2px;
+	margin: 0 $size__spacing-unit -3px 0;
 
 	a {
 		color: $color__text-main;

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2100,7 +2100,6 @@ a:focus {
   color: #111;
   font-weight: 700;
   margin: 0 0 0 1rem;
-  position: relative;
   top: 2px;
 }
 

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2099,8 +2099,7 @@ a:focus {
 .site-title {
   color: #111;
   font-weight: 700;
-  margin: 0 0 0 1rem;
-  top: 2px;
+  margin: 0 0 -3px 1rem;
 }
 
 .site-title a {

--- a/style.css
+++ b/style.css
@@ -2106,7 +2106,6 @@ a:focus {
   color: #111;
   font-weight: 700;
   margin: 0 1rem 0 0;
-  position: relative;
   top: 2px;
 }
 

--- a/style.css
+++ b/style.css
@@ -2105,8 +2105,7 @@ a:focus {
 .site-title {
   color: #111;
   font-weight: 700;
-  margin: 0 1rem 0 0;
-  top: 2px;
+  margin: 0 1rem -3px 0;
 }
 
 .site-title a {

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -2047,7 +2047,6 @@ a:focus {
   color: #111;
   font-weight: 700;
   margin: 0 0 0 1rem;
-  position: relative;
   top: 2px;
 }
 

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -2046,8 +2046,7 @@ a:focus {
 .site-title {
   color: #111;
   font-weight: 700;
-  margin: 0 0 0 1rem;
-  top: 2px;
+  margin: 0 0 -3px 1rem;
 }
 
 .site-title a {

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -2052,8 +2052,7 @@ a:focus {
 .site-title {
   color: #111;
   font-weight: 700;
-  margin: 0 1rem 0 0;
-  top: 2px;
+  margin: 0 1rem -3px 0;
 }
 
 .site-title a {

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -2053,7 +2053,6 @@ a:focus {
   color: #111;
   font-weight: 700;
   margin: 0 1rem 0 0;
-  position: relative;
   top: 2px;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a relative positioning and top position I'd added to the site title to fix its vertical placement, and replaces it with a negative margin. The `position: relative` was causing the 'Hide Site Title' option in the Customizer not to preview correctly. 

Closes #57 .

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Site Identity and try to hide the Site Title.
2. Confirm it's still visible in the preview.
3. Apply the PR and refresh the Customizer.
4. Try hiding the site title again and confirm it actually hides. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
