### PR TITLE
Add 'Feature' template for articles

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -199,6 +199,13 @@
 			flex-basis: calc( 35% - 24px );
 		}
 	}
+
+	&.post-template-single-feature {
+		.main-content {
+			margin-left: auto;
+			margin-right: auto;
+		}
+	}
 }
 
 .page.home .entry .entry-content {

--- a/single-feature.php
+++ b/single-feature.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Template Name: Article feature
+ * Template Post Type: post
+ *
+ * The template for displaying all single posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package Newspack
+ */
+
+get_header();
+?>
+
+	<section id="primary" class="content-area">
+		<main id="main" class="site-main">
+
+			<?php
+
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+				?>
+
+				<header class="entry-header">
+					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+				</header>
+
+				<?php newspack_post_thumbnail(); ?>
+
+				<div class="main-content">
+
+					<?php
+					get_template_part( 'template-parts/content/content', 'single' );
+
+					if ( is_singular( 'attachment' ) ) {
+						// Parent post navigation.
+						the_post_navigation(
+							array(
+								/* translators: %s: parent post link */
+								'prev_text' => sprintf( __( '<span class="meta-nav">Published in</span><span class="post-title">%s</span>', 'newspack' ), '%title' ),
+							)
+						);
+					} elseif ( is_singular( 'post' ) ) {
+						// Previous/next post navigation.
+						the_post_navigation(
+							array(
+								'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next Post', 'newspack' ) . '</span> ' .
+									'<span class="screen-reader-text">' . __( 'Next post:', 'newspack' ) . '</span> <br/>' .
+									'<span class="post-title">%title</span>',
+								'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous Post', 'newspack' ) . '</span> ' .
+									'<span class="screen-reader-text">' . __( 'Previous post:', 'newspack' ) . '</span> <br/>' .
+									'<span class="post-title">%title</span>',
+							)
+						);
+					}
+
+					// If comments are open or we have at least one comment, load up the comment template.
+					if ( comments_open() || get_comments_number() ) {
+						comments_template();
+					}
+					?>
+				</div>
+
+			<?php endwhile; ?>
+
+		</main><!-- #main -->
+	</section><!-- #primary -->
+
+<?php
+get_footer();

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -2323,6 +2323,11 @@ a:focus {
   }
 }
 
+.single-post.post-template-single-feature .main-content {
+  margin-right: auto;
+  margin-left: auto;
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -2329,6 +2329,11 @@ a:focus {
   }
 }
 
+.single-post.post-template-single-feature .main-content {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -2270,6 +2270,11 @@ a:focus {
   }
 }
 
+.single-post.post-template-single-feature .main-content {
+  margin-right: auto;
+  margin-left: auto;
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -2276,6 +2276,11 @@ a:focus {
   }
 }
 
+.single-post.post-template-single-feature .main-content {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .page.home .entry .entry-content {
   max-width: 100%;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a second template for the articles.

Right now, the markup is identical to the existing single.php, except it doesn't have the `get_sidebar()`. In the styles, the content is centered rather than sitting to the left.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Edit an existing post; confirm that there's a template option under 'Post Attributes'
3. Switch from 'Default template' to 'Article feature'
4. Save and publish
5. Confirm that the content is now centred on the front end.

Note: editor styles (title size, and content alignment for the default template) still need to be updated; that'll come in a separate PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
