### PR TITLE
Add sidebar, fix alignment on blog posts page

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,6 +39,7 @@ get_header();
 		?>
 
 		</main><!-- .site-main -->
+		<?php get_sidebar(); ?>
 	</section><!-- .content-area -->
 
 <?php

--- a/template-parts/content/content.php
+++ b/template-parts/content/content.php
@@ -14,36 +14,36 @@
 		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 	</header>
 
-		<?php newspack_post_thumbnail(); ?>
+	<?php newspack_post_thumbnail(); ?>
 
-		<div class="entry-content">
-			<?php
-			the_content(
-				sprintf(
-					wp_kses(
-						/* translators: %s: Name of current post. Only visible to screen readers */
-						__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'newspack' ),
-						array(
-							'span' => array(
-								'class' => array(),
-							),
-						)
-					),
-					get_the_title()
-				)
-			);
+	<div class="entry-content">
+		<?php
+		the_content(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'newspack' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
 
-			wp_link_pages(
-				array(
-					'before' => '<div class="page-links">' . __( 'Pages:', 'newspack' ),
-					'after'  => '</div>',
-				)
-			);
-			?>
-		</div><!-- .entry-content -->
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . __( 'Pages:', 'newspack' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
 
-		<footer class="entry-footer">
-			<?php newspack_entry_footer(); ?>
-		</footer><!-- .entry-footer -->
-	</article><!-- #post-${ID} -->
-</div> <!-- .main-content -->
+	<footer class="entry-footer">
+		<?php newspack_entry_footer(); ?>
+	</footer><!-- .entry-footer -->
+</article><!-- #post-${ID} -->
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes up an alignment issue on the blog posts page, and adds a sidebar.

### How to test the changes in this Pull Request:

1. If you haven't already, set a static front page and a blog posts page under Customizer > Homepage Settings.
2. Navigate to the blog posts page and scroll down.
3. Note the first post is aligned centre, but the subsequent posts are the full width of the browser window. The first post is also wider than usual.
4. Apply the patch.
5. Confirm that all the posts are now the same width. The posts will still be too wide, but that should be fixed in #63 (as well as moving the sidebar content from below the posts, to next to them). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->
