### PR TITLE
Update default accent colour to be Newspack blue

### DIFF
--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -8,7 +8,7 @@
 /**
  * Define default color filters.
  */
-define( 'NEWSPACK_DEFAULT_PRIMARY', '#0073a8' ); // Hex
+define( 'NEWSPACK_DEFAULT_PRIMARY', '#2A7DE1' ); // Hex
 define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
 /**

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -7,7 +7,7 @@ $headings: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu
 $body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
 
 $body-color: #111;
-$highlights-color: #0073aa;
+$highlights-color: #2A7DE1;
 
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -1,6 +1,6 @@
 
 // Custom Colors - defaults
-$color__primary: #0073aa;
+$color__primary: #2A7DE1;
 $color__primary-variation: darken( $color__primary, 10% );
 $color__secondary: #666;
 $color__secondary-variation: darken( $color__secondary, 10% );
@@ -31,7 +31,7 @@ $color__link-hover: $color__secondary-variation;
 
 // Borders
 $color__border: #ccc;
-$color__border-link: #0073aa;
+$color__border-link: #2A7DE1;
 $color__border-link-hover: $color__primary-variation;
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;

--- a/style-editor.css
+++ b/style-editor.css
@@ -313,7 +313,7 @@ figcaption,
 }
 
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
-  background: #0073aa;
+  background: #2A7DE1;
 }
 
 .wp-block-button:not(.is-style-squared) .wp-block-button__link {
@@ -322,7 +322,7 @@ figcaption,
 
 .wp-block-button.is-style-outline, .wp-block-button.is-style-outline:hover, .wp-block-button.is-style-outline:focus, .wp-block-button.is-style-outline:active {
   background: transparent;
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link, .wp-block-button.is-style-outline:hover .wp-block-button__link, .wp-block-button.is-style-outline:focus .wp-block-button__link, .wp-block-button.is-style-outline:active .wp-block-button__link {
@@ -330,7 +330,7 @@ figcaption,
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 /** === Blockquote === */

--- a/style-rtl.css
+++ b/style-rtl.css
@@ -443,7 +443,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
-.use-heading-font,
+.use-header-font,
 h1,
 h2,
 h3,
@@ -656,11 +656,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 *,
@@ -752,7 +752,7 @@ figure {
 }
 
 blockquote {
-  border-right: 2px solid #0073aa;
+  border-right: 2px solid #2A7DE1;
   margin-right: 0;
   padding: 0 1rem 0 0;
 }
@@ -786,7 +786,7 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -872,8 +872,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #2A7DE1;
+  outline: thin solid rgba(42, 125, 225, 0.15);
   outline-offset: -4px;
 }
 
@@ -977,13 +977,13 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #2A7DE1;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
-  color: #0073aa;
+  color: #2A7DE1;
   font-weight: 700;
   margin-left: 0.5rem;
 }
@@ -994,7 +994,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1055,7 +1055,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   color: #fff;
   list-style: none;
   padding-right: 0;
@@ -1119,13 +1119,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1675,7 +1675,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -1849,7 +1849,7 @@ a:focus {
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -2188,7 +2188,7 @@ a:focus {
 .entry-meta a:hover,
 .entry-footer a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry-meta .svg-icon,
@@ -2266,7 +2266,7 @@ a:focus {
 }
 
 .entry-content .more-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2368,7 +2368,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2586,7 +2586,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2594,7 +2594,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #4e93e6;
   left: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2629,7 +2629,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2661,7 +2661,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .comment .comment-content {
@@ -2701,7 +2701,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .discussion-avatar-list {
@@ -2886,7 +2886,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 #colophon .site-info .imprint,
@@ -2905,11 +2905,11 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .widget_archive ul,
@@ -3192,7 +3192,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
@@ -3233,7 +3233,7 @@ a:focus {
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
   border-color: currentColor;
 }
 
@@ -3404,7 +3404,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   padding-right: 0;
   padding-left: 0;
 }
@@ -3730,7 +3730,7 @@ a:focus {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
-  background: #0073aa;
+  background: #2A7DE1;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 20px;
   line-height: 1.2;
@@ -3895,12 +3895,12 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
-  background-color: #005177;
+  background-color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-background-color,
@@ -3921,13 +3921,13 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-color,
@@ -4143,5 +4143,5 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #2a7de1;
 }

--- a/style.css
+++ b/style.css
@@ -656,11 +656,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 *,
@@ -752,7 +752,7 @@ figure {
 }
 
 blockquote {
-  border-left: 2px solid #0073aa;
+  border-left: 2px solid #2A7DE1;
   margin-left: 0;
   padding: 0 0 0 1rem;
 }
@@ -786,7 +786,7 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -872,8 +872,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #2A7DE1;
+  outline: thin solid rgba(42, 125, 225, 0.15);
   outline-offset: -4px;
 }
 
@@ -977,13 +977,13 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #2A7DE1;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
-  color: #0073aa;
+  color: #2A7DE1;
   font-weight: 700;
   margin-right: 0.5rem;
 }
@@ -994,7 +994,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1055,7 +1055,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   color: #fff;
   list-style: none;
   padding-left: 0;
@@ -1119,13 +1119,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1675,7 +1675,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -1849,7 +1849,7 @@ a:focus {
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -2194,7 +2194,7 @@ a:focus {
 .entry-meta a:hover,
 .entry-footer a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry-meta .svg-icon,
@@ -2272,7 +2272,7 @@ a:focus {
 }
 
 .entry-content .more-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2374,7 +2374,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2592,7 +2592,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2600,7 +2600,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #4e93e6;
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2635,7 +2635,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2667,7 +2667,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .comment .comment-content {
@@ -2707,7 +2707,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .discussion-avatar-list {
@@ -2892,7 +2892,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 #colophon .site-info .imprint,
@@ -2911,11 +2911,11 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .widget_archive ul,
@@ -3204,7 +3204,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
@@ -3245,7 +3245,7 @@ a:focus {
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
   border-color: currentColor;
 }
 
@@ -3416,7 +3416,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   padding-left: 0;
   padding-right: 0;
 }
@@ -3742,7 +3742,7 @@ a:focus {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
-  background: #0073aa;
+  background: #2A7DE1;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 20px;
   line-height: 1.2;
@@ -3907,12 +3907,12 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
-  background-color: #005177;
+  background-color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-background-color,
@@ -3933,13 +3933,13 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-color,
@@ -4155,5 +4155,5 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #2a7de1;
 }

--- a/styles/style-1-editor.css
+++ b/styles/style-1-editor.css
@@ -313,7 +313,7 @@ figcaption,
 }
 
 .wp-block-button:not(.is-style-outline) .wp-block-button__link {
-  background: #0073aa;
+  background: #2A7DE1;
 }
 
 .wp-block-button:not(.is-style-squared) .wp-block-button__link {
@@ -322,7 +322,7 @@ figcaption,
 
 .wp-block-button.is-style-outline, .wp-block-button.is-style-outline:hover, .wp-block-button.is-style-outline:focus, .wp-block-button.is-style-outline:active {
   background: transparent;
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link, .wp-block-button.is-style-outline:hover .wp-block-button__link, .wp-block-button.is-style-outline:focus .wp-block-button__link, .wp-block-button.is-style-outline:active .wp-block-button__link {
@@ -330,7 +330,7 @@ figcaption,
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color), .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 /** === Blockquote === */

--- a/styles/style-1-rtl.css
+++ b/styles/style-1-rtl.css
@@ -390,7 +390,7 @@ textarea {
 .site-title,
 .site-info,
 #cancel-comment-reply-link,
-.use-heading-font,
+.use-header-font,
 h1,
 h2,
 h3,
@@ -603,11 +603,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 *,
@@ -699,7 +699,7 @@ figure {
 }
 
 blockquote {
-  border-right: 2px solid #0073aa;
+  border-right: 2px solid #2A7DE1;
   margin-right: 0;
   padding: 0 1rem 0 0;
 }
@@ -733,7 +733,7 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -819,8 +819,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #2A7DE1;
+  outline: thin solid rgba(42, 125, 225, 0.15);
   outline-offset: -4px;
 }
 
@@ -924,13 +924,13 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #2A7DE1;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
-  color: #0073aa;
+  color: #2A7DE1;
   font-weight: 700;
   margin-left: 0.5rem;
 }
@@ -941,7 +941,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1002,7 +1002,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   color: #eee;
   list-style: none;
   padding-right: 0;
@@ -1066,13 +1066,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1622,7 +1622,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -1796,7 +1796,7 @@ a:focus {
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -2135,7 +2135,7 @@ a:focus {
 .entry-meta a:hover,
 .entry-footer a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry-meta .svg-icon,
@@ -2213,7 +2213,7 @@ a:focus {
 }
 
 .entry-content .more-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2315,7 +2315,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2533,7 +2533,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2541,7 +2541,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #4e93e6;
   left: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2576,7 +2576,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2608,7 +2608,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .comment .comment-content {
@@ -2648,7 +2648,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .discussion-avatar-list {
@@ -2833,7 +2833,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 #colophon .site-info .imprint,
@@ -2852,11 +2852,11 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .widget_archive ul,
@@ -3139,7 +3139,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
@@ -3180,7 +3180,7 @@ a:focus {
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
   border-color: currentColor;
 }
 
@@ -3351,7 +3351,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   padding-right: 0;
   padding-left: 0;
 }
@@ -3677,7 +3677,7 @@ a:focus {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
-  background: #0073aa;
+  background: #2A7DE1;
   font-family: "IBM Plex Serif", Georgia, serif;
   font-size: 20px;
   line-height: 1.2;
@@ -3842,12 +3842,12 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
-  background-color: #005177;
+  background-color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-background-color,
@@ -3868,13 +3868,13 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-color,
@@ -4090,7 +4090,7 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #2a7de1;
 }
 
 /* Style pack-specific overrides */

--- a/styles/style-1.css
+++ b/styles/style-1.css
@@ -603,11 +603,11 @@ html {
 }
 
 ::-moz-selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 ::selection {
-  background-color: #bfdcea;
+  background-color: #cadff8;
 }
 
 *,
@@ -699,7 +699,7 @@ figure {
 }
 
 blockquote {
-  border-left: 2px solid #0073aa;
+  border-left: 2px solid #2A7DE1;
   margin-left: 0;
   padding: 0 0 0 1rem;
 }
@@ -733,7 +733,7 @@ input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -819,8 +819,8 @@ input[type="datetime"]:focus,
 input[type="datetime-local"]:focus,
 input[type="color"]:focus,
 textarea:focus {
-  border-color: #0073aa;
-  outline: thin solid rgba(0, 115, 170, 0.15);
+  border-color: #2A7DE1;
+  outline: thin solid rgba(42, 125, 225, 0.15);
   outline-offset: -4px;
 }
 
@@ -924,13 +924,13 @@ a:focus {
 }
 
 .main-navigation .main-menu > li {
-  color: #0073aa;
+  color: #2A7DE1;
   display: inline;
   position: relative;
 }
 
 .main-navigation .main-menu > li > a {
-  color: #0073aa;
+  color: #2A7DE1;
   font-weight: 700;
   margin-right: 0.5rem;
 }
@@ -941,7 +941,7 @@ a:focus {
 
 .main-navigation .main-menu > li > a:hover,
 .main-navigation .main-menu > li > a:hover + svg {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .main-navigation .main-menu > li.menu-item-has-children {
@@ -1002,7 +1002,7 @@ a:focus {
 }
 
 .main-navigation .sub-menu {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   color: #eee;
   list-style: none;
   padding-left: 0;
@@ -1066,13 +1066,13 @@ a:focus {
 .main-navigation .sub-menu > li > a:hover, .main-navigation .sub-menu > li > a:focus,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > a:hover:after, .main-navigation .sub-menu > li > a:focus:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:hover:after,
 .main-navigation .sub-menu > li > .menu-item-link-return:focus:after {
-  background: #005177;
+  background: #1b64bd;
 }
 
 .main-navigation .sub-menu > li > .menu-item-link-return {
@@ -1622,7 +1622,7 @@ a:focus {
 }
 
 .post-navigation .nav-links a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 @media only screen and (min-width: 1168px) {
@@ -1796,7 +1796,7 @@ a:focus {
 .site-main #infinite-handle span button:hover,
 .site-main #infinite-handle span button:focus {
   transition: background 150ms ease-in-out;
-  background: #0073aa;
+  background: #2A7DE1;
   border: none;
   border-radius: 5px;
   box-sizing: border-box;
@@ -2141,7 +2141,7 @@ a:focus {
 .entry-meta a:hover,
 .entry-footer a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry-meta .svg-icon,
@@ -2219,7 +2219,7 @@ a:focus {
 }
 
 .entry-content .more-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2321,7 +2321,7 @@ a:focus {
 }
 
 .author-bio .author-description .author-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2539,7 +2539,7 @@ a:focus {
 }
 
 .comment .comment-author .fn a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .comment .comment-author .post-author-badge {
@@ -2547,7 +2547,7 @@ a:focus {
   display: block;
   height: 18px;
   position: absolute;
-  background: #008fd3;
+  background: #4e93e6;
   right: calc(100% - 2.5rem);
   top: -3px;
   width: 18px;
@@ -2582,7 +2582,7 @@ a:focus {
 
 .comment .comment-metadata > a:hover,
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #005177;
+  color: #1b64bd;
   text-decoration: none;
 }
 
@@ -2614,7 +2614,7 @@ a:focus {
 }
 
 .comment .comment-metadata .comment-edit-link:hover {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .comment .comment-content {
@@ -2654,7 +2654,7 @@ a:focus {
 
 .comment-reply-link:hover,
 #cancel-comment-reply-link:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .discussion-avatar-list {
@@ -2839,7 +2839,7 @@ a:focus {
 
 #colophon .site-info a:hover {
   text-decoration: none;
-  color: #005177;
+  color: #1b64bd;
 }
 
 #colophon .site-info .imprint,
@@ -2858,11 +2858,11 @@ a:focus {
 }
 
 .widget a {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .widget a:hover {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .widget_archive ul,
@@ -3151,7 +3151,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background) {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .wp-block-button .wp-block-button__link:not(.has-text-color) {
@@ -3192,7 +3192,7 @@ a:focus {
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:focus:not(.has-text-color),
 .entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:active:not(.has-text-color) {
-  color: #0073aa;
+  color: #2A7DE1;
   border-color: currentColor;
 }
 
@@ -3363,7 +3363,7 @@ a:focus {
 }
 
 .entry .entry-content .wp-block-pullquote.is-style-solid-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
   padding-left: 0;
   padding-right: 0;
 }
@@ -3689,7 +3689,7 @@ a:focus {
   transition: background 150ms ease-in-out;
   border: none;
   border-radius: 5px;
-  background: #0073aa;
+  background: #2A7DE1;
   font-family: "IBM Plex Serif", Georgia, serif;
   font-size: 20px;
   line-height: 1.2;
@@ -3854,12 +3854,12 @@ a:focus {
 
 .entry .entry-content .has-primary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-background-color {
-  background-color: #0073aa;
+  background-color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color {
-  background-color: #005177;
+  background-color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-background-color,
@@ -3880,13 +3880,13 @@ a:focus {
 .entry .entry-content .has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
-  color: #0073aa;
+  color: #2A7DE1;
 }
 
 .entry .entry-content .has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
-  color: #005177;
+  color: #1b64bd;
 }
 
 .entry .entry-content .has-secondary-color,
@@ -4102,7 +4102,7 @@ svg {
 }
 
 .gallery-item > div > a:focus {
-  box-shadow: 0 0 0 2px #0073aa;
+  box-shadow: 0 0 0 2px #2a7de1;
 }
 
 /* Style pack-specific overrides */

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -89,7 +89,7 @@ a.button:hover, a.button:visited {
   top: 0;
   right: 0;
   display: inline-block;
-  background: #0073aa;
+  background: #2A7DE1;
   color: #fff;
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -159,11 +159,11 @@ a.button:hover, a.button:visited {
 }
 
 .woocommerce-info {
-  background: #0073aa;
+  background: #2A7DE1;
 }
 
 .woocommerce-store-notice {
-  background: #0073aa;
+  background: #2A7DE1;
   color: #fff;
   padding: 1rem;
   position: absolute;
@@ -541,8 +541,8 @@ table.variations select {
 }
 
 .woocommerce-tabs ul li.active a {
-  color: #0073aa;
-  box-shadow: 0 2px 0 #0073aa;
+  color: #2A7DE1;
+  box-shadow: 0 2px 0 #2A7DE1;
 }
 
 .woocommerce-tabs .panel > * {

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -89,7 +89,7 @@ a.button:hover, a.button:visited {
   top: 0;
   left: 0;
   display: inline-block;
-  background: #0073aa;
+  background: #2A7DE1;
   color: #fff;
   display: inline-block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
@@ -159,11 +159,11 @@ a.button:hover, a.button:visited {
 }
 
 .woocommerce-info {
-  background: #0073aa;
+  background: #2A7DE1;
 }
 
 .woocommerce-store-notice {
-  background: #0073aa;
+  background: #2A7DE1;
   color: #fff;
   padding: 1rem;
   position: absolute;
@@ -541,8 +541,8 @@ table.variations select {
 }
 
 .woocommerce-tabs ul li.active a {
-  color: #0073aa;
-  box-shadow: 0 2px 0 #0073aa;
+  color: #2A7DE1;
+  box-shadow: 0 2px 0 #2A7DE1;
 }
 
 .woocommerce-tabs .panel > * {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a small one that updates the main accent colour in the theme to use Newspack blue. 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. If you have custom colours set, navigate to the Customizer > Colours, and switch it to the default palette.
3. Confirm that, rather than the darker blue used by Twenty Nineteen, the theme is now using Newspack's mighty blue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
