### PR TITLE
Add sidebar to page template

### DIFF
--- a/page.php
+++ b/page.php
@@ -30,6 +30,7 @@ get_header();
 			?>
 
 		</main><!-- #main -->
+		<?php get_sidebar(); ?>
 	</section><!-- #primary -->
 
 <?php

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -25,7 +25,8 @@
 }
 
 .archive,
-.blog {
+.blog,
+.page:not(.newspack-front-page) {
 	&.has-sidebar #primary {
 		display: flex;
 		flex-wrap: wrap;

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -27,7 +27,12 @@
 
 .entry-title {
 
+	font-size: $font__size-xxl;
 	margin: 0;
+
+	@include media(desktop) {
+		font-size: $font__size-xxxl;
+	}
 
 	a {
 		color: inherit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a sidebar space to the page template, so sidebar widgets will appear on single pages. It also updates the styles so the sidebar sits on the right, and the page title is slightly larger.

### How to test the changes in this Pull Request:

1. Apply PR.
2. Add a sidebar widget to your test site, if there isn't one already.
3. View the page; confirm the sidebar sits to the right.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->
