### PR TITLE
Try out second approach for customizing headers

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,81 +21,98 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
-		<header id="masthead" class="site-header">
+	<header id="masthead" class="site-header">
 
-			<div class="top-header-contain">
-				<div class="wrapper">
-					<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
-						<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'secondary-menu',
-									'menu_class'     => 'secondary-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-									'depth'          => 1,
-								)
-							);
-							?>
-						</nav>
-					<?php endif; ?>
-					<?php if ( has_nav_menu( 'social' ) ) : ?>
-						<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'social',
-									'menu_class'     => 'social-links-menu',
-									'link_before'    => '<span class="screen-reader-text">',
-									'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-									'depth'          => 1,
-								)
-							);
-							?>
-						</nav><!-- .social-navigation -->
-					<?php endif; ?>
-				</div><!-- .wrapper -->
-			</div><!-- .site-menu-container -->
+		<div class="top-header-contain">
+			<div class="wrapper">
+				<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
+					<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'secondary-menu',
+								'menu_class'     => 'secondary-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav>
+				<?php endif; ?>
 
-			<div class="middle-header-contain">
-				<div class="wrapper">
-					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
+				<?php if ( has_nav_menu( 'social' ) && false === get_theme_mod( 'header_center_logo', false ) ) : ?>
+					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'social',
+								'menu_class'     => 'social-links-menu',
+								'link_before'    => '<span class="screen-reader-text">',
+								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .social-navigation -->
+				<?php endif; ?>
+			</div><!-- .wrapper -->
+		</div><!-- .top-header-contain -->
 
-					<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
-						<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'tertiary-menu',
-									'menu_class'     => 'tertiary-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-									'depth'          => 1,
-								)
-							);
-							?>
-						</nav>
-					<?php endif; ?>
-				</div><!-- .wrapper -->
-			</div><!-- .site-branding-container -->
+		<div class="middle-header-contain">
+			<div class="wrapper">
+				<?php if ( has_nav_menu( 'social' ) && true === get_theme_mod( 'header_center_logo', false ) ) : ?>
+					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'social',
+								'menu_class'     => 'social-links-menu',
+								'link_before'    => '<span class="screen-reader-text">',
+								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .social-navigation -->
+				<?php endif; ?>
 
-			<div class="bottom-header-contain">
-				<div class="wrapper">
-					<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
-						<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'primary-menu',
-									'menu_class'     => 'main-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-								)
-							);
-							?>
-						</nav><!-- #site-navigation -->
-					<?php endif; ?>
-				</div><!-- .wrapper -->
-			</div><!-- .bottom-header-contain -->
+				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-		</header><!-- #masthead -->
+				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
+					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'tertiary-menu',
+								'menu_class'     => 'tertiary-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav>
+				<?php endif; ?>
+			</div><!-- .wrapper -->
+		</div><!-- .middle-header-contain -->
+
+		<div class="bottom-header-contain">
+			<div class="wrapper">
+				<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'primary-menu',
+								'menu_class'     => 'main-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							)
+						);
+						?>
+					</nav><!-- #site-navigation -->
+				<?php endif; ?>
+			</div><!-- .wrapper -->
+		</div><!-- .bottom-header-contain -->
+
+	</header><!-- #masthead -->
 
 	<div id="content" class="site-content">

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -18,6 +18,8 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 	}
 
+	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
+	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
 	$theme_css = '
 		/* Set primary background color */
@@ -168,6 +170,22 @@ function newspack_custom_colors_css() {
 		::-moz-selection {
 			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}';
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+		$theme_css .= '
+			.site-header {
+				background-color: ' . $primary_color . ';
+			}
+			.site-header, .site-header a, .site-header a:visited,
+			.site-title, .site-title a:link, .site-title a:visited,
+			.site-description,
+			.main-navigation .main-menu > li,
+			.main-navigation ul.main-menu > li > a,
+			.main-navigation ul.main-menu > li > a:hover {
+				color: ' . $primary_color_contrast . ';
+			}
+		';
+	}
 
 	$editor_css = '
 		/*

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -173,15 +173,19 @@ function newspack_custom_colors_css() {
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
-			.site-header {
+			.header-solid-background .site-header {
 				background-color: ' . $primary_color . ';
 			}
-			.site-header, .site-header a, .site-header a:visited,
-			.site-title, .site-title a:link, .site-title a:visited,
-			.site-description,
-			.main-navigation .main-menu > li,
-			.main-navigation ul.main-menu > li > a,
-			.main-navigation ul.main-menu > li > a:hover {
+			.header-solid-background .site-header,
+			.header-solid-background .site-title,
+			.header-solid-background .site-title a:link,
+			.header-solid-background .site-title a:visited,
+			.header-solid-background .site-description,
+			.header-solid-background .main-navigation .main-menu > li,
+			.header-solid-background .main-navigation ul.main-menu > li > a,
+			.header-solid-background .main-navigation ul.main-menu > li > a:hover,
+			.header-solid-background .top-header-contain,
+			.header-solid-background .middle-header-contain {
 				color: ' . $primary_color_contrast . ';
 			}
 		';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -98,6 +98,60 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - add option to center logo.
+	$wp_customize->add_setting(
+		'header_center_logo',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_center_logo',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Center Logo', 'newspack' ),
+			'description' => esc_html__( 'Check to center the logo in the header.', 'newspack' ),
+			'section'     => 'title_tagline',
+		)
+	);
+
+	// Header - add option for solid background colour.
+	$wp_customize->add_setting(
+		'header_solid_background',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_solid_background',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Solid Background', 'newspack' ),
+			'description' => esc_html__( 'Check to use the primary color as the header background.', 'newspack' ),
+			'section'     => 'title_tagline',
+		)
+	);
+
+	// Header - add option to make header short.
+	$wp_customize->add_setting(
+		'header_short',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_short',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Short Header', 'newspack' ),
+			'description' => esc_html__( 'Check to use a shorter header.', 'newspack' ),
+			'section'     => 'title_tagline',
+		)
+	);
+
 	// Add option to hide page title on static front page.
 	$wp_customize->add_setting(
 		'hide_front_page_title',

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -134,24 +134,6 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Header - add option to make header short.
-	$wp_customize->add_setting(
-		'header_short',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'header_short',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Short Header', 'newspack' ),
-			'description' => esc_html__( 'Check to use a shorter header.', 'newspack' ),
-			'section'     => 'title_tagline',
-		)
-	);
-
 	// Add option to hide page title on static front page.
 	$wp_customize->add_setting(
 		'hide_front_page_title',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -36,6 +36,22 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-homepage-title';
 	}
 
+	// Adds classes to reflect the header layout
+	$header_solid_background = get_theme_mod( 'header_solid_background', false );
+	if ( true === $header_solid_background ) {
+		$classes[] = 'header-solid-background';
+	}
+
+	$header_center_logo = get_theme_mod( 'header_center_logo', false );
+	if ( true === $header_center_logo ) {
+		$classes[] = 'header-center-logo';
+	}
+
+	$header_short = get_theme_mod( 'header_short', false );
+	if ( true === $header_short ) {
+		$classes[] = 'header-short';
+	}
+
 	// Adds a class of has-sidebar when there is a sidebar present.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
 		$classes[] = 'has-sidebar';
@@ -384,4 +400,44 @@ function newspack_adjust_brightness( $hex, $steps ) {
 	}
 
 	return $new_shade;
+}
+
+/**
+ * Pick either white or black, whatever has sufficient contrast with the color being passed to it.
+ *
+ * @param  string $hex Hexidecimal value of the color to adjust.
+ * @return string Either black or white hexidecimal values.
+ *
+ * @ref https://stackoverflow.com/questions/1331591/given-a-background-color-black-or-white-text
+ */
+function newspack_get_color_contrast( $hex ) {
+	// hex RGB
+	$r1 = hexdec( substr( $hex, 1, 2 ) );
+	$g1 = hexdec( substr( $hex, 3, 2 ) );
+	$b1 = hexdec( substr( $hex, 5, 2 ) );
+	// Black RGB
+	$black_color    = '#000';
+	$r2_black_color = hexdec( substr( $black_color, 1, 2 ) );
+	$g2_black_color = hexdec( substr( $black_color, 3, 2 ) );
+	$b2_black_color = hexdec( substr( $black_color, 5, 2 ) );
+	// Calc contrast ratio
+	$l1             = 0.2126 * pow( $r1 / 255, 2.2 ) +
+		0.7152 * pow( $g1 / 255, 2.2 ) +
+		0.0722 * pow( $b1 / 255, 2.2 );
+	$l2             = 0.2126 * pow( $r2_black_color / 255, 2.2 ) +
+		0.7152 * pow( $g2_black_color / 255, 2.2 ) +
+		0.0722 * pow( $b2_black_color / 255, 2.2 );
+	$contrast_ratio = 0;
+	if ( $l1 > $l2 ) {
+		$contrast_ratio = (int) ( ( $l1 + 0.05 ) / ( $l2 + 0.05 ) );
+	} else {
+		$contrast_ratio = (int) ( ( $l2 + 0.05 ) / ( $l1 + 0.05 ) );
+	}
+	if ( $contrast_ratio > 5 ) {
+		// If contrast is more than 5, return black color
+		return '#000';
+	} else {
+		// if not, return white color.
+		return '#fff';
+	}
 }

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -47,11 +47,6 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'header-center-logo';
 	}
 
-	$header_short = get_theme_mod( 'header_short', false );
-	if ( true === $header_short ) {
-		$classes[] = 'header-short';
-	}
-
 	// Adds a class of has-sidebar when there is a sidebar present.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
 		$classes[] = 'has-sidebar';

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -468,25 +468,3 @@
 		opacity: 1;
 	}
 }
-
-.header-center-logo {
-	.main-navigation {
-		border-bottom: 1px solid lighten( $color__text-main, 80% );
-		border-top: 1px solid lighten( $color__text-main, 80% );
-		justify-content: center;
-		padding: #{0.25 * $size__spacing-unit} 0 #{0.5 * $size__spacing-unit};
-	}
-}
-
-.header-solid-background {
-	.bottom-nav-contain {
-		background-color: $color__background-body;
-	}
-
-	.main-navigation .main-menu > li {
-		color: $color__text-main;
-		> a {
-			color: $color__text-main;
-		}
-	}
-}

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -468,3 +468,25 @@
 		opacity: 1;
 	}
 }
+
+.header-center-logo {
+	.main-navigation {
+		border-bottom: 1px solid lighten( $color__text-main, 80% );
+		border-top: 1px solid lighten( $color__text-main, 80% );
+		justify-content: center;
+		padding: #{0.25 * $size__spacing-unit} 0 #{0.5 * $size__spacing-unit};
+	}
+}
+
+.header-solid-background {
+	.bottom-nav-contain {
+		background-color: $color__background-body;
+	}
+
+	.main-navigation .main-menu > li {
+		color: $color__text-main;
+		> a {
+			color: $color__text-main;
+		}
+	}
+}

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -1,9 +1,10 @@
 /* Social menu */
 
 .social-navigation {
-	text-align: left;
+	align-items: center;
+	display: flex;
 
-	ul.social-links-menu {
+	ul {
 		display: flex;
 		margin: 0;
 		padding: 0;

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -31,38 +31,42 @@ nav.tertiary-menu {
 		}
 
 		&:last-child {
-			a {
-				background-color: $color__primary;
-				color: #fff;
-
-				&:hover {
-					background-color: $color__primary-variation;
-				}
-			}
+			font-weight: 700;
 		}
 	}
 
 	a {
-		background-color: lighten($color__text-light, 45%);
-		color: $color__text-main;
-		@include button-transition;
-		border-radius: 5px;
+		color: inherit;
 		display: inline-block;
-		font-size: $font__size-sm;
-		font-weight: 700;
 		margin: #{$size__spacing-unit * 0.25} 0;
-		padding: ($size__spacing-unit * 0.5) ($size__spacing-unit * 0.75);
-
-		&:hover {
-			background-color: $color__text-main;
-			color: #fff;
-		}
+		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.5};
 	}
 }
 
-.header-solid-background {
-	.tertiary-menu a {
-		background: transparent;
-		padding: 0;
+body:not(.header-solid-background) {
+	nav.tertiary-menu {
+		a {
+			background-color: lighten($color__text-light, 45%);
+			color: $color__text-main;
+			@include button-transition;
+			border-radius: 5px;
+			font-size: $font__size-sm;
+			font-weight: 700;
+			padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+
+			&:hover {
+				background-color: $color__text-main;
+				color: #fff;
+			}
+		}
+
+		li:last-child a {
+			background-color: $color__primary;
+			color: #fff;
+
+			&:hover {
+				background-color: $color__primary-variation;
+			}
+		}
 	}
 }

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -59,3 +59,10 @@ nav.tertiary-menu {
 		}
 	}
 }
+
+.header-solid-background {
+	.tertiary-menu a {
+		background: transparent;
+		padding: 0;
+	}
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -1,5 +1,4 @@
 // Site header
-
 .site-header {
 	margin: 0 0 $size__spacing-unit;
 
@@ -9,17 +8,16 @@
 }
 
 // Site branding
-
 .site-branding {
 	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
+	padding: #{ 2 * $size__spacing-unit } 0;
 	position: relative;
 }
 
 // Site logo
-
 .custom-logo-link {
 	box-sizing: content-box;
 	line-height: 1;
@@ -39,7 +37,6 @@
 }
 
 // Site title
-
 .site-title {
 	color: $color__text-main;
 	font-weight: 700;
@@ -60,7 +57,6 @@
 }
 
 // Site description
-
 .site-description {
 	color: $color__text-light;
 	font-weight: normal;
@@ -70,22 +66,23 @@
 }
 
 // Top bar
-
 .top-header-contain {
 	background-color: #4a4a4a;
 	color: #fff;
-	padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
+
+	.wrapper > * {
+		padding-bottom: #{ 0.3 * $size__spacing-unit };
+		padding-top: #{ 0.3 * $size__spacing-unit };
+	}
 }
 
 // Middle bar
-
 .middle-header-contain {
 	align-items: center;
 	padding: $size__spacing-unit 0;
 }
 
 // Bottom bar
-
 .bottom-header-contain {
 	.wrapper {
 		border-bottom: 1px solid #4a4a4a;
@@ -93,7 +90,11 @@
 	}
 }
 
-// Header Customizations
+/**
+ * Header options.
+ */
+
+// Default
 
 body:not(.header-center-logo) {
 	.site-branding {
@@ -111,22 +112,55 @@ body:not(.header-center-logo) {
 	}
 }
 
+// Centred Logo
+
 .header-center-logo {
 	.site-branding {
-		flex-grow: 1;
+		display: block;
+		flex-grow: 2;
 		text-align: center;
 	}
+
+	.social-navigation,
+	nav.tertiary-menu {
+		justify-content: center;
+		width: 100%;
+
+		@include media( tablet ) {
+			justify-content: space-between;
+			width: auto;
+		}
+	}
 }
+
+// Solid Background
 
 .header-solid-background {
 	.site-header {
+		background-color: $color__primary;
 		padding-bottom: 0;
 	}
-}
-
-.header-short {
 	.site-header,
-	.site-branding-container {
-		padding: 0;
+	.site-title a,
+	.site-title a:visited,
+	.site-description,
+	.middle-header-contain {
+		color: #fff;
+	}
+
+	.top-header-contain {
+		background-color: transparent;
+	}
+
+	.bottom-header-contain {
+		background-color: #4a4a4a;
+		.wrapper {
+			border: 0;
+		}
+
+		.main-navigation .main-menu > li,
+		.main-navigation .main-menu > li > a {
+			color: #fff;
+		}
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -11,7 +11,6 @@
 // Site branding
 
 .site-branding {
-	align-items: center;
 	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
@@ -64,7 +63,6 @@
 
 .site-description {
 	color: $color__text-light;
-	flex: 1 1 auto;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	font-style: italic;
@@ -95,3 +93,40 @@
 	}
 }
 
+// Header Customizations
+
+body:not(.header-center-logo) {
+	.site-branding {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+
+		@include media(tablet) {
+			flex-basis: 60%;
+		}
+	}
+
+	.site-description {
+		flex: 1 1 auto;
+	}
+}
+
+.header-center-logo {
+	.site-branding {
+		flex-grow: 1;
+		text-align: center;
+	}
+}
+
+.header-solid-background {
+	.site-header {
+		padding-bottom: 0;
+	}
+}
+
+.header-short {
+	.site-header,
+	.site-branding-container {
+		padding: 0;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a second approach to the header customization approach (the first being #61). 

Instead of using a dropdown to pick between solid background and centred logo, it uses checkboxes, so you can mix and match three options:

* Solid background
* Center logo
* Short header (horribly described, but intended to be used for the compact heading style)

The known fourth option should be 'overlapped header' (as shown in the Style C mockups); I've left it out for now for simplicity. 

### How to test the changes in this Pull Request:

1. Apply PR.
2. Navigate to the Customizer > Site Identity.
3. Test out combinations of the three checkboxes now available.

The header styles aren't without bugs -- they're a bit messed up, and the solid colour preview doesn't use the correct colours. But I'd love to get feedback on this approach, especially contrasted against the one in #61 -- it seems like it'd be easier to create different header combinations with minimal options, but I'd be interested in getting additional opinions on that. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
