### PR TITLE
Reorder single post and update styles

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -72,6 +72,15 @@ function newspack_infinite_scroll_render() {
 }
 
 /**
+ * Remove Jetpack Share icons from standard location so they can be moved.
+ */
+function newspack_remove_jetpack_share() {
+	remove_filter( 'the_content', 'sharing_display', 19 );
+	remove_filter( 'the_excerpt', 'sharing_display', 19 );
+}
+add_action( 'loop_start', 'newspack_remove_jetpack_share' );
+
+/**
  * Alter gallery widget default width.
  */
 function newspack_gallery_widget_content_width( $width ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -41,6 +41,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
+	// Adds class if singular post or page has a featured image.
+	if ( is_singular() && has_post_thumbnail() ) {
+		$classes[] = 'has-featured-image';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -84,23 +84,38 @@ if ( ! function_exists( 'newspack_comment_count' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'newspack_categories' ) ) :
+	/**
+	 * Prints HTML with the current post's categories.
+	 */
+	function newspack_categories() {
+		$categories_list = get_the_category_list( ' ' );
+		if ( $categories_list ) {
+			printf(
+				/* translators: 1: posted in label, only visible to screen readers. 2: list of categories. */
+				'<span class="cat-links"><span class="screen-reader-text">%1$s</span>%2$s</span>',
+				esc_html__( 'Posted in', 'newspack' ),
+				$categories_list
+			); // WPCS: XSS OK.
+		}
+	}
+endif;
+
 if ( ! function_exists( 'newspack_entry_footer' ) ) :
 	/**
-	 * Prints HTML with meta information for the categories, tags and comments.
+	 * Prints HTML with meta information for the tags and comments.
 	 */
 	function newspack_entry_footer() {
 
 		// Hide author, post date, category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
 
-			/* translators: used between list items, there is a space after the comma. */
-			$tags_list = get_the_tag_list( '', __( ', ', 'newspack' ) );
+			$tags_list = get_the_tag_list( '', ' ' );
 			if ( $tags_list ) {
 				printf(
-					/* translators: 1: SVG icon. 2: posted in label, only visible to screen readers. 3: list of tags. */
-					'<span class="tags-links">%1$s<span class="screen-reader-text">%2$s </span>%3$s</span>',
-					newspack_get_icon_svg( 'tag', 16 ),
-					__( 'Tags:', 'newspack' ),
+					/* translators: 1: posted in label, only visible to screen readers. 2: list of tags. */
+					'<span class="tags-links"><span>%1$s </span>%2$s</span>',
+					esc_html__( 'Tagged:', 'newspack' ),
 					$tags_list
 				); // WPCS: XSS OK.
 			}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -951,6 +951,10 @@
 			@include media(tablet) {
 				margin-left: 0;
 			}
+
+			&.wp-block-image img {
+				width: 100%;
+			}
 		}
 	}
 }

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -17,15 +17,6 @@
 			.meta-nav {
 				color: $color__text-light;
 				user-select: none;
-
-				&:before,
-				&:after {
-					display: none;
-					content: "—";
-					width: 2em;
-					color: $color__text-light;
-					height: 1em;
-				}
 			}
 
 			.post-title {
@@ -46,12 +37,6 @@
 		}
 
 		.nav-previous {
-			order: 2;
-
-			@include media(desktop) {
-				order: 1;
-			}
-
 			+ .nav-next {
 				margin-bottom: $size__spacing-unit;
 			}
@@ -64,10 +49,8 @@
 		}
 
 		.nav-next {
-			order: 1;
 
 			@include media(desktop) {
-				order: 2;
 				padding-left: $size__spacing-unit;
 			}
 

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -7,10 +7,10 @@
 }
 
 .comments-area {
-	margin: calc(2 * #{$size__spacing-unit}) $size__spacing-unit;
+	margin: calc(2 * #{$size__spacing-unit}) 0;
 
 	@include media(tablet) {
-		margin: calc(3 * #{$size__spacing-unit}) auto;
+		margin: calc(3 * #{$size__spacing-unit}) 0;
 	}
 
 	& > * {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -38,6 +38,36 @@
 	}
 }
 
+.cat-links {
+	font-size: $font__size-xs;
+	margin: 0 0 calc( #{$size__spacing-unit} * 2 );
+
+	a {
+		background-color: $color__primary;
+		color: #fff;
+		display: inline-block;
+		padding: 0.5em 0.75em;
+		text-transform: uppercase;
+
+		&:hover {
+			background-color: $color__primary-variation;
+		}
+	}
+}
+
+.tags-links {
+	span {
+		font-weight: bold;
+		text-transform: uppercase;
+	}
+
+	a {
+		background-color: #f1f1f1;
+		display: inline-block;
+		padding: 0.5em 0.75em;
+	}
+}
+
 .entry-meta,
 .entry-footer {
 
@@ -79,19 +109,17 @@
 }
 
 .entry-footer {
-	margin: calc(2 * #{$size__spacing-unit}) 0 $size__spacing-unit;
-	@include media(desktop) {
-		max-width: $size__site-desktop-content;
-	}
-
 	> span {
-
 		margin-right: $size__spacing-unit;
 		display: inline-block;
 
 		&:last-child {
 			margin-right: 0;
 		}
+	}
+
+	a {
+		color: $color__primary;
 	}
 }
 
@@ -203,6 +231,23 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
+	}
+
+	@include media(mobile) {
+		.entry-subhead {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+			width: 100%;
+
+			.entry-meta {
+				flex-grow: 2;
+			}
+		}
+	}
+
+	div.sharedaddy h3.sd-title {
+		display: none;
 	}
 }
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -21,7 +21,8 @@
 }
 
 .entry-header {
-	margin: calc(3 * #{ $size__spacing-unit}) 0 $size__spacing-unit;
+	margin: calc(3 * #{ $size__spacing-unit}) 0 0;
+	padding: 0 0 $size__spacing-unit;
 	position: relative;
 }
 
@@ -39,13 +40,13 @@
 }
 
 .cat-links {
+	display: block;
 	font-size: $font__size-xs;
-	margin: 0 0 calc( #{$size__spacing-unit} * 2 );
+	margin: 0 0 $size__spacing-unit;
 
 	a {
 		background-color: $color__primary;
 		color: #fff;
-		display: inline-block;
 		padding: 0.5em 0.75em;
 		text-transform: uppercase;
 
@@ -90,8 +91,6 @@
 }
 
 .entry-meta {
-	margin: $size__spacing-unit 0;
-
 	.author-avatar {
 		float: left;
 		margin-right: #{ $size__spacing-unit * 0.5 };
@@ -208,8 +207,13 @@
 		width: 100%;
 	}
 
+	&:not(.has-featured-image) .entry-header {
+		border-bottom: 1px solid #ddd;
+	}
+
 	.entry-title {
 		font-size: $font__size-xxxl;
+		margin: 0 0 0.5em;
 
 		@include media(desktop) {
 			font-size: $font__size-xxxxl;
@@ -248,6 +252,13 @@
 
 	div.sharedaddy h3.sd-title {
 		display: none;
+	}
+
+	.sd-content {
+		margin-bottom: -0.7em; // offsets Jetpack's default styles w/out using !important
+		ul li {
+			margin-bottom: 0;
+		}
 	}
 }
 

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -5,6 +5,7 @@
 .comment-author .fn,
 .discussion-meta-info,
 .entry-meta,
+.cat-links,
 .entry-footer,
 .main-navigation,
 .no-comments,
@@ -34,6 +35,7 @@ h6 {
 .post-navigation .post-title,
 .pagination .nav-links,
 .comments-title,
+.cat-links,
 .comment-author .fn,
 .no-comments,
 .site-title,
@@ -100,6 +102,7 @@ h3 {
 .no-comments,
 h2.author-title,
 p.author-bio,
+.tags-links span,
 h4 {
 	font-size: $font__size-md;
 }

--- a/single.php
+++ b/single.php
@@ -43,11 +43,9 @@ get_header();
 						// Previous/next post navigation.
 						the_post_navigation(
 							array(
-								'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next Post', 'newspack' ) . '</span> ' .
-									'<span class="screen-reader-text">' . __( 'Next post:', 'newspack' ) . '</span> <br/>' .
+								'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next article:', 'newspack' ) . '</span><br/>' .
 									'<span class="post-title">%title</span>',
-								'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous Post', 'newspack' ) . '</span> ' .
-									'<span class="screen-reader-text">' . __( 'Previous post:', 'newspack' ) . '</span> <br/>' .
+								'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous article:', 'newspack' ) . '</span><br/>' .
 									'<span class="post-title">%title</span>',
 							)
 						);
@@ -58,7 +56,7 @@ get_header();
 						comments_template();
 					}
 					?>
-				</div>
+				</div><!-- .main-content -->
 
 			<?php
 				endwhile;

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -9,6 +9,11 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 
 
 <?php if ( is_singular() ) : ?>
+	<?php
+	if ( ! is_page() ) :
+		newspack_categories();
+	endif;
+	?>
 	<h1 class="entry-title">
 		<?php echo wp_kses_post( get_the_title() ); ?>
 	</h1>
@@ -21,8 +26,16 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 <?php endif; ?>
 
 <?php if ( ! is_page() ) : ?>
-<div class="entry-meta">
-	<?php newspack_posted_by(); ?>
-	<?php newspack_posted_on(); ?>
-</div><!-- .meta-info -->
+	<div class="entry-subhead">
+		<div class="entry-meta">
+			<?php newspack_posted_by(); ?>
+			<?php newspack_posted_on(); ?>
+		</div><!-- .meta-info -->
+		<?php
+			// Display Jetpack Share icons, if enabled
+			if ( function_exists( 'sharing_display' ) ) {
+				sharing_display( '', true );
+			}
+		?>
+	</div>
 <?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a version rescuing changes I made, and tried to recover, from #69. I originally thought I accidentally merged some of that PR, but on inspection it looks like I just blew it up without affecting the master branch (CC @jeffersonrabb, since i mislead you on this point earlier). 

This PR makes updates to the single article's appearance and order to match the mockups; specific changes include:

1. Moving Jetpack's sharing icon output to site up next to the title.
2. Moving the category output above the title.
3. Adjusts general styles and spacing.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build` (edited to add the build).
2. Activate Jetpack's share buttons; set to just show icons.
3. Review single stories and compare against the mockups; make sure they generally look correct. Note: the sharing icons display different with AMP enabled (large and rectangular, not smaller and rounded) - I'm less familiar with the styling there, so have opted not to try to override it for now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
