### PR TITLE
Add separate front-page.php template to theme

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts
+ * The template for displaying the static front page.
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *

--- a/front-page.php
+++ b/front-page.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * The template for displaying all single posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package Newspack
+ */
+
+get_header();
+?>
+	<section id="primary" class="content-area">
+		<main id="main" class="site-main">
+
+			<?php
+
+			/* Start the Loop */
+			while ( have_posts() ) :
+				the_post();
+
+				get_template_part( 'template-parts/content/content', 'page' );
+
+				// If comments are open or we have at least one comment, load up the comment template.
+				if ( comments_open() || get_comments_number() ) {
+					comments_template();
+				}
+
+			endwhile; // End of the loop.
+			?>
+
+		</main><!-- #main -->
+	</section><!-- #primary -->
+
+<?php
+get_footer();

--- a/functions.php
+++ b/functions.php
@@ -306,7 +306,7 @@ function newspack_is_static_front_page() {
 	global $post;
 	$page_on_front = intval( get_option( 'page_on_front' ) );
 	return isset( $post->ID ) && intval( $post->ID ) === $page_on_front;
-};
+}
 
 /**
  * Add body class on editor pages if editing the static front page.
@@ -326,6 +326,17 @@ function newspack_enqueue_editor_static_front_page_assets( $classes ) {
 add_filter( 'admin_body_class', 'newspack_filter_admin_body_class', 10, 1 );
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_editor_static_front_page_assets' );
 
+/**
+ * Use front-page.php when Front page displays is set to a static page.
+ *
+ * @param string $template front-page.php.
+ *
+ * @return string The template to be used: blank if is_home() is true (defaults to index.php), else $template.
+ */
+function newspack_front_page_template( $template ) {
+	return is_home() ? '' : $template;
+}
+add_filter( 'frontpage_template', 'newspack_front_page_template' );
 
 /**
  * Display custom color CSS in customizer and on frontend.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a front-page.php template to the theme. There's also a filter to make sure this template is only used on the static front page and not when the front page is set to a blog posts page, just in case -- the filter is borrowed from the same approach used in Twenty Seventeen, and saves having to add a home.php as well to avoid that issue.

I opted to add a new template instead of a conditional check to page.php so the sidebar wouldn't show up, in case we need additional changes to the front page. 

Closes #99 .

### How to test the changes in this Pull Request:

1. Set up your test site with a sidebar. 
2. View the static front page; confirm that the sidebar content displays below the page content.
3. Apply the PR and run `npm run build`. 
4. Refresh the static front page; confirm that the sidebar content is gone. 
5. Navigate to Customizer > Homepage Settings, and set the homepage to display the blog posts 
6. View the front page; confirm that the sidebar is visible (confirming that it's not using the new front-page.php). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?