### PR TITLE
Adds fallback location for featured image when less than 1200 wide.

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -46,6 +46,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-featured-image';
 	}
 
+	// Adds a class if singular post has a large featured image
+	$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+	if ( is_single() && has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+		$classes[] = 'has-large-featured-image';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -223,7 +223,8 @@
 		width: 100%;
 	}
 
-	&:not(.has-featured-image) .entry-header {
+	&:not(.has-featured-image) .entry-header,
+	&.has-large-featured-image .entry-header {
 		border-bottom: 1px solid #ddd;
 	}
 
@@ -245,6 +246,12 @@
 		.main-content {
 			margin-left: auto;
 			margin-right: auto;
+		}
+	}
+
+	.main-content {
+		.post-thumbnail:first-child {
+			margin-top: #{ 2 * $size__spacing-unit };
 		}
 	}
 

--- a/single-feature.php
+++ b/single-feature.php
@@ -11,6 +11,7 @@
  */
 
 get_header();
+$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 ?>
 
 	<section id="primary" class="content-area">
@@ -27,9 +28,21 @@ get_header();
 					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 				</header>
 
-				<?php newspack_post_thumbnail(); ?>
+				<?php
+				// Place larger featured images above content area.
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
+					newspack_post_thumbnail();
+				}
+				?>
 
 				<div class="main-content">
+
+					<?php
+					// Place smaller featured images inside of 'content' area.
+					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+						newspack_post_thumbnail();
+					}
+					?>
 
 					<?php
 					get_template_part( 'template-parts/content/content', 'single' );

--- a/single.php
+++ b/single.php
@@ -8,6 +8,7 @@
  */
 
 get_header();
+$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 ?>
 
 	<section id="primary" class="content-area">
@@ -24,9 +25,21 @@ get_header();
 					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 				</header>
 
-				<?php newspack_post_thumbnail(); ?>
+				<?php
+				// Place larger featured images above content area.
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
+					newspack_post_thumbnail();
+				}
+				?>
 
 				<div class="main-content">
+
+					<?php
+					// Place smaller featured images inside of 'content' area.
+					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+						newspack_post_thumbnail();
+					}
+					?>
 
 					<?php
 					get_template_part( 'template-parts/content/content', 'single' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the single article templates rely on featured images at least 1200px wide to look correct. If you upload something smaller, they can look a bit sad:

![image](https://user-images.githubusercontent.com/177561/61324066-61578680-a7c6-11e9-8fad-9c766517386b.png)

If you add something really small, it can look downright broken:

![image](https://user-images.githubusercontent.com/177561/61324113-81874580-a7c6-11e9-8c1c-fe58036c803b.png)

The latter is an edge case, but it's pretty reasonable that a news story may have a featured image smaller than 1200px. This PR adds a check for image size, and 'moves' the image into the main content area if it less than 1200px wide:

![image](https://user-images.githubusercontent.com/177561/61324821-26eee900-a7c8-11e9-9b95-4cbb0f62b602.png)

Ideally the image would still be at least 780px wide to fill the column, but if it's not (like above) it doesn't fail badly. 

### How to test the changes in this Pull Request:

1. Set up a post with a smaller featured image -- about 600px - 700px wide. 
2. View the post on the front end and note its appearance.
3. Apply the PR and run `npm run build`.
4. Reassess the featured image's appearance; make sure it sits next to the sidebar and doesn't look 'weird'.
5. Test with a larger featured image (1200px wide and higher) and make sure it still displays nicely above both the content and sidebar columns. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?