### PR TITLE
Build out theme footer styles

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -32,26 +32,26 @@
 				</a>
 
 				<?php
-				if ( has_nav_menu( 'footer' ) ) :
-				?>
-					<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'newspack' ); ?>">
-						<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'footer',
-									'menu_class'     => 'footer-menu',
-									'depth'          => 1,
-								)
-							);
-						?>
-					</nav><!-- .footer-navigation -->
-				<?php
-				endif;
-
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
 				}
 				?>
+
+				<?php if ( ! is_active_sidebar( 'footer-1' ) && has_nav_menu( 'social' ) ) : ?>
+					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'social',
+								'menu_class'     => 'social-links-menu',
+								'link_before'    => '<span class="screen-reader-text">',
+								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav><!-- .social-navigation -->
+				<?php endif; ?>
 			</div><!-- .wrapper -->
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->

--- a/footer.php
+++ b/footer.php
@@ -14,36 +14,45 @@
 	</div><!-- #content -->
 
 	<footer id="colophon" class="site-footer">
+		<?php get_template_part( 'template-parts/footer/footer', 'branding' ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
+
 		<div class="site-info">
-			<?php $blog_info = get_bloginfo( 'name' ); ?>
-			<?php if ( ! empty( $blog_info ) ) : ?>
-				<a class="site-name" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a><span class="comma">,</span>
-			<?php endif; ?>
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'newspack' ) ); ?>" class="imprint">
-				<?php
-				/* translators: %s: WordPress. */
-				printf( __( 'Proudly powered by %s.', 'newspack' ), 'WordPress' );
-				?>
-			</a>
-			<?php
-			if ( function_exists( 'the_privacy_policy_link' ) ) {
-				the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
-			}
-			?>
-			<?php if ( has_nav_menu( 'footer' ) ) : ?>
-				<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'newspack' ); ?>">
+			<div class="wrapper">
+				<?php $blog_info = get_bloginfo( 'name' ); ?>
+				<?php if ( ! empty( $blog_info ) ) : ?>
+					&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>.
+				<?php endif; ?>
+
+				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'newspack' ) ); ?>" class="imprint">
 					<?php
-					wp_nav_menu(
-						array(
-							'theme_location' => 'footer',
-							'menu_class'     => 'footer-menu',
-							'depth'          => 1,
-						)
-					);
+					/* translators: %s: WordPress. */
+					printf( esc_html__( 'Proudly powered by %s.', 'newspack' ), 'WordPress' );
 					?>
-				</nav><!-- .footer-navigation -->
-			<?php endif; ?>
+				</a>
+
+				<?php
+				if ( has_nav_menu( 'footer' ) ) :
+				?>
+					<nav class="footer-navigation" aria-label="<?php esc_attr_e( 'Footer Menu', 'newspack' ); ?>">
+						<?php
+							wp_nav_menu(
+								array(
+									'theme_location' => 'footer',
+									'menu_class'     => 'footer-menu',
+									'depth'          => 1,
+								)
+							);
+						?>
+					</nav><!-- .footer-navigation -->
+				<?php
+				endif;
+
+				if ( function_exists( 'the_privacy_policy_link' ) ) {
+					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+				}
+				?>
+			</div><!-- .wrapper -->
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->
 

--- a/footer.php
+++ b/footer.php
@@ -35,23 +35,11 @@
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
 				}
-				?>
 
-				<?php if ( ! is_active_sidebar( 'footer-1' ) && has_nav_menu( 'social' ) ) : ?>
-					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'social',
-								'menu_class'     => 'social-links-menu',
-								'link_before'    => '<span class="screen-reader-text">',
-								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav><!-- .social-navigation -->
-				<?php endif; ?>
+				if ( ! is_active_sidebar( 'footer-1' ) ) {
+					newspack_social_menu();
+				}
+				?>
 			</div><!-- .wrapper -->
 		</div><!-- .site-info -->
 	</footer><!-- #colophon -->

--- a/functions.php
+++ b/functions.php
@@ -57,7 +57,6 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
 				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
 				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
-				'footer'         => __( 'Footer Menu', 'newspack' ),
 				'social'         => __( 'Social Links Menu', 'newspack' ),
 			)
 		);

--- a/functions.php
+++ b/functions.php
@@ -226,6 +226,49 @@ function newspack_widgets_init() {
 add_action( 'widgets_init', 'newspack_widgets_init' );
 
 /**
+ * Counts the number of widgets in a specific sidebar
+ *
+ * @param  string $id the widget area ID.
+ * @return integer number of widgets in the sidebar.
+ */
+function newspack_count_widgets( $id ) {
+	$count            = 0;
+	$sidebars_widgets = wp_get_sidebars_widgets();
+
+	if ( array_key_exists( $id, $sidebars_widgets ) ) {
+
+		foreach ( (array) $sidebars_widgets[ $id ] as $value ) {
+			// Don't count the Cookies or Mailchimp widgets, since they're not visible in the widget area.
+			if ( strpos( $value, 'eu_cookie_law_widget' ) === false && strpos( $value, 'widget_mailchimp_subscriber_popup' ) === false ) {
+				$count++;
+			}
+		}
+	}
+	return $count;
+}
+
+/**
+ * Widget column class helper
+ *
+ * @param  string $widget_id the widget area ID.
+ * @return string grid class.
+ */
+function newspack_widget_column_class( $widget_id ) {
+	$count = newspack_count_widgets( $widget_id );
+	$class = '';
+	if ( $count >= 4 ) {
+		$class .= 'widgets-four';
+	} elseif ( 3 == $count ) {
+		$class .= 'widgets-three';
+	} elseif ( 2 == $count ) {
+		$class .= 'widgets-two';
+	} else {
+		$class .= 'widget-one';
+	}
+	return $class;
+}
+
+/**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
  * Priority 0 to make it available to lower priority callbacks.

--- a/functions.php
+++ b/functions.php
@@ -57,8 +57,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
 				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
 				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
-				'footer'         => __( 'Footer Menu', 'newspack' ),
 				'social'         => __( 'Social Links Menu', 'newspack' ),
+				'footer'         => __( 'Footer Menu', 'newspack' ),
 			)
 		);
 

--- a/functions.php
+++ b/functions.php
@@ -57,8 +57,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
 				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
 				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
-				'social'         => __( 'Social Links Menu', 'newspack' ),
 				'footer'         => __( 'Footer Menu', 'newspack' ),
+				'social'         => __( 'Social Links Menu', 'newspack' ),
 			)
 		);
 
@@ -224,49 +224,6 @@ function newspack_widgets_init() {
 
 }
 add_action( 'widgets_init', 'newspack_widgets_init' );
-
-/**
- * Counts the number of widgets in a specific sidebar
- *
- * @param  string $id the widget area ID.
- * @return integer number of widgets in the sidebar.
- */
-function newspack_count_widgets( $id ) {
-	$count            = 0;
-	$sidebars_widgets = wp_get_sidebars_widgets();
-
-	if ( array_key_exists( $id, $sidebars_widgets ) ) {
-
-		foreach ( (array) $sidebars_widgets[ $id ] as $value ) {
-			// Don't count the Cookies or Mailchimp widgets, since they're not visible in the widget area.
-			if ( strpos( $value, 'eu_cookie_law_widget' ) === false && strpos( $value, 'widget_mailchimp_subscriber_popup' ) === false ) {
-				$count++;
-			}
-		}
-	}
-	return $count;
-}
-
-/**
- * Widget column class helper
- *
- * @param  string $widget_id the widget area ID.
- * @return string grid class.
- */
-function newspack_widget_column_class( $widget_id ) {
-	$count = newspack_count_widgets( $widget_id );
-	$class = '';
-	if ( $count >= 4 ) {
-		$class .= 'widgets-four';
-	} elseif ( 3 == $count ) {
-		$class .= 'widgets-three';
-	} elseif ( 2 == $count ) {
-		$class .= 'widgets-two';
-	} else {
-		$class .= 'widget-one';
-	}
-	return $class;
-}
 
 /**
  * Set the content width in pixels, based on the theme's design and stylesheet.

--- a/functions.php
+++ b/functions.php
@@ -391,6 +391,31 @@ function newspack_typography_css_wrap() {
 }
 add_action( 'wp_head', 'newspack_typography_css_wrap' );
 
+
+/**
+ * Display social links menu.
+ */
+function newspack_social_menu() {
+	if ( ! has_nav_menu( 'social' ) ) {
+		return;
+	}
+	?>
+	<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+		<?php
+		wp_nav_menu(
+			array(
+				'theme_location' => 'social',
+				'menu_class'     => 'social-links-menu',
+				'link_before'    => '<span class="screen-reader-text">',
+				'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+				'depth'          => 1,
+			)
+		);
+		?>
+	</nav><!-- .social-navigation -->
+<?php
+}
+
 /**
  * Returns an array of 'acceptable' SVG tags to use with wp_kses().
  */

--- a/header.php
+++ b/header.php
@@ -40,21 +40,7 @@
 					</nav>
 				<?php endif; ?>
 
-				<?php if ( has_nav_menu( 'social' ) && false === get_theme_mod( 'header_center_logo', false ) ) : ?>
-					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'social',
-								'menu_class'     => 'social-links-menu',
-								'link_before'    => '<span class="screen-reader-text">',
-								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav><!-- .social-navigation -->
-				<?php endif; ?>
+				<?php newspack_social_menu(); ?>
 			</div><!-- .wrapper -->
 		</div><!-- .top-header-contain -->
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -2,32 +2,49 @@
 
 #colophon {
 
-	.widget-area,
-	.site-info {
-		margin: calc(2 * #{$size__spacing-unit}) auto;
-		max-width: 90%;
-		width: $size__site-main;
+	.footer-branding {}
 
-		@include media(tablet) {
-			margin: calc(3 * #{$size__spacing-unit}) auto;
+	.widget-area {
+
+		.wrapper {
+			justify-content: flex-start;
 		}
-	}
-
-	.widget-column {
-		display: flex;
-		flex-wrap: wrap;
 
 		.widget {
 			width: 100%;
-			@include media(desktop) {
+			@include media(tablet) {
 				margin-right: calc(3 * #{$size__spacing-unit});
-				width: calc(33% - (3 * #{$size__spacing-unit}));
+				width: calc(25% - (3 * #{$size__spacing-unit}));
+			}
+		}
+
+		&.widgets-two {
+			.widget {
+				@include media(tablet) {
+					width: calc(50% - (3 * #{$size__spacing-unit}));
+				}
+			}
+		}
+
+		&.widgets-three {
+			.widget {
+				@include media(tablet) {
+					&:first-child {
+						width: calc(50% - (3 * #{$size__spacing-unit}));
+					}
+				}
 			}
 		}
 	}
 
 	.site-info {
 		color: $color__text-light;
+
+		.wrapper {
+			border-top: 1px solid #ccc;
+			justify-content: flex-start;
+			padding: $size__spacing-unit 0;
+		}
 
 		a {
 			color: inherit;

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -1,39 +1,52 @@
 /* Site footer */
 
 #colophon {
+	margin: #{ 2 * $size__spacing-unit } 0 0;
 
-	.footer-branding {}
+	a {
+		color: $color__text-light;
+	}
+
+	.footer-branding {
+		.wrapper {
+			border-top: 4px solid #ccc;
+			padding-top: $size__spacing-unit;
+		}
+
+		.custom-logo-link {
+			margin-bottom: $size__spacing-unit;
+		}
+	}
 
 	.widget-area {
+		padding: $size__spacing-unit 0 #{ 2 * $size__spacing-unit };
 
 		.wrapper {
-			justify-content: flex-start;
+			flex-wrap: wrap;
+			justify-content: space-between;
 		}
 
 		.widget {
 			width: 100%;
-			@include media(tablet) {
-				margin-right: calc(3 * #{$size__spacing-unit});
-				width: calc(25% - (3 * #{$size__spacing-unit}));
+
+			@include media( mobile ) {
+				flex: 1 0 0;
+				margin-right: $size__spacing-unit;
+				min-width: calc( 50% - #{ $size__spacing-unit } );
+			}
+
+			@include media( tablet ) {
+				min-width: calc( 25% - #{ $size__spacing-unit } );
+			}
+
+			&:last-child {
+				margin-right: 0;
 			}
 		}
 
-		&.widgets-two {
-			.widget {
-				@include media(tablet) {
-					width: calc(50% - (3 * #{$size__spacing-unit}));
-				}
-			}
-		}
-
-		&.widgets-three {
-			.widget {
-				@include media(tablet) {
-					&:first-child {
-						width: calc(50% - (3 * #{$size__spacing-unit}));
-					}
-				}
-			}
+		.widget-title {
+			color: $color__text-light;
+			font-size: inherit;
 		}
 	}
 
@@ -42,7 +55,7 @@
 
 		.wrapper {
 			border-top: 1px solid #ccc;
-			justify-content: flex-start;
+			justify-content: space-between;
 			padding: $size__spacing-unit 0;
 		}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -30,7 +30,7 @@
 			width: 100%;
 
 			@include media( mobile ) {
-				flex: 1 0 0;
+				flex: 1 0 0px;
 				margin-right: $size__spacing-unit;
 				min-width: calc( 50% - #{ $size__spacing-unit } );
 			}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -27,6 +27,7 @@
 		height: auto;
 		min-height: inherit;
 		max-height: 100px;
+		max-width: 200px;
 		width: auto;
 
 		@include media( tablet ) {

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -1,8 +1,7 @@
 .widget {
-	color: $color__text-main;
 	font-family: $font__heading;
 	font-size: $font__size-sm;
-	margin: 0 0 #{$size__spacing-unit * 2};
+	margin: 0 0 $size__spacing-unit;
 	word-wrap: break-word;
 
 	@include media( tablet ) {
@@ -42,9 +41,11 @@
 
 		li {
 			font-family: $font__heading;
+			margin-bottom: #{ 0.25 * $size__spacing-unit };
 
 			ul {
 				margin-left: 1.5em;
+				margin-top: #{ 0.5 * $size__spacing-unit };
 			}
 		}
 	}
@@ -53,7 +54,7 @@
 .widget_recent_comments,
 .widget_recent_entries {
 	li {
-		margin-bottom: 1em;
+		margin-bottom: #{ 0.5 * $size__spacing-unit };
 	}
 }
 

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -13,23 +13,8 @@ if ( is_active_sidebar( 'footer-1' ) ) : ?>
 				<?php the_custom_logo(); ?>
 			<?php
 			endif;
-
-			if ( has_nav_menu( 'social' ) ) :
+			newspack_social_menu();
 			?>
-				<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-					<?php
-					wp_nav_menu(
-						array(
-							'theme_location' => 'social',
-							'menu_class'     => 'social-links-menu',
-							'link_before'    => '<span class="screen-reader-text">',
-							'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-							'depth'          => 1,
-						)
-					);
-					?>
-				</nav><!-- .social-navigation -->
-			<?php endif; ?>
 		</div><!-- .wrapper -->
 	</div><!-- .footer-branding -->
 <?php endif; ?>

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -4,30 +4,32 @@
  *
  * @package Newspack
  */
-?>
 
-<div class="footer-branding">
-	<div class="wrapper">
-		<?php if ( has_custom_logo() ) : ?>
-			<div class="site-logo"><?php the_custom_logo(); ?></div>
-		<?php
-		endif;
 
-		if ( has_nav_menu( 'social' ) ) :
-		?>
-			<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-				<?php
-				wp_nav_menu(
-					array(
-						'theme_location' => 'social',
-						'menu_class'     => 'social-links-menu',
-						'link_before'    => '<span class="screen-reader-text">',
-						'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-						'depth'          => 1,
-					)
-				);
-				?>
-			</nav><!-- .social-navigation -->
-		<?php endif; ?>
-	</div><!-- .wrapper -->
-</div><!-- .footer-branding -->
+if ( is_active_sidebar( 'footer-1' ) ) : ?>
+	<div class="footer-branding">
+		<div class="wrapper">
+			<?php if ( has_custom_logo() ) : ?>
+				<?php the_custom_logo(); ?>
+			<?php
+			endif;
+
+			if ( has_nav_menu( 'social' ) ) :
+			?>
+				<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+					<?php
+					wp_nav_menu(
+						array(
+							'theme_location' => 'social',
+							'menu_class'     => 'social-links-menu',
+							'link_before'    => '<span class="screen-reader-text">',
+							'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+							'depth'          => 1,
+						)
+					);
+					?>
+				</nav><!-- .social-navigation -->
+			<?php endif; ?>
+		</div><!-- .wrapper -->
+	</div><!-- .footer-branding -->
+<?php endif; ?>

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Displays the footer branding and social links.
+ *
+ * @package Newspack
+ */
+?>
+
+<div class="footer-branding">
+	<div class="wrapper">
+		<?php if ( has_custom_logo() ) : ?>
+			<div class="site-logo"><?php the_custom_logo(); ?></div>
+		<?php
+		endif;
+
+		if ( has_nav_menu( 'social' ) ) :
+		?>
+			<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+				<?php
+				wp_nav_menu(
+					array(
+						'theme_location' => 'social',
+						'menu_class'     => 'social-links-menu',
+						'link_before'    => '<span class="screen-reader-text">',
+						'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+						'depth'          => 1,
+					)
+				);
+				?>
+			</nav><!-- .social-navigation -->
+		<?php endif; ?>
+	</div><!-- .wrapper -->
+</div><!-- .footer-branding -->

--- a/template-parts/footer/footer-widgets.php
+++ b/template-parts/footer/footer-widgets.php
@@ -7,16 +7,14 @@
 
 if ( is_active_sidebar( 'footer-1' ) ) : ?>
 
-	<aside class="widget-area" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
-		<?php
-		if ( is_active_sidebar( 'footer-1' ) ) {
+	<aside class="widget-area <?php echo esc_attr( newspack_widget_column_class( 'footer-1' ) ); ?>" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
+		<div class="wrapper">
+			<?php
+			if ( is_active_sidebar( 'footer-1' ) ) {
+				dynamic_sidebar( 'footer-1' );
+			}
 			?>
-					<div class="widget-column footer-widget-1">
-					<?php dynamic_sidebar( 'footer-1' ); ?>
-					</div>
-				<?php
-		}
-		?>
+		</div><!-- .wrapper -->
 	</aside><!-- .widget-area -->
 
 <?php endif; ?>

--- a/template-parts/footer/footer-widgets.php
+++ b/template-parts/footer/footer-widgets.php
@@ -7,7 +7,7 @@
 
 if ( is_active_sidebar( 'footer-1' ) ) : ?>
 
-	<aside class="widget-area <?php echo esc_attr( newspack_widget_column_class( 'footer-1' ) ); ?>" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
+	<aside class="widget-area" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
 		<div class="wrapper">
 			<?php
 			if ( is_active_sidebar( 'footer-1' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is an initial pass at the theme's footer styles.

I'm initially trying an approach where the different layouts presented in the mockups can be achieved by the content you assign. So if you add footer widgets, the existing social navigation and theme's logo will automatically appear above them.

![image](https://user-images.githubusercontent.com/177561/61339662-a80fa580-a7f3-11e9-8c3d-833658e972b5.png)

In this example, the widgets will take up even amounts of room, up to four across, at which point they will wrap (with the first four taking up 25% of the space, and the next one taking up 100%, or the next two, 50% each, next three, 33% each -- basically up to 25% each to fill the next line before wrapping again). Ideally sites will only use four widgets if they take this approach.

If you don't add widgets, the social navigation will instead appear next to the copyright information:

![image](https://user-images.githubusercontent.com/177561/61339694-cfff0900-a7f3-11e9-9303-853fa548635c.png)

This approach should help us recreate two of the three footer mockups presented. The third -- with the asymmetrical columns from the style E mockups needs a bit more thought, so is not addressed in this PR:

![image](https://user-images.githubusercontent.com/177561/61339816-603d4e00-a7f4-11e9-908d-e2e91b34faa8.png)

The columns themselves can be achieved by using the experimental widget block in Gutenberg 6, which lets you insert a column block into the widget area and adjust the columns widths, then nest regular widgets inside. The positioning of the social icons, though, might mean we need to add an option to show the social links next to the logo above the widgets, or alone below them, instead of relying on whether or not there are widgets assigned. 

I'll explore that in another PR -- right now let's focus on the first two examples :) 

### How to test the changes in this Pull Request:

To test layout 1:
1. Apply the PR and run `npm run build`. 
2. If your site doesn't have one already, add a logo and social navigation.
3. Add one widget; confirm it fills the available space.
4. Do the same with 2 through four (which should look like the first mockup above).
5. Add a fifth width and confirm it wraps to a new line.
6. Test the above with a few screen sizes to make sure elements stack.

To test layout 2:
1. Remove all footer widgets.
2. Confirm that the logo no longer displays in the footer but the social links do (similar in layout -- though not background colour -- to the second mockup above). 
3. Test the above with a few screen sizes to make sure elements stack.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?