### PR TITLE
Updates search form styles

### DIFF
--- a/classes/class-newspack-svg-icons.php
+++ b/classes/class-newspack-svg-icons.php
@@ -165,6 +165,11 @@ class Newspack_SVG_Icons {
         <path fill="currentColor" fill-rule="nonzero" d="M12 2c5.52 0 10 4.48 10 10s-4.48 10-10 10S2 17.52 2 12 6.48 2 12 2zM6 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/>
     </g>
 </svg>',
+		'search'                   => /* martial-design - search */ '
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>',
 
 	);
 

--- a/functions.php
+++ b/functions.php
@@ -392,6 +392,36 @@ function newspack_typography_css_wrap() {
 add_action( 'wp_head', 'newspack_typography_css_wrap' );
 
 /**
+ * Returns an array of 'acceptable' SVG tags to use with wp_kses().
+ */
+function newspack_sanitize_svgs() {
+	$svg_args = array(
+		'svg'   => array(
+			'class'           => true,
+			'aria-hidden'     => true,
+			'aria-labelledby' => true,
+			'role'            => true,
+			'xmlns'           => true,
+			'width'           => true,
+			'height'          => true,
+			'viewbox'         => true,
+		),
+		'g'     => array(
+			'fill' => true,
+		),
+		'title' => array(
+			'title' => true,
+		),
+		'path'  => array(
+			'd'    => true,
+			'fill' => true,
+		),
+	);
+
+	return $svg_args;
+}
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';

--- a/sass/forms/_forms.scss
+++ b/sass/forms/_forms.scss
@@ -1,3 +1,5 @@
 @import "buttons";
 
 @import "fields";
+
+@import "search";

--- a/sass/forms/_search.scss
+++ b/sass/forms/_search.scss
@@ -1,0 +1,24 @@
+.search-form {
+	position: relative;
+
+	input {
+		padding-right: #{ 2.5 * $size__spacing-unit };
+		width: 100%;
+	}
+
+	button {
+		background-color: transparent;
+		bottom: 0;
+		color: $color__text-main;
+		position: absolute;
+		margin: 0;
+		padding: 0 #{ 0.5 * $size__spacing-unit };
+		right: 0;
+		top: 0;
+
+		svg {
+			position: relative;
+			top: 2px;
+		}
+	}
+}

--- a/sass/forms/_search.scss
+++ b/sass/forms/_search.scss
@@ -8,17 +8,24 @@
 
 	button {
 		background-color: transparent;
-		bottom: 0;
+		bottom: 2px;
 		color: $color__text-main;
 		position: absolute;
 		margin: 0;
 		padding: 0 #{ 0.5 * $size__spacing-unit };
-		right: 0;
-		top: 0;
+		right: 2px;
+		top: 2px;
 
 		svg {
 			position: relative;
 			top: 2px;
 		}
+
+		&:active,
+		&:hover,
+		&:focus {
+			color: $color__primary;
+		}
+
 	}
 }

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -83,18 +83,3 @@
 	color: $color__text-light;
 	font-style: italic;
 }
-
-/* 404 & Not found */
-
-.error-404.not-found,
-.no-results.not-found {
-
-	.search-submit {
-		vertical-align: middle;
-		margin: $size__spacing-unit 0;
-	}
-
-	.search-field {
-		width: 100%;
-	}
-}

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -72,18 +72,6 @@
 	}
 }
 
-.widget_search {
-
-	.search-field {
-		width: 100%;
-	}
-
-	.search-submit {
-		display: block;
-		margin-top: $size__spacing-unit;
-	}
-}
-
 .widget_calendar .calendar_wrap {
 	text-align: center;
 

--- a/searchform.php
+++ b/searchform.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Template for displaying search forms.
+ *
+ * @package Newspack
+ */
+
+$unique_id = wp_unique_id( 'search-form-' );
+?>
+
+<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<label for="<?php echo esc_attr( $unique_id ); ?>">
+		<span class="screen-reader-text"><?php echo esc_html_x( 'Search for:', 'label', 'newspack' ); ?></span>
+	</label>
+	<input type="search" id="<?php echo esc_attr( $unique_id ); ?>" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'newspack' ); ?>" value="<?php echo get_search_query(); ?>" name="s" />
+	<button type="submit" class="search-submit">
+		<?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?>
+		<span class="screen-reader-text">
+			<?php echo esc_html_x( 'Search', 'submit button', 'newspack' ); ?>
+		</span>
+	</button>
+</form>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR swaps Twenty Nineteen's default search styles -- with the button that wraps below the input -- with an inline version with an icon.

This isn't actually mocked up, but I've included before and after screenshots to set expectations:

Before - 404 page:

![image](https://user-images.githubusercontent.com/177561/61423294-220f5f80-a8c4-11e9-840b-65bc344e9111.png)

Before - search widget: 

![image](https://user-images.githubusercontent.com/177561/61423310-2cc9f480-a8c4-11e9-9569-4ddf187787d7.png)

After - 404 page:

![image](https://user-images.githubusercontent.com/177561/61423353-5420c180-a8c4-11e9-9c56-2d3a56131644.png)

After - search widget: 

![image](https://user-images.githubusercontent.com/177561/61423363-597e0c00-a8c4-11e9-9259-6b3c46bfad4b.png)

Tangentially related to work that needs to be done to build out the header in #96.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Check the appearance of the search box when in the content area -- it appears both on the 404 page, and on a search results page that returns no results. I usually add nonsense to the end of the URL to access each -- `/adjslaksd` for the former and `?s=asdka;kdsl;asd` for the latter.
3. Make sure the search field matches the mockup.
4. Make sure very long text entered in the field cut off before the search icon, not overlapping it.
5. Add a search widget to the sidebar or footer area.
6. Like the above, make sure the search field matches the mockup and that very long strings of text don't appear to overlap the icon. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
