### PR TITLE
Add option to have the header overlap the content, and related styles.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -191,6 +191,17 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+	if ( true === get_theme_mod( 'header_overlap', false ) ) {
+		$theme_css .= '
+			.header-overlap.header-solid-background .bottom-header-contain {
+				background-color: ' . $primary_color . ';
+			}
+			.header-overlap .site-content #primary {
+				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
+			}
+		';
+	}
+
 	$editor_css = '
 		/*
 		 * Set colors for:

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -134,6 +134,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - add option for header overlap.
+	$wp_customize->add_setting(
+		'header_overlap',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_overlap',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Content Overlap', 'newspack' ),
+			'description' => esc_html__( 'Check to have the content overlap the header.', 'newspack' ),
+			'section'     => 'title_tagline',
+		)
+	);
+
 	// Add option to hide page title on static front page.
 	$wp_customize->add_setting(
 		'hide_front_page_title',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -47,6 +47,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'header-center-logo';
 	}
 
+	$header_overlap = get_theme_mod( 'header_overlap', false );
+	if ( true === $header_overlap ) {
+		$classes[] = 'header-overlap';
+	}
+
 	// Adds a class of has-sidebar when there is a sidebar present.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
 		$classes[] = 'has-sidebar';

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -180,7 +180,7 @@ body:not(.header-center-logo) {
 
 			@include media(tablet) {
 				border-top-width: 4px;
-				padding: #{ 0.5 * $size__spacing-unit } #{ 2.5 * $size__spacing-unit } 0;
+				padding: #{ 1 * $size__spacing-unit } #{ 3 * $size__spacing-unit } 0;
 			}
 
 			@include media(desktop) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -150,6 +150,10 @@ body:not(.header-center-logo) {
 		}
 	}
 
+	.bottom-header-contain .wrapper {
+		border: 0;
+	}
+
 	&.header-solid-background .bottom-header-contain {
 		background-color: $color__primary;
 	}
@@ -180,8 +184,14 @@ body:not(.header-center-logo) {
 			}
 
 			@include media(desktop) {
-				padding: #{ 2 * $size__spacing-unit } #{ 4 * $size__spacing-unit } 0;
+				padding: #{ 2.5 * $size__spacing-unit } #{ 4 * $size__spacing-unit } 0;
 			}
+		}
+	}
+
+	&.newspack-front-page.hide-homepage-title {
+		.entry .entry-content > * {
+			margin-top: 0;
 		}
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -184,7 +184,7 @@ body:not(.header-center-logo) {
 			}
 
 			@include media(desktop) {
-				padding: #{ 2.5 * $size__spacing-unit } #{ 4 * $size__spacing-unit } 0;
+				padding: #{ 2 * $size__spacing-unit } #{ 4.5 * $size__spacing-unit } 0;
 			}
 		}
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -135,12 +135,62 @@ body:not(.header-center-logo) {
 	}
 }
 
+// Header Overlap
+
+.header-overlap {
+	.site-header {
+		padding-bottom: #{ 2 * $size__spacing-unit };
+
+		@include media(tablet) {
+			padding-bottom: #{ 4 * $size__spacing-unit };
+		}
+
+		@include media( desktop ) {
+			padding-bottom: #{ 9 * $size__spacing-unit };
+		}
+	}
+
+	&.header-solid-background .bottom-header-contain {
+		background-color: $color__primary;
+	}
+
+	&:not(.header-solid-background) .site-header {
+		background-color: #efefef;
+	}
+
+	.site-content {
+		margin-top: #{ -2 * $size__spacing-unit };
+
+		@include media(tablet) {
+			margin-top: #{ -4 * $size__spacing-unit };
+		}
+
+		@include media(desktop) {
+			margin-top: #{ -9 * $size__spacing-unit };
+		}
+
+		#primary {
+			background: #fff;
+			border-top: 2px solid $color__primary-variation;
+			padding: $size__spacing-unit;
+
+			@include media(tablet) {
+				border-top-width: 4px;
+				padding: #{ 0.5 * $size__spacing-unit } #{ 2.5 * $size__spacing-unit } 0;
+			}
+
+			@include media(desktop) {
+				padding: #{ 2 * $size__spacing-unit } #{ 4 * $size__spacing-unit } 0;
+			}
+		}
+	}
+}
+
 // Solid Background
 
 .header-solid-background {
 	.site-header {
 		background-color: $color__primary;
-		padding-bottom: 0;
 	}
 	.site-header,
 	.site-title a,
@@ -166,13 +216,12 @@ body:not(.header-center-logo) {
 			color: #fff;
 		}
 	}
-}
 
-.header-center-logo.header-solid-background {
-	// Middle bar
-	.middle-header-contain {
-		.wrapper {
-			padding: #{ 3 * $size__spacing-unit } 0;
-		}
+	&.header-center-logo .middle-header-contain .wrapper {
+		padding: #{ 3 * $size__spacing-unit } 0;
+	}
+
+	&:not(.header-overlap) .site-header {
+		padding-bottom: 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to have the content area overlap the header, similar to what's mocked up in the Style C mockups:

![image](https://user-images.githubusercontent.com/177561/61495578-39a32280-a96e-11e9-866f-f5307dcdea95.png)

There's still one outstanding header customization option -- the ability to switch to a simpler header -- so it's not possible to create an identical header yet.

This style is ideally paired with a solid background colour, but without there is a light grey background to help distinguish the header from the content area: 

![image](https://user-images.githubusercontent.com/177561/61498120-d79aeb00-a976-11e9-9c9a-ccaa69fa3971.png)

And here's how it will look with a solid background on the header, and no primary menu:

![image](https://user-images.githubusercontent.com/177561/61498159-05802f80-a977-11e9-85cc-0062955ecfa8.png)

Part of #96.

### How to test the changes in this Pull Request:

1. Apply the PR, and run `npm run build`. 
2. Navigate to Customize > Site Identity, and check 'Content Overlap' 
3. Verify that the content overlaps the header, and that it looks okay.
4. Test with the other two header customization options -- background and centred logo.

Smaller screens overall for the header still need to be finalized, but things should still look okay on mobile, just in need of some scaling/spacing finalizing. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?