### PR TITLE
Make sure sidebar fills up all the available space on mobile

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -31,9 +31,11 @@
 
 .single {
 	&.has-sidebar #main {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
+		@include media( tablet ) {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+		}
 	}
 }
 
@@ -41,9 +43,11 @@
 .blog,
 .page:not(.newspack-front-page) {
 	&.has-sidebar #primary {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
+		@include media(tablet) {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+		}
 	}
 
 	@include media(tablet) {
@@ -60,11 +64,11 @@
 .single-post {
 	@include media(tablet) {
 		.main-content {
-			flex-basis: 65%;
+			flex-basis: calc( 65% - #{$size__spacing-unit} );
 		}
 
 		#secondary {
-			flex-basis: 30%;
+			flex-basis: calc( 35% - #{$size__spacing-unit} );
 		}
 	}
 }

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -52,11 +52,11 @@
 
 	@include media(tablet) {
 		#main {
-			flex-basis: calc( 65% - #{$size__spacing-unit} );
+			max-width: calc( 65% - #{$size__spacing-unit} );
 		}
 
 		#secondary {
-			flex-basis: calc( 35% - #{$size__spacing-unit} );
+			max-width: calc( 35% - #{$size__spacing-unit} );
 		}
 	}
 }
@@ -64,11 +64,11 @@
 .single-post {
 	@include media(tablet) {
 		.main-content {
-			flex-basis: calc( 65% - #{$size__spacing-unit} );
+			max-width: calc( 65% - #{$size__spacing-unit} );
 		}
 
 		#secondary {
-			flex-basis: calc( 35% - #{$size__spacing-unit} );
+			max-width: calc( 35% - #{$size__spacing-unit} );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make sure sidebar fills up all the available space on mobile in all cases.

Closes #114 .

### How to test the changes in this Pull Request:

1. Add just a search widget to the sidebar widget area.
2. Make the browser narrow enough that the sidebar and primary content areas are stacked. 
3. Look at the width of the search bar; note it doesn't fill the available space.
4. Apply the patch and run `npm run build`
5. Confirm that the search now does fill the available space.

This issue happens with any widgets with narrower content, even if set to display at 100% width -- for example, category or archive widgets may display this issue, as well as recent posts if the post titles are short. 

Before: 
![image](https://user-images.githubusercontent.com/177561/61656555-e2ef5e80-ac75-11e9-998b-20e110793288.png)

After:
![image](https://user-images.githubusercontent.com/177561/61656603-ff8b9680-ac75-11e9-9e83-f9295be51280.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
