### PR TITLE
Adds search toggle and search box to header

### DIFF
--- a/classes/class-newspack-svg-icons.php
+++ b/classes/class-newspack-svg-icons.php
@@ -166,7 +166,7 @@ class Newspack_SVG_Icons {
     </g>
 </svg>',
 
-		'search'                   => /* martial-design - search */ '
+		'search'                   => /* material-design - search */ '
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
     <path d="M0 0h24v24H0z" fill="none"/>

--- a/classes/class-newspack-svg-icons.php
+++ b/classes/class-newspack-svg-icons.php
@@ -165,9 +165,16 @@ class Newspack_SVG_Icons {
         <path fill="currentColor" fill-rule="nonzero" d="M12 2c5.52 0 10 4.48 10 10s-4.48 10-10 10S2 17.52 2 12 6.48 2 12 2zM6 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm6 0a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/>
     </g>
 </svg>',
+
 		'search'                   => /* martial-design - search */ '
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>',
+
+		'close'                    => /* material-design - close */ '
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>',
 

--- a/functions.php
+++ b/functions.php
@@ -263,7 +263,7 @@ function newspack_scripts() {
 		'close_search' => esc_html__( 'Close Search', 'newspack' ),
 	);
 
-	if ( ! ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
+	if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) {
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/amp-fallback.js' ), array(), '1.0', true );
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}

--- a/functions.php
+++ b/functions.php
@@ -258,8 +258,14 @@ function newspack_scripts() {
 		wp_enqueue_script( 'comment-reply' );
 	}
 
+	$newspack_l10n = array(
+		'open_search'  => esc_html__( 'Open Search', 'newspack' ),
+		'close_search' => esc_html__( 'Close Search', 'newspack' ),
+	);
+
 	if ( ! ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/amp-fallback.js' ), array(), '1.0', true );
+		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );

--- a/functions.php
+++ b/functions.php
@@ -257,6 +257,10 @@ function newspack_scripts() {
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
+
+	if ( ! ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
+		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/amp-fallback.js' ), array(), '1.0', true );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
 

--- a/header.php
+++ b/header.php
@@ -111,17 +111,9 @@
 					</nav><!-- #site-navigation -->
 				<?php endif; ?>
 
-				<button id="search-toggle" on="tap:AMP.setState({searchVisible: !searchVisible})" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
-					<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
-						<?php esc_html_e( 'Open Search', 'newspack' ); ?>
-					</span>
-					<span class="search-icon"><?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?></span>
-					<span class="close-icon"><?php echo wp_kses( newspack_get_icon_svg( 'close', 28 ), newspack_sanitize_svgs() ); ?></span>
-				</button>
+				<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
 			</div><!-- .wrapper -->
 		</div><!-- .bottom-header-contain -->
-
-		<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
 
 	</header><!-- #masthead -->
 

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
-	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search' : 'hide-header-search'">
+	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
 		<div class="top-header-contain">
 			<div class="wrapper">

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
-	<header id="masthead" class="site-header">
+	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search' : 'hide-header-search'">
 
 		<div class="top-header-contain">
 			<div class="wrapper">
@@ -111,18 +111,18 @@
 					</nav><!-- #site-navigation -->
 				<?php endif; ?>
 
-				<button id="search-toggle" on="tap:AMP.setState({visible: !visible})">
-					<?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?>
+				<button id="search-toggle" on="tap:AMP.setState({searchVisible: !searchVisible})" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+					<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
+						<?php esc_html_e( 'Open Search', 'newspack' ); ?>
+					</span>
+					<span class="search-icon"><?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?></span>
+					<span class="close-icon"><?php echo wp_kses( newspack_get_icon_svg( 'close', 28 ), newspack_sanitize_svgs() ); ?></span>
 				</button>
 			</div><!-- .wrapper -->
 		</div><!-- .bottom-header-contain -->
 
-	</header><!-- #masthead -->
+		<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
 
-	<div id="header-search" [class]="visible ? 'show' : 'hide'" class="hide">
-		<div class="wrapper">
-			<?php get_search_form(); ?>
-		</div><!-- .wrapper -->
-	</div><!-- #header-search -->
+	</header><!-- #masthead -->
 
 	<div id="content" class="site-content">

--- a/header.php
+++ b/header.php
@@ -110,9 +110,19 @@
 						?>
 					</nav><!-- #site-navigation -->
 				<?php endif; ?>
+
+				<button id="search-toggle" on="tap:AMP.setState({visible: !visible})">
+					<?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?>
+				</button>
 			</div><!-- .wrapper -->
 		</div><!-- .bottom-header-contain -->
 
 	</header><!-- #masthead -->
+
+	<div id="header-search" [class]="visible ? 'show' : 'hide'" class="hide">
+		<div class="wrapper">
+			<?php get_search_form(); ?>
+		</div><!-- .wrapper -->
+	</div><!-- #header-search -->
 
 	<div id="content" class="site-content">

--- a/js/amp-fallback.js
+++ b/js/amp-fallback.js
@@ -1,0 +1,16 @@
+/**
+ * File amp-fallback.js.
+ *
+ * AMP fallback JavaScript.
+ */
+
+(function() {
+	// Toggle the search in the header.
+	var menuToggle = document.getElementById( 'search-toggle' ),
+		headerSearch = document.getElementById( 'header-search' );
+
+	menuToggle.onclick = function() {
+		headerSearch.classList.toggle('hide');
+	};
+
+} )( );

--- a/js/amp-fallback.js
+++ b/js/amp-fallback.js
@@ -5,12 +5,30 @@
  */
 
 (function() {
-	// Toggle the search in the header.
-	var menuToggle = document.getElementById( 'search-toggle' ),
-		headerSearch = document.getElementById( 'header-search' );
 
-	menuToggle.onclick = function() {
-		headerSearch.classList.toggle('hide');
-	};
+	var headerContain           = document.getElementById( 'masthead' ),
+		headerSearch            = document.getElementById( 'header-search' ),
+		searchToggle            = document.getElementById( 'search-toggle' ),
+		searchToggleTextContain = searchToggle.getElementsByTagName( 'span' )[0],
+		searchToggleTextDefault = searchToggleTextContain.innerText;
 
-} )( );
+	searchToggle.addEventListener('click', function() {
+
+		// Toggle the search visibility.
+		headerContain.classList.toggle( 'hide-header-search' );
+
+		// Toggle screen reader text label and aria settings.
+		if ( searchToggleTextDefault === searchToggleTextContain.innerText ) {
+			searchToggleTextContain.innerText = newspackScreenReaderText.close_search;
+			headerSearch.setAttribute( 'aria-expanded', 'true' );
+			searchToggle.setAttribute( 'aria-expanded', 'true' );
+		} else {
+			searchToggleTextContain.innerText = searchToggleTextDefault;
+			headerSearch.setAttribute( 'aria-expanded', 'false' );
+			searchToggle.setAttribute( 'aria-expanded', 'false' );
+		}
+
+	}, false );
+
+
+} )();

--- a/js/amp-fallback.js
+++ b/js/amp-fallback.js
@@ -8,6 +8,7 @@
 
 	var headerContain           = document.getElementById( 'masthead' ),
 		headerSearch            = document.getElementById( 'header-search' ),
+		headerSearchInput       = headerSearch.getElementsByTagName( 'input' )[0],
 		searchToggle            = document.getElementById( 'search-toggle' ),
 		searchToggleTextContain = searchToggle.getElementsByTagName( 'span' )[0],
 		searchToggleTextDefault = searchToggleTextContain.innerText;
@@ -22,10 +23,13 @@
 			searchToggleTextContain.innerText = newspackScreenReaderText.close_search;
 			headerSearch.setAttribute( 'aria-expanded', 'true' );
 			searchToggle.setAttribute( 'aria-expanded', 'true' );
+			headerSearchInput.focus();
+
 		} else {
 			searchToggleTextContain.innerText = searchToggleTextDefault;
 			headerSearch.setAttribute( 'aria-expanded', 'false' );
 			searchToggle.setAttribute( 'aria-expanded', 'false' );
+			searchToggle.focus();
 		}
 
 	}, false );

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -72,3 +72,7 @@
 .single .main-content {
 	@include postContentMaxWidth();
 }
+
+.hide {
+	display: none;
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -176,3 +176,11 @@ body:not(.header-center-logo) {
 		}
 	}
 }
+
+// Search toggle
+
+#search-toggle {
+	background-color: transparent;
+	color: $color__text-main;
+	padding: #{ 0.25 * $size__spacing-unit };
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -104,7 +104,7 @@
 
 	#header-search {
 		position: absolute;
-		top: calc( 100% + 2px );
+		top: calc( 100% + 4px );
 		width: 300px;
 
 		@include media (tablet) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -1,10 +1,6 @@
 // Site header
 .site-header {
-	margin: 0 0 $size__spacing-unit;
 
-	@include media(tablet) {
-		margin-bottom: #{ $size__spacing-unit * 1 };
-	}
 }
 
 // Site branding
@@ -92,6 +88,43 @@
 	}
 }
 
+// Search toggle
+
+#search-toggle {
+	background-color: transparent;
+	color: $color__text-main;
+	padding: #{ 0.25 * $size__spacing-unit } 0 0;
+
+	.search-icon {
+		display: none;
+	}
+}
+
+#header-search {
+	padding: $size__spacing-unit 0;
+	width: 100%;
+	z-index: 2;
+
+	.search-form {
+		width: 100%;
+	}
+}
+
+.hide-header-search {
+	#search-toggle {
+		.search-icon {
+			display: block;
+		}
+
+		.close-icon {
+			display: none;
+		}
+	}
+	#header-search {
+		display: none;
+	}
+}
+
 /**
  * Header options.
  */
@@ -175,12 +208,9 @@ body:not(.header-center-logo) {
 			padding: #{ 3 * $size__spacing-unit } 0;
 		}
 	}
-}
 
-// Search toggle
-
-#search-toggle {
-	background-color: transparent;
-	color: $color__text-main;
-	padding: #{ 0.25 * $size__spacing-unit };
+	// Header search
+	#header-search {
+		background-color: #eee;
+	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -198,7 +198,8 @@ body:not(.header-center-logo) {
 		}
 
 		.main-navigation .main-menu > li,
-		.main-navigation .main-menu > li > a {
+		.main-navigation .main-menu > li > a,
+		#search-toggle {
 			color: #fff;
 		}
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -89,7 +89,6 @@
 }
 
 // Search toggle
-
 #search-toggle {
 	background-color: transparent;
 	color: $color__text-main;
@@ -100,13 +99,17 @@
 	}
 }
 
-#header-search {
-	padding: $size__spacing-unit 0;
-	width: 100%;
-	z-index: 2;
+.header-search-contain {
+	position: relative;
 
-	.search-form {
-		width: 100%;
+	#header-search {
+		position: absolute;
+		top: calc( 100% + 2px );
+		width: 300px;
+
+		@include media (tablet) {
+			right: 0;
+		}
 	}
 }
 
@@ -207,10 +210,5 @@ body:not(.header-center-logo) {
 		.wrapper {
 			padding: #{ 3 * $size__spacing-unit } 0;
 		}
-	}
-
-	// Header search
-	#header-search {
-		background-color: #eee;
 	}
 }

--- a/template-parts/header/header-search.php
+++ b/template-parts/header/header-search.php
@@ -7,7 +7,7 @@
 ?>
 
 <div class="header-search-contain">
-	<button id="search-toggle" on="tap:AMP.setState({searchVisible: !searchVisible})" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+	<button id="search-toggle" on="tap:AMP.setState( { searchVisible: !searchVisible } )" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
 		<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
 			<?php esc_html_e( 'Open Search', 'newspack' ); ?>
 		</span>

--- a/template-parts/header/header-search.php
+++ b/template-parts/header/header-search.php
@@ -7,7 +7,7 @@
 ?>
 
 <div class="header-search-contain">
-	<button id="search-toggle" on="tap:AMP.setState( { searchVisible: !searchVisible } )" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+	<button id="search-toggle" on="tap:AMP.setState( { searchVisible: !searchVisible } ), search-form-1.focus" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
 		<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
 			<?php esc_html_e( 'Open Search', 'newspack' ); ?>
 		</span>

--- a/template-parts/header/header-search.php
+++ b/template-parts/header/header-search.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Displays the search form for the header.
+ *
+ * @package Newspack
+ */
+?>
+
+<div id="header-search" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+	<div class="wrapper">
+		<?php get_search_form(); ?>
+	</div><!-- .wrapper -->
+</div><!-- #header-search -->

--- a/template-parts/header/header-search.php
+++ b/template-parts/header/header-search.php
@@ -6,8 +6,15 @@
  */
 ?>
 
-<div id="header-search" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
-	<div class="wrapper">
+<div class="header-search-contain">
+	<button id="search-toggle" on="tap:AMP.setState({searchVisible: !searchVisible})" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+		<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
+			<?php esc_html_e( 'Open Search', 'newspack' ); ?>
+		</span>
+		<span class="search-icon"><?php echo wp_kses( newspack_get_icon_svg( 'search', 28 ), newspack_sanitize_svgs() ); ?></span>
+		<span class="close-icon"><?php echo wp_kses( newspack_get_icon_svg( 'close', 28 ), newspack_sanitize_svgs() ); ?></span>
+	</button>
+	<div id="header-search" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
 		<?php get_search_form(); ?>
-	</div><!-- .wrapper -->
-</div><!-- #header-search -->
+	</div><!-- #header-search -->
+</div><!-- .header-search-contain -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a search box and toggle to the theme's header.

It builds out the functionality using AMP, and includes a JavaScript fallback that should only be loaded on non-AMP pages. 

Right now it's pretty basic visually; it displays a search form that floats below the toggle. I didn't want to get too far into the weeds for how it should function with the different header layouts, so it remains next to the primary menu, whether or not the header is centred.

Search icon in line with the primary menu:  
![image](https://user-images.githubusercontent.com/177561/61729571-610e3c80-ad2c-11e9-9b08-432d60d2099b.png)

Search opened:
![image](https://user-images.githubusercontent.com/177561/61729623-7be0b100-ad2c-11e9-9d0d-774dfa32fd60.png)


Related to #96

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Make sure AMP is set to 'standard', or 'transitional', and that you are viewing an AMP-enabled version of a page.
3. Click on the search icon, and confirm that the search opens; toggle it a couple times to check the following:
    * Confirm that the search icon turns into an 'X', and back to a magnifying glass.
    * Inspect the element and check that the screenreader text label changes from 'Open Search' to 'Close Search'
    * Confirm that the `aria-expanded` attributes on both the button and search container toggle between 'true' (opened) and 'false' (closed). 
4. Navigate to a non-AMP page, or switch AMP to Transitional or Reader mode, and test the the points in step three again to make sure they work the same. 

I welcome any pointers for the AMP implementation, too -- I mostly relied on toggling classes to show/hide things, but that might not be the best approach. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
