### PR TITLE
Add option to hide tagline

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -103,6 +103,7 @@ function newspack_customize_register( $wp_customize ) {
 		'header_display_tagline',
 		array(
 			'default'           => true,
+			'transport'         => 'postMessage',
 			'sanitize_callback' => 'newspack_sanitize_checkbox',
 		)
 	);

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -98,6 +98,23 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - add option to hide tagline.
+	$wp_customize->add_setting(
+		'header_display_tagline',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_display_tagline',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Display Tagline', 'newspack' ),
+			'section' => 'title_tagline',
+		)
+	);
+
 	// Header - add option to center logo.
 	$wp_customize->add_setting(
 		'header_center_logo',

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -36,6 +36,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-homepage-title';
 	}
 
+	$show_tagline = get_theme_mod( 'header_display_tagline', true );
+	if ( false === $show_tagline ) {
+		$classes[] = 'hide-site-tagline';
+	}
+
 	// Adds classes to reflect the header layout
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {

--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -7,6 +7,17 @@
  */
 
 (function( $ ) {
+	// Hide site tagline
+	wp.customize( 'header_display_tagline', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( 'body' ).addClass( 'hide-site-tagline' );
+			} else {
+				$( 'body' ).removeClass( 'hide-site-tagline' );
+			}
+		});
+	});
+
 	// Hide Front Page Title
 	wp.customize( 'hide_front_page_title', function( value ) {
 		value.bind( function( to ) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -64,6 +64,11 @@
 	margin: 7px 0 0;
 }
 
+.hide-site-tagline .site-description {
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute;
+}
+
 // Top bar
 .top-header-contain {
 	background-color: #4a4a4a;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to hide the site tagline. 

This is so you can achieve a header like [this](https://cloudup.com/iWwXMrBMFGP) -- without a tagline displaying -- but still have that information filled out for SEO purposes (since it's also used in the site's meta tags).

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customizer > Site Identity. 
3. Uncheck 'Show Tagline' and confirm it disappears in the preview.
4. Publish the changes, and confirm the tagline is also hidden on the front end.
5. Navigate back to Customizer > Site Identity and check 'Show Tagline' again, and confirm it shows again in the Customizer and on the live site when published. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
