### PR TITLE
Removes more unneeded priority menu code

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -221,42 +221,6 @@ function newspack_get_discussion_data() {
 }
 
 /**
- * Add an extra menu to our nav for our priority+ navigation to use
- *
- * @param object $nav_menu  Nav menu.
- * @param object $args      Nav menu args.
- * @return string More link for hidden menu items.
- */
-function newspack_add_ellipses_to_nav( $nav_menu, $args ) {
-
-	if ( 'primary-menu' === $args->theme_location ) :
-
-		$nav_menu .= '<div class="main-menu-more">';
-		$nav_menu .= '<ul class="main-menu">';
-		$nav_menu .= '<li class="menu-item menu-item-has-children">';
-		$nav_menu .= '<button class="submenu-expand main-menu-more-toggle is-empty" tabindex="-1" aria-label="More" aria-haspopup="true" aria-expanded="false">';
-		$nav_menu .= '<span class="screen-reader-text">' . esc_html__( 'More', 'newspack' ) . '</span>';
-		$nav_menu .= newspack_get_icon_svg( 'arrow_drop_down_ellipsis' );
-		$nav_menu .= '</button>';
-		$nav_menu .= '<ul class="sub-menu hidden-links">';
-		$nav_menu .= '<li id="menu-item--1" class="mobile-parent-nav-menu-item menu-item--1">';
-		$nav_menu .= '<button class="menu-item-link-return">';
-		$nav_menu .= newspack_get_icon_svg( 'chevron_left' );
-		$nav_menu .= esc_html__( 'Back', 'newspack' );
-		$nav_menu .= '</button>';
-		$nav_menu .= '</li>';
-		$nav_menu .= '</ul>';
-		$nav_menu .= '</li>';
-		$nav_menu .= '</ul>';
-		$nav_menu .= '</div>';
-
-	endif;
-
-	return $nav_menu;
-}
-add_filter( 'wp_nav_menu', 'newspack_add_ellipses_to_nav', 10, 2 );
-
-/**
  * WCAG 2.0 Attributes for Dropdown Menus
  *
  * Adjustments to menu attributes tot support WCAG 2.0 recommendations
@@ -332,41 +296,6 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 	return $output;
 }
 add_filter( 'walker_nav_menu_start_el', 'newspack_add_dropdown_icons', 10, 4 );
-
-/**
- * Create a nav menu item to be displayed on mobile to navigate from submenu back to the parent.
- *
- * This duplicates each parent nav menu item and makes it the first child of itself.
- *
- * @param array  $sorted_menu_items Sorted nav menu items.
- * @param object $args              Nav menu args.
- * @return array Amended nav menu items.
- */
-function newspack_add_mobile_parent_nav_menu_items( $sorted_menu_items, $args ) {
-	static $pseudo_id = 0;
-	if ( ! isset( $args->theme_location ) || 'primary-menu' !== $args->theme_location ) {
-		return $sorted_menu_items;
-	}
-
-	$amended_menu_items = array();
-	foreach ( $sorted_menu_items as $nav_menu_item ) {
-		$amended_menu_items[] = $nav_menu_item;
-		if ( in_array( 'menu-item-has-children', $nav_menu_item->classes, true ) ) {
-			$parent_menu_item                   = clone $nav_menu_item;
-			$parent_menu_item->original_id      = $nav_menu_item->ID;
-			$parent_menu_item->ID               = --$pseudo_id;
-			$parent_menu_item->db_id            = $parent_menu_item->ID;
-			$parent_menu_item->object_id        = $parent_menu_item->ID;
-			$parent_menu_item->classes          = array( 'mobile-parent-nav-menu-item' );
-			$parent_menu_item->menu_item_parent = $nav_menu_item->ID;
-
-			$amended_menu_items[] = $parent_menu_item;
-		}
-	}
-
-	return $amended_menu_items;
-}
-add_filter( 'wp_nav_menu_objects', 'newspack_add_mobile_parent_nav_menu_items', 10, 2 );
 
 /**
  * Adjust a hexidecimal colour value to lighten or darken it.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes two more functions related to Twenty Nineteen's menu functionality that is no longer needed in the theme.

The first adds the 'more' `...` menu; the second duplicates menu items on mobile to help create the sliding layered mobile menu the theme uses. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Make sure you don't get any PHP or JavaScript errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
