### PR TITLE
Adds option for 'simplified' header

### DIFF
--- a/header.php
+++ b/header.php
@@ -23,46 +23,52 @@
 
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
-		<div class="top-header-contain">
-			<div class="wrapper">
-				<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
-					<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'secondary-menu',
-								'menu_class'     => 'secondary-menu',
-								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav>
-				<?php endif; ?>
+		<?php if ( false === get_theme_mod( 'header_simplified', false ) ) : ?>
+			<div class="top-header-contain">
+				<div class="wrapper">
+					<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
+						<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+							<?php
+							wp_nav_menu(
+								array(
+									'theme_location' => 'secondary-menu',
+									'menu_class'     => 'secondary-menu',
+									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+									'depth'          => 1,
+								)
+							);
+							?>
+						</nav>
+					<?php endif; ?>
 
-				<?php newspack_social_menu(); ?>
-			</div><!-- .wrapper -->
-		</div><!-- .top-header-contain -->
+					<?php if ( has_nav_menu( 'social' ) && false === get_theme_mod( 'header_center_logo', false ) ) : ?>
+						<?php newspack_social_menu(); ?>
+					<?php endif; ?>
+				</div><!-- .wrapper -->
+			</div><!-- .top-header-contain -->
+		<?php endif; ?>
 
 		<div class="middle-header-contain">
 			<div class="wrapper">
 				<?php if ( has_nav_menu( 'social' ) && true === get_theme_mod( 'header_center_logo', false ) ) : ?>
-					<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'social',
-								'menu_class'     => 'social-links-menu',
-								'link_before'    => '<span class="screen-reader-text">',
-								'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav><!-- .social-navigation -->
+					<?php newspack_social_menu(); ?>
 				<?php endif; ?>
 
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
+
+				<?php if ( has_nav_menu( 'primary-menu' ) && true === get_theme_mod( 'header_simplified', false ) ) : ?>
+					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'primary-menu',
+								'menu_class'     => 'main-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+							)
+						);
+						?>
+					</nav><!-- #site-navigation -->
+				<?php endif; ?>
 
 				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
 					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
@@ -81,25 +87,27 @@
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->
 
-		<div class="bottom-header-contain">
-			<div class="wrapper">
-				<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
-					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'primary-menu',
-								'menu_class'     => 'main-menu',
-								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-							)
-						);
-						?>
-					</nav><!-- #site-navigation -->
-				<?php endif; ?>
 
-				<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
-			</div><!-- .wrapper -->
-		</div><!-- .bottom-header-contain -->
+		<?php if ( false === get_theme_mod( 'header_simplified', false ) ) : ?>
+			<div class="bottom-header-contain">
+				<div class="wrapper">
+					<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
+						<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+							<?php
+							wp_nav_menu(
+								array(
+									'theme_location' => 'primary-menu',
+									'menu_class'     => 'main-menu',
+									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								)
+							);
+							?>
+						</nav><!-- #site-navigation -->
+					<?php endif; ?>
+					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+				</div><!-- .wrapper -->
+			</div><!-- .bottom-header-contain -->
+		<?php endif; ?>
 
 	</header><!-- #masthead -->
 

--- a/header.php
+++ b/header.php
@@ -23,7 +23,12 @@
 
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
-		<?php if ( false === get_theme_mod( 'header_simplified', false ) ) : ?>
+		<?php
+			$header_simplified  = get_theme_mod( 'header_simplified', false );
+			$header_center_logo = get_theme_mod( 'header_center_logo', false );
+		?>
+
+		<?php if ( false === $header_simplified ) : ?>
 			<div class="top-header-contain">
 				<div class="wrapper">
 					<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
@@ -54,9 +59,24 @@
 					<?php newspack_social_menu(); ?>
 				<?php endif; ?>
 
+				<?php if ( has_nav_menu( 'tertiary-menu' ) && true === $header_center_logo && true === $header_simplified ) : ?>
+					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+						<?php
+						wp_nav_menu(
+							array(
+								'theme_location' => 'tertiary-menu',
+								'menu_class'     => 'tertiary-menu',
+								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+								'depth'          => 1,
+							)
+						);
+						?>
+					</nav>
+				<?php endif; ?>
+
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-				<?php if ( has_nav_menu( 'primary-menu' ) && true === get_theme_mod( 'header_simplified', false ) ) : ?>
+				<?php if ( has_nav_menu( 'primary-menu' ) && true === $header_simplified ) : ?>
 					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 						<?php
 						wp_nav_menu(
@@ -70,7 +90,7 @@
 					</nav><!-- #site-navigation -->
 				<?php endif; ?>
 
-				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
+				<?php if ( has_nav_menu( 'tertiary-menu' ) && ! ( true === $header_center_logo && true === $header_simplified ) ) : ?>
 					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
 						<?php
 						wp_nav_menu(
@@ -87,8 +107,7 @@
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->
 
-
-		<?php if ( false === get_theme_mod( 'header_simplified', false ) ) : ?>
+		<?php if ( false === $header_simplified ) : ?>
 			<div class="bottom-header-contain">
 				<div class="wrapper">
 					<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>

--- a/header.php
+++ b/header.php
@@ -59,19 +59,24 @@
 					<?php newspack_social_menu(); ?>
 				<?php endif; ?>
 
-				<?php if ( has_nav_menu( 'tertiary-menu' ) && true === $header_center_logo && true === $header_simplified ) : ?>
-					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'tertiary-menu',
-								'menu_class'     => 'tertiary-menu',
-								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav>
+				<?php if ( true === $header_simplified && true === $header_center_logo ) : ?>
+
+					<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
+						<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+							<?php
+							wp_nav_menu(
+								array(
+									'theme_location' => 'tertiary-menu',
+									'menu_class'     => 'tertiary-menu',
+									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+									'depth'          => 1,
+								)
+							);
+							?>
+						</nav>
+					<?php else : ?>
+						<div></div>
+					<?php endif; ?>
 				<?php endif; ?>
 
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>

--- a/header.php
+++ b/header.php
@@ -46,7 +46,7 @@
 						</nav>
 					<?php endif; ?>
 
-					<?php if ( has_nav_menu( 'social' ) && false === get_theme_mod( 'header_center_logo', false ) ) : ?>
+					<?php if ( has_nav_menu( 'social' ) && false === $header_center_logo ) : ?>
 						<?php newspack_social_menu(); ?>
 					<?php endif; ?>
 				</div><!-- .wrapper -->
@@ -55,7 +55,7 @@
 
 		<div class="middle-header-contain">
 			<div class="wrapper">
-				<?php if ( has_nav_menu( 'social' ) && true === get_theme_mod( 'header_center_logo', false ) ) : ?>
+				<?php if ( has_nav_menu( 'social' ) && true === $header_center_logo && false === $header_simplified ) : ?>
 					<?php newspack_social_menu(); ?>
 				<?php endif; ?>
 
@@ -102,6 +102,9 @@
 							)
 						);
 						?>
+						<?php if ( true === $header_simplified ) : ?>
+							<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+						<?php endif; ?>
 					</nav>
 				<?php endif; ?>
 			</div><!-- .wrapper -->

--- a/header.php
+++ b/header.php
@@ -91,6 +91,10 @@
 								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 							)
 						);
+
+						if ( true === $header_center_logo ) :
+							get_template_part( 'template-parts/header/header', 'search' );
+						endif;
 						?>
 					</nav><!-- #site-navigation -->
 				<?php endif; ?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -152,6 +152,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - add option for simplified short header.
+	$wp_customize->add_setting(
+		'header_simplified',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_simplified',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Simplified', 'newspack' ),
+			'description' => esc_html__( 'Displays header as a shorter, simplier version.', 'newspack' ),
+			'section'     => 'title_tagline',
+		)
+	);
+
 	// Add option to hide page title on static front page.
 	$wp_customize->add_setting(
 		'hide_front_page_title',

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -165,7 +165,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Simplify Header', 'newspack' ),
-			'description' => esc_html__( 'Displays header as a shorter, simplier version.', 'newspack' ),
+			'description' => esc_html__( 'Displays header as a shorter, simpler version.', 'newspack' ),
 			'section'     => 'title_tagline',
 		)
 	);

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -164,7 +164,7 @@ function newspack_customize_register( $wp_customize ) {
 		'header_simplified',
 		array(
 			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Simplified', 'newspack' ),
+			'label'       => esc_html__( 'Simplify Header', 'newspack' ),
 			'description' => esc_html__( 'Displays header as a shorter, simplier version.', 'newspack' ),
 			'section'     => 'title_tagline',
 		)

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -164,7 +164,7 @@ function newspack_customize_register( $wp_customize ) {
 		'header_simplified',
 		array(
 			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Simplify Header', 'newspack' ),
+			'label'       => esc_html__( 'Short Header', 'newspack' ),
 			'description' => esc_html__( 'Displays header as a shorter, simpler version.', 'newspack' ),
 			'section'     => 'title_tagline',
 		)

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -52,6 +52,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'header-center-logo';
 	}
 
+	$header_simplified = get_theme_mod( 'header_simplified', false );
+	if ( true === $header_simplified ) {
+		$classes[] = 'header-simplified';
+	}
+
 	// Adds a class of has-sidebar when there is a sidebar present.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
 		$classes[] = 'has-sidebar';

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -6,7 +6,6 @@ nav.tertiary-menu {
 	font-family: $font__heading;
 	font-size: $font__size-sm;
 	list-style: none;
-	margin: 0.5em 0;
 	padding: 0;
 
 	@include media(tablet) {

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -20,7 +20,7 @@ nav.tertiary-menu {
 	}
 
 	li {
-		display: inline;
+		display: inline-block;
 		margin: 0;
 		padding: 0;
 
@@ -43,7 +43,7 @@ nav.tertiary-menu {
 	}
 }
 
-body:not(.header-solid-background) {
+body:not(.header-solid-background):not(.header-simplified) {
 	nav.tertiary-menu {
 		a {
 			background-color: lighten($color__text-light, 45%);
@@ -67,6 +67,32 @@ body:not(.header-solid-background) {
 			&:hover {
 				background-color: $color__primary-variation;
 			}
+		}
+	}
+}
+
+.header-simplified {
+	nav.tertiary-menu {
+		font-size: $font__size_base;
+		margin-left: $size__spacing-unit;
+		li {
+			a {
+				font-size: $font__size-xs;
+				padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+			}
+
+			&:last-child a {
+				border: 1px solid currentColor;
+			}
+		}
+	}
+}
+
+.header-center-logo {
+	nav.tertiary-menu {
+		margin-left: 0;
+		@include media(tablet) {
+			text-align: center;
 		}
 	}
 }

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -36,6 +36,10 @@ nav.tertiary-menu {
 		margin: #{$size__spacing-unit * 0.25} 0;
 		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.5};
 	}
+
+	#search-toggle {
+		margin-left: #{$size__spacing-unit * 0.5}
+	}
 }
 
 body:not(.header-solid-background):not(.header-simplified) {

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -28,10 +28,6 @@ nav.tertiary-menu {
 				margin: 0 0 0 #{$size__spacing-unit * 0.5};
 			}
 		}
-
-		&:last-child {
-			font-weight: 700;
-		}
 	}
 
 	a {
@@ -58,15 +54,6 @@ body:not(.header-solid-background):not(.header-simplified) {
 				color: #fff;
 			}
 		}
-
-		li:last-child a {
-			background-color: $color__primary;
-			color: #fff;
-
-			&:hover {
-				background-color: $color__primary-variation;
-			}
-		}
 	}
 }
 
@@ -78,10 +65,6 @@ body:not(.header-solid-background):not(.header-simplified) {
 			a {
 				font-size: $font__size-xs;
 				padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
-			}
-
-			&:last-child a {
-				border: 1px solid currentColor;
 			}
 		}
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -5,11 +5,15 @@
 
 // Site branding
 .site-branding {
+	align-items: center;
 	color: $color__text-light;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	position: relative;
+	@include media(tablet) {
+		flex-basis: 60%;
+	}
 }
 
 // Site logo
@@ -55,6 +59,7 @@
 // Site description
 .site-description {
 	color: $color__text-light;
+	//flex: 1 1 auto;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	font-style: italic;
@@ -138,24 +143,6 @@
  * Header options.
  */
 
-// Default
-
-body:not(.header-center-logo) {
-	.site-branding {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-
-		@include media(tablet) {
-			flex-basis: 60%;
-		}
-	}
-
-	.site-description {
-		flex: 1 1 auto;
-	}
-}
-
 // Centred Logo
 
 .header-center-logo {
@@ -188,7 +175,9 @@ body:not(.header-center-logo) {
 	.site-title a,
 	.site-title a:visited,
 	.site-description,
-	.middle-header-contain {
+	.middle-header-contain,
+	.main-navigation .main-menu > li,
+	.main-navigation .main-menu > li > a {
 		color: #fff;
 	}
 
@@ -209,9 +198,10 @@ body:not(.header-center-logo) {
 			color: #fff;
 		}
 	}
+
 }
 
-.header-center-logo.header-solid-background {
+.header-center-logo.header-solid-background:not(.header-simplified) {
 	// Middle bar
 	.middle-header-contain {
 		.wrapper {
@@ -223,15 +213,58 @@ body:not(.header-center-logo) {
 // Simplified Header
 
 .header-simplified {
-	&,
-	&:not(.header-center-logo) {
+	.site-header .wrapper {
+		justify-content: flex-start;
+	}
+
+	.site-branding {
+		display: flex;
+		flex-basis: auto;
+	}
+
+	// Site logo
+	.custom-logo-link .custom-logo {
+		max-height: 50px;
+	}
+
+	.site-branding {
+		flex-grow: 2;
+		margin-right: $size__spacing-unit;
+	}
+
+	.site-description {
+		margin: 0;
+	}
+
+	&.hide-site-tagline {
 		.site-branding {
-			display: block;
-			flex-basis: auto;
+			flex-grow: 0;
+		}
+		.main-navigation {
+			flex-grow: 2;
 		}
 	}
 
 	.middle-header-contain .wrapper {
+		align-items: center;
 		padding: #{ 0.5 * $size__spacing-unit } 0;
+	}
+
+	&.header-center-logo {
+
+		.wrapper > * {
+			flex: 1 0 0;
+			min-width: 33%;
+		}
+
+		.site-branding {
+			flex-wrap: wrap;
+		}
+
+		.custom-logo-link,
+		.site-title,
+		.site-description {
+			width: 100%;
+		}
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -219,3 +219,19 @@ body:not(.header-center-logo) {
 		}
 	}
 }
+
+// Simplified Header
+
+.header-simplified {
+	&,
+	&:not(.header-center-logo) {
+		.site-branding {
+			display: block;
+			flex-basis: auto;
+		}
+	}
+
+	.middle-header-contain .wrapper {
+		padding: #{ 0.5 * $size__spacing-unit } 0;
+	}
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -102,7 +102,7 @@
 // Search toggle
 #search-toggle {
 	background-color: transparent;
-	color: $color__text-main;
+	color: inherit;
 	padding: #{ 0.25 * $size__spacing-unit } 0 0;
 
 	.search-icon {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds an option to display a more simplified version of the header. 

This version of the menu will not show the 'secondary' or 'social' menus; I've added another item to #96 to explore adding an off-screen menu space where we can show those if it's found to be necessary. 

A couple known issues:
* The code in header.php is getting pretty gnarly -- there's a lot of checking for the different header settings to reorder things that could be simplified. This PR already has a lot going on in it though, so I plan to tackle that in a future PR; however, if the current state makes it hard to review, let me know and I can take a swing at it! 
* The 'stand out' link styling for the tertiary menu is currently applied to the last menu item; this needs to be switched so it can be applied with a class, to any item. 
* There might be some spacing weirdness if this is tested before #118 is merged; the extra markup one of those functions adds makes for extra space. 

The following screenshots should capture what some of the setting combinations should look like:

**Just 'Simplify Header':**

![image](https://user-images.githubusercontent.com/177561/61750340-fd9b0380-ad59-11e9-90d8-5e45cb08726d.png)

**Simplify Header + Solid Background:** 

![image](https://user-images.githubusercontent.com/177561/61750375-173c4b00-ad5a-11e9-940b-36749a28324f.png)

**Simplify Header + Centre Logo:**

![image](https://user-images.githubusercontent.com/177561/61750415-3509b000-ad5a-11e9-8218-4380fa4a71c0.png)

**Simplify Header + Centre Logo + Solid Background:**

![image](https://user-images.githubusercontent.com/177561/61750451-4f438e00-ad5a-11e9-9579-dbd965cdaef0.png)

**Bonus: + 'Hide Site Tagline':**

If tested after #117 is merged, hiding the site tagline should place the primary navigation next to the site title/logo on the left, rather than the tertiary navigation on the right:

![image](https://user-images.githubusercontent.com/177561/61750572-9cbffb00-ad5a-11e9-8315-5ea8e5409710.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Make sure you have a primary and tertiary menu set up.
3. Navigate to Customizer > Site Identity and check 'Simplify Header'. 
4. Make sure nothing generally looks terrible.
5. Navigate to Customizer > Site Identity and test the 'Simplify Header' option with both the 'Solid Background' and 'Center Logo' options independently, and all three together. 
6. If testing after #117 is merged, can also be tested with 'Show Site Tagline' unchecked, specifically when 'Center Logo' is unchecked. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
