### PR TITLE
WIP: Adds mobile menu using AMP

### DIFF
--- a/classes/class-newspack-svg-icons.php
+++ b/classes/class-newspack-svg-icons.php
@@ -171,6 +171,11 @@ class Newspack_SVG_Icons {
     <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>',
+		'menu'                     => /* material-design - menu */ '
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+</svg>',
 
 		'close'                    => /* material-design - close */ '
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">

--- a/header.php
+++ b/header.php
@@ -18,6 +18,9 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php get_template_part( 'template-parts/header/mobile', 'sidebar' ); ?>
+
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
@@ -77,6 +80,13 @@
 						);
 						?>
 					</nav>
+				<?php endif; ?>
+
+				<?php if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) : ?>
+					<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<?php esc_html_e( 'Menu', 'newspack' ); ?>
+					</button>
 				<?php endif; ?>
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->

--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@
 
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
-		<div class="top-header-contain">
+		<div class="top-header-contain desktop-navigation">
 			<div class="wrapper">
 				<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 					<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
@@ -68,12 +68,11 @@
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
 				<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
-					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+					<nav class="tertiary-menu desktop-navigation" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
 						<?php
 						wp_nav_menu(
 							array(
 								'theme_location' => 'tertiary-menu',
-								'menu_class'     => 'tertiary-menu',
 								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 								'depth'          => 1,
 							)
@@ -91,7 +90,7 @@
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->
 
-		<div class="bottom-header-contain">
+		<div class="bottom-header-contain desktop-navigation">
 			<div class="wrapper">
 				<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
 					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -226,6 +226,42 @@ function newspack_get_discussion_data() {
 }
 
 /**
+ * Add an extra menu to our nav for our priority+ navigation to use
+ *
+ * @param object $nav_menu  Nav menu.
+ * @param object $args      Nav menu args.
+ * @return string More link for hidden menu items.
+ */
+function newspack_add_ellipses_to_nav( $nav_menu, $args ) {
+
+	if ( 'primary-menu' === $args->theme_location ) :
+
+		$nav_menu .= '<div class="main-menu-more">';
+		$nav_menu .= '<ul class="main-menu">';
+		$nav_menu .= '<li class="menu-item menu-item-has-children">';
+		$nav_menu .= '<button class="submenu-expand main-menu-more-toggle is-empty" tabindex="-1" aria-label="More" aria-haspopup="true" aria-expanded="false">';
+		$nav_menu .= '<span class="screen-reader-text">' . esc_html__( 'More', 'newspack' ) . '</span>';
+		$nav_menu .= newspack_get_icon_svg( 'arrow_drop_down_ellipsis' );
+		$nav_menu .= '</button>';
+		$nav_menu .= '<ul class="sub-menu hidden-links">';
+		$nav_menu .= '<li id="menu-item--1" class="mobile-parent-nav-menu-item menu-item--1">';
+		$nav_menu .= '<button class="menu-item-link-return">';
+		$nav_menu .= newspack_get_icon_svg( 'chevron_left' );
+		$nav_menu .= esc_html__( 'Back', 'newspack' );
+		$nav_menu .= '</button>';
+		$nav_menu .= '</li>';
+		$nav_menu .= '</ul>';
+		$nav_menu .= '</li>';
+		$nav_menu .= '</ul>';
+		$nav_menu .= '</div>';
+
+	endif;
+
+	return $nav_menu;
+}
+add_filter( 'wp_nav_menu', 'newspack_add_ellipses_to_nav', 10, 2 );
+
+/**
  * WCAG 2.0 Attributes for Dropdown Menus
  *
  * Adjustments to menu attributes tot support WCAG 2.0 recommendations
@@ -301,6 +337,41 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 	return $output;
 }
 add_filter( 'walker_nav_menu_start_el', 'newspack_add_dropdown_icons', 10, 4 );
+
+/**
+ * Create a nav menu item to be displayed on mobile to navigate from submenu back to the parent.
+ *
+ * This duplicates each parent nav menu item and makes it the first child of itself.
+ *
+ * @param array  $sorted_menu_items Sorted nav menu items.
+ * @param object $args              Nav menu args.
+ * @return array Amended nav menu items.
+ */
+function newspack_add_mobile_parent_nav_menu_items( $sorted_menu_items, $args ) {
+	static $pseudo_id = 0;
+	if ( ! isset( $args->theme_location ) || 'primary-menu' !== $args->theme_location ) {
+		return $sorted_menu_items;
+	}
+
+	$amended_menu_items = array();
+	foreach ( $sorted_menu_items as $nav_menu_item ) {
+		$amended_menu_items[] = $nav_menu_item;
+		if ( in_array( 'menu-item-has-children', $nav_menu_item->classes, true ) ) {
+			$parent_menu_item                   = clone $nav_menu_item;
+			$parent_menu_item->original_id      = $nav_menu_item->ID;
+			$parent_menu_item->ID               = --$pseudo_id;
+			$parent_menu_item->db_id            = $parent_menu_item->ID;
+			$parent_menu_item->object_id        = $parent_menu_item->ID;
+			$parent_menu_item->classes          = array( 'mobile-parent-nav-menu-item' );
+			$parent_menu_item->menu_item_parent = $nav_menu_item->ID;
+
+			$amended_menu_items[] = $parent_menu_item;
+		}
+	}
+
+	return $amended_menu_items;
+}
+add_filter( 'wp_nav_menu_objects', 'newspack_add_mobile_parent_nav_menu_items', 10, 2 );
 
 /**
  * Adjust a hexidecimal colour value to lighten or darken it.

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -36,7 +36,11 @@
 }
 
 #mobile-sidebar {
+	background-color: $color__primary;
+	color: #fff;
+	font-size: $font__size-sm;
 	padding: $size__spacing-unit;
+
 	ul {
 		list-style: none;
 		margin: 0 0 $size__spacing-unit;
@@ -45,5 +49,9 @@
 		ul {
 			margin-left: $size__spacing-unit;
 		}
+	}
+
+	a {
+		color: #fff;
 	}
 }

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -1,0 +1,49 @@
+.mobile-menu-toggle {
+	background-color: transparent;
+	color: $color__text-main;
+	padding: 0;
+
+	&:hover,
+	&:focus {
+		background-color: transparent;
+	}
+
+	.svg-icon {
+		position: relative;
+		top: 4px;
+	}
+
+	@include media(tablet) {
+		display: none;
+	}
+}
+
+.top-header-contain,
+.bottom-header-contain,
+.site-header .tertiary-menu {
+	display: none;
+}
+
+@include media( tablet ) {
+	.top-header-contain,
+	.bottom-header-contain {
+		display: block;
+	}
+
+	.site-header .tertiary-menu {
+		display: flex;
+	}
+}
+
+#mobile-sidebar {
+	padding: $size__spacing-unit;
+	ul {
+		list-style: none;
+		margin: 0 0 $size__spacing-unit;
+		padding: 0;
+
+		ul {
+			margin-left: $size__spacing-unit;
+		}
+	}
+}

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -18,40 +18,55 @@
 	}
 }
 
-.top-header-contain,
-.bottom-header-contain,
-.site-header .tertiary-menu {
+.desktop-navigation {
 	display: none;
 }
 
 @include media( tablet ) {
-	.top-header-contain,
-	.bottom-header-contain {
+	.desktop-navigation {
 		display: block;
-	}
 
-	.site-header .tertiary-menu {
-		display: flex;
+		&.tertiary-menu {
+			display: flex;
+		}
 	}
 }
 
 #mobile-sidebar {
 	background-color: $color__primary;
-	color: #fff;
 	font-size: $font__size-sm;
 	padding: $size__spacing-unit;
 
-	ul {
-		list-style: none;
+	& > * {
+		margin-bottom: $size__spacing-unit;
+	}
+
+	.mobile-menu-toggle {
+		color: #fff;
+		font-size: 1em;
 		margin: 0 0 $size__spacing-unit;
+		padding: 0;
+	}
+
+	ul {
+		font-weight: 700;
+		list-style: none;
+		margin: 0;
 		padding: 0;
 
 		ul {
+			font-weight: 400;
 			margin-left: $size__spacing-unit;
 		}
 	}
 
 	a {
 		color: #fff;
+		display: inline-block;
+		padding: #{ 0.25 * $size__spacing-unit } 0;
+	}
+
+	.submenu-expand {
+		display: none;
 	}
 }

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -1,5 +1,4 @@
 /* Social menu */
-
 .social-links-menu {
 	align-items: center;
 	display: flex;

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -1,49 +1,45 @@
 /* Social menu */
 
-.social-navigation {
+.social-links-menu {
 	align-items: center;
 	display: flex;
+	margin: 0;
+	padding: 0;
 
-	ul {
-		display: flex;
-		margin: 0;
-		padding: 0;
+	li {
+		list-style: none;
 
-		li {
-			list-style: none;
+		&:nth-child(n+2) {
+			margin-left: 0.5em;
+		}
 
-			&:nth-child(n+2) {
-				margin-left: 0.5em;
+		a {
+			border-bottom: 1px solid transparent;
+			display: block;
+			color: inherit;
+			margin-bottom: -1px;
+			transition: opacity $link_transition ease-in-out;
+
+			&:hover,
+			&:active {
+				opacity: 0.6;
 			}
 
-			a {
-				border-bottom: 1px solid transparent;
+			&:focus {
+				opacity: 1;
+				border-bottom: 1px solid $color__text-main;
+			}
+
+			svg {
 				display: block;
-				color: inherit;
-				margin-bottom: -1px;
-				transition: opacity $link_transition ease-in-out;
+				width: 24px;
+				height: 24px;
 
-				&:hover,
-				&:active {
-					opacity: 0.6;
-				}
+				// Prevent icons from jumping in Safari using hardware acceleration.
+				transform: translateZ(0);
 
-				&:focus {
-					opacity: 1;
-					border-bottom: 1px solid $color__text-main;
-				}
-
-				svg {
-					display: block;
-					width: 24px;
-					height: 24px;
-
-					// Prevent icons from jumping in Safari using hardware acceleration.
-					transform: translateZ(0);
-
-					&#ui-icon-link {
-						transform: rotate(-45deg);
-					}
+				&#ui-icon-link {
+					transform: rotate(-45deg);
 				}
 			}
 		}

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -1,6 +1,6 @@
 /** === Tertiary menu === */
 
-nav.tertiary-menu {
+.tertiary-menu {
 	align-items: center;
 	display: flex;
 	font-family: $font__heading;
@@ -44,7 +44,7 @@ nav.tertiary-menu {
 }
 
 body:not(.header-solid-background) {
-	nav.tertiary-menu {
+	.tertiary-menu {
 		a {
 			background-color: lighten($color__text-light, 45%);
 			color: $color__text-main;

--- a/sass/navigation/_navigation.scss
+++ b/sass/navigation/_navigation.scss
@@ -11,6 +11,7 @@
 @import "menu-tertiary-navigation";
 @import "menu-social-navigation";
 @import "menu-footer-navigation";
+@import "menu-mobile-navigation";
 
 /*--------------------------------------------------------------
 ## Next / Previous

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -173,7 +173,7 @@ body:not(.header-center-logo) {
 	}
 
 	.social-navigation,
-	nav.tertiary-menu {
+	.tertiary-menu {
 		justify-content: center;
 		width: 100%;
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -55,10 +55,15 @@
 // Site description
 .site-description {
 	color: $color__text-light;
+	display: none;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	font-style: italic;
 	margin: 7px 0 0;
+
+	@include media( mobile ) {
+		display: block;
+	}
 }
 
 .hide-site-tagline .site-description {
@@ -79,10 +84,12 @@
 
 // Middle bar
 .middle-header-contain {
-	align-items: center;
-
 	.wrapper {
-		padding: #{ 2 * $size__spacing-unit } 0;
+		align-items: center;
+		padding: $size__spacing-unit 0;
+		@include media( mobile ) {
+			padding: #{ 2 * $size__spacing-unit } 0;
+		}
 	}
 }
 

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -20,6 +20,7 @@
 .site-info,
 #cancel-comment-reply-link,
 .use-header-font,
+#mobile-sidebar,
 h1,
 h2,
 h3,

--- a/template-parts/header/mobile-sidebar.php
+++ b/template-parts/header/mobile-sidebar.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Template for display the mobile navigation.
+ *
+ * @package Newspack
+ */
+?>
+
+<amp-sidebar id="mobile-sidebar" layout="nodisplay" side="right">
+
+	<button class="hamburger" on='tap:mobile-sidebar.toggle'>
+		<?php esc_html_e( 'Close', 'newspack' ); ?>
+	</button>
+
+	<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
+		<nav aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'tertiary-menu',
+					'menu_class'     => 'tertiary-menu',
+					'container'      => false,
+					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+					'depth'          => 1,
+				)
+			);
+			?>
+		</nav>
+	<?php endif; ?>
+
+	<?php get_search_form(); ?>
+
+	<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
+		<nav aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'primary-menu',
+					'container'      => false,
+					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				)
+			);
+			?>
+		</nav>
+	<?php endif; ?>
+
+	<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
+		<nav aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'secondary-menu',
+					'container'      => false,
+					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				)
+			);
+			?>
+		</nav>
+	<?php endif; ?>
+
+	<?php if ( has_nav_menu( 'social' ) && false === get_theme_mod( 'header_center_logo', false ) ) : ?>
+		<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'social',
+					'menu_class'     => 'social-links-menu',
+					'link_before'    => '<span class="screen-reader-text">',
+					'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+					'depth'          => 1,
+					'container'      => false,
+				)
+			);
+			?>
+		</nav><!-- .social-navigation -->
+	<?php endif; ?>
+
+</amp-sidebar>

--- a/template-parts/header/mobile-sidebar.php
+++ b/template-parts/header/mobile-sidebar.php
@@ -18,7 +18,6 @@
 			wp_nav_menu(
 				array(
 					'theme_location' => 'tertiary-menu',
-					'menu_class'     => 'tertiary-menu',
 					'container'      => false,
 					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 					'depth'          => 1,

--- a/template-parts/header/mobile-sidebar.php
+++ b/template-parts/header/mobile-sidebar.php
@@ -8,7 +8,7 @@
 
 <amp-sidebar id="mobile-sidebar" layout="nodisplay" side="right">
 
-	<button class="hamburger" on='tap:mobile-sidebar.toggle'>
+	<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
 		<?php esc_html_e( 'Close', 'newspack' ); ?>
 	</button>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a WIP of adding a mobile-style menu using AMP functionality. 

I wanted to share it to get some feedback on the approach -- it does duplicate quite a bit of code, and essentially hides the dupes when not in use (so they're ignored by screen readers, but still there). 

AMP does have an approach ([toolbar-target](https://amp.dev/documentation/components/amp-sidebar/#toolbar-target)) where you can have a `nav` in the sidebar automatically copied into a specific ID at a certain breakpoint, which would reduce the duplication. However:

* We'd need to add the duplication back for the non-AMP fallback. So it wouldn't be in the output of an AMP site, but it would be in the PHP files in some form.
* I'm a little worried the `toolbar-target` approach would get confusing with the complexity already in the header (it will involve empty divs). 
* Out of the box I got some weird styling trying the `toolbar-target` approach (a menu displaying in a very small space with scrollbars); but I didn't dig to far into how much work it would be to override. 
* It might also make sense to stick with this duplication approach for now, and optimize it later on. 

I'm not against trying the `toolbar-target` approach, but I didn't want to get too far into the weeds before getting a second opinion. 

See #96.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Add all the menus; primary, secondary, tertiary. 
3. Make sure AMP is set to 'standard'.
4. Shrink down the browser window until the mobile styles kick in (the regular menus will disappear and a 'Menu' toggle will display). 
5. Open close the menu; review the appearance. 
6. Check over the code (the bulk of the duplication is in the new mobile-sidebar.php file) and weigh in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
