### PR TITLE
#106 fixes the npm run build initial errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,19 @@
     "extends @wordpress/browserslist-config"
   ],
   "scripts": {
-    "build:style": "node-sass sass/style.scss style.css --output-style expanded && postcss -r style.css",
-    "build:style-1": "node-sass sass/styles/style-1/style-1.scss styles/style-1.css --output-style expanded && postcss -r styles/style-1.css",
+    "prebuild:style": "node-sass sass/style.scss style.css --output-style expanded && postcss -r style.css",
+    "prebuild:style-1": "node-sass sass/styles/style-1/style-1.scss styles/style-1.css --output-style expanded && postcss -r styles/style-1.css",
     "build:style-editor": "node-sass sass/style-editor.scss styles/style-editor.css --output-style expanded && postcss -r styles/style-editor.css",
     "build:style-editor-static-front-page": "node-sass sass/style-editor-static-front-page.scss styles/style-editor-static-front-page.css --output-style expanded && postcss -r styles/style-editor-static-front-page.css",
     "build:style-editor-customizer": "node-sass sass/style-editor-customizer.scss styles/style-editor-customizer.css --output-style expanded && postcss -r styles/style-editor-customizer.css",
     "build:style-1-editor": "node-sass sass/styles/style-1/style-1-editor.scss styles/style-1-editor.css --output-style expanded && postcss -r styles/style-1-editor.css",
-    "build:style-woocommerce": "node-sass sass/plugins/woocommerce.scss styles/woocommerce.css --output-style expanded && postcss -r styles/woocommerce.css",
+    "prebuild:style-woocommerce": "node-sass sass/plugins/woocommerce.scss styles/woocommerce.css --output-style expanded && postcss -r styles/woocommerce.css",
     "build:rtl": "rtlcss style.css style-rtl.css",
     "build:rtl-style-1": "rtlcss styles/style-1.css styles/style-1-rtl.css",
     "build:rtl-woocommerce": "rtlcss styles/woocommerce.css styles/woocommerce-rtl.css",
     "build:print": "node-sass sass/print.scss styles/print.css --output-style expanded && postcss -r styles/print.css",
     "build": "run-p \"build:*\"",
+    "prebuild": "run-p \"prebuild:*\"",
     "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # 106.

By configuring a prebuild script inside the package.json file for the missing styles, they can be generated before the rtl styles build takes place fixing the error described above.

### How to test the changes in this Pull Request:

1. npm run build

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
