### PR TITLE
Clean up search result styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -25,7 +25,7 @@ function newspack_custom_colors_css() {
 		/* Set primary background color */
 
 		.main-navigation .sub-menu,
-		.sticky-post,
+		.cat-links a,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
@@ -98,7 +98,6 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary color */
 
-		a, a:visited,
 		.entry .entry-content > .has-secondary-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
@@ -116,6 +115,7 @@ function newspack_custom_colors_css() {
 		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
+		.cat-links a:hover,
 		.entry .entry-content > .has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -39,6 +39,7 @@
 
 .archive,
 .blog,
+.search,
 .page:not(.newspack-front-page) {
 	&.has-sidebar #primary {
 		display: flex;

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -98,7 +98,7 @@
 			}
 
 			&.current {
-				background-color: $secondary__primary;
+				background-color: $color__text-light;
 				color: #fff;
 			}
 		}

--- a/sass/navigation/_next-previous.scss
+++ b/sass/navigation/_next-previous.scss
@@ -65,16 +65,27 @@
 
 // Index/archive navigation
 .pagination {
+	margin: #{ 3 * $size__spacing-unit } 0;
 
 	.nav-links {
-
 		display: flex;
 		flex-wrap: wrap;
-		padding: 0 calc(.5 * #{$size__spacing-unit});
-
+		justify-content: center;
 
 		& > * {
-			padding: calc(.5 * #{$size__spacing-unit});
+			background-color: #eee;
+			margin-right: #{ 0.5 * $size__spacing-unit };
+			padding: #{0.5 * $size__spacing-unit} #{0.75 * $size__spacing-unit} #{0.25 * $size__spacing-unit};
+
+			&:last-child {
+				margin-right: 0;
+			}
+
+			&.dots,
+			&.next,
+			&.prev {
+				background-color: transparent;
+			}
 
 			&.dots,
 			&.prev {
@@ -84,6 +95,11 @@
 			&.dots,
 			&.next {
 				padding-right: 0;
+			}
+
+			&.current {
+				background-color: $secondary__primary;
+				color: #fff;
 			}
 		}
 
@@ -108,22 +124,8 @@
 		}
 
 		@include media(tablet) {
-
 			margin-left: 0 auto;
 			padding: 0;
-
-			.prev,
-			.next {
-
-				& > * {
-					display: inline-block;
-					vertical-align: text-bottom;
-				}
-			}
-
-			& > * {
-				padding: $size__spacing-unit;
-			}
 		}
 	}
 }

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -28,13 +28,22 @@
 	}
 }
 
-.archive {
+.archive,
+.search {
 	.page-header {
 		margin: 0 0 #{ $size__spacing-unit * 3 };
 	}
 
 	.page-description {
 		display: block;
+	}
+
+	.entry-header {
+		padding: 0;
+	}
+
+	.post-thumbnail {
+		margin: 0 0 #{ 0.5 * $size__spacing-unit };
 	}
 
 	@include media( tablet ) {
@@ -71,7 +80,7 @@
 	}
 }
 
-.page-title {
+.archive .page-title {
 	color: $color__primary;
 }
 
@@ -82,4 +91,13 @@
 .taxonomy-description {
 	color: $color__text-light;
 	font-style: italic;
+}
+
+.search {
+	.cat-links {
+		margin-bottom: 0;
+		a {
+			padding: 0.25em 0.5em;
+		}
+	}
 }

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -1,8 +1,11 @@
 .archive,
 .search {
-	.search-term,
+	.page-header {
+		margin: 0 0 #{ $size__spacing-unit * 3 };
+	}
+
 	.page-description {
-		display: inherit;
+		display: block;
 		clear: both;
 	}
 
@@ -18,6 +21,14 @@
 		}
 	}
 
+	.post-thumbnail {
+		margin: 0 0 #{ 0.5 * $size__spacing-unit };
+	}
+
+	.entry-header {
+		padding: 0;
+	}
+
 	.entry-header,
 	.entry-content > p {
 		margin: 0;
@@ -25,25 +36,6 @@
 
 	.entry-meta {
 		margin: #{ $size__spacing-unit * 0.5 } 0;
-	}
-}
-
-.archive,
-.search {
-	.page-header {
-		margin: 0 0 #{ $size__spacing-unit * 3 };
-	}
-
-	.page-description {
-		display: block;
-	}
-
-	.entry-header {
-		padding: 0;
-	}
-
-	.post-thumbnail {
-		margin: 0 0 #{ 0.5 * $size__spacing-unit };
 	}
 
 	@include media( tablet ) {
@@ -61,14 +53,6 @@
 			}
 		}
 
-		&:not(paged) article.has-post-thumbnail:first-of-type {
-			display: block;
-
-			.entry-header {
-				margin: $size__spacing-unit 0 0;
-			}
-		}
-
 		.byline,
 		.posted-on {
 			display: inline;
@@ -80,8 +64,29 @@
 	}
 }
 
-.archive .page-title {
-	color: $color__primary;
+.archive {
+	.page-title {
+		color: $color__primary;
+	}
+
+	@include media(tablet) {
+		&:not(paged) article.has-post-thumbnail:first-of-type {
+			display: block;
+
+			.entry-header {
+				margin: $size__spacing-unit 0 0;
+			}
+		}
+	}
+}
+
+.search {
+	.cat-links {
+		margin-bottom: 0;
+		a {
+			padding: 0.25em 0.5em;
+		}
+	}
 }
 
 .page-description {
@@ -93,11 +98,3 @@
 	font-style: italic;
 }
 
-.search {
-	.cat-links {
-		margin-bottom: 0;
-		a {
-			padding: 0.25em 0.5em;
-		}
-	}
-}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -157,7 +157,6 @@ body.page {
 		img {
 			position: relative;
 			display: block;
-			width: 100%;
 		}
 	}
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -43,7 +43,7 @@
 	}
 }
 
-.page {
+body.page {
 	.entry-title {
 		font-size: $font__size-xl;
 		margin: 0;
@@ -57,11 +57,13 @@
 .cat-links {
 	display: block;
 	font-size: $font__size-xs;
-	margin: 0 0 $size__spacing-unit;
+	margin: 0 0 #{ 0.75 * $size__spacing-unit };
 
 	a {
 		background-color: $color__primary;
 		color: #fff;
+		display: inline-block;
+		margin: 0 0 #{ 0.25 * $size__spacing-unit };
 		padding: 0.5em 0.75em;
 		text-transform: uppercase;
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -67,8 +67,13 @@ body.page {
 		padding: 0.5em 0.75em;
 		text-transform: uppercase;
 
+		&:visited {
+			color: #fff;
+		}
+
 		&:hover {
 			background-color: $color__primary-variation;
+			color: #fff;
 		}
 	}
 }

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -91,6 +91,7 @@ h2 {
 .has-large-font-size,
 .comments-title,
 .archive .entry-title,
+.search .entry-title,
 h3 {
 	font-size: $font__size-lg;
 }
@@ -143,8 +144,6 @@ h6 {
 
 .post-navigation .post-title,
 .entry-title,
-.not-found .page-title,
-.error-404 .page-title,
 .comments-title,
 blockquote {
 	hyphens: auto;

--- a/search.php
+++ b/search.php
@@ -11,15 +11,16 @@ get_header();
 ?>
 
 	<section id="primary" class="content-area">
+
 		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
 
 			<header class="page-header">
 				<h1 class="page-title">
-					<?php _e( 'Search results for:', 'newspack' ); ?>
+					<?php esc_html_e( 'Search results', 'newspack' ); ?>
 				</h1>
-				<div class="page-description"><?php echo get_search_query(); ?></div>
+				<?php get_search_form(); ?>
 			</header><!-- .page-header -->
 
 			<?php
@@ -47,6 +48,7 @@ get_header();
 		endif;
 		?>
 		</main><!-- #main -->
+		<?php get_sidebar(); ?>
 	</section><!-- #primary -->
 
 <?php

--- a/template-parts/content/content-excerpt.php
+++ b/template-parts/content/content-excerpt.php
@@ -14,6 +14,11 @@
 	<?php newspack_post_thumbnail(); ?>
 
 	<div class="entry-container">
+		<?php
+		if ( ! is_page() && ! is_archive() ) :
+			newspack_categories();
+		endif;
+		?>
 		<header class="entry-header">
 			<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 		</header><!-- .entry-header -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR cleans up the styles on the search results page. 

### How to test the changes in this Pull Request:

1. Run a search that will return results (a good one on 99% of test sites is 'the'). 
2. Observe the appearance of the page (screenshots below); overall, things are huge, there is no sidebar, page titles (vs post titles) are too small, and the pagination looks 'off'. 
3. Apply the PR and run `npm run build`. 
4. Confirm things are looking generally better (screenshots below) -- the major areas are: sizing; the search results header, and the pagination. 

---

**Before:**

![image](https://user-images.githubusercontent.com/177561/61827628-e4f22280-ae19-11e9-86be-59316a5e53bc.png)

![image](https://user-images.githubusercontent.com/177561/61827643-ecb1c700-ae19-11e9-9374-b3e8bf283767.png)

---

**After:** 

![image](https://user-images.githubusercontent.com/177561/61827574-bf651900-ae19-11e9-82e8-de2b1e10a33e.png)

![image](https://user-images.githubusercontent.com/177561/61827592-c8ee8100-ae19-11e9-8c67-9e8c51828620.png)


Note: if this is tested prior to #115 being applied, the content area will take up all available space if there isn't a sidebar; it will actually take up 65% of the available space, with or without a sidebar. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?