### PR TITLE
Style Newspack homepage block headers in theme

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -50,6 +50,7 @@ function newspack_custom_colors_css() {
 		.comment .comment-metadata .comment-edit-link:hover,
 		#colophon .site-info a:hover,
 		.widget a, .widget a:visited,
+		.accent-header, .article-section-title,
 		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.entry .entry-content > .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
@@ -204,7 +205,8 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink,
+		.editor-block-list__layout .editor-block-list__block .article-section-title {
 			color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -82,6 +82,15 @@ h6 {
 	font-size: $font__size-xs;
 }
 
+.article-section-title {
+	border-bottom: 4px solid #ccc;
+	color: $color__primary;
+	font-size: $font__size-sm;
+	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
+	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
+	text-transform: uppercase;
+}
+
 a {
 	@include link-transition;
 	color: $color__link;

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -158,10 +158,11 @@ blockquote {
 	}
 }
 
-.accent-header {
+.accent-header,
+.article-section-title {
 	border-bottom: 4px solid #ccc;
 	color: $color__primary;
-	font-size: 1em;
+	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
 	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
 	text-transform: uppercase;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I thought I'd merged something like this ages ago! 

This PR makes sure the section headers in the Newspack block use the styles from the theme, both on the front-end and in the editor. 

@jeffersonrabb and I talked about not using the block's classes in the theme if at all possible and going with something generic, but I've been stuck on finding something that made sense in this case for so long, I've put off getting this style in. 

Right now, the section title does use an `h2` and will inherit the theme's styles/fonts for that. But the way we styled it in the mockups -- with a special alternative header style -- needed a special class. I wanted to leave the block class in the theme more related to its containing block than its appearance (it may not always use a 'special header style') so the best approach seemed to be to use the block's existing class in the theme. 

Another approach would be to remove the class altogether and just use the HTML hierarchy (`.wp-block-newspack-blocks-homepage-articles > h2`) but I think this is less clunky, and will make it easier to customize the blocks on a theme-by-theme (or style-variation-by-style-variation) basis.

### How to test the changes in this Pull Request:

1. Set up a homepage block, and add a section title.
2. Confirm it's appearance -- it should be scaled correctly, but just black sans-serif text.
3. Apply PR and run `npm run build`.
4. Confirm that the block is now using the mocked up styles, both on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/61834743-f34a3980-ae2d-11e9-953c-3de1ebe77a71.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
