### PR TITLE
Fixes sidebar spacing

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -49,27 +49,29 @@
 			justify-content: space-between;
 		}
 	}
+}
 
+.archive #main,
+.blog #main,
+.page:not(.newspack-front-page) #main,
+.single-post .main-content {
 	@include media(tablet) {
-		#main {
-			max-width: calc( 65% - #{$size__spacing-unit} );
-		}
-
-		#secondary {
-			max-width: calc( 35% - #{$size__spacing-unit} );
-		}
+		max-width: calc( 65% - #{ 2 * $size__spacing-unit} );
+	}
+	@include media(desktop) {
+		max-width: calc( 65% - #{ 3 * $size__spacing-unit} );
 	}
 }
 
-.single-post {
+.archive #secondary,
+.blog #secondary,
+.page:not(.newspack-front-page) #secondary,
+.single-post #secondary {
 	@include media(tablet) {
-		.main-content {
-			max-width: calc( 65% - #{$size__spacing-unit} );
-		}
-
-		#secondary {
-			max-width: calc( 35% - #{$size__spacing-unit} );
-		}
+		max-width: calc( 35% - #{ 2 * $size__spacing-unit } );
+	}
+	@include media(desktop) {
+		max-width: calc( 35% - #{ 3 * $size__spacing-unit } );
 	}
 }
 

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -56,10 +56,7 @@
 .page:not(.newspack-front-page) #main,
 .single-post .main-content {
 	@include media(tablet) {
-		max-width: calc( 65% - #{ 2 * $size__spacing-unit} );
-	}
-	@include media(desktop) {
-		max-width: calc( 65% - #{ 3 * $size__spacing-unit} );
+		max-width: 65%;
 	}
 }
 
@@ -73,10 +70,6 @@
 	@include media(desktop) {
 		max-width: calc( 35% - #{ 3 * $size__spacing-unit } );
 	}
-}
-
-.single .main-content {
-	@include postContentMaxWidth();
 }
 
 .hide {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The updates made for the archive or search styles caused a regression in the content/sidebar spacing on the single posts. This PR:

* Fixes the spacing issue
* Makes the Sass a bit more concise (originally the widths were repeated twice because the markup isn't the same; this PR puts them together)
* Reduces the spacing width a bit for tablet-sized screens. 

Before:

![image](https://user-images.githubusercontent.com/177561/61914450-7c787380-aef5-11e9-8086-1e6f6b88053e.png)

After: 

![image](https://user-images.githubusercontent.com/177561/61914524-bc3f5b00-aef5-11e9-99e3-c988537827ae.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that the spacing between content and sidebar on single posts is improved.
3. Confirm that there isn't a regression/change in this spacing on the archive/search results pages. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
