### PR TITLE
Fix up entry-footer/tag styles on single posts

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -72,37 +72,28 @@
 }
 
 .tags-links {
+	& > * {
+		display: inline-block;
+		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
+	}
+
 	span {
 		font-weight: bold;
+		font-size: $font__size-sm;
+		margin-right: $size__spacing-unit;
 		text-transform: uppercase;
 	}
 
 	a {
 		background-color: #f1f1f1;
-		display: inline-block;
-		padding: 0.5em 0.75em;
+		font-size: $font__size-xs;
+		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 	}
 }
 
 .entry-meta,
 .entry-footer {
-
 	color: $color__text-light;
-	font-weight: 500;
-
-	a {
-		@include link-transition;
-		color: inherit;
-
-		&:visited {
-			color: inherit;
-		}
-
-		&:hover {
-			text-decoration: none;
-			color: $color__primary-variation;
-		}
-	}
 }
 
 .entry-meta {
@@ -123,6 +114,7 @@
 }
 
 .entry-footer {
+	margin: $size__spacing-unit 0 #{ 3 * $size__spacing-unit };
 	> span {
 		margin-right: $size__spacing-unit;
 		display: inline-block;
@@ -134,6 +126,14 @@
 
 	a {
 		color: $color__primary;
+	}
+
+	.edit-link {
+		font-size: $font__size-sm;
+
+		svg {
+			margin: 0 #{ 0.25 * $size__spacing-unit } 0 0;
+		}
 	}
 }
 

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -113,7 +113,6 @@ h4 {
 }
 
 .entry-meta,
-.entry-footer,
 .main-navigation,
 .pagination .nav-links,
 .comment-content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the post tag styles; they were a bit too big compared to the mockup still, and the spacing was off. 

It also removes some redundant styles from the `.entry-footer` area (which is the section the tags appear in), and tweaked the appearance of the Edit link.

Mockup:

![image](https://user-images.githubusercontent.com/177561/61915303-bd25bc00-aef8-11e9-8b7d-9dc9e842f267.png)

(I've deliberately omitted the borders on each tag; they were too busy in application). 

Before: 

![image](https://user-images.githubusercontent.com/177561/61915283-a67f6500-aef8-11e9-966f-6d006539bbe2.png)

After:

![image](https://user-images.githubusercontent.com/177561/61915364-ef371e00-aef8-11e9-93e6-04e427aacc99.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. View a post with tags in the footer; confirm the sizing is closer to the mockups. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
