### PR TITLE
Correct 'accent header' sizing

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -317,6 +317,7 @@
 	}
 
 	h2 {
+		font-size: 1em;
 		span {
 			color: $color__text-light;
 			display: block;

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -93,6 +93,10 @@
 			margin-top: 0;
 		}
 	}
+
+	.widget-title {
+		font-size: $font__size-md;
+	}
 }
 
 .single-post #secondary {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple small font sizing issues introduced with recent changes to the `.accent-header` styles, and is possibly the tiniest PR I've ever written. Both the sidebar widget titles and author bio header started displaying too small:

Before:

![image](https://user-images.githubusercontent.com/177561/61915901-4a6a1000-aefb-11e9-92c3-4bd9f9e74a3b.png)

![image](https://user-images.githubusercontent.com/177561/61915896-450cc580-aefb-11e9-90bc-b3b75f788496.png)

After:

![image](https://user-images.githubusercontent.com/177561/61915820-08d96500-aefb-11e9-8a43-c08c205d1f9f.png)

![image](https://user-images.githubusercontent.com/177561/61915941-78e7eb00-aefb-11e9-98d0-5bfdca978734.png)

### How to test the changes in this Pull Request:

1. Observe the current font size of the widget titles in the sidebar area, and the first line of the author bio at the bottom of the single posts.
2. Apply the PR and run `npm run build`
3. Confirm that the font sizes are a bit larger again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?