### PR TITLE
Adds pullquote block styles to the editor

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -14,8 +14,9 @@
 	}
 
 	&.alignwide {
-		@include media(tablet) {
-			margin-right: -53%;
+		@include media( tablet ) {
+			margin-left: calc(25% - 25vw);
+			margin-right: calc(25% - 25vw);
 			max-width: 100vw;
 		}
 	}
@@ -26,25 +27,19 @@
 		max-width: 100vw;
 		position: relative;
 		width: 100vw;
-
-		@include media(tablet) {
-			clear: both;
-			margin-left: calc(77% - 50vw);
-			margin-right: auto;
-		}
 	}
 
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
-		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
 		margin-left: 0;
+		margin-right: 0;
 		/*rtl:ignore*/
 		margin-right: $size__spacing-unit;
 
-		@include media(tablet) {
-			max-width: calc(4 * (100vw / 12));
+		@include media(mobile) {
+			max-width: 50%;
 			/*rtl:ignore*/
 			margin-right: calc(2 * #{$size__spacing-unit});
 		}
@@ -53,15 +48,14 @@
 	&.alignright {
 		/*rtl:ignore*/
 		float: right;
-		max-width: calc(5 * (100vw / 12));
 		margin-top: 0;
+		margin-left: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
 
-		@include media(tablet) {
-			max-width: calc(4 * (100vw / 12));
-			margin-right: 0;
+		@include media(mobile) {
+			max-width: 50%;
 			/*rtl:ignore*/
 			margin-left: calc(2 * #{$size__spacing-unit});
 		}
@@ -334,31 +328,33 @@
 	//! Pullquote
 	.wp-block-pullquote {
 		border-color: transparent;
-		border-width: 2px;
-		padding: $size__spacing-unit;
+		border-width: 4px 0 2px;
+		padding: $size__spacing-unit 0;
+		text-align: left;
 
 		blockquote {
 			color: $color__text-main;
 			border: none;
-			margin-top: calc(4 * #{ $size__spacing-unit});
-			margin-bottom: calc(4.33 * #{ $size__spacing-unit});
+			margin-top: $size__spacing-unit;
+			margin-bottom: calc(1.25 * #{ $size__spacing-unit});
 			margin-right: 0;
 			padding-left: 0;
 		}
 
 		p {
-			font-size: $font__size-lg;
+			font-size: $font__size-md;
 			font-style: italic;
 			line-height: 1.3;
 			margin-bottom: 0.5em;
 			margin-top: 0.5em;
+
 
 			em {
 				font-style: normal;
 			}
 
 			@include media(tablet) {
-				font-size: $font__size-xl;
+				font-size: $font__size-lg;
 			}
 		}
 
@@ -376,10 +372,20 @@
 			font-size: calc( 1rem * #{$font__size-xs} );
 		}
 
+		&.alignfull {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
+		}
+
 		&.alignleft,
 		&.alignright {
-			width: 100%;
 			padding: 0;
+			width: 100%;
+
+			@include media(mobile) {
+				border-bottom-width: 0;
+				width: 50%;
+			}
 
 			blockquote {
 				margin: $size__spacing-unit 0;
@@ -387,8 +393,16 @@
 				text-align: left;
 				max-width: 100%;
 
-				p:first-child {
-					margin-top: 0;
+				p {
+					font-size: 1rem;
+
+					@include media(tablet) {
+						font-size: $font__size-md;
+					}
+
+					&:first-child {
+						margin-top: 0;
+					}
 				}
 			}
 		}
@@ -399,19 +413,8 @@
 			padding-right: 0;
 
 			@include media(tablet) {
-				padding-left: 10%;
-				padding-right: 10%;
-			}
-
-			p {
-				font-size: $font__size-lg;
-				line-height: 1.3;
-				margin-bottom: 0.5em;
-				margin-top: 0.5em;
-
-				@include media(tablet) {
-					font-size: $font__size-xl;
-				}
+				padding-left: #{ 1.5 * $size__spacing-unit };
+				padding-right: #{ 1.5 * $size__spacing-unit };
 			}
 
 			a {
@@ -447,19 +450,11 @@
 
 			&.alignright,
 			&.alignleft {
-
 				@include media(tablet) {
 					padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
 				}
 			}
 
-			&.alignfull {
-
-				@include media(tablet) {
-					padding-left: calc(10% + 58px + (2 * #{$size__spacing-unit}));
-					padding-right: calc(10% + 58px + (2 * #{$size__spacing-unit}));
-				}
-			}
 		}
 	}
 
@@ -931,7 +926,7 @@
 	}
 }
 
-.single.has-sidebar,
+.single.post-template-default.has-sidebar,
 .blog.has-sidebar {
 	.entry .entry-content > *,
 	.entry .entry-summary > * {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -18,6 +18,24 @@ body {
 			max-width: 1230px;
 		}
 	}
+
+	.wp-block[data-align="left"] {
+		@include media( desktop ) {
+			left: #{-2 * $size__spacing-unit };
+		}
+		@include media( wide ) {
+			left: #{-4 * $size__spacing-unit };
+		}
+	}
+
+	.wp-block[data-align="right"] {
+		@include media( desktop ) {
+			right: #{-2 * $size__spacing-unit };
+		}
+		@include media( wide ) {
+			right: #{-4 * $size__spacing-unit };
+		}
+	}
 }
 
 /** === Content Width === */
@@ -405,10 +423,6 @@ figcaption,
 		margin: #{ 1.5 * $size__spacing-unit } 0;
 	}
 
-	&:not(.is-style-solid-color) .wp-block-pullquote__citation {
-		color: $color__text-light;
-	}
-
 	&.is-style-solid-color {
 
 		padding: $size__spacing-unit #{ 3 * $size__spacing-unit } #{ 1.25 * $size__spacing-unit };
@@ -455,6 +469,11 @@ figcaption,
 		font-size: $font__size-xs;
 		line-height: 1.6;
 		text-transform: none;
+
+		&:before {
+			content: "\2014";
+			margin-right: #{ 0.25 * $size__spacing-unit };
+		}
 	}
 
 	em {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -396,14 +396,13 @@ figcaption,
 
 .wp-block-pullquote {
 	border-color: transparent;
-	border-width: 2px;
+	border-width: 4px 0 2px;
 	color: #000;
+	padding: $size__spacing-unit 0;
+	text-align: left;
 
 	blockquote {
-		margin-top: calc(3 * #{ $size__spacing-unit});
-		margin-bottom: calc(3.33 * #{ $size__spacing-unit});
-		hyphens: auto;
-		word-break: break-word;
+		margin: #{ 1.5 * $size__spacing-unit } 0;
 	}
 
 	&:not(.is-style-solid-color) .wp-block-pullquote__citation {
@@ -412,9 +411,11 @@ figcaption,
 
 	&.is-style-solid-color {
 
+		padding: $size__spacing-unit #{ 3 * $size__spacing-unit } #{ 1.25 * $size__spacing-unit };
+
 		blockquote {
-			width: calc(100% - (2 * #{ $size__spacing-unit}));
-			max-width: calc( 100% - (2 * #{ $size__spacing-unit}));
+			max-width: 100%;
+			width: 100%;
 
 			a,
 			&.has-text-color p,
@@ -425,10 +426,6 @@ figcaption,
 			&:not(.has-text-color) {
 				color: $color__background-body;
 			}
-
-			@include media(tablet) {
-				max-width: 80%;
-			}
 		}
 
 		&:not(.has-background-color) {
@@ -437,21 +434,19 @@ figcaption,
 	}
 }
 
-.wp-block[data-type="core/pullquote"],
-.wp-block[data-type="core/pullquote"][data-align="left"],
-.wp-block[data-type="core/pullquote"][data-align="right"] {
+.wp-block[data-type="core/pullquote"] {
 
 	blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 	blockquote > .editor-rich-text p,
 	p {
-		font-size: $font__size-lg;
+		font-size: $font__size-md;
 		font-style: italic;
 		line-height: 1.3;
 		margin-bottom: 0.5em;
 		margin-top: 0.5em;
 
 		@include media(tablet) {
-			font-size: $font__size-xl;
+			font-size: $font__size-lg;
 		}
 	}
 
@@ -470,34 +465,40 @@ figcaption,
 .wp-block[data-type="core/pullquote"][data-align="left"],
 .wp-block[data-type="core/pullquote"][data-align="right"] {
 
+	.wp-block-pullquote {
+		@include media( tablet ) {
+			border-bottom: 0;
+		}
+	}
+
 	.editor-block-list__block-edit {
-		width: calc(4 * (100vw / 12));
 		max-width: 50%;
+		width: 50%;
 
 		.wp-block-pullquote:not(.is-style-solid-color) {
 			padding: 0;
 		}
 
 		.wp-block-pullquote.is-style-solid-color {
-			padding: 1em;
+			padding: $size__spacing-unit #{ 2 * $size__spacing-unit };
 		}
 	}
 
 	blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 	blockquote > .editor-rich-text p,
-	p,
-	.wp-block-pullquote__citation {
-		text-align: left;
+	p {
+		font-size: 1rem;
+
+		@include media(tablet) {
+			font-size: $font__size-md;
+		}
 	}
 }
 
 .wp-block[data-type="core/pullquote"][data-align="full"] {
-
-	@include media(tablet) {
-
-		.wp-block-pullquote blockquote {
-			max-width: calc(80% - 128px);
-		}
+	.wp-block-pullquote {
+		padding-left: $size__spacing-unit;
+		padding-right: $size__spacing-unit;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This mockup styles the pullquote block to match the mockups.

From the mockups:

![image](https://user-images.githubusercontent.com/177561/61971264-805ad300-af93-11e9-8ff2-e25722d97a2d.png)

![image](https://user-images.githubusercontent.com/177561/61971304-949ed000-af93-11e9-90ac-95dc67c34877.png)


### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Copy and paste [this test content](https://cloudup.com/cUvnEwJ5zmg) into the block editor in code view. It includes the Pullquote with the three available styles (normal, borders and solid background), in all available alignments (none, left, right, wide and full -- the latter two will only work with the 'Article feature' template).
3. Do a visual review in a single post in the editor, with a larger and smaller window size.

Note: If you refresh or close the editor at any point, you might be getting an error, "This block contains unexpected or invalid content" for the pullquotes with the borders. These can be fixed by clicking on the More (vertical dots) icon on the right, and clicking 'Attempt Block Recovery' -- clicking 'Resolve' wouldn't work for me:

![image](https://user-images.githubusercontent.com/177561/61970769-51902d00-af92-11e9-9bbb-d04bc3785518.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
