### PR TITLE
Fix up a couple visual issues with Infinite Scroll

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -20,6 +20,7 @@ function newspack_jetpack_setup() {
 			'container' => 'main',
 			'render'    => 'newspack_infinite_scroll_render',
 			'footer'    => 'page',
+			'wrapper'   => false,
 		)
 	);
 
@@ -67,7 +68,11 @@ add_action( 'after_setup_theme', 'newspack_jetpack_setup' );
 function newspack_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
-		get_template_part( 'template-parts/content/content' );
+		if ( is_archive() ) {
+			get_template_part( 'template-parts/content/content', 'archive' );
+		} else {
+			get_template_part( 'template-parts/content/content' );
+		}
 	}
 }
 

--- a/sass/navigation/_infinite-scroll.scss
+++ b/sass/navigation/_infinite-scroll.scss
@@ -38,26 +38,15 @@
 .site-main #infinite-handle span button:focus {
 	@include button-transition;
 	background: $color__background-button;
-	border: none;
-	border-radius: 5px;
-	box-sizing: border-box;
 	color: $color__background-body;
 	font-family: $font__heading;
 	font-weight: 700;
 	line-height: $font__line-height-heading;
-	outline: none;
 	padding: ( $size__spacing-unit * .76 ) $size__spacing-unit;
-	text-decoration: none;
-	vertical-align: bottom;
 
 	&:hover {
 		background: $color__background-button-hover;
 		cursor: pointer;
-	}
-
-	&:visited {
-		color: $color__background-body;
-		text-decoration: none;
 	}
 
 	&:focus {
@@ -65,8 +54,4 @@
 		outline: thin dotted;
 		outline-offset: -4px;
 	}
-}
-
-.site-main .infinite-wrap .entry:first-of-type {
-	margin-top: calc(6 * 1rem);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Infinite scroll isn't available in a lot of places in the theme -- basically, the blog posts page (which isn't a huge focal point when paired with custom blocks for the static front page), and the archive pages. 

But right now, it has a couple minor visual hiccups:

* On the archive pages, if you load most posts, they're formatted incorrectly (they're using the wrong template part). 
* On each new 'page' of posts, there's more space than normal (mostly noticeable on mobile). 

### How to test the changes in this Pull Request:

1. Turn on infinite scroll (Dashboard > Jetpack > Settings > Writing, and under "Infinite Scroll" select "Load more posts as the reader scrolls down" or "Load more posts in page with a button" -- the theme has been set to always load new posts on click, I'll also be updating that in a future PR).
2. Visit on the archive pages that has a lot of posts (if you have a lot of test posts, there's a good chance that `www.website.com/category/uncategorized/` will meet the needs; otherwise, `www.website.com/author/yourusername` is another good bet). 
3. Scroll to the bottom and click 'Older Posts'
4. Note that the next set of posts loads each post's full content (in the "Archive page before" screenshot, this starts at "Template: Excerpt (Generated)").
5. Also note the space before the newly loaded page worth of posts is wider than usual.
6. Apply the PR. 
7. Confirm that the post content is no longer loading on the second 'page' of posts, and the spacing is more consistent. 
8. Double-check the blog posts page (the page you've set to display the blog posts) still displays full posts when you click 'Older Posts' (I'll be iterating on this page in the future).

**Archive page before:**

![image](https://user-images.githubusercontent.com/177561/62084116-4c8ae200-b20d-11e9-9b17-5e0f568481ac.png)

**Archive page after:**
![Screen Shot 2019-07-29 at 2 33 16 PM](https://user-images.githubusercontent.com/177561/62084369-0b470200-b20e-11e9-8a4e-f81c36daf5a4.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
