### PR TITLE
Update Infinite Scroll to use load on scroll when available

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -16,7 +16,6 @@ function newspack_jetpack_setup() {
 	add_theme_support(
 		'infinite-scroll',
 		array(
-			'type'      => 'click',
 			'container' => 'main',
 			'render'    => 'newspack_infinite_scroll_render',
 			'footer'    => 'page',
@@ -70,6 +69,18 @@ function newspack_infinite_scroll_render() {
 		get_template_part( 'template-parts/content/content' );
 	}
 }
+
+/**
+ * Toggle between click to load or scroll to load for infinite scroll.
+ */
+function newspack_toggle_infinite_scroll_type() {
+	if ( is_active_sidebar( 'footer-1' ) || ( ( jetpack_is_mobile( '', true ) && is_active_sidebar( 'sidebar-1' ) ) ) ) {
+		return true;
+	}
+	return false;
+}
+add_filter( 'infinite_scroll_has_footer_widgets', 'newspack_toggle_infinite_scroll_type' );
+
 
 /**
  * Remove Jetpack Share icons from standard location so they can be moved.

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -74,7 +74,10 @@ function newspack_infinite_scroll_render() {
  * Toggle between click to load or scroll to load for infinite scroll.
  */
 function newspack_toggle_infinite_scroll_type() {
-	if ( is_active_sidebar( 'footer-1' ) || ( ( jetpack_is_mobile( '', true ) && is_active_sidebar( 'sidebar-1' ) ) ) ) {
+	if ( is_active_sidebar( 'footer-1' ) ) {
+		return true;
+	}
+	if ( jetpack_is_mobile( '', true ) && is_active_sidebar( 'sidebar-1' ) ) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This theme doesn't showcase infinite scroll, but it should work in a predictable way. 

The settings originally set it up to always use click to scroll (so the older posts button is there), but anecdotally this confuses folks, especially since the Jetpack settings always offer both options when a theme supports infinite scroll, regardless what 'type' it sets:

![image](https://user-images.githubusercontent.com/177561/62085904-9f669880-b211-11e9-83b8-1e11edf31626.png)

However, this update also makes sure infinite scroll is switched to 'click' when a page has footer widgets -- otherwise, it's impossible to get to those widgets, and that can be frustrating.

It also switches to click to scroll on small screens if you have a sidebar widget for similar reasons to the above -- on smaller screens the sidebar will wrap below the content and also be difficult to get to if posts are loading on scroll. 

The theme doesn't 'show off' infinite scroll in any way, and it's unlikely that the scroll-to-load functionality will actually be available on many sites due to footer widgets, but I want to make sure it works in a correct, not-confusing way.

This PR compliments work in #134, which is to make sure infinite scroll also displays correctly. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Remove all widgets. 
3. Turn on infinite scroll (Dashboard > Jetpack > Settings > Writing, and click 'Load more posts as the reader scrolls down'). 
4. Navigate to the blog posts page and confirm that more posts load as you scroll down the page.
6. Return to the Customizer and add a footer widget.
7. Navigate to the blog posts page and confirm that it now displays an 'Older Posts' button.
8. Return to the Customizer; remove the footer widget and add a sidebar widget. 
9. On a laptop/desktop computer, navigate to the blog posts page and confirm that it loads more posts as you scroll. 
10. On a mobile device, navigate to the blog posts page and confirm it displays the 'Older Posts' button. (Note: this must be a real mobile device or Mac's iOS simulator and not just a narrow browser window; it uses Jetpack's [`jetpack_is_mobile()`](https://github.com/Automattic/jetpack/blob/3699f34bb90a2b0a2af221042dacacf777238d2b/class.jetpack-user-agent.php#L13) function, which checks for actual devices). 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
