### PR TITLE
Fix search sidebar styles

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -54,6 +54,7 @@
 
 .archive #main,
 .blog #main,
+.search #main,
 .page:not(.newspack-front-page) #main,
 .single-post .main-content {
 	@include media(tablet) {
@@ -63,6 +64,7 @@
 
 .archive #secondary,
 .blog #secondary,
+.search #secondary,
 .page:not(.newspack-front-page) #secondary,
 .single-post #secondary {
 	@include media(tablet) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I thought it was so careful not to introduce any regressions in #126, but I still broke the search results page! 🤦‍♀ 

This PR makes sure the sidebar goes back to acting like a sidebar again on the search results page. 

**Before:**

![image](https://user-images.githubusercontent.com/177561/62087032-19e4e780-b215-11e9-86ef-fa006913854a.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62087008-05085400-b215-11e9-93f4-d641b1aa4631.png)

### How to test the changes in this Pull Request:

1. Make sure you have a sidebar widget.
2. Run a search and view the search results page.
3. See that huge wide single column of content, and a sidebar hidden far below, and despair. 
4. Apply the PR and run `npm run build`.
5. View the search results page again; be filled with joy at the sight of it displaying correctly again. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
