### PR TITLE
Fix up the spacing between the header and content

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -23,10 +23,22 @@
 	overflow: hidden;
 }
 
+#content {
+	margin-top: #{ 1.5 * $size__spacing-unit };
+
+	@include media( tablet ) {
+		margin-top: #{ 4 * $size__spacing-unit }
+	}
+}
+
 #primary {
 	margin: auto;
 	max-width: 90%;
 	width: $size__site-main;
+}
+
+#secondary {
+	margin-top: $size__spacing-unit;
 }
 
 .single {

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -2,6 +2,10 @@
 .search {
 	.page-header {
 		margin: 0 0 #{ $size__spacing-unit * 3 };
+
+		h1 {
+			margin-top: 0;
+		}
 	}
 
 	.page-description {
@@ -25,11 +29,6 @@
 		margin: 0 0 #{ 0.5 * $size__spacing-unit };
 	}
 
-	.entry-header {
-		padding: 0;
-	}
-
-	.entry-header,
 	.entry-content > p {
 		margin: 0;
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -21,8 +21,6 @@
 }
 
 .entry-header {
-	margin: 0;
-	padding: 0 0 $size__spacing-unit;
 	position: relative;
 }
 
@@ -225,7 +223,7 @@ body.page {
 
 .single-post {
 	.entry-header {
-		margin: calc(3 * #{ $size__spacing-unit}) 0 0;
+		padding: 0 0 $size__spacing-unit;
 		width: 100%;
 	}
 
@@ -241,11 +239,6 @@ body.page {
 		@include media(desktop) {
 			font-size: $font__size-xxxxl;
 		}
-	}
-
-	.main-content,
-	#secondary {
-		margin-top: $size__spacing-unit;
 	}
 
 	&.post-template-single-feature {
@@ -290,11 +283,18 @@ body.page {
 	max-width: 100%;
 }
 
-/* Hide page title on the homepage */
+/* Static Front Page. */
 
-.newspack-front-page.hide-homepage-title {
-	.entry-header {
+.newspack-front-page {
+	&.hide-homepage-title .entry-header {
 		display: none;
+	}
+
+	#content {
+		margin-top: 0;
+		@include media(tablet) {
+			margin-top: #{ 0.5 * $size__spacing-unit };
+		}
 	}
 }
 


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Through building out the different templates of the theme, I've created some amazingly inconsistent spacing between the content and header, breaking it in one spot when I fixed it in another. 

This PR moves the spacing styles to a shared location, to make them much easier to keep track of -- with overrides in section-specific Sass files -- and reintroduces some spacing between pages that have lost it.

Note that this spacing will need to be adjusted again once we have an ad space underneath the site header, so we don't end up with something too gappy in that case. 

**Home - Before:**
![image](https://user-images.githubusercontent.com/177561/62089261-2a00c500-b21d-11e9-8b11-7fc4730a3b4c.png)

**Home - After:**
![image](https://user-images.githubusercontent.com/177561/62089570-5bc65b80-b21e-11e9-8e7e-799e34923f70.png)

**Blog Posts Page:**
![image](https://user-images.githubusercontent.com/177561/62089283-371db400-b21d-11e9-9174-4ee3baacaaaf.png)

**Blog Posts After:**
![image](https://user-images.githubusercontent.com/177561/62089502-11dd7580-b21e-11e9-9d3b-4fff34262ed5.png)

**Archive Page - Before**
![image](https://user-images.githubusercontent.com/177561/62089408-b01d0b80-b21d-11e9-8374-52f42179c229.png)

**Archive Page - After**
![image](https://user-images.githubusercontent.com/177561/62089423-c62acc00-b21d-11e9-9e2c-06c68586cb1d.png)

**Search Results Page - Before**

_Note: The missing sidebar is fixed in #136._

![image](https://user-images.githubusercontent.com/177561/62089329-659b8f00-b21d-11e9-8972-634812b0a67b.png)

**Search Results Page - After**
![image](https://user-images.githubusercontent.com/177561/62089514-228deb80-b21e-11e9-9c95-9a1254ebc342.png)

**Single Page - Before**
![image](https://user-images.githubusercontent.com/177561/62089354-7c41e600-b21d-11e9-8d88-c160b4b80d8c.png)

**Single Page After**
![image](https://user-images.githubusercontent.com/177561/62089476-ff633c00-b21d-11e9-8f4a-5fab8c0d3d45.png)

**Single Post Before**
![image](https://user-images.githubusercontent.com/177561/62089380-8d8af280-b21d-11e9-96dc-e697eb3d49ac.png)

**Single Post After**
![image](https://user-images.githubusercontent.com/177561/62089461-ebb7d580-b21d-11e9-9e07-e21d1ec3a6d8.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Run through the main different pages and make sure the spacing looks consistent -- they are:
    * the static front page
    * the blog posts page
    * the archive
    * the search results
    * a single page
    * a single post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
