### PR TITLE
Clean up image block styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -572,7 +572,7 @@
 		}
 
 		figcaption {
-			border-bottom: 1px solid #ccc;
+			border-bottom: 1px solid $color__border;
 			margin: auto;
 			max-width: 780px;
 		}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -539,22 +539,7 @@
 		}
 
 		.aligncenter {
-
-			@include media(tablet) {
-				margin: 0;
-				width: 100%;
-
-				img {
-					margin: 0 auto;
-				}
-			}
-
-			@include media(desktop) {
-
-				img {
-					margin: 0 auto;
-				}
-			}
+			margin: 0 auto;
 		}
 
 		&.alignfull img {
@@ -564,6 +549,10 @@
 
 		&.alignwide {
 			max-width: 100vw;
+		}
+
+		figcaption {
+			border-bottom: 1px solid #ccc;
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -152,6 +152,20 @@
 		padding: 20px 30px;
 	}
 
+	//! Captions
+	.wp-block-audio figcaption,
+	.wp-block-video figcaption,
+	.wp-block-image figcaption,
+	.wp-block-gallery .blocks-gallery-image figcaption,
+	.wp-block-gallery .blocks-gallery-item figcaption {
+		font-family: $font__heading;
+		font-size: $font__size-xs;
+		line-height: $font__line-height-pre;
+		margin: 0;
+		padding: ( $size__spacing-unit * .5 );
+		text-align: center;
+	}
+
 	//! Audio
 	.wp-block-audio {
 
@@ -555,6 +569,8 @@
 
 		figcaption {
 			border-bottom: 1px solid #ccc;
+			margin: auto;
+			max-width: 780px;
 		}
 	}
 
@@ -630,20 +646,6 @@
 		figcaption a {
 			color: #fff;
 		}
-	}
-
-	//! Captions
-	.wp-block-audio figcaption,
-	.wp-block-video figcaption,
-	.wp-block-image figcaption,
-	.wp-block-gallery .blocks-gallery-image figcaption,
-	.wp-block-gallery .blocks-gallery-item figcaption {
-		font-family: $font__heading;
-		font-size: $font__size-xs;
-		line-height: $font__line-height-pre;
-		margin: 0;
-		padding: ( $size__spacing-unit * .5 );
-		text-align: center;
 	}
 
 	//! Separator

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -29,6 +29,7 @@
 		width: 100vw;
 	}
 
+	&.wp-block-image .alignleft, // Gah image block, why are you marked up like this??
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
@@ -53,6 +54,7 @@
 		}
 	}
 
+	&.wp-block-image .alignright,
 	&.alignright {
 		/*rtl:ignore*/
 		float: right;
@@ -540,6 +542,7 @@
 
 			@include media(tablet) {
 				margin: 0;
+				width: 100%;
 
 				img {
 					margin: 0 auto;
@@ -943,6 +946,7 @@
 .single.post-template-default.has-sidebar {
 	.entry .entry-content > *,
 	.entry .entry-summary > * {
+		&.wp-block-image .alignleft,
 		&.alignleft {
 			margin-left: 0;
 
@@ -953,6 +957,7 @@
 				margin-left: #{ -4 * $size__spacing-unit };
 			}
 		}
+		&.wp-block-image .alignright,
 		&.alignright {
 			margin-right: 0;
 		}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -40,18 +40,20 @@
 		margin-right: 0;
 		/*rtl:ignore*/
 		margin-right: $size__spacing-unit;
+		max-width: 50%;
 
 		@include media(mobile) {
-			max-width: 50%;
 			/*rtl:ignore*/
 			margin-right: calc(2 * #{$size__spacing-unit});
 		}
 
 		@include media( tablet ) {
+			/*rtl:ignore*/
 			margin-left: #{ -4 * $size__spacing-unit }
 		}
 
 		@include media( desktop ) {
+			/*rtl:ignore*/
 			margin-left: #{ -6 * $size__spacing-unit }
 		}
 	}
@@ -65,18 +67,20 @@
 		margin-right: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
+		max-width: 50%;
 
 		@include media(mobile) {
-			max-width: 50%;
 			/*rtl:ignore*/
 			margin-left: calc(2 * #{$size__spacing-unit});
 		}
 
 		@include media( tablet ) {
+			/*rtl:ignore*/
 			margin-right: #{ -4 * $size__spacing-unit }
 		}
 
 		@include media( desktop ) {
+			/*rtl:ignore*/
 			margin-right: #{ -6 * $size__spacing-unit }
 		}
 	}
@@ -941,10 +945,12 @@
 	.entry .entry-summary > * {
 		&.wp-block-image .alignleft,
 		&.alignleft {
+			/*rtl:ignore*/
 			margin-left: 0;
 		}
 		&.wp-block-image .alignright,
 		&.alignright {
+			/*rtl:ignore*/
 			margin-right: 0;
 		}
 		&.alignwide {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -29,7 +29,9 @@
 		width: 100vw;
 	}
 
-	&.wp-block-image .alignleft, // Gah image block, why are you marked up like this??
+	// When the image block is aligned left or right, the markup changes,
+	// making a slighly different selector necessary.
+	&.wp-block-image .alignleft,
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
@@ -938,13 +940,6 @@
 		&.wp-block-image .alignleft,
 		&.alignleft {
 			margin-left: 0;
-
-			@include media(desktop) {
-				margin-left: #{ -2 * $size__spacing-unit };
-			}
-			@include media(wide) {
-				margin-left: #{ -4 * $size__spacing-unit };
-			}
 		}
 		&.wp-block-image .alignright,
 		&.alignright {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -332,7 +332,7 @@ figcaption,
 
 .wp-block-image {
 	.block-editor-rich-text__editable {
-		border-bottom: 1px solid #ccc;
+		border-bottom: 1px solid $color__border;
 		padding-bottom: $size__spacing-unit;
 		margin: auto;
 		max-width: 780px;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -339,6 +339,21 @@ figcaption,
 	}
 }
 
+.wp-block[data-type="core/image"][data-align="left"].wp-block .block-editor-block-list__block-edit,
+.wp-block[data-type="core/image"][data-align="right"].wp-block .block-editor-block-list__block-edit {
+	max-width: 50%;
+
+	.wp-block-image {
+		table-layout: fixed;
+		max-width: 100%;
+	}
+
+	.wp-block-image > div > div {
+		max-width: 100%;
+		width: 100% !important; // !important to override inline styles.
+	}
+}
+
 /** === Gallery === */
 
 .wp-block-gallery {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -328,6 +328,15 @@ figcaption,
 	}
 }
 
+/** === Image === */
+
+.wp-block-image {
+	.block-editor-rich-text__editable {
+		border-bottom: 1px solid #ccc;
+		padding-bottom: $size__spacing-unit;
+	}
+}
+
 /** === Gallery === */
 
 .wp-block-gallery {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -334,6 +334,8 @@ figcaption,
 	.block-editor-rich-text__editable {
 		border-bottom: 1px solid #ccc;
 		padding-bottom: $size__spacing-unit;
+		margin: auto;
+		max-width: 780px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes up and adds some styles for the image blocks, in the editor and on the front-end.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Copy-paste [this test data](https://cloudup.com/cT3iW9y49cq) into a post, in the Code Editor view -- it includes images with captions, with no alignment, aligned left, right, centred, wide and full.
3. Do a visual review on the front-end and check for any weirdness.
4. Do a visual review in the editor and check for any weirdness. 
5. Switch templates to the 'Article feature' and do a visual review on the front-end.

**General notes:**

* Wide and full images should only display as such using the 'Article feature'.
* Right-aligned images should only pull out of the content area using the 'Article feature'.
* Left-aligned images should always pull out of the content area to the left, but less so with the default article template.

**Default template - images aligned left and right**
![image](https://user-images.githubusercontent.com/177561/62149994-c7a5d400-b2b1-11e9-811a-30ada17fc37a.png)

**Default template - images aligned wide and full**
![image](https://user-images.githubusercontent.com/177561/62150028-d4c2c300-b2b1-11e9-8436-036d25c06206.png)

**Article feature - images aligned left and right:**
![image](https://user-images.githubusercontent.com/177561/62149855-87deec80-b2b1-11e9-9506-8f2e7e3a686f.png)

**Article feature - images aligned wide and full:**
![image](https://user-images.githubusercontent.com/177561/62149886-9cbb8000-b2b1-11e9-8290-b4083eb9f4f7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?