### PR TITLE
Move some of the more opinionated default styles out of the 'base' stylesheet

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -54,4 +54,5 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Galleries
 --------------------------------------------------------------*/
 @import "variables-site/variables-site";
+@import "styles/style-default/style-default";
 @import "style-base";

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -1,19 +1,3 @@
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
-/* Style pack-specific overrides */
-#colophon .widget-title,
-.article-section-title {
-	border-bottom: 4px solid;
-	font-family: $font__body;
-	font-size: 1em;
-}
-
-.wp-block-newspack-blocks-homepage-articles {
-	&:not(.is-grid) {
-		article:not(:last-of-type) {
-			border-bottom: 2px solid darken( $color__background-body, 5% );
-			padding-bottom: 1em;
-		}
-	}
-}

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -1,0 +1,11 @@
+/* Headers */
+
+.accent-header,
+.article-section-title {
+	border-bottom: 4px solid #ccc;
+	color: $color__primary;
+	font-size: $font__size-sm;
+	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
+	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
+	text-transform: uppercase;
+}

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -156,16 +156,6 @@ blockquote {
 	}
 }
 
-.accent-header,
-.article-section-title {
-	border-bottom: 4px solid #ccc;
-	color: $color__primary;
-	font-size: $font__size-sm;
-	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
-	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
-	text-transform: uppercase;
-}
-
 .page-header {
 	width: 100%;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed when starting to experiment with stylesheet styles that matched the mockups that there were a few things in the default styles that would have to be overridden in each and everyone one:

- the 'accent' headers
- the button-like styles on all the tertiary navigation
- the backgrounds on the category links

This PR starts the process of moving those styles into a separate SCSS file that isn't included in the other style packs, and it moves over the 'accent' header styles. 

It also removes some of the placeholder styles from the "Style 1" style pack, to make testing easier. 

I will circle back and tackle the other more opinionated styles in separate PRs.

**Accent header with the default stylepack:**
![image](https://user-images.githubusercontent.com/177561/62176589-fa25f000-b2f6-11e9-9e4d-de2d4b63a67c.png)

**Accent headers with Style Pack 1:** (which just changes the font and background colour now)
![image](https://user-images.githubusercontent.com/177561/62176832-aa93f400-b2f7-11e9-9078-4575e1137441.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that the 'accent' headers continue to look correct. These can be tested on the homepage, in the 'section header' of the homepage block, and as the sidebar widget's titles.
3. Navigate to Customizer > Style Packs and switch to Style 1 (note this will not preview correctly due to #52). 
4. On the front end, confirm that this header is no longer all caps, blue, or has a bottom border. This gives us a cleaner slate with this element to customize for the other style packs. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
