### PR TITLE
Remove `!important`  from the print styles

### DIFF
--- a/sass/print.scss
+++ b/sass/print.scss
@@ -36,7 +36,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	body {
 		font: 13pt Georgia, "Times New Roman", Times, serif;
 		line-height: 1.3;
-		background: #fff !important;
+		background: #fff;
 		color: #000;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the `!important` from the print.scss file -- it's currently used to set the white background on the `body`. AMP doesn't like `!important1, and the theme doesn't have any customization options built in that would require that level of override (the theme doesn't support any background customization). 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Make sure there are no errors.
3. Make sure the `!important` is toast.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?