### PR TITLE
Switch #ccc colour to use the existing (and matching) colour variabl …

### DIFF
--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -871,7 +871,7 @@ table.variations {
 		li {
 			list-style: none;
 			padding: 0.5rem 0;
-			border-bottom: 1px solid #ccc;
+			border-bottom: 1px solid $color__border;
 
 			&:first-child {
 				padding-top: 0;

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -9,7 +9,7 @@
 
 	.footer-branding {
 		.wrapper {
-			border-top: 4px solid #ccc;
+			border-top: 4px solid $color__border;
 			padding-top: $size__spacing-unit;
 		}
 
@@ -54,7 +54,7 @@
 		color: $color__text-light;
 
 		.wrapper {
-			border-top: 1px solid #ccc;
+			border-top: 1px solid $color__border;
 			justify-content: space-between;
 			padding: $size__spacing-unit 0;
 		}

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -101,7 +101,7 @@ h6 {
 }
 
 .article-section-title {
-	border-bottom: 4px solid #ccc;
+	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -156,7 +156,7 @@ blockquote {
 
 .accent-header,
 .article-section-title {
-	border-bottom: 4px solid #ccc;
+	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR swaps out the colour `#ccc`, which is being used for borders, for the existing `$color__border` variable that was already set to `#ccc`.

Came up in feedback in #139.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Make sure all instances of 
3. Spot check a couple of the locations to make sure they look correct -- specifically the footer borders, the 'accent header' borders.

Accent header: 
![image](https://user-images.githubusercontent.com/177561/62247428-af5db400-b39a-11e9-8b99-25f01b2def53.png)

Footer: 

![image](https://user-images.githubusercontent.com/177561/62247491-cd2b1900-b39a-11e9-8637-03b7a97c3d7d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
