### PR TITLE
Update table block styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -705,6 +705,16 @@
 		td {
 			border-color: $color__text-light;
 		}
+
+		&.aligncenter {
+			margin-left: auto;
+			margin-right: auto;
+		}
+
+		&.alignfull {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
+		}
 	}
 
 	//! File
@@ -967,6 +977,8 @@
 		&.alignfull {
 			margin-left: 0;
 			margin-right: 0;
+			padding-left: 0;
+			padding-right: 0;
 			max-width: 100%;
 			width: 100%;
 

--- a/sass/elements/_tables.scss
+++ b/sass/elements/_tables.scss
@@ -3,6 +3,7 @@ table {
 	border-collapse: collapse;
 	width: 100%;
 	font-family: $font__heading;
+	font-size: $font__size-sm;
 
 	td,
 	th {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -130,6 +130,11 @@ a {
 	}
 }
 
+table td,
+table th {
+	font-size: $font__size-sm;
+}
+
 // Use white text against these backgrounds by default.
 .has-primary-background-color,
 .has-primary-variation-background-color,
@@ -553,6 +558,7 @@ figcaption,
 
 .wp-block-verse,
 .wp-block-verse pre {
+	font-style: italic;
 	padding: 0;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the table block styles, specifically to:

* Make sure centred table blocks are centred on the front-end.
* Make sure fullwidth table blocks don't get cut off on the edges.
* Reduce the font size in the tablet slightly.

**Centred table - before:**

![image](https://user-images.githubusercontent.com/177561/62258448-53f1ed00-b3bf-11e9-86b8-508357e0928a.png)

**Centred table - after:**

![image](https://user-images.githubusercontent.com/177561/62258410-345ac480-b3bf-11e9-889f-46b56223dc14.png)

**Full-width table - before:**

![image](https://user-images.githubusercontent.com/177561/62258459-5ce2be80-b3bf-11e9-8472-58028d1abda3.png)

**Full-width table - after:** 

![image](https://user-images.githubusercontent.com/177561/62258423-3de42c80-b3bf-11e9-9997-56c1488615f6.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Copy paste [this test content](https://cloudup.com/cvC4cw02sn1) into the Code Editor view of the post -- includes tables with all style (regular and striped) and alignment (none, left, right, centre, wide, full) variations.
3. Confirm that each variation is displaying correctly, on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
