### PR TITLE
Add custom typography to editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -410,7 +410,7 @@ function newspack_typography_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-fonts">
-		<?php echo esc_html( newspack_custom_typography_css() ); ?>
+		<?php echo wp_kses( newspack_custom_typography_css(), '' ); ?>
 	</style>
 
 <?php

--- a/functions.php
+++ b/functions.php
@@ -266,6 +266,15 @@ function newspack_scripts() {
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/amp-fallback.js' ), array(), '1.0', true );
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}
+	// Load custom fonts, if any.
+	if ( get_theme_mod( 'custom_font_import_code', '' ) ) {
+		wp_enqueue_style( 'newspack-font-import', newspack_custom_typography_link( 'custom_font_import_code' ), array(), null );
+	}
+
+	if ( get_theme_mod( 'custom_font_import_code_alternate', '' ) ) {
+		wp_enqueue_style( 'newspack-font-alternative-import', newspack_custom_typography_link( 'custom_font_import_code_alternate' ), array(), null );
+	}
+
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
 
@@ -299,11 +308,31 @@ function newspack_editor_customizer_styles() {
 
 	wp_enqueue_style( 'newspack-editor-customizer-styles', get_theme_file_uri( '/styles/style-editor-customizer.css' ), false, '1.1', 'all' );
 
+	// Check for color or font customizations.
+	$theme_customizations = '';
 	if ( 'custom' === get_theme_mod( 'theme_colors' ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
-		wp_add_inline_style( 'newspack-editor-customizer-styles', newspack_custom_colors_css() );
+		$theme_customizations .= newspack_custom_colors_css();
 	}
+
+	if ( get_theme_mod( 'font_body', '' ) || get_theme_mod( 'font_header', '' ) ) {
+		$theme_customizations .= newspack_custom_typography_css();
+	}
+
+	// If there are any, add those styles inline.
+	if ( $theme_customizations ) {
+		wp_add_inline_style( 'newspack-editor-customizer-styles', $theme_customizations );
+	}
+
+	// If custom fonts are assigned, enqueue them as well.
+	if ( get_theme_mod( 'custom_font_import_code', '' ) ) {
+		wp_enqueue_style( 'newspack-font-import', newspack_custom_typography_link( 'custom_font_import_code' ), array(), null );
+	}
+	if ( get_theme_mod( 'custom_font_import_code_alternate', '' ) ) {
+		wp_enqueue_style( 'newspack-font-alternative-import', newspack_custom_typography_link( 'custom_font_import_code_alternate' ), array(), null );
+	}
+
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_editor_customizer_styles' );
 
@@ -371,31 +400,20 @@ function newspack_colors_css_wrap() {
 add_action( 'wp_head', 'newspack_colors_css_wrap' );
 
 /**
- * Display custom color CSS in customizer and on frontend.
+ * Display custom font CSS in customizer and on frontend.
  */
 function newspack_typography_css_wrap() {
 
-	if ( is_admin() ) {
+	if ( is_admin() || ( ! get_theme_mod( 'font_body', '' ) && ! get_theme_mod( 'font_header', '' ) ) ) {
 		return;
 	}
+	?>
 
-	require_once get_parent_theme_file_path( '/inc/typography.php' );
+	<style type="text/css" id="custom-theme-fonts">
+		<?php echo esc_html( newspack_custom_typography_css() ); ?>
+	</style>
 
-	$allowed_html = array(
-		'link'  => array(
-			'href' => true,
-			'rel'  => true,
-		),
-		'style' => array(
-			'type' => true,
-			'id'   => true,
-		),
-	);
-
-	echo wp_kses( newspack_custom_typography_link( 'custom_font_import_code' ), $allowed_html );
-	echo wp_kses( newspack_custom_typography_link( 'custom_font_import_code_alternate' ), $allowed_html );
-	echo wp_kses( newspack_custom_typography_css(), $allowed_html );
-
+<?php
 }
 add_action( 'wp_head', 'newspack_typography_css_wrap' );
 
@@ -480,6 +498,10 @@ require get_template_directory() . '/inc/template-functions.php';
  */
 require get_template_directory() . '/inc/color-filters.php';
 
+/**
+ * Custom typography functions.
+ */
+require get_template_directory() . '/inc/typography.php';
 
 /**
  * SVG Icons related functions.

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -10,14 +10,14 @@
  */
 function newspack_custom_typography_css() {
 
-	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack', 'serif' ) );
-	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack', 'serif' ) );
+	$font_body   = newspack_font_stack( get_theme_mod( 'font_body', '' ), get_theme_mod( 'font_body_stack', 'serif' ) );
+	$font_header = newspack_font_stack( get_theme_mod( 'font_header', '' ), get_theme_mod( 'font_header_stack', 'serif' ) );
 
-	$css_blocks        = array();
-	$editor_css_blocks = array();
+	$css_blocks        = '';
+	$editor_css_blocks = '';
 
-	if ( get_theme_mod( 'font_header' ) ) {
-		$css_blocks[] = "
+	if ( get_theme_mod( 'font_header', '' ) ) {
+		$css_blocks .= "
 		/* _headings.scss */
 		.author-description .author-link,
 		.comment-metadata,
@@ -107,57 +107,54 @@ function newspack_custom_typography_css() {
 			font-family: $font_header;
 		}";
 
-		$editor_css_blocks[] = "
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6,
-		figcaption,
-		.gallery-caption,
+
+		$editor_css_blocks .= "
+		.editor-block-list__layout .editor-block-list__block h1,
+		.editor-block-list__layout .editor-block-list__block h2,
+		.editor-block-list__layout .editor-block-list__block h3,
+		.editor-block-list__layout .editor-block-list__block h4,
+		.editor-block-list__layout .editor-block-list__block h5,
+		.editor-block-list__layout .editor-block-list__block h6,
+		.editor-block-list__layout .editor-block-list__block figcaption,
+		.editor-block-list__layout .editor-block-list__block .gallery-caption,
 
 		/* Post Title */
-		.editor-post-title__block .editor-post-title__input
-		.entry-meta
-
-		/* Paragraph */
-		.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+		.editor-styles-wrapper .editor-post-title .editor-post-title__block .editor-post-title__input,
 
 		/* Table Block */
-		.wp-block-table,
+		.editor-block-list__layout .editor-block-list__block .wp-block-table,
 
 		/* Cover Block */
-		.wp-block-cover h2,
-		.wp-block-cover .wp-block-cover-text,
+		.editor-block-list__layout .editor-block-list__block .wp-block-cover h2,
+		.editor-block-list__layout .editor-block-list__block .wp-block-cover .wp-block-cover-text,
 
 		/* Button Block */
-		.wp-block-button .wp-block-button__link,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button .wp-block-button__link,
 
 		/* Blockquote Block */
-		.wp-block-quote cite,
-		.wp-block-quote footer,
-		.wp-block-quote .wp-block-quote__citation,
+		.editor-block-list__layout .editor-block-list__block .wp-block-quote cite,
+		.editor-block-list__layout .editor-block-list__block .wp-block-quote footer,
+		.editor-block-list__layout .editor-block-list__block .wp-block-quote .wp-block-quote__citation,
 
 		/* Pullquote Block */
-		.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-		.wp-block[data-type='core/pullquote'][data-align='left'] .wp-block-pullquote__citation,
-		.wp-block[data-type='core/pullquote'][data-align='right'] .wp-block-pullquote__citation,
+		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='left'] .wp-block-pullquote__citation,
+		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='right'] .wp-block-pullquote__citation,
 
 		/* File Block */
-		.wp-block-file,
+		.editor-block-list__layout .editor-block-list__block .wp-block-file,
 
 		/* Widget blocks */
-		ul.wp-block-archives li,
-		.wp-block-categories li,
-		.wp-block-latest-posts li,
+		.editor-block-list__layout .editor-block-list__block ul.wp-block-archives li,
+		.editor-block-list__layout .editor-block-list__block .wp-block-categories li,
+		.editor-block-list__layout .editor-block-list__block .wp-block-latest-posts li,
 
 		/* Latest Comments blocks */
-		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
+		.editor-block-list__layout .editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 
 		/* Classic Editor */
-		.wp-caption dd,
-		.wp-block-freeform blockquote cite
+		.editor-block-list__layout .editor-block-list__block .wp-caption dd,
+		.editor-block-list__layout .editor-block-list__block .wp-block-freeform blockquote cite
 
 		{
 			font-family: $font_header;
@@ -165,8 +162,8 @@ function newspack_custom_typography_css() {
 		";
 	}
 
-	if ( get_theme_mod( 'font_body' ) ) {
-		$css_blocks[] = "
+	if ( get_theme_mod( 'font_body', '' ) ) {
+		$css_blocks .= "
 		/* _typography.scss */
 		body,
 		button,
@@ -176,15 +173,14 @@ function newspack_custom_typography_css() {
 		textarea,
 
 		/* _blocks.scss */
-		.entry .entry-content .wp-block-verse,
-		.page-title
+		.wp-block-verse
 		{
 			font-family: $font_body;
 		}
 		";
 
-		$editor_css_blocks[] = "
-			body,
+		$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block,
 			.editor-default-block-appender .editor-default-block-appender__content
 			{
 				font-family: $font_body;
@@ -192,16 +188,20 @@ function newspack_custom_typography_css() {
 		";
 	}
 
-	if ( count( $css_blocks ) > 0 ) {
-		$theme_css = "<style type='text/css' id='custom-typography'>\n" . implode( '', $css_blocks ) . "\n</style>";
+	if ( '' !== $css_blocks ) {
+		$theme_css = $css_blocks;
 	} else {
 		$theme_css = '';
 	}
 
-	if ( count( $editor_css_blocks ) > 0 ) {
-		$editor_css = "<style type='text/css' id='custom-typography'>\n" . implode( '', $css_blocks ) . "\n</style>";
+	if ( '' !== $editor_css_blocks ) {
+		$editor_css = $editor_css_blocks;
 	} else {
 		$editor_css = '';
+	}
+
+	if ( function_exists( 'register_block_type' ) && is_admin() ) {
+		$theme_css = $editor_css;
 	}
 
 	return $theme_css;
@@ -211,13 +211,11 @@ function newspack_custom_typography_css() {
  * Generate link elements for custom typography stylesheets.
  */
 function newspack_custom_typography_link( $theme_mod ) {
-
-	$font_code = get_theme_mod( $theme_mod );
-
-	if ( $font_code ) {
-		return "<link rel='stylesheet' href='" . esc_url( $font_code ) . "'>";
+	$font_code = get_theme_mod( $theme_mod, '' );
+	if ( ! $font_code ) {
+		return false;
 	}
-	return '';
+	return $font_code;
 }
 
 /**

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -13,7 +13,8 @@ function newspack_custom_typography_css() {
 	$font_body   = newspack_font_stack( get_theme_mod( 'font_body' ), get_theme_mod( 'font_body_stack', 'serif' ) );
 	$font_header = newspack_font_stack( get_theme_mod( 'font_header' ), get_theme_mod( 'font_header_stack', 'serif' ) );
 
-	$css_blocks = array();
+	$css_blocks        = array();
+	$editor_css_blocks = array();
 
 	if ( get_theme_mod( 'font_header' ) ) {
 		$css_blocks[] = "
@@ -105,7 +106,65 @@ function newspack_custom_typography_css() {
 		{
 			font-family: $font_header;
 		}";
+
+		$editor_css_blocks[] = "
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6,
+		figcaption,
+		.gallery-caption,
+
+		/* Post Title */
+		.editor-post-title__block .editor-post-title__input
+		.entry-meta
+
+		/* Paragraph */
+		.wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+
+		/* Table Block */
+		.wp-block-table,
+
+		/* Cover Block */
+		.wp-block-cover h2,
+		.wp-block-cover .wp-block-cover-text,
+
+		/* Button Block */
+		.wp-block-button .wp-block-button__link,
+
+		/* Blockquote Block */
+		.wp-block-quote cite,
+		.wp-block-quote footer,
+		.wp-block-quote .wp-block-quote__citation,
+
+		/* Pullquote Block */
+		.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+		.wp-block[data-type='core/pullquote'][data-align='left'] .wp-block-pullquote__citation,
+		.wp-block[data-type='core/pullquote'][data-align='right'] .wp-block-pullquote__citation,
+
+		/* File Block */
+		.wp-block-file,
+
+		/* Widget blocks */
+		ul.wp-block-archives li,
+		.wp-block-categories li,
+		.wp-block-latest-posts li,
+
+		/* Latest Comments blocks */
+		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
+
+		/* Classic Editor */
+		.wp-caption dd,
+		.wp-block-freeform blockquote cite
+
+		{
+			font-family: $font_header;
+		}
+		";
 	}
+
 	if ( get_theme_mod( 'font_body' ) ) {
 		$css_blocks[] = "
 		/* _typography.scss */
@@ -123,11 +182,26 @@ function newspack_custom_typography_css() {
 			font-family: $font_body;
 		}
 		";
+
+		$editor_css_blocks[] = "
+			body,
+			.editor-default-block-appender .editor-default-block-appender__content
+			{
+				font-family: $font_body;
+			}
+		";
 	}
+
 	if ( count( $css_blocks ) > 0 ) {
 		$theme_css = "<style type='text/css' id='custom-typography'>\n" . implode( '', $css_blocks ) . "\n</style>";
 	} else {
 		$theme_css = '';
+	}
+
+	if ( count( $editor_css_blocks ) > 0 ) {
+		$editor_css = "<style type='text/css' id='custom-typography'>\n" . implode( '', $css_blocks ) . "\n</style>";
+	} else {
+		$editor_css = '';
 	}
 
 	return $theme_css;

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -173,7 +173,8 @@ function newspack_custom_typography_css() {
 		textarea,
 
 		/* _blocks.scss */
-		.wp-block-verse
+		.entry .entry-content .wp-block-verse,
+		.page-title
 		{
 			font-family: $font_body;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR enqueues the custom typography styles and fonts in to the editor, to match the behaviour on the front-end. 

It also reworks how the fonts were originally set up a bit to mirror how the colours are set up, to try to reduce repetition in the editor code. The big changes were:

* Switching the variable that holds the font styles from an array to a string.
* Removing the `<style></style>` tags in the function and using `wp_add_inline_style()` to add the block of CSS to the editor.
* Removing the `<link...>` from the fonts, and just returning the URL and using `wp_enqueue_style()` to add them to the front-end and the editor.

Fixes #45 .

### How to test the changes in this Pull Request:

1. Apply the PR.
2. In the Customizer, add at least one outrageous font from a third-party source to the Font Provider URL (so it's easier to tell if it's working).  I used //fonts.googleapis.com/css?family=Beth+Ellen|Saira+Stencil+One&display=swap.
3. Assign a Header and Body font -- from the above, you could use "Beth Ellen" and "Saira Stencil One".
4. Publish changes.
5. Confirm custom fonts are displaying on the front end. 
6. Edit a post and confirm they're being used in the editor.
7. Try a few variations of the above -- I'd recommend using both "Font Provider" fields, or only the second one; only having a header or body font, etc. 

Note: There will definitely be elements that the fonts aren't being applied to due to errors in the selectors -- I personally think we should handle those in a separate PR, but please feel free to note them here. Both the fonts and colours functionality need a careful sweep one the theme development slows down a bit, to catch all the stuff that feel through the cracks. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
