### PR TITLE
Update approach wide and full styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -13,22 +13,6 @@
 		margin-bottom: 0;
 	}
 
-	&.alignwide {
-		@include media( tablet ) {
-			margin-left: calc(25% - 25vw);
-			margin-right: calc(25% - 25vw);
-			max-width: 100vw;
-		}
-	}
-
-	&.alignfull {
-		margin-left: calc(50% - 50vw);
-		margin-right: calc(50% - 50vw);
-		max-width: 100vw;
-		position: relative;
-		width: 100vw;
-	}
-
 	// When the image block is aligned left or right, the markup changes,
 	// making a slighly different selector necessary.
 	&.wp-block-image .alignleft,
@@ -41,21 +25,6 @@
 		/*rtl:ignore*/
 		margin-right: $size__spacing-unit;
 		max-width: 50%;
-
-		@include media(mobile) {
-			/*rtl:ignore*/
-			margin-right: calc(2 * #{$size__spacing-unit});
-		}
-
-		@include media( tablet ) {
-			/*rtl:ignore*/
-			margin-left: #{ -4 * $size__spacing-unit }
-		}
-
-		@include media( desktop ) {
-			/*rtl:ignore*/
-			margin-left: #{ -6 * $size__spacing-unit }
-		}
 	}
 
 	&.wp-block-image .alignright,
@@ -68,22 +37,8 @@
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
 		max-width: 50%;
-
-		@include media(mobile) {
-			/*rtl:ignore*/
-			margin-left: calc(2 * #{$size__spacing-unit});
-		}
-
-		@include media( tablet ) {
-			/*rtl:ignore*/
-			margin-right: #{ -4 * $size__spacing-unit }
-		}
-
-		@include media( desktop ) {
-			/*rtl:ignore*/
-			margin-right: #{ -6 * $size__spacing-unit }
-		}
 	}
+
 	&.aligncenter {
 		margin-left: auto;
 		margin-right: auto;
@@ -408,11 +363,6 @@
 			}
 		}
 
-		&.alignfull {
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
-		}
-
 		&.alignleft,
 		&.alignright {
 			padding: 0;
@@ -562,15 +512,6 @@
 			margin: 0 auto;
 		}
 
-		&.alignfull img {
-			width: 100vw;
-			max-width: 100vw;
-		}
-
-		&.alignwide {
-			max-width: 100vw;
-		}
-
 		figcaption {
 			border-bottom: 1px solid $color__border;
 			margin: auto;
@@ -612,28 +553,6 @@
 			@include media(tablet) {
 				padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
 			}
-		}
-
-		&.alignfull {
-
-			.wp-block-cover-image-text,
-			.wp-block-cover-text,
-			h2 {
-				@include postContentMaxWidth();
-			}
-
-			@include media(tablet) {
-
-				.wp-block-cover-image-text,
-				.wp-block-cover-text,
-				h2 {
-					padding: 0;
-				}
-			}
-		}
-
-		&.alignwide {
-			width: auto;
 		}
 	}
 
@@ -710,11 +629,6 @@
 			margin-left: auto;
 			margin-right: auto;
 		}
-
-		&.alignfull {
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
-		}
 	}
 
 	//! File
@@ -768,12 +682,6 @@
 
 	//! Columns
 	.wp-block-columns {
-
-		&.alignfull {
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
-		}
-
 		@include media(mobile) {
 			flex-wrap: nowrap;
 		}
@@ -796,12 +704,6 @@
 				&:last-child {
 					margin-right: 0;
 				}
-			}
-
-			&.alignfull,
-			&.alignfull .wp-block-column {
-				padding-left: calc(2 * #{$size__spacing-unit});
-				padding-right: calc(2 * #{$size__spacing-unit});
 			}
 		}
 	}
@@ -950,42 +852,117 @@
 	}
 }
 
-.single.post-template-default.has-sidebar {
+//! 'Feature' alignments
+.post-template-single-feature {
 	.entry .entry-content > *,
 	.entry .entry-summary > * {
-		&.wp-block-image .alignleft,
-		&.alignleft {
-			/*rtl:ignore*/
-			margin-left: 0;
-		}
-		&.wp-block-image .alignright,
-		&.alignright {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
 		&.alignwide {
-			@include media(tablet) {
-				margin-left: 0;
-				margin-right: 0;
-				max-width: 100%;
+			@include media( tablet ) {
+				margin-left: calc(25% - 25vw);
+				margin-right: calc(25% - 25vw);
+				max-width: 100vw;
 			}
 		}
 
 		&.alignfull {
-			margin-left: 0;
-			margin-right: 0;
-			padding-left: 0;
-			padding-right: 0;
-			max-width: 100%;
-			width: 100%;
+			margin-left: calc(50% - 50vw);
+			margin-right: calc(50% - 50vw);
+			max-width: 100vw;
+			position: relative;
+			width: 100vw;
+		}
+
+		&.alignleft {
+			@include media(mobile) {
+				/*rtl:ignore*/
+				margin-right: calc(2 * #{$size__spacing-unit});
+			}
+
+			@include media( tablet ) {
+				/*rtl:ignore*/
+				margin-left: #{ -4 * $size__spacing-unit }
+			}
+
+			@include media( desktop ) {
+				/*rtl:ignore*/
+				margin-left: #{ -6 * $size__spacing-unit }
+			}
+		}
+
+		&.alignright {
+			@include media(mobile) {
+				/*rtl:ignore*/
+				margin-left: calc(2 * #{$size__spacing-unit});
+			}
+
+			@include media( tablet ) {
+				/*rtl:ignore*/
+				margin-right: #{ -4 * $size__spacing-unit }
+			}
+
+			@include media( desktop ) {
+				/*rtl:ignore*/
+				margin-right: #{ -6 * $size__spacing-unit }
+			}
+		}
+	}
+
+	//! Image Block
+	.wp-block-image {
+		&.alignfull img {
+			width: 100vw;
+			max-width: 100vw;
+		}
+
+		&.alignwide {
+			max-width: 100vw;
+		}
+	}
+
+	//! Cover Block
+	.wp-block-cover,
+	.wp-block-cover-image {
+		&.alignfull {
+
+			.wp-block-cover-image-text,
+			.wp-block-cover-text,
+			h2 {
+				@include postContentMaxWidth();
+			}
 
 			@include media(tablet) {
-				margin-left: 0;
-			}
 
-			&.wp-block-image img {
-				width: 100%;
+				.wp-block-cover-image-text,
+				.wp-block-cover-text,
+				h2 {
+					padding: 0;
+				}
 			}
+		}
+
+		&.alignwide {
+			width: auto;
+		}
+	}
+
+	//! Columns Block
+	.wp-block-columns {
+		@include media( tablet ) {
+			&.alignfull,
+			&.alignfull .wp-block-column {
+				padding-left: calc(2 * #{$size__spacing-unit});
+				padding-right: calc(2 * #{$size__spacing-unit});
+			}
+		}
+	}
+
+	//! Add padding to some fullalign blocks to prevent text cut-offs.
+	.wp-block-pullquote,
+	.wp-block-columns,
+	.wp-block-table {
+		&.alignfull {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
 		}
 	}
 }

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -872,7 +872,8 @@
 			width: 100vw;
 		}
 
-		&.alignleft {
+		&.alignleft,
+		&.wp-block-image .alignleft {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-right: calc(2 * #{$size__spacing-unit});
@@ -889,7 +890,8 @@
 			}
 		}
 
-		&.alignright {
+		&.alignright,
+		&.wp-block-image .alignright {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-left: calc(2 * #{$size__spacing-unit});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reworks the wide and full styles a bit -- they were originally set up as the default, but then overridden on a template basis. But in reality, so far only the 'article feature' template uses the wide and full styles --  the default post and page styles don't, and the archive and search views only show excerpts, not full posts.

This PR inverts this, so the wide and full styles, and pulling the left and right alignments outside of the content area, is only applied to the article feature template.

Down the road, we could also add a 'page' template that would allow you to do the same thing there, but I think I'll hold off and see if we get a request for this.

Closes #150  

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Copy and paste [this test content](https://cloudup.com/cnGd7pFmIXh) into the Code Editor view of the editor -- it include example of all the block variations that have changed: wide, full, left and right, plus image, cover, columns, pull quote and table, since their full-width styles have all be moved. 
3. Test a single post with the default template and a sidebar widget. All the content should stay 'inside' of the content area.
4. Test a single post with the default template and without a sidebar widget. All the content should still stay 'inside' of the content area.
5. Test a single post with the 'feature article' template. Left and right aligned blocks should pop outside of the content area a bit on larger browser windows (but move over as you scale the browser window down), and wide and full-width blocks should extend outside of the content area.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?