### PR TITLE
Move more opinionated 'tertiary menu' styles to the default style.scss.

### DIFF
--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -42,25 +42,6 @@ nav.tertiary-menu {
 	}
 }
 
-body:not(.header-solid-background):not(.header-simplified) {
-	nav.tertiary-menu {
-		a {
-			background-color: lighten($color__text-light, 45%);
-			color: $color__text-main;
-			@include button-transition;
-			border-radius: 5px;
-			font-size: $font__size-sm;
-			font-weight: 700;
-			padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
-
-			&:hover {
-				background-color: $color__text-main;
-				color: #fff;
-			}
-		}
-	}
-}
-
 .header-simplified {
 	nav.tertiary-menu {
 		font-size: $font__size_base;

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -54,5 +54,5 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	## Galleries
 --------------------------------------------------------------*/
 @import "variables-site/variables-site";
-@import "styles/style-default/style-default";
 @import "style-base";
+@import "styles/style-default/style-default";

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -9,3 +9,24 @@
 	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
 	text-transform: uppercase;
 }
+
+/* Navigation */
+
+body:not(.header-solid-background):not(.header-simplified) {
+	nav.tertiary-menu {
+		a {
+			background-color: lighten($color__text-light, 45%);
+			color: $color__text-main;
+			@include button-transition;
+			border-radius: 5px;
+			font-size: $font__size-sm;
+			font-weight: 700;
+			padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+
+			&:hover {
+				background-color: $color__text-main;
+				color: #fff;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a continuation of work started in #142: pulling some of the more opinionated default styles into a separate stylesheet, so they don't need to be overridden in every other style variation.

This PR moves the 'tertiary menu' styles (the button-like links on the right) into a separate stylesheet.

![image](https://user-images.githubusercontent.com/177561/62386437-b0aeee00-b50c-11e9-95c0-c57f7906c767.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Visually confirm the tertiary menu looks correct -- it is only applied when the header does not use the solid background or the short styles.
3. Navigate to the Customizer and switch to Style 1, and confirm that the links no longer have backgrounds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
