### PR TITLE
More more opinionated category styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -25,7 +25,6 @@ function newspack_custom_colors_css() {
 		/* Set primary background color */
 
 		.main-navigation .sub-menu,
-		.cat-links a,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
@@ -115,7 +114,6 @@ function newspack_custom_colors_css() {
 		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
 		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
-		.cat-links a:hover,
 		.entry .entry-content > .has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
@@ -168,6 +166,20 @@ function newspack_custom_colors_css() {
 		::-moz-selection {
 			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}';
+
+	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$theme_css .= '
+			.cat-links a,
+			.cat-links a:visited {
+				background-color: ' . $primary_color . ';
+				color: ' . $primary_color_contrast . ';
+			}
+			.cat-links a:hover {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
+				color: ' . $primary_color_contrast . ';
+			}
+		';
+	}
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -89,7 +89,8 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 	 * Prints HTML with the current post's categories.
 	 */
 	function newspack_categories() {
-		$categories_list = get_the_category_list( ' ' );
+		/* translators: used between list items */
+		$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '</span> ' );
 		if ( $categories_list ) {
 			printf(
 				/* translators: 1: posted in label, only visible to screen readers. 2: list of categories. */

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -80,16 +80,6 @@
 	}
 }
 
-.blog,
-.search {
-	.cat-links {
-		margin-bottom: 0;
-		a {
-			padding: 0.25em 0.5em;
-		}
-	}
-}
-
 .page-description {
 	color: $color__text-main;
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -56,24 +56,6 @@ body.page {
 	display: block;
 	font-size: $font__size-xs;
 	margin: 0 0 #{ 0.75 * $size__spacing-unit };
-
-	a {
-		background-color: $color__primary;
-		color: #fff;
-		display: inline-block;
-		margin: 0 0 #{ 0.25 * $size__spacing-unit };
-		padding: 0.5em 0.75em;
-		text-transform: uppercase;
-
-		&:visited {
-			color: #fff;
-		}
-
-		&:hover {
-			background-color: $color__primary-variation;
-			color: #fff;
-		}
-	}
 }
 
 .tags-links {

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -30,3 +30,41 @@ body:not(.header-solid-background):not(.header-simplified) {
 		}
 	}
 }
+
+/* Posts and pages */
+
+.cat-links {
+	a {
+		background-color: $color__primary;
+		color: #fff;
+		display: inline-block;
+		margin: 0 0 #{ 0.25 * $size__spacing-unit };
+		padding: 0.5em 0.75em;
+		text-transform: uppercase;
+
+		&:visited {
+			color: #fff;
+		}
+
+		&:hover {
+			background-color: $color__primary-variation;
+			color: #fff;
+		}
+	}
+
+	.sep {
+		display: none;
+	}
+}
+
+/* Archives */
+
+.blog,
+.search {
+	.cat-links {
+		margin-bottom: 0;
+		a {
+			padding: 0.25em 0.5em;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a continuation of work started in #142: moving more opinionated default styles to a separate stylesheet, so they don't need to be manually overridden in each of the other style variations.

This PR focuses on the background colour on each category link.

**Single post - default style pack:**

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/177561/62426990-ee448000-b6a0-11e9-9c68-65ea485675b6.png">

**Single post - style pack 1:**

<img width="1256" alt="image" src="https://user-images.githubusercontent.com/177561/62427005-2055e200-b6a1-11e9-919d-00230ddddc52.png">

**Search results/blog post - default style pack:**

<img width="835" alt="image" src="https://user-images.githubusercontent.com/177561/62426997-04ead700-b6a1-11e9-8446-a5434e917a77.png">

**Search results/blog post - style pack 1:**

<img width="826" alt="image" src="https://user-images.githubusercontent.com/177561/62427000-13d18980-b6a1-11e9-8a02-5eb4bbb3e2f3.png">

**Post with multiple categories - default style pack:**

<img width="859" alt="image" src="https://user-images.githubusercontent.com/177561/62427026-7b87d480-b6a1-11e9-8a35-8a27436e5c4c.png">

**Post with multiple categories - style pack 1:** 

<img width="800" alt="image" src="https://user-images.githubusercontent.com/177561/62427028-89d5f080-b6a1-11e9-8a2a-f7361adc3214.png">


### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. With the default style pack selected - in each case, the categories should display with solid background colour, with just space separating them:
   * Do a visual review of a single post
   * Do a visual review of the search results
   * Do a visual review of a post with multiple categories
   * Change to a custom colour and do a visual review of a single post - the background colour on the category should change.
3. With the 'Style 1' style pack selected - in each case, the categories should display with no background, and multiple categories should have a comma separating them:
   * Do a visual review of a single post
   * Do a visual review of the search results
   * Do a visual review of a post with multiple categories
   * Change to a custom colour and do a visual review of a single post - nothing about the category should change.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?