### PR TITLE
Switch tables to use the body font

### DIFF
--- a/sass/elements/_tables.scss
+++ b/sass/elements/_tables.scss
@@ -2,7 +2,6 @@ table {
 	margin: 0 0 $size__spacing-unit;
 	border-collapse: collapse;
 	width: 100%;
-	font-family: $font__heading;
 	font-size: $font__size-sm;
 
 	td,

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -132,6 +132,7 @@ a {
 
 table td,
 table th {
+	font-family: $font__body;
 	font-size: $font__size-sm;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR switches table headers and cells to use the same font family as the rest of the body text, rather than a sans-serif font.

I thought the sans-serif font would help tables stand out, but in reality, the different fonts can look odd in certain situations, like the WooCommerce checkout pages, which came up in #153.

**Before:**

![image](https://user-images.githubusercontent.com/177561/62483324-37153b00-b76c-11e9-8688-5dc8665c95c4.png)

**After:** 

![image](https://user-images.githubusercontent.com/177561/62483264-1a790300-b76c-11e9-8241-40f544ee741d.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that `td` and `th` tags are using the current body font on the front end (a serif font, by default).
3. Confirm that the table block is using the serif font in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
