### PR TITLE
Add hooks for additional ad locations

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -11,6 +11,8 @@
 
 ?>
 
+	<?php do_action( 'before_footer' ); ?>
+
 	</div><!-- #content -->
 
 	<footer id="colophon" class="site-footer">

--- a/header.php
+++ b/header.php
@@ -18,6 +18,9 @@
 </head>
 
 <body <?php body_class(); ?>>
+
+<?php do_action( 'before_header' ); ?>
+
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
@@ -143,3 +146,5 @@
 	</header><!-- #masthead -->
 
 	<div id="content" class="site-content">
+
+	<?php do_action( 'after_header' ); ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -12,5 +12,7 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 ?>
 
 <aside id="secondary" class="widget-area">
+	<?php do_action( 'before_sidebar' ); ?>
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
+	<?php do_action( 'after_sidebar' ); ?>
 </aside><!-- #secondary -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds additional hooks to the theme, to be used for ads. They are:

`before_header`
`after_header`
`before_sidebar`
`after_sidebar`
`before_footer`

I'd love confirmation that all of these are needed, and if additional spots will be added. I also anticipate some styling weirdness once ads are displaying in these locations -- misalignments, or weird vertical spacing -- but I can tackle those in separate PRs once we have ads previewing. 

Closes #70 .

### How to test the changes in this Pull Request:

1. Apply PR. 
2. Make sure the hooks work as expected -- I've been using this hacky approach:

```
function my_fake_ad(){
	echo '<div style="background: #eee; padding: 2em">hello world</div>';
}
add_action( 'before_sidebar', 'my_fake_ad' );
```

... which places a grey box in each ad location.

3. Provide any feedback on naming, locations, and anything else I may have missed!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?