### PR TITLE
Adds amp mobile menu functionality

### DIFF
--- a/classes/class-newspack-svg-icons.php
+++ b/classes/class-newspack-svg-icons.php
@@ -177,6 +177,11 @@ class Newspack_SVG_Icons {
     <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>',
+		'menu'                     => /* material-design - menu */ '
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/>
+</svg>',
 
 	);
 

--- a/footer.php
+++ b/footer.php
@@ -39,7 +39,7 @@
 				}
 
 				if ( ! is_active_sidebar( 'footer-1' ) ) {
-					newspack_social_menu();
+					newspack_social_menu_footer();
 				}
 				?>
 			</div><!-- .wrapper -->

--- a/functions.php
+++ b/functions.php
@@ -422,31 +422,6 @@ function newspack_typography_css_wrap() {
 }
 add_action( 'wp_head', 'newspack_typography_css_wrap' );
 
-
-/**
- * Display social links menu.
- */
-function newspack_social_menu() {
-	if ( ! has_nav_menu( 'social' ) ) {
-		return;
-	}
-	?>
-	<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
-		<?php
-		wp_nav_menu(
-			array(
-				'theme_location' => 'social',
-				'menu_class'     => 'social-links-menu',
-				'link_before'    => '<span class="screen-reader-text">',
-				'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
-				'depth'          => 1,
-			)
-		);
-		?>
-	</nav><!-- .social-navigation -->
-<?php
-}
-
 /**
  * Returns an array of 'acceptable' SVG tags to use with wp_kses().
  */

--- a/header.php
+++ b/header.php
@@ -21,6 +21,12 @@
 
 <?php do_action( 'before_header' ); ?>
 
+<?php
+	if ( newspack_is_amp() ) {
+		get_template_part( 'template-parts/header/mobile', 'sidebar' );
+	}
+?>
+
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
@@ -31,113 +37,132 @@
 			$header_center_logo = get_theme_mod( 'header_center_logo', false );
 		?>
 
-		<?php if ( false === $header_simplified ) : ?>
+		<?php
+		// Header is NOT short:
+		if ( false === $header_simplified ) :
+		?>
 			<div class="top-header-contain">
 				<div class="wrapper">
-					<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
-						<nav class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'secondary-menu',
-									'menu_class'     => 'secondary-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-									'depth'          => 1,
-								)
-							);
-							?>
-						</nav>
-					<?php endif; ?>
+					<div id="secondary-nav-contain">
+						<?php
+						if ( ! newspack_is_amp() ) {
+							newspack_secondary_menu();
+						}
+						?>
+					</div>
 
-					<?php if ( has_nav_menu( 'social' ) && false === $header_center_logo ) : ?>
-						<?php newspack_social_menu(); ?>
+					<?php
+					// Logo is NOT centered:
+					if ( false === $header_center_logo ) :
+					?>
+						<div id="social-nav-contain">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_social_menu_header();
+							}
+							?>
+						</div>
 					<?php endif; ?>
 				</div><!-- .wrapper -->
 			</div><!-- .top-header-contain -->
 		<?php endif; ?>
 
+
+
+
 		<div class="middle-header-contain">
 			<div class="wrapper">
-				<?php if ( has_nav_menu( 'social' ) && true === $header_center_logo && false === $header_simplified ) : ?>
-					<?php newspack_social_menu(); ?>
+				<?php
+				// Centered logo AND NOT short header.
+				if ( true === $header_center_logo && false === $header_simplified ) :
+				?>
+					<div id="social-nav-contain">
+						<?php
+						if ( ! newspack_is_amp() ) {
+							newspack_social_menu_header();
+						}
+						?>
+					</div>
 				<?php endif; ?>
 
-				<?php if ( true === $header_simplified && true === $header_center_logo ) : ?>
-
-					<?php if ( has_nav_menu( 'tertiary-menu' ) ) : ?>
-						<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'tertiary-menu',
-									'menu_class'     => 'tertiary-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-									'depth'          => 1,
-								)
-							);
-							?>
-						</nav>
-					<?php else : ?>
-						<div></div>
-					<?php endif; ?>
+				<?php
+				// Centered logo AND short header.
+				if ( true === $header_center_logo && true === $header_simplified ) :
+				?>
+					<div id="tertiary-nav-contain">
+						<?php
+						if ( ! newspack_is_amp() ) {
+							newspack_tertiary_menu();
+						}
+						?>
+					</div>
 				<?php endif; ?>
+
 
 				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
-				<?php if ( has_nav_menu( 'primary-menu' ) && true === $header_simplified ) : ?>
-					<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+				<?php
+				// Short header:
+				if ( true === $header_simplified ) :
+				?>
+					<div id="site-navigation">
 						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'primary-menu',
-								'menu_class'     => 'main-menu',
-								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-							)
-						);
+						if ( ! newspack_is_amp() ) {
+							newspack_primary_menu();
+						}
 
-						if ( true === $header_center_logo ) :
+						// Centered logo:
+						if ( true === $header_center_logo ) {
 							get_template_part( 'template-parts/header/header', 'search' );
-						endif;
+						}
 						?>
-					</nav><!-- #site-navigation -->
+					</div>
 				<?php endif; ?>
 
-				<?php if ( has_nav_menu( 'tertiary-menu' ) && ! ( true === $header_center_logo && true === $header_simplified ) ) : ?>
-					<nav class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+
+				<?php
+				// Logo NOT centered and header NOT short:
+				if ( ! ( true === $header_center_logo && true === $header_simplified ) ) :
+				?>
+					<div id="tertiary-nav-contain">
 						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'tertiary-menu',
-								'menu_class'     => 'tertiary-menu',
-								'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-								'depth'          => 1,
-							)
-						);
+						if ( ! newspack_is_amp() ) {
+							newspack_tertiary_menu();
+						}
+
+						// Header simplified:
+						if ( true === $header_simplified ) {
+							get_template_part( 'template-parts/header/header', 'search' );
+						}
 						?>
-						<?php if ( true === $header_simplified ) : ?>
-							<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
-						<?php endif; ?>
-					</nav>
+					</div>
 				<?php endif; ?>
+
+				<?php if ( newspack_is_amp() ) : ?>
+					<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<?php esc_html_e( 'Menu', 'newspack' ); ?>
+					</button>
+				<?php endif; ?>
+
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->
 
-		<?php if ( false === $header_simplified ) : ?>
+
+		<?php
+		// Header is NOT short:
+		if ( false === $header_simplified ) :
+		?>
 			<div class="bottom-header-contain">
 				<div class="wrapper">
-					<?php if ( has_nav_menu( 'primary-menu' ) ) : ?>
-						<nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
-							<?php
-							wp_nav_menu(
-								array(
-									'theme_location' => 'primary-menu',
-									'menu_class'     => 'main-menu',
-									'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-								)
-							);
-							?>
-						</nav><!-- #site-navigation -->
-					<?php endif; ?>
+
+					<div id="site-navigation">
+						<?php
+						if ( ! newspack_is_amp() ) {
+							newspack_primary_menu();
+						}
+						?>
+					</div>
 					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
 				</div><!-- .wrapper -->
 			</div><!-- .bottom-header-contain -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -215,3 +215,117 @@ if ( ! function_exists( 'newspack_the_posts_navigation' ) ) :
 		);
 	}
 endif;
+
+/**
+ * Displays primary menu; created a function to reduce duplication.
+ */
+function newspack_primary_menu() {
+	if ( ! has_nav_menu( 'primary-menu' ) ) {
+		return;
+	}
+	?>
+	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+		<?php
+		wp_nav_menu(
+			array(
+				'theme_location' => 'primary-menu',
+				'menu_class'     => 'main-menu',
+				'container'      => false,
+				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+			)
+		);
+		?>
+	</nav>
+<?php
+}
+
+/**
+ * Displays secondary menu; created a function to reduce duplication.
+ */
+function newspack_secondary_menu() {
+	if ( ! has_nav_menu( 'secondary-menu' ) ) {
+		return;
+	}
+	?>
+	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+		<?php
+		wp_nav_menu(
+			array(
+				'theme_location' => 'secondary-menu',
+				'menu_class'     => 'secondary-menu',
+				'container'      => false,
+				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				'depth'          => 1,
+			)
+		);
+		?>
+	</nav>
+<?php
+}
+
+/**
+ * Displays tertiary menu; created a function to reduce duplication.
+ */
+function newspack_tertiary_menu() {
+	if ( ! has_nav_menu( 'tertiary-menu' ) ) {
+		return;
+	}
+	?>
+		<nav toolbar="(min-width: 767px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'tertiary-menu',
+					'container'      => false,
+					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+					'depth'          => 1,
+				)
+			);
+			?>
+		</nav>
+<?php
+}
+
+/**
+ * Displays social links menu; create a function for the wp_nav_menu settings to reduce duplication.
+ */
+function newspack_social_menu_settings() {
+	wp_nav_menu(
+		array(
+			'theme_location' => 'social',
+			'menu_class'     => 'social-links-menu',
+			'container'      => false,
+			'link_before'    => '<span class="screen-reader-text">',
+			'link_after'     => '</span>' . newspack_get_icon_svg( 'link' ),
+			'depth'          => 1,
+		)
+	);
+}
+
+/**
+ * Displays social links menu for the header; includes AMP toolbar and toolbar-target attributes.
+ */
+function newspack_social_menu_header() {
+	if ( ! has_nav_menu( 'social' ) ) {
+		return;
+	}
+	?>
+	<nav toolbar="(min-width: 767px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+		<?php newspack_social_menu_settings(); ?>
+	</nav><!-- .social-navigation -->
+<?php
+}
+
+/**
+ * Displays social links menu for the footer; without AMP-related attributes, to prevent duplication errors.
+ */
+function newspack_social_menu_footer() {
+	if ( ! has_nav_menu( 'social' ) ) {
+		return;
+	}
+	?>
+	<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+		<?php newspack_social_menu_settings(); ?>
+	</nav><!-- .social-navigation -->
+<?php
+}

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -1,13 +1,6 @@
 /** === Main menu === */
 
 .main-navigation {
-	font-size: $font__size-xs;
-
-	> div {
-		display: inline;
-	}
-
-
 	/* Un-style buttons */
 	button {
 		display: inline-block;
@@ -40,15 +33,21 @@
 		}
 	}
 
-	.main-menu {
-		display: inline-block;
+	ul,
+	li {
+		list-style: none;
 		margin: 0;
 		padding: 0;
+	}
+
+	.main-menu {
+		margin: 0;
+		overflow: visible;
+		padding: 0;
+		width: 100%;
 
 		> li {
 			color: #555;
-			display: inline-block;
-			padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
 			position: relative;
 
 			> a {
@@ -114,28 +113,11 @@
 	}
 
 	.sub-menu {
-
-		background-color: $color__primary;
-		color: $color__background-body;
 		list-style: none;
 		padding-left: 0;
 
-		position: absolute;
-		opacity: 0;
-		left: -9999px;
-		z-index: 99999;
-
-		@include media(tablet) {
-			width: auto;
-			min-width: -moz-max-content;
-			min-width: -webkit-max-content;
-			min-width: max-content;
-		}
-
 		> li {
-
 			display: block;
-			float: none;
 			position: relative;
 
 			&.menu-item-has-children {
@@ -171,46 +153,14 @@
 				}
 			}
 
-			> a,
-			> .menu-item-link-return {
-
+			> a {
 				color: $color__background-body;
 				display: block;
 				line-height: $font__line-height-heading;
-				text-shadow: none;
-				padding: calc( .5 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( .5 * #{$size__spacing-unit} ) $size__spacing-unit;
-				white-space: nowrap;
-
-				&:hover,
-				&:focus {
-					background: $color__primary-variation;
-
-					&:after {
-						background: $color__primary-variation;
-					}
-				}
-			}
-
-			> .menu-item-link-return {
-				width: 100%;
-				font-size: $font__size_base;
-				font-weight: normal;
-				text-align: left;
 			}
 
 			> a:empty {
 				display: none;
-			}
-
-			&.mobile-parent-nav-menu-item {
-				display: none;
-				font-size: $font__size-sm;
-				font-weight: normal;
-
-				svg {
-					position: relative;
-					margin-right: calc( .25 * #{$size__spacing-unit} );
-				}
 			}
 		}
 	}
@@ -228,7 +178,6 @@
 		margin-top: 0;
 		opacity: 1;
 		width: auto;
-		min-width: 100%;
 
 		/* Non-mobile position */
 		@include media(tablet) {
@@ -283,13 +232,6 @@
 		/* Nested sub-menu dashes */
 		.sub-menu {
 			counter-reset: submenu;
-		}
-
-		.sub-menu > li > a::before {
-			font-family: $font__body;
-			font-weight: normal;
-			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
-			counter-increment: submenu
 		}
 	}
 
@@ -355,95 +297,42 @@
 				max-width: 100%;
 			}
 		}
-
-		/* Nested sub-menu dashes */
-		.sub-menu {
-			counter-reset: submenu;
-		}
-
-		.sub-menu > li > a::before {
-			font-family: $font__body;
-			font-weight: normal;
-			content: "\2013\00a0" counters(submenu, "\2013\00a0", none);
-			counter-increment: submenu
-		}
 	}
+}
 
-	/**
-	 * Fade-in animation for top-level submenus
-	 */
-	.main-menu > .menu-item-has-children:not(.off-canvas):hover > .sub-menu {
-		animation: fade_in 0.1s forwards;
-	}
 
-	/**
-	 * Off-canvas touch device styles
-	 */
-	.main-menu .menu-item-has-children.off-canvas .sub-menu {
+/* Desktop-specific styles */
 
-		.submenu-expand .svg-icon {
-			transform: rotate(270deg);
-		}
+.site-header {
+	.main-navigation {
+		font-size: $font__size-xs;
 
-		.sub-menu {
-			opacity: 0;
-			position: absolute;
-			z-index: 0;
-			transform: translateX(-100%);
-		}
+		.main-menu {
+			display: inline-block;
 
-		li:hover,
-		li:focus,
-		li > a:hover,
-		li > a:focus {
-			background-color: transparent;
-		}
-
-		> li > a,
-		> li > .menu-item-link-return {
-			white-space: inherit;
-		}
-
-		&.expanded-true {
-
-			display: table;
-			margin-top: 0;
-			opacity: 1;
-			padding-left: 0;
-
-			/* Mobile position */
-			left: 0;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			position: fixed;
-			z-index: 100000; /* Make sure appears above mobile admin bar */
-			width: 100vw;
-			height:  100vh;
-			max-width: 100vw;
-			transform: translateX(+100%);
-			animation: slide_in_right 0.3s forwards;
-
-			> .mobile-parent-nav-menu-item {
-				display: block;
+			> li {
+				display: inline-block;
+				padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
 			}
 
-			/* Prevent menu from being blocked by admin bar */
-			.admin-bar & {
-				top: 46px;
-				height: calc( 100vh - 46px );
+			.sub-menu {
+				background-color: $color__primary;
+				color: $color__background-body;
+				position: absolute;
+				opacity: 0;
+				left: -9999px;
+				z-index: 99999;
 
-				.sub-menu.expanded-true {
-					top: 0;
-				}
+				> li > a {
+					padding: calc( .5 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( .5 * #{$size__spacing-unit} ) $size__spacing-unit;
 
-				/* WP core breakpoint */
-				@media only screen and ( min-width: 782px ) {
-					top: 32px;
-					height: calc( 100vh - 32px );
+					&:hover,
+					&:focus {
+						background: $color__primary-variation;
 
-					.sub-menu.expanded-true {
-						top: 0;
+						&:after {
+							background: $color__primary-variation;
+						}
 					}
 				}
 			}
@@ -451,26 +340,7 @@
 	}
 }
 
-/* Menu animation */
-
-@keyframes slide_in_right {
-	100% {
-		transform: translateX(0%);
-	}
-}
-
-@keyframes fade_in {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
-.header-center-logo {
-	.main-navigation {
-		flex-basis: 100%;
-		text-align: center;
-	}
+.header-center-logo:not(.header-simplified) .site-header #site-navigation {
+	flex-basis: 100%;
+	text-align: center;
 }

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -66,8 +66,6 @@
 			}
 
 			&.menu-item-has-children {
-
-				display: inline-block;
 				position: inherit;
 
 				@include media(tablet) {

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -51,7 +51,7 @@
 	a {
 		color: #fff;
 		display: inline-block;
-		padding: #{ 0.25 * $size__spacing-unit } 0;
+		padding: #{ 0.5 * $size__spacing-unit } 0;
 	}
 
 	.submenu-expand {

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -1,0 +1,56 @@
+.mobile-menu-toggle {
+	background-color: transparent;
+	color: inherit;
+	padding: 0;
+
+	&:hover,
+	&:focus {
+		background-color: transparent;
+	}
+
+	.svg-icon {
+		position: relative;
+		top: 4px;
+	}
+
+	@include media(tablet) {
+		display: none;
+	}
+}
+
+
+#mobile-sidebar {
+	background-color: $color__primary;
+	color: #fff;
+	font-size: $font__size-sm;
+	padding: $size__spacing-unit;
+
+	& > * {
+		clear: both;
+		margin-bottom: #{ 2 * $size__spacing-unit };
+	}
+
+	.mobile-menu-toggle {
+		font-size: 1em;
+		float: right;
+		margin: 0;
+		padding: 0;
+	}
+
+	ul ul {
+		margin-left: $size__spacing-unit;
+	}
+
+	a {
+		padding: #{ 0.5 * $size__spacing-unit } 0;
+	}
+
+	a {
+		color: #fff;
+		display: inline-block;
+	}
+
+	.submenu-expand {
+		display: none;
+	}
+}

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -12,7 +12,9 @@
 		position: relative;
 		top: 4px;
 	}
+}
 
+.site-header .mobile-menu-toggle {
 	@include media(tablet) {
 		display: none;
 	}
@@ -23,7 +25,12 @@
 	background-color: $color__primary;
 	color: #fff;
 	font-size: $font__size-sm;
+	width: 90%;
 	padding: $size__spacing-unit;
+
+	@include media(tablet) {
+		width: 33%;
+	}
 
 	& > * {
 		clear: both;
@@ -33,7 +40,7 @@
 	.mobile-menu-toggle {
 		font-size: 1em;
 		float: right;
-		margin: 0;
+		margin: 0 0 $size__spacing-unit;
 		padding: 0;
 	}
 
@@ -42,12 +49,9 @@
 	}
 
 	a {
-		padding: #{ 0.5 * $size__spacing-unit } 0;
-	}
-
-	a {
 		color: #fff;
 		display: inline-block;
+		padding: #{ 0.25 * $size__spacing-unit } 0;
 	}
 
 	.submenu-expand {

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -1,24 +1,28 @@
-ul.secondary-menu {
-	align-items: center;
-	display: flex;
-	flex-wrap: wrap;
-	font-family: $font__heading;
-	font-size: $font__size-xs;
-	list-style: none;
-	margin: 0;
-	padding: 0;
+nav.secondary-menu {
 
-	@include media(tablet) {
-		padding: 0;
-	}
-
-	li {
+	ul, li {
+		list-style: none;
 		margin: 0;
 		padding: 0;
 	}
 
 	a {
 		color: inherit;
-		margin-right: #{0.5 * $size__spacing-unit};
+	}
+}
+
+/* Desktop-specific styles */
+.site-header {
+	nav.secondary-menu {
+		ul, li {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+		}
+
+		a {
+			font-size: $font__size-xs;
+			margin-right: #{0.5 * $size__spacing-unit};
+		}
 	}
 }

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -1,51 +1,56 @@
 /* Social menu */
 
-.social-navigation {
+.social-navigation,
+.social-links-menu {
 	align-items: center;
 	display: flex;
+}
 
-	ul {
-		display: flex;
-		margin: 0;
-		padding: 0;
+.social-links-menu {
+	margin: 0;
+	padding: 0;
 
-		li {
-			list-style: none;
+	li {
+		list-style: none;
 
-			&:nth-child(n+2) {
-				margin-left: 0.5em;
+		&:nth-child(n+2) {
+			margin-left: 0.5em;
+		}
+
+		a {
+			border-bottom: 1px solid transparent;
+			display: block;
+			color: inherit;
+			margin-bottom: -1px;
+			transition: opacity $link_transition ease-in-out;
+
+			&:hover,
+			&:active {
+				opacity: 0.6;
 			}
 
-			a {
-				border-bottom: 1px solid transparent;
+			&:focus {
+				opacity: 1;
+				border-bottom: 1px solid $color__text-main;
+			}
+
+			svg {
 				display: block;
-				color: inherit;
-				margin-bottom: -1px;
-				transition: opacity $link_transition ease-in-out;
+				width: 24px;
+				height: 24px;
 
-				&:hover,
-				&:active {
-					opacity: 0.6;
-				}
+				// Prevent icons from jumping in Safari using hardware acceleration.
+				transform: translateZ(0);
 
-				&:focus {
-					opacity: 1;
-					border-bottom: 1px solid $color__text-main;
-				}
-
-				svg {
-					display: block;
-					width: 24px;
-					height: 24px;
-
-					// Prevent icons from jumping in Safari using hardware acceleration.
-					transform: translateZ(0);
-
-					&#ui-icon-link {
-						transform: rotate(-45deg);
-					}
+				&#ui-icon-link {
+					transform: rotate(-45deg);
 				}
 			}
 		}
 	}
+}
+
+.social-navigation .social-links-menu {
+	flex-wrap: nowrap;
+	overflow: visible;
 }

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -1,27 +1,39 @@
 /** === Tertiary menu === */
 
-nav.tertiary-menu {
+.tertiary-menu {
 	align-items: center;
 	display: flex;
-	font-family: $font__heading;
-	font-size: $font__size-sm;
 	list-style: none;
 	padding: 0;
 
-	@include media(tablet) {
-		padding: 0;
-		text-align: right;
-	}
-
-	ul {
+	ul,
+	li {
+		list-style: none;
 		margin: 0;
 		padding: 0;
+	}
+
+	a {
+		color: inherit;
+		display: inline-block;
+	}
+
+	#search-toggle {
+		margin-left: #{$size__spacing-unit * 0.5}
+	}
+}
+
+
+// Styles for when menu items appear in the site-header.
+.site-header .tertiary-menu {
+	font-size: $font__size-sm;
+
+	@include media( tablet ) {
+		text-align: right;
 	}
 
 	li {
 		display: inline-block;
-		margin: 0;
-		padding: 0;
 
 		@include media(tablet) {
 			&:nth-child(n+2) {
@@ -31,19 +43,12 @@ nav.tertiary-menu {
 	}
 
 	a {
-		color: inherit;
-		display: inline-block;
 		margin: #{$size__spacing-unit * 0.25} 0;
 		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.5};
 	}
 
-	#search-toggle {
-		margin-left: #{$size__spacing-unit * 0.5}
-	}
-}
-
-.header-simplified {
-	nav.tertiary-menu {
+	// Short header
+	.header-simplified & {
 		font-size: $font__size_base;
 		margin-left: $size__spacing-unit;
 		li {
@@ -53,10 +58,9 @@ nav.tertiary-menu {
 			}
 		}
 	}
-}
 
-.header-center-logo {
-	nav.tertiary-menu {
+	// Centered logo.
+	.header-center-logo & {
 		margin-left: 0;
 		@include media(tablet) {
 			text-align: center;

--- a/sass/navigation/_navigation.scss
+++ b/sass/navigation/_navigation.scss
@@ -10,6 +10,7 @@
 @import "menu-secondary-navigation";
 @import "menu-tertiary-navigation";
 @import "menu-social-navigation";
+@import "menu-mobile-navigation";
 
 /*--------------------------------------------------------------
 ## Next / Previous

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -26,7 +26,7 @@
 	.custom-logo {
 		height: auto;
 		min-height: inherit;
-		max-height: 100px;
+		max-height: 75px;
 		max-width: 200px;
 		width: auto;
 
@@ -59,11 +59,16 @@
 // Site description
 .site-description {
 	color: $color__text-light;
+	display: none;
 	//flex: 1 1 auto;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	font-style: italic;
 	margin: 7px 0 0;
+
+	@include media( mobile ) {
+		display: block;
+	}
 }
 
 .hide-site-tagline .site-description {
@@ -84,18 +89,23 @@
 
 // Middle bar
 .middle-header-contain {
-	align-items: center;
 
 	.wrapper {
-		padding: #{ 2 * $size__spacing-unit } 0;
+		align-items: center;
+		padding: $size__spacing-unit 0;
+		@include media( mobile ) {
+			padding: #{ 2 * $size__spacing-unit } 0;
+		}
 	}
 }
 
 // Bottom bar
 .bottom-header-contain {
 	.wrapper {
-		border-bottom: 1px solid #4a4a4a;
-		border-top: 1px solid #4a4a4a;
+		@include media( tablet ) {
+			border-bottom: 1px solid #4a4a4a;
+			border-top: 1px solid #4a4a4a;
+		}
 	}
 }
 
@@ -111,7 +121,12 @@
 }
 
 .header-search-contain {
+	display: none;
 	position: relative;
+
+	@include media( tablet ) {
+		display: block;
+	}
 
 	#header-search {
 		position: absolute;
@@ -146,20 +161,11 @@
 // Centred Logo
 
 .header-center-logo {
-	.site-branding {
-		display: block;
-		flex-grow: 2;
-		text-align: center;
-	}
-
-	.social-navigation,
-	nav.tertiary-menu {
-		justify-content: center;
-		width: 100%;
-
-		@include media( tablet ) {
-			justify-content: space-between;
-			width: auto;
+	@include media( tablet ) {
+		.site-branding {
+			display: block;
+			flex-grow: 2;
+			text-align: center;
 		}
 	}
 }
@@ -201,15 +207,6 @@
 
 }
 
-.header-center-logo.header-solid-background:not(.header-simplified) {
-	// Middle bar
-	.middle-header-contain {
-		.wrapper {
-			padding: #{ 3 * $size__spacing-unit } 0;
-		}
-	}
-}
-
 // Simplified Header
 
 .header-simplified {
@@ -219,30 +216,28 @@
 
 	.site-branding {
 		display: flex;
+		flex-grow: 2;
 		flex-basis: auto;
+		margin-right: $size__spacing-unit;
 	}
 
-	// Site logo
 	.custom-logo-link .custom-logo {
 		max-height: 50px;
-	}
-
-	.site-branding {
-		flex-grow: 2;
-		margin-right: $size__spacing-unit;
 	}
 
 	.site-description {
 		margin: 0;
 	}
 
-	&.hide-site-tagline {
-		.site-branding {
-			flex-grow: 0;
-		}
-		.main-navigation {
-			flex-grow: 2;
-		}
+	&:not(.header-center-logo).hide-site-tagline .main-navigation {
+		flex-grow: 2;
+	}
+
+	&:not(.header-center-logo) #tertiary-nav-contain {
+		// Add flexbox; the search appears here.
+		align-items: center;
+		display: flex;
+		justify-content: flex-end;
 	}
 
 	.middle-header-contain .wrapper {
@@ -250,21 +245,35 @@
 		padding: #{ 0.5 * $size__spacing-unit } 0;
 	}
 
+	.header-search-contain {
+		margin-left: $size__spacing-unit;
+	}
+
 	&.header-center-logo {
 
-		.wrapper > * {
-			flex: 1 0 0;
-			min-width: 33%;
-		}
+		@include media( tablet ) {
+			.wrapper > * {
+				flex: 1 0 0;
+				min-width: 33%;
+			}
 
-		.site-branding {
-			flex-wrap: wrap;
-		}
+			.site-branding {
+				flex-wrap: wrap;
+			}
 
-		.custom-logo-link,
-		.site-title,
-		.site-description {
-			width: 100%;
+			.custom-logo-link,
+			.site-title,
+			.site-description {
+				width: 100%;
+			}
+
+			// Add flexbox; the search appears here.
+			#site-navigation {
+				align-items: center;
+				display: flex;
+				justify-content: flex-end;
+			}
+
 		}
 	}
 }

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -13,19 +13,21 @@
 /* Navigation */
 
 body:not(.header-solid-background):not(.header-simplified) {
-	nav.tertiary-menu {
-		a {
-			background-color: lighten($color__text-light, 45%);
-			color: $color__text-main;
-			@include button-transition;
-			border-radius: 5px;
-			font-size: $font__size-sm;
-			font-weight: 700;
-			padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+	.site-header {
+		.tertiary-menu {
+			a {
+				background-color: lighten($color__text-light, 45%);
+				color: $color__text-main;
+				@include button-transition;
+				border-radius: 5px;
+				font-size: $font__size-sm;
+				font-weight: 700;
+				padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
 
-			&:hover {
-				background-color: $color__text-main;
-				color: #fff;
+				&:hover {
+					background-color: $color__text-main;
+					color: #fff;
+				}
 			}
 		}
 	}

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -8,6 +8,8 @@
 .entry-footer,
 .author-bio .author-link,
 .main-navigation,
+.secondary-menu,
+.tertiary-menu,
 .no-comments,
 .not-found .page-title,
 .error-404 .page-title,
@@ -19,6 +21,7 @@
 .site-info,
 #cancel-comment-reply-link,
 .use-header-font,
+#mobile-sidebar,
 h1,
 h2,
 h3,
@@ -107,13 +110,11 @@ h4 {
 	font-size: $font__size-md;
 }
 
-.page-title,
-.main-navigation {
+.page-title {
 	font-size: $font__size_base;
 }
 
 .entry-meta,
-.main-navigation,
 .pagination .nav-links,
 .comment-content,
 h5 {

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -13,7 +13,7 @@ if ( is_active_sidebar( 'footer-1' ) ) : ?>
 				<?php the_custom_logo(); ?>
 			<?php
 			endif;
-			newspack_social_menu();
+			newspack_social_menu_footer();
 			?>
 		</div><!-- .wrapper -->
 	</div><!-- .footer-branding -->

--- a/template-parts/header/mobile-sidebar.php
+++ b/template-parts/header/mobile-sidebar.php
@@ -21,6 +21,6 @@
 
 	<?php newspack_secondary_menu(); ?>
 
-	<?php newspack_social_menu(); ?>
+	<?php newspack_social_menu_header(); ?>
 
 </amp-sidebar>

--- a/template-parts/header/mobile-sidebar.php
+++ b/template-parts/header/mobile-sidebar.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Template for display the AMP mobile navigation.
+ *
+ * @package Newspack
+ */
+?>
+
+<amp-sidebar id="mobile-sidebar" layout="nodisplay" side="right">
+
+	<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
+		<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
+		<?php esc_html_e( 'Close', 'newspack' ); ?>
+	</button>
+
+	<?php newspack_tertiary_menu(); ?>
+
+	<?php get_search_form(); ?>
+
+	<?php newspack_primary_menu(); ?>
+
+	<?php newspack_secondary_menu(); ?>
+
+	<?php newspack_social_menu(); ?>
+
+</amp-sidebar>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR takes a solid swing at adding an AMP-based mobile menu to the theme. 

Unfortunately, even trying to keep things simple, it is a complicated set of changes.

This PR includes:

* Creating and `amp-sidebar` and using AMP's  functionality to show/hide it on mobile screens.
* Uses AMP's `toolbar-toggle` to reduce duplication in the AMP version of the theme.
* Creating functions to output each of the menus to reduce code duplication; includes two for the social navigation so it can be output in the header and footer without chucking an AMP error.
* Simplifies some of the menu styles, so desktop-specific styles are only added when a menu is in the `.site-header` -- that way, we don't have to override certain things on mobile.
* Adds a 'menu' icon to the SVG.

Note: There will be issues with the primary menu if this is tested before #157 lands.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Switch AMP to Standard mode.
3. On a desktop-sized screen, test the following header configurations - the header should look the same as it did prior to applying the PR:
    * Default
    * Centred Logo
    * Short Header
    * Centred Logo + Short header
4. On a mobile-sized screen, test the following header configurations - in each case, the mobile header should have the same layout, with the logo on the left and the menu toggle on the right.
    * Default
    * Centred Logo
    * Short Header
    * Centred Logo + Short header
    * Solid Background (to make sure the menu toggle contrasts sufficiently).
5. Open the mobile menu and review.
6. Switch AMP to reader mode.
7. Confirm that the non-mobile version of the menus still display on small screens -- they will not look good, but we'll be improving on that with the mobile menu fallback! 

I've included a screenshot of the mobile menu from the mockups below; the PR does differ in some non-insignificant ways (the sub menus don't toggle; the tertiary menu doesn't use the 'button-y' styles) but I'm hoping to iterate on that once the bulk of this work is merged:

![image](https://user-images.githubusercontent.com/177561/62511347-05ca5880-b7c8-11e9-8466-5de473fde9e2.png)

**Edited to add:**

Screenshot of how the menu should look with this PR:

![image](https://user-images.githubusercontent.com/177561/62568251-a27d0c80-b841-11e9-8057-a5d5022e2e4e.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
