### PR TITLE
Make sure default style is properly dequeued

### DIFF
--- a/classes/class-newspack-style-packs-core.php
+++ b/classes/class-newspack-style-packs-core.php
@@ -64,20 +64,27 @@ class Newspack_Style_Packs_Core {
 	 * Gets active Style Pack and loads appropriate stylesheet.
 	 */
 	public function init() {
-		$this->style = get_theme_mod( 'active_style_pack' );
+		$this->style = get_theme_mod( 'active_style_pack', 'default' );
 		if ( is_customize_preview() ) {
 			$preview_style = $this->get_preview_style();
 			if ( ! empty( $preview_style ) ) {
 				$this->style = $preview_style;
 			}
-		} elseif ( ! empty( $this->style ) ) {
+		} elseif ( 'default' !== $this->style ) {
+			/**
+			 * Dequeue and deregister default styles.
+			 */
+			function remove_default_styles() {
+				wp_dequeue_style( 'newspack-style' );
+				wp_deregister_style( 'newspack-style' );
+			}
+			add_action( 'wp_print_styles', 'remove_default_styles', 20 );
+
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_fonts' ), 20 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_style' ), 20 );
-			// If not the default styles, remove original editor styles and add new ones.
-			if ( 'default' !== $this->style ) {
-				remove_editor_styles();
-				add_editor_style( 'styles/' . $this->style . '-editor.css' );
-			}
+
+			remove_editor_styles();
+			add_editor_style( 'styles/' . $this->style . '-editor.css' );
 		}
 	}
 	/**
@@ -111,8 +118,6 @@ class Newspack_Style_Packs_Core {
 			wp_enqueue_style( $this->get_style_pack_id( $this->style ), $stylesheet, array(), $this->theme_version );
 			// Include generated RTL styles.
 			wp_style_add_data( $this->get_style_pack_id( $this->style ), 'rtl', 'replace' );
-			// Dequeue style.css
-			wp_dequeue_style( 'newspack-style' );
 		}
 	}
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed when working on the style variations that the default style.css wasn't properly being dequeued when you used a non-default style variation. 

This PR fixes that. 

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Style Pack, and pick 'Style 1'.
2. Publish changes.
3. View source -- note you can still find both `newspack-theme/style.css` and `newspack-theme/styles/style-1.css` -- only the latter should be there.
4. Apply the PR.
5. Confirm that `newspack-theme/style.css` is no longer being loaded.
6. Navigate to Customize > Style Pack and change back to the default.
7. Confirm that the default styles load correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?