### PR TITLE
Switch max-width to width for sidebar and content areas

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -70,7 +70,7 @@
 .page:not(.newspack-front-page) #main,
 .single-post .main-content {
 	@include media(tablet) {
-		max-width: 65%;
+		width: 65%;
 	}
 }
 
@@ -80,10 +80,10 @@
 .page:not(.newspack-front-page) #secondary,
 .single-post #secondary {
 	@include media(tablet) {
-		max-width: calc( 35% - #{ 2 * $size__spacing-unit } );
+		width: calc( 35% - #{ 2 * $size__spacing-unit } );
 	}
 	@include media(desktop) {
-		max-width: calc( 35% - #{ 3 * $size__spacing-unit } );
+		width: calc( 35% - #{ 3 * $size__spacing-unit } );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes another small issue with the sidebar width (AKA Laurel doesn't understand flexbox).

Issue: When you have something narrow in the sidebar widget, it won't fill the available space and the sidebar will sit too far to the right.

**Before:**

![image](https://user-images.githubusercontent.com/177561/62567642-757c2a00-b840-11e9-9d8c-7813dbcddc81.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62567608-60070000-b840-11e9-9a9e-ae3e09f3f483.png)



### How to test the changes in this Pull Request:

1. Add just a calendar widget to the sidebar widget area, and save and publish.
2. View on front end - note the sidebar sits to the right.
3. Apply the PR and run `npm run build`.
4. View again on the front end and confirm that the sidebar now fills the available space.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
