### PR TITLE
Remove 'smart' text colours with solid background colours

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -759,43 +759,6 @@
 		font-size: $font__size-xl;
 	}
 
-	//! Custom background colors
-	.has-primary-background-color,
-	.has-primary-variation-background-color,
-	.has-secondary-background-color,
-	.has-secondary-variation-background-color {
-
-		// Use white text against these backgrounds by default.
-		color: $color__background-body;
-
-		p,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6,
-		a {
-			color: $color__background-body;
-		}
-	}
-
-	.has-white-background-color {
-		color: $color__text-main;
-
-		// Use dark gray text against this background by default.
-		p,
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6,
-		a {
-			color: $color__text-main;
-		}
-	}
-
 	.has-primary-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-primary-background-color {
 		background-color: $color__primary;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -413,7 +413,6 @@
 
 			blockquote {
 				max-width: 100%;
-				color: $color__background-body;
 				padding-left: 0;
 				margin-left: $size__spacing-unit;
 				margin-right: $size__spacing-unit;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -136,41 +136,6 @@ table th {
 	font-size: $font__size-sm;
 }
 
-// Use white text against these backgrounds by default.
-.has-primary-background-color,
-.has-primary-variation-background-color,
-.has-secondary-background-color,
-.has-secondary-variation-background-color {
-	color: $color__background-body;
-
-	p,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	a {
-		color: $color__background-body;
-	}
-}
-
-// Use dark gray text against this background by default.
-.has-white-background-color {
-	color: $color__text-main;
-
-	p,
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6,
-	a {
-		color: $color__text-main;
-	}
-}
-
 figcaption,
 .gallery-caption {
 	font-family: $font__heading;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -428,10 +428,6 @@ figcaption,
 			&.has-text-color a {
 				color: inherit;
 			}
-
-			&:not(.has-text-color) {
-				color: $color__background-body;
-			}
 		}
 
 		&:not(.has-background-color) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally Twenty Nineteen included styles so when you set a solid background on, say, a pullquote or paragraph block, it would automatically change the block's default text colour to white.

This worked well for that theme because it only allowed customizing the hue; the white background colour would always have sufficient contrast. 

In the Newspack theme, you can pick a lot more variety of colours to be used as those defaults, with varying saturation -- white may not always have sufficient contrast. I was also running into issues getting these styles to work with our theme's styles.

This PR removes those styles; every block that lets you pick a background colour also lets you change the foreground, so you can still make sure blocks with background colours have sufficient contrast. 

**Before:**

![image](https://user-images.githubusercontent.com/177561/62586358-1afbc180-b872-11e9-868b-e004b1727234.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62586338-fd2e5c80-b871-11e9-94f2-3cf8fccadff7.png)

### How to test the changes in this Pull Request:

1. Copy and paste this [test content](https://cloudup.com/cKLk8i6HS3D) into a post.
2. Save and publish and view both in the editor and on the front end; the blocks using a 'default' colour (one set by the theme) automatically use white text, even though they haven't been assigned white text.
3. Apply the PR and run `npm run build`.
4. Confirm that the text in all the blocks matches the rest of the body text. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
