### PR TITLE
Moves opinionated tag styles to 'default' style pack

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -89,8 +89,8 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 	 * Prints HTML with the current post's categories.
 	 */
 	function newspack_categories() {
-		/* translators: used between list items */
-		$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '</span> ' );
+		/* translators: used between list items; followed by a space. */
+		$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '&nbsp;</span>' );
 		if ( $categories_list ) {
 			printf(
 				/* translators: 1: posted in label, only visible to screen readers. 2: list of categories. */
@@ -110,8 +110,8 @@ if ( ! function_exists( 'newspack_entry_footer' ) ) :
 
 		// Hide author, post date, category and tag text for pages.
 		if ( 'post' === get_post_type() ) {
-
-			$tags_list = get_the_tag_list( '', ' ' );
+			/* translators: used between list items; followed by a space. */
+			$tags_list = get_the_tag_list( '', '<span class="sep">' . esc_html__( ',', 'newspack' ) . '&nbsp;</span>' );
 			if ( $tags_list ) {
 				printf(
 					/* translators: 1: posted in label, only visible to screen readers. 2: list of tags. */

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -72,9 +72,7 @@ body.page {
 	}
 
 	a {
-		background-color: #f1f1f1;
 		font-size: $font__size-xs;
-		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 	}
 }
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -61,10 +61,9 @@ body.page {
 .tags-links {
 	& > * {
 		display: inline-block;
-		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
 	}
 
-	span {
+	span:first-child {
 		font-weight: bold;
 		font-size: $font__size-sm;
 		margin-right: $size__spacing-unit;

--- a/sass/styles/style-1/variables-style/_colors.scss
+++ b/sass/styles/style-1/variables-style/_colors.scss
@@ -1,1 +1,1 @@
-$color__background-body: #eee;
+

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -57,6 +57,13 @@ body:not(.header-solid-background):not(.header-simplified) {
 	}
 }
 
+.tags-links {
+	a {
+		background-color: #f1f1f1;
+		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+	}
+}
+
 /* Archives */
 
 .blog,

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -51,16 +51,20 @@ body:not(.header-solid-background):not(.header-simplified) {
 			color: #fff;
 		}
 	}
-
-	.sep {
-		display: none;
-	}
 }
 
 .tags-links {
 	a {
 		background-color: #f1f1f1;
+		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
 		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+	}
+}
+
+.cat-links,
+.tags-links {
+	.sep {
+		display: none;
 	}
 }
 

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -102,7 +102,6 @@ h3 {
 .no-comments,
 h2.author-title,
 p.author-bio,
-.tags-links span,
 h4 {
 	font-size: $font__size-md;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the more opinionated tag styles -- a light grey background and slight padding -- to the 'default' style pack SCSS, so they don't have to be overridden in each style pack.

It also adds a comma between tags (which is displayed in most style packs), and hides it for the default.

This will be easier to test once #159 lands. 

**Tags with the Default style active:**

![image](https://user-images.githubusercontent.com/177561/62588173-a2006800-b879-11e9-9537-11dc96b989ed.png)

**Tags with 'Style 1' active:**

![image](https://user-images.githubusercontent.com/177561/62588525-d7598580-b87a-11e9-93b6-6560cf90a6f0.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. View the tags at the bottom of a single post; confirm that they look the same.
3. Navigate to Customizer > Style Packs and switch to 'Style 1'.
4. Confirm that the light grey background has been removed, and the tags now display as a comma-separated list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?