### PR TITLE
Fix positioning issue for search icon + AMP

### DIFF
--- a/header.php
+++ b/header.php
@@ -105,18 +105,23 @@
 				// Short header:
 				if ( true === $header_simplified ) :
 				?>
-					<div id="site-navigation">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_primary_menu();
-						}
+					<div class="nav-wrapper">
+						<div id="site-navigation">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_primary_menu();
+							}
+							?>
+						</div><!-- #site-navigation -->
 
+						<?php
 						// Centered logo:
 						if ( true === $header_center_logo ) {
 							get_template_part( 'template-parts/header/header', 'search' );
 						}
 						?>
-					</div>
+					</div><!-- .nav-wrapper -->
+
 				<?php endif; ?>
 
 
@@ -124,18 +129,22 @@
 				// Logo NOT centered and header NOT short:
 				if ( ! ( true === $header_center_logo && true === $header_simplified ) ) :
 				?>
-					<div id="tertiary-nav-contain">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_tertiary_menu();
-						}
+					<div class="nav-wrapper">
+						<div id="tertiary-nav-contain">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_tertiary_menu();
+							}
+							?>
+						</div><!-- #tertiary-nav-contain -->
 
+						<?php
 						// Header simplified:
 						if ( true === $header_simplified ) {
 							get_template_part( 'template-parts/header/header', 'search' );
 						}
 						?>
-					</div>
+					</div><!-- .nav-wrapper -->
 				<?php endif; ?>
 
 				<?php if ( newspack_is_amp() ) : ?>
@@ -155,7 +164,6 @@
 		?>
 			<div class="bottom-header-contain">
 				<div class="wrapper">
-
 					<div id="site-navigation">
 						<?php
 						if ( ! newspack_is_amp() ) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -233,13 +233,6 @@
 		flex-grow: 2;
 	}
 
-	&:not(.header-center-logo) #tertiary-nav-contain {
-		// Add flexbox; the search appears here.
-		align-items: center;
-		display: flex;
-		justify-content: flex-end;
-	}
-
 	.middle-header-contain .wrapper {
 		align-items: center;
 		padding: #{ 0.5 * $size__spacing-unit } 0;
@@ -247,6 +240,13 @@
 
 	.header-search-contain {
 		margin-left: $size__spacing-unit;
+	}
+
+	// Wrapper used to align search with menus.
+	.nav-wrapper {
+		align-items: center;
+		display: flex;
+		justify-content: flex-end;
 	}
 
 	&.header-center-logo {
@@ -266,14 +266,6 @@
 			.site-description {
 				width: 100%;
 			}
-
-			// Add flexbox; the search appears here.
-			#site-navigation {
-				align-items: center;
-				display: flex;
-				justify-content: flex-end;
-			}
-
 		}
 	}
 }


### PR DESCRIPTION
… turns out re-using the AMP ones won't work for getting the menu in the right location.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Our AMP mobile menu setup uses `toolbar-target`, which helps you to avoid duplicating menu code by having AMP copy it from its original location in the mobile sidebar, to somewhere else on the site. This new location is determined by ID, and requires you to add empty HTML elements to the page.

I had hoped we could use these empty `divs` to help position the search icon next to the menus, but didn't consider that the menu might not be copied exactly where I expected it to be.

In other words, when you enable AMP with certain header settings, the search icon appears in the wrong spot: 

**With AMP on (incorrect):**
![image](https://user-images.githubusercontent.com/177561/62650766-6b276200-b90c-11e9-9914-8a21de008d59.png)

![image](https://user-images.githubusercontent.com/177561/62650912-b17cc100-b90c-11e9-8f53-2bf2b924e931.png)

**With AMP off (correct):**

![image](https://user-images.githubusercontent.com/177561/62651011-e9840400-b90c-11e9-957d-8724fb208b29.png)

![image](https://user-images.githubusercontent.com/177561/62650940-c3f6fa80-b90c-11e9-9829-e4e055561f9b.png)

This PR fixes this issue by (unfortunately!) adding yet another `div` and reusing the existing styles. 

### How to test the changes in this Pull Request:

1. Under Customizer > Site Identity, check only 'Short Header'.
2. With AMP enabled, view the site and see the search icon is between two menus (tertiary and primary).
3. Under Customizer > Site Identity, check both 'Short Header' and 'Center Logo'
4. With AMP enabled, view the site to see the search is in front of the primary navigation on the right.
5. Apply the patch and run `npm run build`. 
6. Repeat steps 1-4 and confirm the menu now appears on the end.
7. Confirm that each variation of the header (just 'Short', and 'Short' + 'Centered Logo') look correct with AMP turned off. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
