### PR TITLE
Move opinionated footer styles to the default style variation

### DIFF
--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -9,7 +9,6 @@
 
 	.footer-branding {
 		.wrapper {
-			border-top: 4px solid $color__border;
 			padding-top: $size__spacing-unit;
 		}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -24,29 +24,29 @@
 			flex-wrap: wrap;
 			justify-content: space-between;
 		}
+	}
 
-		.widget {
-			width: 100%;
+	.widget {
+		width: 100%;
 
-			@include media( mobile ) {
-				flex: 1 0 0px;
-				margin-right: $size__spacing-unit;
-				min-width: calc( 50% - #{ $size__spacing-unit } );
-			}
-
-			@include media( tablet ) {
-				min-width: calc( 25% - #{ $size__spacing-unit } );
-			}
-
-			&:last-child {
-				margin-right: 0;
-			}
+		@include media( mobile ) {
+			flex: 1 0 0px;
+			margin-right: $size__spacing-unit;
+			min-width: calc( 50% - #{ $size__spacing-unit } );
 		}
 
-		.widget-title {
-			color: $color__text-light;
-			font-size: inherit;
+		@include media( tablet ) {
+			min-width: calc( 25% - #{ $size__spacing-unit } );
 		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	.widget-title {
+		color: $color__text-light;
+		font-size: inherit;
 	}
 
 	.site-info {

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -81,3 +81,9 @@ body:not(.header-solid-background):not(.header-simplified) {
 		}
 	}
 }
+
+/* Footer */
+
+#colophon .footer-branding .wrapper {
+	border-top: 4px solid $color__border;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the light grey border at the top of the footer in the default style variation to a style-pack specific CSS file, so it doesn't need to be overridden in each style pack.

Edited to add: it also removes some unneeded specificity from the footer styles.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. With the 'default' style pack selected, view the footer and confirm there is a light grey border above it.
3. Under Customizer > Style Pack, switch to 'Style 1'.
4. Confirm that there is no border above the footer.

**Default:**

![image](https://user-images.githubusercontent.com/177561/62653405-5cdc4480-b912-11e9-86da-523e69a6ad6f.png)

**Style 1:**

![image](https://user-images.githubusercontent.com/177561/62653357-433afd00-b912-11e9-8749-a165cfefbd3a.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
