### PR TITLE
Fixes alignment issue with full-width blocks on static front page

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -61,10 +61,9 @@
 			}
 		}
 		.alignfull {
-			@include media(tablet) {
-				margin-left: calc(50% - 50vw);
-				margin-right: calc(50% - 50vw);
-			}
+			margin-left: calc(50% - 50vw);
+			margin-right: calc(50% - 50vw);
+			max-width: 100vw;
 		}
 
 		//! Group Block


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue with full-aligned blocks on the static front page, to make sure they fill the available space.

I think this was introduced when trying to standardize the full/wide styles.

**Before:**
![image](https://user-images.githubusercontent.com/177561/62659456-42a96300-b920-11e9-9b51-ca028d74f85a.png)

**After:**
![image](https://user-images.githubusercontent.com/177561/62659476-548b0600-b920-11e9-8b48-00ee10526094.png)

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cWjy1Wikvma) into the code editor view of the static front page.
2. View on the front-end -- note that the group block isn't centred.
3. Apply the PR and run `npm run build`.
4. View the post again and confirm it's fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
