### PR TITLE
Move opinionated accent header styles from general editor styles

### DIFF
--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -100,15 +100,6 @@ h6 {
 	font-size: $font__size-xs;
 }
 
-.article-section-title {
-	border-bottom: 4px solid $color__border;
-	color: $color__primary;
-	font-size: $font__size-sm;
-	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
-	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
-	text-transform: uppercase;
-}
-
 a {
 	@include link-transition;
 	color: $color__link;

--- a/sass/style-editor.scss
+++ b/sass/style-editor.scss
@@ -6,3 +6,4 @@ Newspack Theme Editor Styles
 
 @import "variables-site/variables-site";
 @import "style-editor-base";
+@import "styles/style-default/style-default-editor";

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -15,10 +15,4 @@ Newspack Theme Editor Styles - Style Pack 1
 			padding-bottom: 1em;
 		}
 	}
-
-	.article-section-title {
-		border-bottom: 4px solid;
-		font-family: $font__body;
-		font-size: 1em;
-	}
 }

--- a/sass/styles/style-default/style-default-editor.scss
+++ b/sass/styles/style-default/style-default-editor.scss
@@ -1,0 +1,8 @@
+.article-section-title {
+	border-bottom: 4px solid $color__border;
+	color: $color__primary;
+	font-size: $font__size-sm;
+	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
+	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
+	text-transform: uppercase;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the more opinionated accent header styles from the generic editor styles to the 'default' style pack editor styles, so it doesn't need to be overridden in each of the other style packs.

It also removes some of the 'placeholder' styles from Style 1's editor styles, to make this easier to test.

**Default style pack:**

![image](https://user-images.githubusercontent.com/177561/62666572-ca02d080-b938-11e9-89ca-f0af4b3a396f.png)

**'Style 1' style pack**

![image](https://user-images.githubusercontent.com/177561/62666676-37166600-b939-11e9-9f6b-4f4bb235e150.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a homepage block to the editor, and add a 'section title'.
3. Confirm that it has blue uppercase text and the underline when you have the default style pack set.
4. Under Customize > Style packs, switch to 'Style 1'
5. In the editor, confirm that the text is not styled as uppercase, not blue, and without the border.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
