### PR TITLE
Style B: Add square image styles for the avatars

### DIFF
--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -29,3 +29,8 @@ Newspack Theme Editor Styles - Style Pack 1
 	color: $color__text-light;
 }
 
+/* Avatar */
+
+.avatar {
+	border-radius: 0;
+}

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -48,6 +48,12 @@
 	color: $color__text-light;
 }
 
+/* Avatar */
+.avatar,
+.entry-content .wp-block-newspack-blocks-homepage-articles .avatar {
+	border-radius: 0;
+}
+
 /* Author Bio */
 
 .author-bio .accent-header {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the avatar styles for Style B, to give them square corners.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs, and switch to Style 1.
3. Verify avatars in the following locations have squared corners:
    * Homepage blocks, front end.
    * Homepage blocks, editor.
    * Single posts, byline (top of page)
    * Single posts, author bio (bottom of page)
    * Comments.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?