### PR TITLE
Style B: Update footer styles

### DIFF
--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -1,7 +1,6 @@
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
-
 /* Style pack-specific overrides */
 
 .accent-header:not(.widget-title),
@@ -63,5 +62,29 @@
 
 	&:before {
 		display: none;
+	}
+}
+
+/* Footer */
+
+#colophon {
+	&,
+	.social-navigation a {
+		color: $color__text-main;
+	}
+
+	.footer-branding .wrapper {
+		border-top: 3px solid currentColor;
+	}
+
+	.widget-title {
+		color: $color__text-main;
+		font-size: $font__size_base;
+		text-transform: uppercase;
+	}
+
+	.widget,
+	.site-info {
+		font-family: $font__heading;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the theme footer to match Style B -- specifically:

* Switches the top border, social nav and widget titles to black.
* Increases the size of the widget titles, and makes them uppercase.
* Makes all the fonts used in the footer match the header font. 

~Testing this PR depends on a couple existing ones: #166 for the font to be correct, and #164 to make the existing footer styles less opinionated.~ (Merged)

**Screenshot:**

![image](https://user-images.githubusercontent.com/177561/62669529-c2492900-b944-11e9-8929-d4221ebad3e6.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs and pick Style 1.
3. Review the footer against the above screenshot and bulleted list, and confirm those items are updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
