### PR TITLE
Style B: Add dropcap styles

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -107,6 +107,12 @@ function newspack_custom_typography_css() {
 			font-family: $font_header;
 		}";
 
+		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$css_blocks .= "
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+				font-family: $font_header;
+			}";
+		}
 
 		$editor_css_blocks .= "
 		.editor-block-list__layout .editor-block-list__block h1,
@@ -160,6 +166,16 @@ function newspack_custom_typography_css() {
 			font-family: $font_header;
 		}
 		";
+
+		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+
+			{
+				font-family: $font_header;
+			}
+			";
+		}
 	}
 
 	if ( get_theme_mod( 'font_body', '' ) ) {

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -34,3 +34,13 @@ Newspack Theme Editor Styles - Style Pack 1
 .avatar {
 	border-radius: 0;
 }
+
+/** === Paragraph === */
+
+.wp-block-paragraph {
+
+	&.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading;
+		font-weight: bold;
+	}
+}

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -71,6 +71,15 @@
 	}
 }
 
+/* Blocks */
+
+.entry .entry-content {
+	.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading;
+		font-weight: bold;
+	}
+}
+
 /* Footer */
 
 #colophon {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the dropcap styles for Style B: bold, and using the header font (instead of the body font). 

~This PR relies on #166 to use the correct header font (Fira Sans Condensed).~ (Merged)

![image](https://user-images.githubusercontent.com/177561/62670109-e4dc4180-b946-11e9-84fd-a0c3631693cf.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Pack and pick 'Style 1'.
3. In the editor, add a paragraph with a dropcap, or [copy-paste this test content](https://cloudup.com/cjKAR4AtYdC) into the code editor view.
4. Confirm that the dropcap is bold and uses the header font in the editor.
5. Confirm the above styles on the front-end.
6. Change the header font under Customizer > Typography (you can even just add a different font to the 'Header Font' field, like `Chalkboard` for Mac or `Comic Sans` for PC).
7. Confirm that this new font is being used on the front-end.
8. Confirm that this new font is being used in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
