### PR TITLE
Style B: Update author name colour

### DIFF
--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -22,3 +22,7 @@ Newspack Theme Editor Styles - Style Pack 1
 		font-size: 1em;
 	}
 }
+
+.entry-meta .byline a {
+	color: $color__text-light;
+}

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -1,3 +1,6 @@
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+.entry-meta .byline a {
+	color: $color__text-light;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR changes the author byline link from using the primary custom colour to grey to match the 'Style B' styles.

![image](https://user-images.githubusercontent.com/177561/62670894-9f6d4380-b949-11e9-9869-fe22dee7a028.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs and pick 'Style 1`.
3. Verify that the author name link is grey -- this will show up:
     * In the homepage article blocks on the front-end.
     * In the homepage article blocks in the editor.
     * In the author byline at the top of single posts. 
     * In the author byline in the archives.
     * In the author byline in the search results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?