### PR TITLE
First pass at adding a non-AMP mobile menu fallback

### DIFF
--- a/header.php
+++ b/header.php
@@ -24,6 +24,8 @@
 <?php
 	if ( newspack_is_amp() ) {
 		get_template_part( 'template-parts/header/mobile', 'sidebar' );
+	} else {
+		get_template_part( 'template-parts/header/mobile', 'sidebar-fallback' );
 	}
 ?>
 
@@ -41,7 +43,7 @@
 		// Header is NOT short:
 		if ( false === $header_simplified ) :
 		?>
-			<div class="top-header-contain">
+			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
 					<div id="secondary-nav-contain">
 						<?php
@@ -67,16 +69,13 @@
 			</div><!-- .top-header-contain -->
 		<?php endif; ?>
 
-
-
-
 		<div class="middle-header-contain">
 			<div class="wrapper">
 				<?php
 				// Centered logo AND NOT short header.
 				if ( true === $header_center_logo && false === $header_simplified ) :
 				?>
-					<div id="social-nav-contain">
+					<div id="social-nav-contain" class="desktop-only">
 						<?php
 						if ( ! newspack_is_amp() ) {
 							newspack_social_menu_header();
@@ -89,7 +88,7 @@
 				// Centered logo AND short header.
 				if ( true === $header_center_logo && true === $header_simplified ) :
 				?>
-					<div id="tertiary-nav-contain">
+					<div id="tertiary-nav-contain" class="desktop-only">
 						<?php
 						if ( ! newspack_is_amp() ) {
 							newspack_tertiary_menu();
@@ -105,7 +104,8 @@
 				// Short header:
 				if ( true === $header_simplified ) :
 				?>
-					<div class="nav-wrapper">
+
+					<div class="nav-wrapper desktop-only">
 						<div id="site-navigation">
 							<?php
 							if ( ! newspack_is_amp() ) {
@@ -129,7 +129,7 @@
 				// Logo NOT centered and header NOT short:
 				if ( ! ( true === $header_center_logo && true === $header_simplified ) ) :
 				?>
-					<div class="nav-wrapper">
+					<div class="nav-wrapper desktop-only">
 						<div id="tertiary-nav-contain">
 							<?php
 							if ( ! newspack_is_amp() ) {
@@ -147,12 +147,10 @@
 					</div><!-- .nav-wrapper -->
 				<?php endif; ?>
 
-				<?php if ( newspack_is_amp() ) : ?>
-					<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
-						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-						<?php esc_html_e( 'Menu', 'newspack' ); ?>
-					</button>
-				<?php endif; ?>
+				<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
+					<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+					<?php esc_html_e( 'Menu', 'newspack' ); ?>
+				</button>
 
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->
@@ -162,7 +160,7 @@
 		// Header is NOT short:
 		if ( false === $header_simplified ) :
 		?>
-			<div class="bottom-header-contain">
+			<div class="bottom-header-contain desktop-only">
 				<div class="wrapper">
 					<div id="site-navigation">
 						<?php

--- a/js/amp-fallback.js
+++ b/js/amp-fallback.js
@@ -6,6 +6,8 @@
 
 (function() {
 
+
+	// Search toggle.
 	var headerContain           = document.getElementById( 'masthead' ),
 		headerSearch            = document.getElementById( 'header-search' ),
 		headerSearchInput       = headerSearch.getElementsByTagName( 'input' )[0],
@@ -33,6 +35,18 @@
 		}
 
 	}, false );
+
+
+	// Mobile menu fallback.
+
+	var menuToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
+		body = document.getElementsByTagName( 'body' )[0];
+
+	for ( var i = 0; i < menuToggle.length; i++ ) {
+		menuToggle[i].addEventListener( 'click', function() {
+			body.classList.toggle( 'menu-opened' );
+		}, false );
+	}
 
 
 } )();

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -21,7 +21,7 @@
 }
 
 
-#mobile-sidebar {
+.mobile-sidebar {
 	background-color: $color__primary;
 	color: #fff;
 	font-size: $font__size-sm;
@@ -54,7 +54,42 @@
 		padding: #{ 0.5 * $size__spacing-unit } 0;
 	}
 
+	.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg,
+	.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand,
 	.submenu-expand {
 		display: none;
 	}
+}
+
+#mobile-sidebar-fallback {
+	bottom: 0;
+	overflow: auto;
+	position: fixed;
+	right: -100%;
+	top: 0;
+	transition: right 0.2s;
+	z-index: 100;
+
+	.menu-opened & {
+		right: 0;
+	}
+
+	.admin-bar & {
+		top: 32px;
+
+		@media only screen and (max-width: 782px) {
+			top: 46px;
+		}
+	}
+}
+
+.menu-opened:after {
+	background-color: rgba( 0, 0, 0, 0.2 );
+	bottom: 0;
+	content: "";
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
+	z-index: 99;
 }

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -25,11 +25,11 @@
 	background-color: $color__primary;
 	color: #fff;
 	font-size: $font__size-sm;
-	width: 90%;
+	width: 80vw;
 	padding: $size__spacing-unit;
 
 	@include media(tablet) {
-		width: 33%;
+		width: 33vw;
 	}
 
 	& > * {
@@ -68,18 +68,10 @@
 	right: -100%;
 	top: 0;
 	transition: right 0.2s;
-	z-index: 100;
+	z-index: 999999;
 
 	.menu-opened & {
 		right: 0;
-	}
-
-	.admin-bar & {
-		top: 32px;
-
-		@media only screen and (max-width: 782px) {
-			top: 46px;
-		}
 	}
 }
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -242,13 +242,6 @@
 		margin-left: #{ 0.75 * $size__spacing-unit };
 	}
 
-	// Wrapper used to align search with menus.
-	.nav-wrapper {
-		align-items: center;
-		display: flex;
-		justify-content: flex-end;
-	}
-
 	&.header-center-logo {
 
 		@include media( tablet ) {
@@ -269,3 +262,19 @@
 		}
 	}
 }
+
+// Wrapper used to align search with menus.
+.nav-wrapper {
+	align-items: center;
+	display: flex;
+	justify-content: flex-end;
+}
+
+.desktop-only {
+	display: none;
+
+	@include media( tablet ) {
+		display: inherit;
+	}
+}
+

--- a/template-parts/header/mobile-sidebar-fallback.php
+++ b/template-parts/header/mobile-sidebar-fallback.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Template for display the AMP mobile navigation.
+ * Template for display the non-AMP mobile navigation.
  *
  * @package Newspack
  */
 ?>
 
-<amp-sidebar id="mobile-sidebar" layout="nodisplay" side="right" class="mobile-sidebar">
+<aside id="mobile-sidebar-fallback" class="mobile-sidebar">
 
-	<button class="mobile-menu-toggle" on='tap:mobile-sidebar.toggle'>
+	<button class="mobile-menu-toggle">
 		<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 		<?php esc_html_e( 'Close', 'newspack' ); ?>
 	</button>
@@ -23,4 +23,4 @@
 
 	<?php newspack_social_menu_header(); ?>
 
-</amp-sidebar>
+</aside>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a non-AMP version of the mobile menu, to be used as a fallback when AMP is not enabled. 

It inherits the styles from the AMP menu, so it shares some of the visual roughness (odd vertical spacing; missing tertiary menu styles and toggles to dig into different levels). 

It will also need some accessibility improvements, to toggle aria labels, and make sure the `focus` is moved to the sidebar when it's opened. 

I'll follow up on these in future PRs. 

![image](https://user-images.githubusercontent.com/177561/62730218-629a5e80-b9d4-11e9-886a-4847d4cf64ff.png)
 
### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Dashboard > AMP > General, and set it to 'Transitional' -- this will make it easier to compare the AMP version of the mobile menu to the non-AMP version by using the 'AMP' button in the Admin Toolbar. 
3. On the front-end, reduce the size of the browser window and toggle the mobile menu open and closed.
4. Switch to the AMP view (using the admin toolbar toggle or by adding `?amp` to the end of the URL), and confirm that the menus have the same appearance. 
6. If you don't have one already, add a really long menu and make sure it scrolls.
5. Test on a real mobile device. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
