### PR TITLE
Style C: Add the styles to make the header overlap.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -261,6 +261,14 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$theme_css .= '
+			.site-content #primary {
+				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
+			}
+		';
+	}
+
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
 			.header-solid-background .site-header {

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -23,7 +23,7 @@
 	overflow: hidden;
 }
 
-#content {
+.site-content {
 	margin-top: #{ 1.5 * $size__spacing-unit };
 
 	@include media( tablet ) {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -88,14 +88,11 @@
 }
 
 // Middle bar
-.middle-header-contain {
-
-	.wrapper {
-		align-items: center;
-		padding: $size__spacing-unit 0;
-		@include media( mobile ) {
-			padding: #{ 2 * $size__spacing-unit } 0;
-		}
+.middle-header-contain .wrapper {
+	align-items: center;
+	padding: $size__spacing-unit 0;
+	@include media( mobile ) {
+		padding: #{ 1.5 * $size__spacing-unit } 0;
 	}
 }
 
@@ -191,6 +188,12 @@
 		background-color: transparent;
 	}
 
+	.middle-header-contain .wrapper {
+		@include media( tablet ) {
+			padding: #{ 1.5 * $size__spacing-unit } 0 #{ 2 * $size__spacing-unit };
+		}
+	}
+
 	.bottom-header-contain {
 		background-color: #4a4a4a;
 		.wrapper {
@@ -204,7 +207,6 @@
 			color: #fff;
 		}
 	}
-
 }
 
 // Simplified Header

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -269,7 +269,7 @@ body.page {
 		display: none;
 	}
 
-	#content {
+	.site-content {
 		margin-top: 0;
 		@include media(tablet) {
 			margin-top: #{ 0.5 * $size__spacing-unit };

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -7,6 +7,88 @@ Newspack Theme Styles - Style Pack 2
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+// Header Overlap
+
+.site-header,
+.header-solid-background .site-header {
+	padding-bottom: $size__spacing-unit;
+
+	@include media(tablet) {
+		padding-bottom: #{ 4 * $size__spacing-unit };
+	}
+
+	@include media( desktop ) {
+		padding-bottom: #{ 7 * $size__spacing-unit };
+	}
+}
+
+.header-simplified .site-header {
+	@include media( tablet ) {
+		padding-top: #{ 0.5 * $size__spacing-unit };
+	}
+
+	@include media( desktop ) {
+		padding: $size__spacing-unit 0 #{ 10 * $size__spacing-unit };
+	}
+}
+
+.header-simplified .site-content {
+	@include media( tablet ) {
+		margin-top: #{ -2 * $size__spacing-unit };
+	}
+}
+
+.site-content,
+.newspack-front-page.hide-homepage-title .site-content {
+	margin-top: #{ -1 * $size__spacing-unit };
+
+	@include media(tablet) {
+		margin-top: #{ -3.5 * $size__spacing-unit };
+	}
+
+	@include media(desktop) {
+		margin-top: #{ -6 * $size__spacing-unit };
+	}
+}
+
+// Header
+
+.bottom-header-contain .wrapper {
+	border: 0;
+}
+
+.header-solid-background .bottom-header-contain {
+	background-color: transparent;
+
+	.main-navigation .main-menu > li,
+	.main-navigation .main-menu > li > a,
+	#search-toggle {
+		color: inherit;
+	}
+}
+
+body:not(.header-solid-background) .site-header {
+	background-color: #efefef;
+}
+
+// Content Area
+
+#primary {
+	background-color: $color__background-body;
+	border-top: 2px solid $color__primary-variation;
+	padding: 0 #{ 0.5 * $size__spacing-unit };
+
+	@include media(tablet) {
+		border-top-width: 4px;
+		padding: $size__spacing-unit #{ 3 * $size__spacing-unit } 0;
+	}
+
+	@include media(desktop) {
+		padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
+	}
+}
+
+
 // Site header
 
 .main-navigation > ul > li,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the styles for the 'overlap' header used in the [Style C](https://cloudup.com/iIgIC67AIBG) style pack.

Note that it doesn't update the menu styles, or anything inside of the content area (outside of adjusting the padding there a bit).

**Mockups:**

![image](https://user-images.githubusercontent.com/177561/62737600-fbd17100-b9e4-11e9-8178-c15b22287c72.png)

![image](https://user-images.githubusercontent.com/177561/62738751-ec075c00-b9e7-11e9-9737-80083a5a2412.png)

I've included screenshots of different menus with different settings under the cut:

<details><summary><strong>Screenshots</strong></summary>

**Default header settings:** 

![image](https://user-images.githubusercontent.com/177561/62738062-37b90600-b9e6-11e9-93e7-8556a05e3d72.png)

**Centred Logo:**

![image](https://user-images.githubusercontent.com/177561/62738322-ee1ceb00-b9e6-11e9-9211-3d272e8d0ad6.png)

**Solid Background:**

![image](https://user-images.githubusercontent.com/177561/62738395-14db2180-b9e7-11e9-98f0-42d306bcf41b.png)

**Short Header:**

![image](https://user-images.githubusercontent.com/177561/62738157-7d75ce80-b9e6-11e9-80b0-a3456b510f0b.png)

**Short Header + Solid Background:** 

![image](https://user-images.githubusercontent.com/177561/62738192-8bc3ea80-b9e6-11e9-81fe-a08444a9f968.png)

**Short Header + Centred Logo:**

![image](https://user-images.githubusercontent.com/177561/62738462-376d3a80-b9e7-11e9-8fbe-34b412bc14b4.png)

</details>

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs, and set it to 'Style 2'. 
3. Test the different header variations - this style is meant to work best with the 'short' header, but it should work with them all:
     * Default (no settings checked)
     * Solid Background
     * Centred Logo
     * Short Header
     * Short Header + Solid Background
     * Short Header + Centred Logo
4. Test the above on smaller screens as well (note: the header overall transitions pretty poorly from desktop to tablet styles -- there are some behaviours in between the desktop and tablet breakpoints that don't display great -- I'll be improving this in a future PR). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
