### PR TITLE
Make the spacing between the primary and tertiary navigations more consistent

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -48,12 +48,12 @@
 
 		> li {
 			color: #555;
+			margin-right: #{0.75 * $size__spacing-unit};
 			position: relative;
 
 			> a {
 				color: inherit;
 				font-weight: 700;
-				margin-right: #{0.5 * $size__spacing-unit};
 
 				+ svg {
 					margin-right: #{0.5 * $size__spacing-unit};
@@ -88,7 +88,6 @@
 				.submenu-expand {
 					display: inline-block;
 					height: 18px;
-					margin-right: #{0.25 * $size__spacing-unit};
 					width: 24px;
 
 					.wp-customizer-unloading &,
@@ -101,11 +100,6 @@
 						top: -0.2em;
 					}
 				}
-			}
-
-			&:last-child > a,
-			&:last-child.menu-item-has-children .submenu-expand {
-				margin-right: 0;
 			}
 		}
 	}

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -37,14 +37,13 @@
 
 		@include media(tablet) {
 			&:nth-child(n+2) {
-				margin: 0 0 0 #{$size__spacing-unit * 0.5};
+				margin: 0 0 0 #{$size__spacing-unit * 0.75};
 			}
 		}
 	}
 
 	a {
 		margin: #{$size__spacing-unit * 0.25} 0;
-		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.5};
 	}
 
 	// Short header
@@ -54,7 +53,6 @@
 		li {
 			a {
 				font-size: $font__size-xs;
-				padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 			}
 		}
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -246,7 +246,7 @@
 	}
 
 	.header-search-contain {
-		margin-left: $size__spacing-unit;
+		margin-left: #{ 0.75 * $size__spacing-unit };
 	}
 
 	&.header-center-logo {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the spacing between the primary and tertiary navigation more consistent by reducing the spacing on the tertiary menu. 

The difference was mostly noticeable with the 'short' header, where the two menus are presented on the same level. Originally, the tertiary navigation (non-bolded one) had more space between links than the primary menu (bolded one):

**Before:**

![image](https://user-images.githubusercontent.com/177561/62742511-af416200-b9f3-11e9-8358-e9ed71b679ec.png)

![image](https://user-images.githubusercontent.com/177561/62742482-96d14780-b9f3-11e9-9105-af25585821c6.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62742407-4fe35200-b9f3-11e9-9958-d26ad95d8dec.png)

![image](https://user-images.githubusercontent.com/177561/62742468-891bc200-b9f3-11e9-8b1e-d6395cc00371.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Test the short header styles (logo aligned left and centred) and confirm whether the individual menu items look consistently spaced.
3. Test the non-short menu header style and make sure no visual weirdness has been introduced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
