### PR TITLE
Replace ':not' pseudo-selectors for the header with classes

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -45,16 +45,22 @@ function newspack_body_classes( $classes ) {
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {
 		$classes[] = 'header-solid-background';
+	} else {
+		$classes[] = 'header-default-background';
 	}
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );
 	if ( true === $header_center_logo ) {
 		$classes[] = 'header-center-logo';
+	} else {
+		$classes[] = 'header-left-logo';
 	}
 
 	$header_simplified = get_theme_mod( 'header_simplified', false );
 	if ( true === $header_simplified ) {
 		$classes[] = 'header-simplified';
+	} else {
+		$classes[] = 'header-default-height';
 	}
 
 	// Adds a class of has-sidebar when there is a sidebar present.

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -332,7 +332,7 @@
 	}
 }
 
-.header-center-logo:not(.header-simplified) .site-header #site-navigation {
+.header-center-logo.header-default-height .site-header #site-navigation {
 	flex-basis: 100%;
 	text-align: center;
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -252,7 +252,7 @@
 	&.header-center-logo {
 
 		@include media( tablet ) {
-			.wrapper > * {
+			.site-header .wrapper > * {
 				flex: 1 0 0;
 				min-width: 33%;
 			}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -229,7 +229,7 @@
 		margin: 0;
 	}
 
-	&:not(.header-center-logo).hide-site-tagline .main-navigation {
+	&.header-left-logo.hide-site-tagline .main-navigation {
 		flex-grow: 2;
 	}
 

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -12,7 +12,7 @@
 
 /* Navigation */
 
-body:not(.header-solid-background):not(.header-simplified) {
+body.header-default-background.header-default-height {
 	.site-header {
 		.tertiary-menu {
 			a {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the `:not()` pseudo-selectors used for the header with actual classes, in hopes it'll help make the styles a bit easier to follow.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Run through the header variations -- these preview correctly in the Customizer so can be tested there. They are:
     * Default (nothing checked).
     * Solid Background
     * Centred Logo
     * Short Header
     * Solid Background + Centred Logo
     * Solid Background + Centred Logo + Short Header
     * Solid Background + Short Header
     * Short Header + Centred Logo
3. Verify that each still displays as described. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?