### PR TITLE
Style B: Style author name, date side by side

### DIFF
--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -47,6 +47,17 @@
 	color: $color__text-light;
 }
 
+.single .entry-meta {
+	@include media( tablet ) {
+		align-items: center;
+		display: flex;
+
+		.posted-on {
+			margin-left: #{ 1.5 * $size__spacing-unit };
+		}
+	}
+}
+
 /* Avatar */
 .avatar,
 .entry-content .wp-block-newspack-blocks-homepage-articles .avatar {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR places the author name and published date side by side on single posts for style B.

On screens tablet-sized and smaller (<768px), the author name and date will stack again.

**Before:**

![image](https://user-images.githubusercontent.com/177561/62824197-656d8e80-bb4f-11e9-96df-2f58f0192f24.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62824189-51c22800-bb4f-11e9-8ba0-c9ac50516476.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to a single post, and confirm the author name and date are now side by side.
3. Shrink the browser window and confirm that the author name and date stack once the window is less than 768px wide.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
