### PR TITLE
Style C: Build out footer styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -191,13 +191,18 @@ function newspack_custom_colors_css() {
 			.page-title:before {
 				background-color: ' . $primary_color . ';
 			}
+
+			.entry .entry-content .wp-block-pullquote blockquote:before {
+				color: ' . $primary_color . ';
+			}
 		';
 	}
 
-	if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$theme_css .= '
-			.entry .entry-content .wp-block-pullquote blockquote:before {
-				color: ' . $primary_color . ';
+			.site-footer {
+				background-color: ' . $primary_color . ';
+				color: ' . $primary_color_contrast . ';
 			}
 		';
 	}

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -1,6 +1,6 @@
 /* Site footer */
 
-#colophon {
+.site-footer {
 	margin: #{ 2 * $size__spacing-unit } 0 0;
 
 	a {
@@ -48,28 +48,28 @@
 		color: $color__text-light;
 		font-size: inherit;
 	}
+}
 
-	.site-info {
-		color: $color__text-light;
+.site-info {
+	color: $color__text-light;
 
-		.wrapper {
-			border-top: 1px solid $color__border;
-			justify-content: space-between;
-			padding: $size__spacing-unit 0;
+	.wrapper {
+		border-top: 1px solid $color__border;
+		justify-content: space-between;
+		padding: $size__spacing-unit 0;
+	}
+
+	a {
+		color: inherit;
+
+		&:hover {
+			text-decoration: none;
+			color: $color__primary-variation;
 		}
+	}
 
-		a {
-			color: inherit;
-
-			&:hover {
-				text-decoration: none;
-				color: $color__primary-variation;
-			}
-		}
-
-		.imprint,
-		.privacy-policy-link {
-			margin-right: $size__spacing-unit;
-		}
+	.imprint,
+	.privacy-policy-link {
+		margin-right: $size__spacing-unit;
 	}
 }

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -68,7 +68,6 @@
 		}
 	}
 
-	.imprint,
 	.privacy-policy-link {
 		margin-right: $size__spacing-unit;
 	}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -252,7 +252,7 @@
 	&.header-center-logo {
 
 		@include media( tablet ) {
-			.wrapper > * {
+			.site-header .wrapper > * {
 				flex: 1 0 0;
 				min-width: 33%;
 			}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -71,10 +71,6 @@ Newspack Theme Styles - Style Pack 2
 	background-color: $color__primary;
 	color: $color__background-body;
 
-	@include media( tablet ) {
-		padding-top: #{ 2 * $size__spacing-unit };
-	}
-
 	a,
 	a:hover,
 	a:visited,
@@ -92,10 +88,15 @@ Newspack Theme Styles - Style Pack 2
 }
 
 .footer-branding {
+	margin-bottom: #{ 2 * $size__spacing-unit };
+
+	@include media( tablet ) {
+		padding-top: #{ 2 * $size__spacing-unit };
+	}
+
 	.wrapper {
 		border-bottom: 1px solid currentColor;
 	}
-	margin-bottom: #{ 2 * $size__spacing-unit };
 }
 
 .site-info {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -64,3 +64,49 @@ Newspack Theme Styles - Style Pack 2
 		color: $color__text-main;
 	}
 }
+
+// Footer
+
+.site-footer {
+	background-color: $color__primary;
+	color: $color__background-body;
+
+	@include media( tablet ) {
+		padding-top: #{ 2 * $size__spacing-unit };
+	}
+
+	a,
+	a:hover,
+	a:visited,
+	.widget a,
+	.widget a:hover,
+	.widget a:visited,
+	.widget-title {
+		color: inherit;
+	}
+
+	.widget-title {
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+	}
+}
+
+.footer-branding {
+	.wrapper {
+		border-bottom: 1px solid currentColor;
+	}
+	margin-bottom: #{ 2 * $size__spacing-unit };
+}
+
+.site-info {
+	background-color: $color__text-main;
+	color: $color__background-body;
+
+	.wrapper {
+		border: 0;
+	}
+
+	a {
+		color: inherit;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR builds out the footer styles for Style C. Primary points include:

* Uses the primary colour as a background, and the text colour as the background on the 'site info' (copyright information).
* Adds a border below the 'site branding'.
* Makes the widget titles uppercase.

This PR also makes the default footer styles a little less specific: it switches an ID for a class, and un-nests an unnecessary level of nesting, to reduce selector numbers.

**Default colour:**

![image](https://user-images.githubusercontent.com/177561/62825295-61953880-bb5e-11e9-829a-cdeabdedb8aa.png)

**Custom colour:**

![image](https://user-images.githubusercontent.com/177561/62825286-432f3d00-bb5e-11e9-910b-c6257ce12d8e.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Navigate to Customize > Style Packs, and switch to Style 2.
3. View the footer on the front-end and confirm it looks like the above screenshots.
4. Try switching the primary colour to something lower contrast, and confirm all the text is still legible.
5. Try removing all the widgets and confirm the 'primary colour' section is removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
