### PR TITLE
Style C: Update header font styles

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -7,6 +7,18 @@ Newspack Theme Styles - Style Pack 2
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+// Site header
+
+.main-navigation > ul > li,
+.tertiary-menu {
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+.site-header .tertiary-menu {
+	font-size: $font__size-xs;
+}
+
 // Accent headers
 
 .accent-header,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the menu fonts used by Style C, to better reflect the mockups.

The font in menus primary and tertiary are uppercase, and the primary and tertiary menus are the same size when using the default header settings.

Default settings:

![image](https://user-images.githubusercontent.com/177561/62825459-d7020880-bb60-11e9-92a9-5193cb5b49fb.png)

Centred logo:

![image](https://user-images.githubusercontent.com/177561/62825470-f1d47d00-bb60-11e9-9ff5-ac52c2f3999a.png)

Solid background:

![image](https://user-images.githubusercontent.com/177561/62825475-04e74d00-bb61-11e9-9714-8db1376740c0.png)

Solid background + short:

![image](https://user-images.githubusercontent.com/177561/62825480-192b4a00-bb61-11e9-8051-3e77a35863cc.png)

Solid background + short + centred logo:

![image](https://user-images.githubusercontent.com/177561/62825481-2811fc80-bb61-11e9-8101-67acce24ac08.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to Style 2.
3. Run through a few different header settings; make sure the header matches the appearance of the above screenshots; check for any weirdness.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
