### PR TITLE
Style C: Updates author link style, entry meta border on single posts.

### DIFF
--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -23,6 +23,12 @@ Newspack Theme Editor Styles - Style Pack 2
 	}
 }
 
+.entry-meta .byline a {
+	color: $color__text-light;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
 // Blocks
 
 .wp-block[data-type="core/pullquote"] {

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -31,8 +31,19 @@ Newspack Theme Editor Styles - Style Pack 2
 
 // Blocks
 
-.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-	font-size: #{ 0.7 * $font__size_base };
+.wp-block-newspack-blocks-homepage-articles {
+	article .entry-meta {
+		font-size: #{ 0.7 * $font__size_base };
+	}
+
+	&.type-scale1,
+	&.type-scale2,
+	&.type-scale3,
+	&.type-scale4 {
+		article .entry-meta {
+			font-size: #{ 0.6 * $font__size_base };
+		}
+	}
 }
 
 .wp-block[data-type="core/pullquote"] {

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -31,6 +31,10 @@ Newspack Theme Editor Styles - Style Pack 2
 
 // Blocks
 
+.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	font-size: #{ 0.7 * $font__size_base };
+}
+
 .wp-block[data-type="core/pullquote"] {
 
 	.wp-block-pullquote {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -86,8 +86,19 @@ Newspack Theme Styles - Style Pack 2
 
 .entry .entry-content {
 
-	.wp-block-newspack-blocks-homepage-articles article .entry-meta {
-		font-size: #{ 0.7 * $font__size_base };
+	.wp-block-newspack-blocks-homepage-articles {
+		 article .entry-meta {
+			font-size: #{ 0.7 * $font__size_base };
+		}
+
+		&.type-scale1,
+		&.type-scale2,
+		&.type-scale3,
+		&.type-scale4 {
+			article .entry-meta {
+				font-size: #{ 0.6 * $font__size_base };
+			}
+		}
 	}
 
 	.wp-block-pullquote {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -85,6 +85,11 @@ Newspack Theme Styles - Style Pack 2
 // Blocks
 
 .entry .entry-content {
+
+	.wp-block-newspack-blocks-homepage-articles article .entry-meta {
+		font-size: #{ 0.7 * $font__size_base };
+	}
+
 	.wp-block-pullquote {
 		border-width: 16px 0 4px;
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -56,6 +56,32 @@ Newspack Theme Styles - Style Pack 2
 	}
 }
 
+// Posts & Pages
+
+.entry-meta {
+	.byline a {
+		color: $color__text-light;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+	}
+}
+
+.single-post {
+	&:not(.has-featured-image) .entry-header,
+	.has-large-featured-image .entry-header {
+		border-bottom: 2px solid $color__text-main;
+
+		@include media( tablet ) {
+			padding-bottom: #{ 2 * $size__spacing-unit };
+			margin-bottom: $size__spacing-unit;
+		}
+	}
+
+	.entry-meta {
+		font-size: $font__size-xs;
+	}
+}
+
 // Blocks
 
 .entry .entry-content {
@@ -111,7 +137,6 @@ Newspack Theme Styles - Style Pack 2
 		}
 	}
 }
-
 
 // Author Bio
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the post meta (author name and published date) styles to match the mockups for Style C. The changes include:

* Switching the link colour from the primary colour to light grey, for both single posts and the homepage blocks.
* Switching the author name to be all caps, and a bit smaller on single posts.
* Increasing the width and contrast on the entry meta bottom border on single posts (it only shows up when there isn't a featured image, or the featured image is too small.

**Homepage blocks:**

![image](https://user-images.githubusercontent.com/177561/62825814-6b229e80-bb66-11e9-97d8-2c914ad33613.png)

**Single post (no featured image):**

![image](https://user-images.githubusercontent.com/177561/62825817-770e6080-bb66-11e9-856e-5de7f227267d.png)

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customize > Style Packs and apply Style 2.
3. View a homepage block on the front-end and in the editor; confirm the author name is all caps, and light grey.
4. View a single post on the front end; confirm that the author name is light grey, all caps, and a bit smaller than usual.
5. View a single post that doesn't have a featured image on the front end; confirm there's a border that separates the post header from the content, that it's two px wide and dark grey.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
