### PR TITLE
Style C: Add dividing border above the author profile

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -45,7 +45,14 @@ Newspack Theme Styles - Style Pack 2
 }
 
 .author-bio {
-	 h2 {
+	border-top: 8px solid $color__text-main;
+	padding-top: #{ 1.5 * $size__spacing-unit };
+
+	@include media( tablet ) {
+		border-top-width: 10px;
+	}
+
+	h2 {
 		color: inherit;
 		font-size: $font__size-md;
 		letter-spacing: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a border on top of the author bio that appears at the bottom of single posts, as the last piece getting them matching the mockups:

![image](https://user-images.githubusercontent.com/177561/62826111-f140e400-bb6a-11e9-87bc-6d74160efae1.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run`npm run build`.
2. To activate the author bio on single posts, navigate to Dashboard > Users, and click edit next to the author you want to show the bio for; add text to the 'Biographical Info' field.
3. View a single post on the front-end, and confirm it matches the appearance of the above screenshot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
