### PR TITLE
Style C: Swap Monserrat 400 for 500, so it's a bit stronger

### DIFF
--- a/inc/style-packs.php
+++ b/inc/style-packs.php
@@ -34,7 +34,7 @@ new Newspack_Style_Packs_Core(
 				'Fira Sans Condensed' => 'https://fonts.googleapis.com/css?family=Fira+Sans+Condensed:400,400i,600,600i',
 			),
 			'style-2' => array(
-				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:400,700,900',
+				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:500,700,900',
 			),
 			'style-3' => array(
 				'Barlow' => 'https://fonts.googleapis.com/css?family=Barlow:400,400i,700,700i&display=swap',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I had a bunch of local copies of the Montserrat font that was messing with what I was seeing vs. what the theme was actually loading.

This PR swaps the 'regular' weight in the theme -- 400 -- for 500, in hopes it helps make the font a bit stronger looking, and closer to the mocks.

A good spot to note this difference is the header, in the secondary and tertiary navigation; it's come up in other issues like #187.

Before: 
![image](https://user-images.githubusercontent.com/177561/62826399-8645dc00-bb6f-11e9-9b07-594a8fe818e7.png)

After: 
![image](https://user-images.githubusercontent.com/177561/62826392-76c69300-bb6f-11e9-8919-d159d6f80f8f.png)

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customizer > Style Pack, and switch to 'Style 2'.
3. Compare the font weights in the header to the above screenshots, specifically the text in the lighter menus (secondary and tertiary).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
