### PR TITLE
Style C: Add styles for dropcap

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -216,6 +216,10 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}
+
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+				border-color: ' . $primary_color . ';
+			}
 		';
 	}
 
@@ -350,6 +354,15 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+
+	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$editor_css .= '
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+				border-color: ' . $primary_color . ';
+			}
+		';
+	}
+
 	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
@@ -372,9 +385,7 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color . ';
 			}
 		';
-	}
 
-	if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				background-color: ' . $primary_color . ';

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -354,7 +354,6 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-
 	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -114,6 +114,13 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
+		if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$css_blocks .= "
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+				font-family: $font_header;
+			}";
+		}
+
 		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
@@ -193,6 +200,17 @@ function newspack_custom_typography_css() {
 			}
 			";
 		}
+
+		if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+
+			{
+				font-family: $font_header;
+			}
+			";
+		}
+
 
 		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -143,7 +143,7 @@ figcaption,
 	.editor-post-title__input {
 		font-family: $font__heading;
 		font-size: $font__size-xxl;
-		font-weight: normal;
+		font-weight: 700;
 
 		@include media(desktop) {
 			font-size: $font__size-xxxl;

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -31,6 +31,7 @@ Newspack Theme Editor Styles - Style Pack 2
 
 // Blocks
 
+
 .wp-block-newspack-blocks-homepage-articles {
 	article .entry-meta {
 		font-size: #{ 0.7 * $font__size_base };
@@ -43,6 +44,16 @@ Newspack Theme Editor Styles - Style Pack 2
 		article .entry-meta {
 			font-size: #{ 0.6 * $font__size_base };
 		}
+	}
+}
+
+.wp-block-paragraph {
+	&.has-drop-cap:not(:focus)::first-letter {
+		border: 7px solid $color__primary;
+		font-family: $font__heading;
+		font-weight: bold;
+		font-size: $font__size-xxl;
+		padding: 0.4em;
 	}
 }
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -128,6 +128,14 @@ Newspack Theme Styles - Style Pack 2
 		}
 	}
 
+	.has-drop-cap:not(:focus)::first-letter {
+		border: 7px solid $color__primary;
+		font-family: $font__heading;
+		font-weight: bold;
+		font-size: $font__size-xxl;
+		padding: 0.4em;
+	}
+
 	.wp-block-pullquote {
 		border-width: 16px 0 4px;
 

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -7,6 +7,10 @@ Newspack Theme Editor Styles - Style Pack 4
 @import "variables-style/variables-style";
 @import "../../style-editor-base";
 
+.editor-post-title__block .editor-post-title__input {
+	font-weight: normal;
+}
+
 .accent-header,
 .article-section-title {
 	color: $color__primary;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the dropcap styles for Style C.

![image](https://user-images.githubusercontent.com/177561/62836876-e2b30500-bc1c-11e9-9f49-0795516ad4b6.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and pick Style 2.
3. Copy paste [this test content](https://cloudup.com/ccLmtoly-JW) into the code editor of a post or page -- it includes a set of dropcaps.
4. On the front end and in the editor, check that they match the above screenshot, using the 'primary colour' as the border on the dropcaps, and the header font (Montserrat).
5. Navigate to Customize > Typography and change the header font; confirm that it updates it in the dropcap on the front-end, and in the editor. 
6. Navigate to Customize > Colours and change the primary colour; confirm that it updates the border colour on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?