### PR TITLE
Move header options to own Customizer section

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -39,7 +39,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'newspack_header_options',
 		array(
-			'title' => esc_html__( 'Site Header Settings', 'newspack' ),
+			'title' => esc_html__( 'Header Settings', 'newspack' ),
 		)
 	);
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -34,6 +34,70 @@ function newspack_customize_register( $wp_customize ) {
 	}
 
 	/**
+	 * Header Options
+	 */
+	$wp_customize->add_section(
+		'newspack_header_options',
+		array(
+			'title' => esc_html__( 'Site Header Settings', 'newspack' ),
+		)
+	);
+
+	// Header - add option to center logo.
+	$wp_customize->add_setting(
+		'header_center_logo',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_center_logo',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Center Logo', 'newspack' ),
+			'description' => esc_html__( 'Check to center the logo in the header.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
+	// Header - add option for solid background colour.
+	$wp_customize->add_setting(
+		'header_solid_background',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_solid_background',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Solid Background', 'newspack' ),
+			'description' => esc_html__( 'Check to use the primary color as the header background.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
+	// Header - add option for simplified short header.
+	$wp_customize->add_setting(
+		'header_simplified',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_simplified',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Short Header', 'newspack' ),
+			'description' => esc_html__( 'Displays header as a shorter, simpler version.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
+	/**
 	 * Primary color.
 	 */
 	$wp_customize->add_setting(
@@ -113,60 +177,6 @@ function newspack_customize_register( $wp_customize ) {
 			'type'    => 'checkbox',
 			'label'   => esc_html__( 'Display Tagline', 'newspack' ),
 			'section' => 'title_tagline',
-		)
-	);
-
-	// Header - add option to center logo.
-	$wp_customize->add_setting(
-		'header_center_logo',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'header_center_logo',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Center Logo', 'newspack' ),
-			'description' => esc_html__( 'Check to center the logo in the header.', 'newspack' ),
-			'section'     => 'title_tagline',
-		)
-	);
-
-	// Header - add option for solid background colour.
-	$wp_customize->add_setting(
-		'header_solid_background',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'header_solid_background',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Solid Background', 'newspack' ),
-			'description' => esc_html__( 'Check to use the primary color as the header background.', 'newspack' ),
-			'section'     => 'title_tagline',
-		)
-	);
-
-	// Header - add option for simplified short header.
-	$wp_customize->add_setting(
-		'header_simplified',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'header_simplified',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Short Header', 'newspack' ),
-			'description' => esc_html__( 'Displays header as a shorter, simpler version.', 'newspack' ),
-			'section'     => 'title_tagline',
 		)
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the three header customization options -- solid background, centre logo and short header -- to their own Customizer section, labelled 'Site Header Settings.'

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that a new section, 'Site Header Settings' now appears in the Customizer.
3. Confirm that the header options are there, and still work.
4. Confirm that they no longer appear under 'Site Identity'.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
