### PR TITLE
Style C: Add styles for entry footer tags.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -40,8 +40,6 @@ function newspack_custom_colors_css() {
 
 		.main-navigation .main-menu > li,
 		.main-navigation ul.main-menu > li > a,
-		.entry .entry-meta a:hover,
-		.entry .entry-footer a:hover,
 		.entry .entry-content .more-link:hover,
 		.main-navigation .main-menu > li > a + svg,
 		.comment .comment-metadata > a:hover,
@@ -177,7 +175,9 @@ function newspack_custom_colors_css() {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 				color: ' . $primary_color_contrast . ';
 			}
-			.accent-header, .article-section-title {
+			.accent-header, .article-section-title,
+			.entry .entry-meta a:hover,
+			.entry .entry-footer a:hover {
 				color: ' . $primary_color . ';
 			}
 		';

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -56,6 +56,35 @@ Newspack Theme Styles - Style Pack 2
 	}
 }
 
+// Posts & Pages
+
+.entry .entry-footer,
+.entry .entry-footer a,
+.entry .entry-footer a:hover {
+	color: $color__text-main;
+}
+
+.tags-links {
+	a {
+		background: $color__background-pre;
+		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
+		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+		text-transform: uppercase;
+
+		&:hover {
+			background: lighten( $color__background-pre, 5% );
+		}
+	}
+
+	.sep {
+		display: none;
+	}
+}
+
+.post-edit-link {
+	text-transform: uppercase;
+}
+
 // Blocks
 
 .entry .entry-content {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the styles for the Style C tags, and edit link:

![image](https://user-images.githubusercontent.com/177561/62837402-d7170c80-bc23-11e9-8917-629698724723.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and pick 'Style 2'.
3. View a post that has tags; scroll to the bottom of the content and confirm they're styled to match the screenshot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
