### PR TITLE
Style D: Add entry meta -- byline and published date -- styles.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -176,8 +176,20 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color_contrast . ';
 			}
 			.accent-header, .article-section-title,
-			.entry .entry-meta a:hover,
 			.entry .entry-footer a:hover {
+				color: ' . $primary_color . ';
+			}
+		';
+	}
+
+	if (
+		'default' === get_theme_mod( 'active_style_pack', 'default' ) ||
+		'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ||
+		'style-4' === get_theme_mod( 'active_style_pack', 'default' )
+	) {
+		$theme_css .= '
+			.entry-meta .byline a,
+			.entry .entry-meta a:hover {
 				color: ' . $primary_color . ';
 			}
 		';
@@ -248,6 +260,7 @@ function newspack_custom_colors_css() {
 		 * - buttons
 		 */
 		.editor-block-list__layout .editor-block-list__block a,
+		.entry-meta .byline a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
@@ -286,6 +299,18 @@ function newspack_custom_colors_css() {
 			color: inherit;
 		}
 		';
+
+		if (
+			'default' === get_theme_mod( 'active_style_pack', 'default' ) ||
+			'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ||
+			'style-4' === get_theme_mod( 'active_style_pack', 'default' )
+		) {
+			$editor_css .= '
+				.editor-block-list__layout .editor-block-list__block .entry-meta .byline a {
+					color: ' . $primary_color . ';
+				}
+			';
+		}
 
 		if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css .= '

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -32,6 +32,13 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
+.entry-meta {
+	.byline a,
+	.entry-date {
+		text-transform: uppercase;
+	}
+}
+
 .wp-block[data-type="core/pullquote"] {
 
 	.wp-block-pullquote {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -68,6 +68,18 @@ Newspack Theme Styles - Style Pack 3
 
 // Posts & Pages
 
+.entry-meta {
+	.byline a,
+	.entry-date {
+		text-transform: uppercase;
+	}
+}
+
+.single-post:not(.has-featured-image) .entry-header,
+.single-post.has-large-featured-image .entry-header {
+	border-bottom: 1px dotted $color__text-main;
+}
+
 .entry .entry-footer {
 	color: $color__primary;
 }
@@ -178,3 +190,4 @@ Newspack Theme Styles - Style Pack 3
 		}
 	}
 }
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the author and date styles to Style D, and updates the bottom border under this post meta on single posts. 

With these changes I adjusted the custom colours for the authors a bit, so they didn't need to be overridden for style-1 and style-2, the two style packs that don't use the primary colour for that link.

Like with Style C, the font size used in the homepage block will need to be adjusted so it's not larger than the section headers; I held off for now because I figured I'd do a better job of it after #196 was merged (but will tack it onto this PR when that happens). 

**Homepage blocks:**

![image](https://user-images.githubusercontent.com/177561/62838857-970d5500-bc36-11e9-887e-a62b47e49164.png)

**Single post:** 

![image](https://user-images.githubusercontent.com/177561/62838850-84931b80-bc36-11e9-8c28-a8e33c25d27a.png)


### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`
2. Navigate to Customize > Style Packs and apply Style 3.
3. View a homepage block on the front-end and in the editor; confirm the author name is all caps and uses the primary colour, and that the date is also in all-caps.
4. View a single post on the front end; confirm that the author name uses the primary colour, and it and the date are in all-caps.
5. View a single post that doesn't have a featured image on the front end; confirm there's a border that separates the post header from the content, that it's 1px wide and dotted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
