### PR TITLE
Style D: Adds dropcap styles

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -114,6 +114,13 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
+		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$css_blocks .= "
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+				font-family: $font_header;
+			}";
+		}
+
 		$editor_css_blocks .= "
 		.editor-block-list__layout .editor-block-list__block h1,
 		.editor-block-list__layout .editor-block-list__block h2,
@@ -168,6 +175,16 @@ function newspack_custom_typography_css() {
 		";
 
 		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+
+			{
+				font-family: $font_header;
+			}
+			";
+		}
+
+		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -23,3 +23,10 @@ Newspack Theme Editor Styles - Style Pack 3
 		width: 32px;
 	}
 }
+
+.wp-block-paragraph {
+	&.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading;
+		font-weight: bold;
+	}
+}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -7,6 +7,7 @@ Newspack Theme Styles - Style Pack 3
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+
 // Accent headers
 
 .accent-header,
@@ -56,5 +57,12 @@ Newspack Theme Styles - Style Pack 3
 			font-size: $font__size-xs;
 			text-transform: uppercase;
 		}
+	}
+}
+
+.entry .entry-content {
+	.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading;
+		font-weight: bold;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the dropcap styles for Style D. They are bold and are set to use the header font (though in Style D, the body and header are the same, so this won't really be noticeable unless you change one of the two fonts).

![image](https://user-images.githubusercontent.com/177561/62838912-65e15480-bc37-11e9-92d5-2305bb18a2af.png)

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to Style 3.
3. Copy paste this [test content](https://cloudup.com/ccLmtoly-JW) into the code editor to get a post with dropcaps.
4. View in the editor and on the front-end and confirm it looks like the above.
5. Under Customize > Typography, change the Header font. Confirm it changes it for the dropcap, on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
