### PR TITLE
Style D: Add styles for post tags.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -217,6 +217,14 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$theme_css .= '
+			.entry .entry-footer {
+				color: ' . $primary_color . ';
+			}
+		';
+	}
+
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
 			.header-solid-background .site-header {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -68,7 +68,10 @@ Newspack Theme Styles - Style Pack 3
 
 // Posts & Pages
 
-.entry .entry-footer,
+.entry .entry-footer {
+	color: $color__primary;
+}
+
 .entry .entry-footer a,
 .entry .entry-footer a:hover {
 	color: $color__text-main;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -7,7 +7,6 @@ Newspack Theme Styles - Style Pack 3
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
-
 // Accent headers
 
 .accent-header,
@@ -64,5 +63,29 @@ Newspack Theme Styles - Style Pack 3
 	.has-drop-cap:not(:focus)::first-letter {
 		font-family: $font__heading;
 		font-weight: bold;
+	}
+}
+
+// Posts & Pages
+
+.entry .entry-footer,
+.entry .entry-footer a,
+.entry .entry-footer a:hover {
+	color: $color__text-main;
+}
+
+.tags-links {
+	a {
+		background: $color__background-pre;
+		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
+		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+
+		&:hover {
+			background: lighten( $color__background-pre, 5% );
+		}
+	}
+
+	.sep {
+		display: none;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the tags in the footer for Style D to use the same colour as the text for the links, and add a light grey background to the links:

![image](https://user-images.githubusercontent.com/177561/62839069-f91b8980-bc39-11e9-897f-e1688a82101d.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 3.
3. View a single post with tags; confirm they look like the above screenshot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
