### PR TITLE
Style D: Add cutout styles for homepage article blocks

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -7,7 +7,6 @@ Newspack Theme Editor Styles - Style Pack 3
 @import "variables-style/variables-style";
 @import "../../style-editor-base";
 
-
 .accent-header,
 .article-section-title {
 	color: $color__primary;
@@ -36,6 +35,17 @@ Newspack Theme Editor Styles - Style Pack 3
 	.byline a,
 	.entry-date {
 		text-transform: uppercase;
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) {
+	.post-has-image .entry-title {
+		background-color: $color__background-body;
+		margin-top: -1.75em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
 	}
 }
 
@@ -121,5 +131,6 @@ Newspack Theme Editor Styles - Style Pack 3
 		height: 5px;
 		margin-top: #{ 1.25 * $size__spacing-unit };
 		width: 32px;
+
 	}
 }

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -106,6 +106,18 @@ Newspack Theme Styles - Style Pack 3
 }
 
 .entry .entry-content {
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) {
+		.post-has-image .entry-title {
+			background-color: $color__background-body;
+			margin-top: -1.5em;
+			padding: 0.5em 0.25em 0 0;
+			position: relative;
+			width: 85%;
+			z-index: 1;
+		}
+	}
+
+
 	.wp-block-pullquote {
 		border-width: 0;
 		position: relative;
@@ -190,4 +202,3 @@ Newspack Theme Styles - Style Pack 3
 		}
 	}
 }
-


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the 'cutout' style to the homepage blocks for Style D.

![image](https://user-images.githubusercontent.com/177561/62839790-89f76280-bc44-11e9-907b-51be503e3ea6.png)

It relies on an open PR for the blocks as well, to add a class to make sure the image is set to show before these styles are applied: 

https://github.com/Automattic/newspack-blocks/pull/66

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Apply https://github.com/Automattic/newspack-blocks/pull/66 and run `npm run build:webpack`.
3. Navigate to Customize > Style Packs and switch to Style 3.
4. Add some homepage blocks with a few different settings:
      * Show Image
      * Don't show image
      * Show image + align image left
      * Show image + align image right
      * Varying type scales.
5. Review the above; the overlap style should only be applied to articles that are set to show images, actually have and image to show, and that aren't aligning that image left or right. The overlap should roughly line up the bottom of the first line of text with the bottom of the image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
