### PR TITLE
Style D: Add image caption styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -205,22 +205,16 @@ function newspack_custom_colors_css() {
 	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$theme_css .= '
 			.cat-links a,
-			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
+			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+			.entry .entry-footer {
 				color: ' . $primary_color . ';
 			}
 
 			.accent-header:before,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title:before,
-			.cat-links:before {
+			.cat-links:before,
+			.entry .entry-content .wp-block-image figcaption:after {
 				background-color: ' . $primary_color . ';
-			}
-		';
-	}
-
-	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
-		$theme_css .= '
-			.entry .entry-footer {
-				color: ' . $primary_color . ';
 			}
 		';
 	}
@@ -318,7 +312,8 @@ function newspack_custom_colors_css() {
 				}
 
 				.editor-block-list__layout .editor-block-list__block .accent-header:before,
-				.editor-block-list__layout .editor-block-list__block .article-section-title:before {
+				.editor-block-list__layout .editor-block-list__block .article-section-title:before,
+				.editor-block-list__layout .editor-block-list__block .wp-block-image figcaption.block-editor-rich-text__editable:after {
 					background-color: ' . $primary_color . ';
 				}
 			';

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -7,6 +7,7 @@ Newspack Theme Editor Styles - Style Pack 3
 @import "variables-style/variables-style";
 @import "../../style-editor-base";
 
+
 .accent-header,
 .article-section-title {
 	color: $color__primary;
@@ -97,5 +98,21 @@ Newspack Theme Editor Styles - Style Pack 3
 		&:before {
 			border-left: 0;
 		}
+	}
+}
+
+.wp-block-image figcaption.block-editor-rich-text__editable {
+	border: none;
+	padding-left: 0;
+	padding-right: 0;
+	text-align: left;
+
+	&:after {
+		background-color: $color__primary;
+		content: "";
+		display: block;
+		height: 5px;
+		margin-top: #{ 1.25 * $size__spacing-unit };
+		width: 32px;
 	}
 }

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -161,4 +161,20 @@ Newspack Theme Styles - Style Pack 3
 			left: 8px;
 		}
 	}
+
+	.wp-block-image figcaption {
+		border: none;
+		padding-left: 0;
+		padding-right: 0;
+		text-align: left;
+
+		&:after {
+			background-color: $color__primary;
+			content: "";
+			display: block;
+			height: 5px;
+			margin-top: #{ 0.75 * $size__spacing-unit };
+			width: 32px;
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the image caption styles for the image block for Style D -- instead of the light grey border, it's a small block that uses the primary colour as the background.

![image](https://user-images.githubusercontent.com/177561/62840204-76032f00-bc4b-11e9-8c43-15e85cbb9f10.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Copy-paste [this test data](https://cloudup.com/cnGd7pFmIXh) into the code editor; it will add image blocks with all the alignments.
3. View the images in the editor and confirm the caption style matches the screenshot above.
4. View the images on the front-end and confirm that the caption styles match the screenshot above.
5. Navigate to Customize > Colours, and change the primary colour.
6. Confirm the caption style inherits the primary colour on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?