### PR TITLE
Style D: Update solid header to use secondary colour

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -218,6 +218,10 @@ function newspack_custom_colors_css() {
 
 	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$theme_css .= '
+			.site-content #primary {
+				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
+			}
+
 			.site-footer {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
@@ -267,15 +271,8 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
-		$theme_css .= '
-			.site-content #primary {
-				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
-			}
-		';
-	}
+	if ( true === get_theme_mod( 'header_solid_background', false ) && 'style-3' !== get_theme_mod( 'active_style_pack', 'default' ) ) {
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
 			.header-solid-background .site-header {
 				background-color: ' . $primary_color . ';
@@ -289,8 +286,30 @@ function newspack_custom_colors_css() {
 			.header-solid-background .main-navigation ul.main-menu > li > a,
 			.header-solid-background .main-navigation ul.main-menu > li > a:hover,
 			.header-solid-background .top-header-contain,
-			.header-solid-background .middle-header-contain {
+			.header-solid-background .middle-header-contain,
+			.main-navigation .sub-menu a {
 				color: ' . $primary_color_contrast . ';
+			}
+		';
+	}
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) && 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$theme_css .= '
+			.header-solid-background .site-header,
+			.site-header .main-navigation .main-menu .sub-menu {
+				background-color: ' . $secondary_color . ';
+			}
+			.header-solid-background .site-header,
+			.header-solid-background .site-title,
+			.header-solid-background .site-title a:link,
+			.header-solid-background .site-title a:visited,
+			.header-solid-background .site-description,
+			.header-solid-background .main-navigation .main-menu > li,
+			.header-solid-background .main-navigation ul.main-menu > li > a,
+			.header-solid-background .main-navigation ul.main-menu > li > a:hover,
+			.header-solid-background .top-header-contain,
+			.header-solid-background .middle-header-contain {
+				color: ' . $secondary_color_contrast . ';
 			}
 		';
 	}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -293,27 +293,6 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) && 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
-		$theme_css .= '
-			.header-solid-background .site-header,
-			.header-solid-background .site-header .main-navigation .main-menu .sub-menu {
-				background-color: ' . $secondary_color . ';
-			}
-			.header-solid-background .site-header,
-			.header-solid-background .site-title,
-			.header-solid-background .site-title a:link,
-			.header-solid-background .site-title a:visited,
-			.header-solid-background .site-description,
-			.header-solid-background .main-navigation .main-menu > li,
-			.header-solid-background .main-navigation ul.main-menu > li > a,
-			.header-solid-background .main-navigation ul.main-menu > li > a:hover,
-			.header-solid-background .top-header-contain,
-			.header-solid-background .middle-header-contain {
-				color: ' . $secondary_color_contrast . ';
-			}
-		';
-	}
-
 	$editor_css = '
 		/*
 		 * Set colors for:

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -296,7 +296,7 @@ function newspack_custom_colors_css() {
 	if ( true === get_theme_mod( 'header_solid_background', false ) && 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$theme_css .= '
 			.header-solid-background .site-header,
-			.site-header .main-navigation .main-menu .sub-menu {
+			.header-solid-background .site-header .main-navigation .main-menu .sub-menu {
 				background-color: ' . $secondary_color . ';
 			}
 			.header-solid-background .site-header,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -12,7 +12,7 @@ Newspack Theme Styles - Style Pack 3
 .header-solid-background {
 	.site-header,
 	.site-header .main-navigation .main-menu .sub-menu {
-		background-color: $color__secondary;
+		background-color: $color__background-dark;
 	}
 }
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -14,6 +14,10 @@ Newspack Theme Styles - Style Pack 3
 	.site-header .main-navigation .main-menu .sub-menu {
 		background-color: $color__background-dark;
 	}
+
+	.bottom-header-contain {
+		background-color: darken( $color__background-dark, 5% );
+	}
 }
 
 // Accent headers

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -7,6 +7,15 @@ Newspack Theme Styles - Style Pack 3
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+// Header
+
+.header-solid-background {
+	.site-header,
+	.site-header .main-navigation .main-menu .sub-menu {
+		background-color: $color__secondary;
+	}
+}
+
 // Accent headers
 
 .accent-header,

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -15,6 +15,7 @@ $color__background-button-hover: #111;
 $color__background-pre: #eee;
 $color__background-ins: #fff9c0;
 $color__background_selection: mix( $color__background-body, $color__primary, 75% ); // lighten( salmon, 22.5% ); // lighten( #0999d4, 48% );
+$color__background-dark: #333;
 
 // Text
 $color__text-main: #111;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I've been noodling a bit on how best to handle the dark grey headers shown in the mockups for Style D and E.

One approach would simply be to always set the header to dark grey when the 'solid header' option is chosen for these two style packs, rather than the primary colour. 

The other would be to use the 'secondary' colour instead, so it could be set to a more neutral colour. I've explored that approach here.

I think this could be the most flexible way to do it (it would, for example, let you set the header to other colours, too) but I'd be interested in getting a second opinion as well as the code tested. 

Right now, the non-short headers looks a little weird; I need to explore that further, but wanted to get the approach sorted first.

Any suggestions welcome!

![image](https://user-images.githubusercontent.com/177561/62840347-22461500-bc4e-11e9-8454-116f1adeb89a.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Pack and select 'Style 3'.
3. Set the header to 'Solid Background'; test with both 'Short Header' and without.
4. Navigate to Customize > Colours and try changing the secondary colour; confirm the header changes as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?