### PR TITLE
Style E: Add dropcap styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -242,7 +242,8 @@ function newspack_custom_colors_css() {
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 			.cat-links,
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
-				color: ' . $primary_color . ';
+				background-color: ' . $primary_color . ';
+				color: ' . $primary_color_contrast . ';
 			}
 		';
 	}
@@ -372,7 +373,8 @@ function newspack_custom_colors_css() {
 	if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
-				color: ' . $primary_color . ';
+				background-color: ' . $primary_color . ';
+				color: ' . $primary_color_contrast . ';
 			}
 		';
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -240,7 +240,10 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.accent-header,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-			.cat-links,
+			.cat-links {
+				color: ' . $primary_color . ';
+			}
+
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -240,7 +240,8 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.accent-header,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-			.cat-links {
+			.cat-links,
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
 				color: ' . $primary_color . ';
 			}
 		';
@@ -366,6 +367,15 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color . ';
 			}
 		';
+	}
+
+	if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$editor_css .= '
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+				color: ' . $primary_color . ';
+			}
+		';
+
 	}
 
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -121,6 +121,13 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
+		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$css_blocks .= "
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+				font-family: $font_header;
+			}";
+		}
+
 		$editor_css_blocks .= "
 		.editor-block-list__layout .editor-block-list__block h1,
 		.editor-block-list__layout .editor-block-list__block h2,
@@ -185,6 +192,16 @@ function newspack_custom_typography_css() {
 		}
 
 		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+			$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+
+			{
+				font-family: $font_header;
+			}
+			";
+		}
+
+		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -36,3 +36,12 @@ Newspack Theme Editor Styles - Style Pack 4
 		left: 0;
 	}
 }
+
+.wp-block-paragraph {
+
+	&.has-drop-cap:not(:focus)::first-letter {
+		color: $color__primary;
+		font-family: $font__heading;
+		font-weight: bold;
+	}
+}

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -40,8 +40,11 @@ Newspack Theme Editor Styles - Style Pack 4
 .wp-block-paragraph {
 
 	&.has-drop-cap:not(:focus)::first-letter {
-		color: $color__primary;
+		background-color: $color__primary;
+		color: #fff;
 		font-family: $font__heading;
 		font-weight: bold;
+		font-size: $font__size-xxl;
+		padding: 0.4em;
 	}
 }

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -107,3 +107,11 @@ Newspack Theme Styles - Style Pack 4
 		}
 	}
 }
+
+.entry .entry-content {
+	.has-drop-cap:not(:focus)::first-letter {
+		color: $color__primary;
+		font-family: $font__heading;
+		font-weight: bold;
+	}
+}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -110,8 +110,11 @@ Newspack Theme Styles - Style Pack 4
 
 .entry .entry-content {
 	.has-drop-cap:not(:focus)::first-letter {
-		color: $color__primary;
+		background-color: $color__primary;
+		color: #fff;
 		font-family: $font__heading;
 		font-weight: bold;
+		font-size: $font__size-xxl;
+		padding: 0.4em;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the dropcap styles for Style E.

![image](https://user-images.githubusercontent.com/177561/62891639-149a9900-bcfb-11e9-8414-6019bcac4c13.png)

Note that they differ from how they were [mocked up](https://cloudup.com/iqRQm45T63T); I made a mistake about what would be possible with the `:first-letter` selector. You can't set a height or width, so it's not possible to give the letters a perfect circle background. So I switched to square, which is a bit more forgiving.

We may be able to achieve this another way, like wrapping the letter in a span with a class, but for now the style pack itself won't be exactly as mocked up.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to Style 4.
3. Copy paste [this test content](https://cloudup.com/ccLmtoly-JW) into the code editor.
4. View in the editor and confirm it looks like the screenshots.
5. View on the front-end and confirm it looks like the screenshots.
6. Try changing the primary colour and confirm the dropcap uses it on the front-end and in the editor.
7. Try changing the header font and confirm the dropcap uses it on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?