### PR TITLE
Style E: Build out single post headers

### DIFF
--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -143,7 +143,7 @@ figcaption,
 	.editor-post-title__input {
 		font-family: $font__heading;
 		font-size: $font__size-xxl;
-		font-weight: 700;
+		font-weight: normal;
 
 		@include media(desktop) {
 			font-size: $font__size-xxxl;

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -146,11 +146,14 @@ Newspack Theme Styles - Style Pack 4
 	.entry-subhead {
 		border-bottom: 1px solid $color__border;
 		border-top: 1px solid $color__border;
+		display: block;
 		margin-bottom: $size__spacing-unit;
 		padding: #{ 0.75 * $size__spacing-unit } 0;
 		text-align: center;
 
-		@include media( tablet ) {
+
+		@include media( mobile ) {
+			display: flex;
 			margin-bottom: #{ 2 * $size__spacing-unit };
 			text-align: left;
 		}
@@ -162,7 +165,7 @@ Newspack Theme Styles - Style Pack 4
 		.author-avatar {
 			display: none;
 
-			@include media( tablet ) {
+			@include media( mobile ) {
 				display: block;
 			}
 		}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -108,6 +108,12 @@ Newspack Theme Styles - Style Pack 4
 	}
 }
 
+.entry-title {
+	font-weight: normal;
+}
+
+// Posts & Pages
+
 .entry .entry-content {
 	.has-drop-cap:not(:focus)::first-letter {
 		background-color: $color__primary;
@@ -116,5 +122,54 @@ Newspack Theme Styles - Style Pack 4
 		font-weight: bold;
 		font-size: $font__size-xxl;
 		padding: 0.4em;
+	}
+}
+
+.single-post {
+	.cat-links {
+		text-align: center;
+	}
+
+	.entry-header .entry-title {
+		margin-bottom: #{ 1.5 * $size__spacing-unit };
+		margin-top: $size__spacing-unit;
+		text-align: center;
+
+		@include media( tablet ) {
+			margin-bottom: #{ 3 * $size__spacing-unit };
+			margin-left: auto;
+			margin-right: auto;
+			width: 85%;
+		}
+	}
+
+	.entry-subhead {
+		border-bottom: 1px solid $color__border;
+		border-top: 1px solid $color__border;
+		padding: #{ 0.75 * $size__spacing-unit } 0;
+		text-align: center;
+
+		.sd-content {
+			text-align: inherit;
+		}
+
+		@include media( tablet ) {
+			text-align: left;
+		}
+
+		.author-avatar {
+			display: none;
+
+			@include media( tablet ) {
+				display: block;
+			}
+		}
+	}
+
+	&:not(.has-featured-image),
+	&.has-large-featured-image {
+		.entry-header {
+			border-bottom: 0;
+		}
 	}
 }

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -146,15 +146,17 @@ Newspack Theme Styles - Style Pack 4
 	.entry-subhead {
 		border-bottom: 1px solid $color__border;
 		border-top: 1px solid $color__border;
+		margin-bottom: $size__spacing-unit;
 		padding: #{ 0.75 * $size__spacing-unit } 0;
 		text-align: center;
 
-		.sd-content {
-			text-align: inherit;
+		@include media( tablet ) {
+			margin-bottom: #{ 2 * $size__spacing-unit };
+			text-align: left;
 		}
 
-		@include media( tablet ) {
-			text-align: left;
+		.sd-content {
+			text-align: inherit;
 		}
 
 		.author-avatar {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR builds out the styles for the single posts header on the front-end.

In the editor, the post title isn't centred; I'm going to tackle that in a separate PR since it involves settings a class in the editor.

![image](https://user-images.githubusercontent.com/177561/62893160-ba033c00-bcfe-11e9-8588-f3231112fc3d.png)

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 4.
3. View a single post on the front end; confirm the styles match the screenshot: centred text, normal weight on the post title, borders on both the top and bottom of the post meta.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
