### PR TITLE
Style E: Add styles to center post title in editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -354,7 +354,16 @@ function newspack_is_static_front_page() {
  * Add body class on editor pages if editing the static front page.
  */
 function newspack_filter_admin_body_class( $classes ) {
-	return newspack_is_static_front_page() ? $classes . ' newspack-static-front-page' : $classes;
+
+	if ( newspack_is_static_front_page() ) {
+		$classes .= ' newspack-static-front-page';
+	}
+
+	if ( 'default' !== get_theme_mod( 'active_style_pack', 'default' ) ) {
+		$classes .= ' style-pack-' . get_theme_mod( 'active_style_pack', 'default' );
+	}
+
+	return $classes;
 }
 add_filter( 'admin_body_class', 'newspack_filter_admin_body_class', 10, 1 );
 

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -41,5 +41,15 @@ body.post-type-post {
 			}
 		}
 	}
+
+	&.style-pack-style-4 {
+		.editor-post-title__block {
+			max-width: 1020px; // 85% of 1200px.
+			.editor-post-title__input {
+				text-align: center;
+			}
+		}
+	}
 }
+
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is complementary to #206: it centres the post title text in the editor:

![image](https://user-images.githubusercontent.com/177561/62893883-62fe6680-bd00-11e9-87b4-aa2359a2bf9c.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 4.
3. Edit a post, and confirm that the post titled is centred.
4. Edit a page, and confirm that the title is aligned left.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
