### PR TITLE
Style E: Adds styles for author bio

### DIFF
--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -84,6 +84,10 @@ Newspack Theme Styles - Style Pack 4
 		}
 	}
 
+	h2 {
+		margin: 0;
+	}
+
 	.author-bio-text {
 		width: 100%;
 
@@ -96,6 +100,7 @@ Newspack Theme Styles - Style Pack 4
 
 	.author-bio-header {
 		@include media( tablet ) {
+			align-items: center;
 			display: flex;
 			justify-content: center;
 			text-align: left;

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -60,10 +60,45 @@ Newspack Theme Styles - Style Pack 4
 	}
 }
 
+// Author bio
+
 .author-bio {
+	display: block;
+	text-align: center;
+
 	h2 {
 		color: $color__text-main;
 		margin: 0 0 #{ 0.5 * $size__spacing-unit };
 		text-align: left;
+	}
+
+	.avatar {
+		height: 60px;
+		margin-left: auto;
+		margin-right: auto;
+		width: 60px;
+
+		@include media( tablet ) {
+			margin-left: 0;
+			margin-right: $size__spacing-unit;
+		}
+	}
+
+	.author-bio-text {
+		width: 100%;
+
+		@include media( tablet ) {
+			margin-left: auto;
+			margin-right: auto;
+			width: 80%;
+		}
+	}
+
+	.author-bio-header {
+		@include media( tablet ) {
+			display: flex;
+			justify-content: center;
+			text-align: left;
+		}
 	}
 }

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -7,7 +7,9 @@
 
 if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-bio">
+
 	<?php
+	if ( 'style-4' !== get_theme_mod( 'active_style_pack', 'default' ) ) :
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 		if ( $author_avatar ) :
 			echo wp_kses(
@@ -23,16 +25,42 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 				)
 			);
 		endif;
+	endif;
 	?>
 
 	<div class="author-bio-text">
-		<h2 class="accent-header">
-			<?php echo esc_html( get_the_author() ); ?>
-			<span><?php esc_html_e( 'Staff Writer', 'newspack-theme' ); ?></span>
-		</h2>
-		<div class="author-meta">
-			<a href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
-		</div>
+		<div class="author-bio-header">
+			<?php
+			if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) :
+				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
+				if ( $author_avatar ) :
+					echo wp_kses(
+						$author_avatar,
+						array(
+							'img' => array(
+								'src'    => array(),
+								'alt'    => array(),
+								'class'  => array(),
+								'width'  => array(),
+								'height' => array(),
+							),
+						)
+					);
+				endif;
+			endif;
+			?>
+
+			<div>
+				<h2 class="accent-header">
+					<?php echo esc_html( get_the_author() ); ?>
+					<span><?php esc_html_e( 'Staff Writer', 'newspack-theme' ); ?></span>
+				</h2>
+				<div class="author-meta">
+					<a href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
+				</div>
+			</div>
+		</div><!-- .author-bio-header -->
+
 		<p>
 			<?php the_author_meta( 'description' ); ?>
 		</p><!-- .author-description -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the Author Bio styles for Style E.

![image](https://user-images.githubusercontent.com/177561/62896594-3e0cf200-bd06-11e9-9f0c-68fe1220e201.png)

Unfortunately, the only way to change the position of the avatar was to adjust the markup a bit for this style pack, but it thankfully was a pretty minor change (moving the avatar).

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to Style 4.
3. View a single post and visually review the author bio against the screenshot above. 
4. Switch to a different style pack and confirm that these changes don't affect the standard layout (image aligned left, the text on the right).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
