### PR TITLE
Style E: Add styles for footer.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -249,6 +249,10 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}
+
+			.site-footer  .widget .widget-title {
+				color: ' . $primary_color . ';
+			}
 		';
 	}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -250,7 +250,7 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color_contrast . ';
 			}
 
-			.site-footer  .widget .widget-title {
+			.site-footer .widget .widget-title {
 				color: ' . $primary_color . ';
 			}
 		';

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -300,7 +300,10 @@ Newspack Theme Styles - Style Pack 4
 		font-weight: bold;
 	}
 
-	a {
+	.widget a,
+	.widget a:visited,
+	a,
+	a:visited {
 		color: inherit;
 	}
 }

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -289,3 +289,41 @@ Newspack Theme Styles - Style Pack 4
 		text-align: center;
 	}
 }
+
+
+.site-footer {
+	background-color: #f1f1f1;
+	color: $color__text-main;
+
+	.widget .widget-title {
+		color: $color__primary;
+		font-weight: bold;
+	}
+
+	a {
+		color: inherit;
+	}
+}
+
+.footer-branding {
+	padding-top: $size__spacing-unit;
+
+	@include media( tablet ) {
+		padding-top: #{ 2 * $size__spacing-unit };
+	}
+}
+
+.site-info {
+	background-color: $color__text-main;
+
+	.wrapper {
+		border: 0;
+	}
+
+	&,
+	a,
+	a:hover,
+	a:visited {
+		color: $color__background-body;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR builds out the footer styles for Style E:

![image](https://user-images.githubusercontent.com/177561/62898778-2c7a1900-bd0b-11e9-8e34-0c3fa70e623d.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 4.
3. Add at least one footer widget.
4. Confirm that the footer's appearance matches the screenshot above.
5. Change the primary colour; confirm that the widget headers change colour.
6. Remove the footer widget; confirm that the light grey part of the footer is gone completely, and just the black bottom bar remains.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
