### PR TITLE
Style E: Add styles for story tags

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -240,7 +240,8 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.accent-header,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-			.cat-links {
+			.cat-links,
+			.entry .entry-footer {
 				color: ' . $primary_color . ';
 			}
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -178,3 +178,35 @@ Newspack Theme Styles - Style Pack 4
 		}
 	}
 }
+
+.entry .entry-footer {
+	color: $color__primary;
+	text-align: center;
+
+	a,
+	a:hover {
+		color: $color__text-main;
+	}
+}
+
+.tags-links {
+
+	span:first-child {
+		text-transform: none;
+	}
+
+	a {
+		background: $color__background-pre;
+		color: $color__text-main;
+		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
+		padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+
+		&:hover {
+			background: lighten( $color__background-pre, 5% );
+		}
+	}
+
+	.sep {
+		display: none;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR styles the story tags for Style E, that appear at the bottom of each article:

![image](https://user-images.githubusercontent.com/177561/62900490-18381b00-bd0f-11e9-8339-66f97c6a1e33.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs and select Style 4.
3. View the front-end of a post with tags and confirm it matches the above screenshot.
4. Navigate to Customize > Colors and switch the primary colour; confirm it changes the 'Tags' text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
