### PR TITLE
Style E: Build out pullquote styles

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -206,11 +206,10 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
-			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
-			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
-			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] p,
-			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
 				font-family: $font_header;
 			}";
 		}

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -123,11 +123,9 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
-				font-family: $font_header;
-			}
-
-			.taxonomy-description {
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.taxonomy-description,
+			.entry .entry-content blockquote, .entry .entry-content blockquote cite, .entry .entry-content .wp-block-pullquote cite {
 				font-family: $font_header;
 			}
 			";
@@ -208,12 +206,13 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
-
-			{
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
+			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] p,
+			.editor-styles-wrapper .wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
 				font-family: $font_header;
-			}
-			";
+			}";
 		}
 	}
 

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -52,3 +52,68 @@ Newspack Theme Editor Styles - Style Pack 4
 .wp-block-image figcaption.block-editor-rich-text__editable {
 	font-weight: bold;
 }
+
+blockquote,
+cite {
+	font-family: $font__heading;
+	font-style: italic;
+	text-align: center;
+
+	em,
+	i {
+		font-style: normal;
+	}
+}
+
+.wp-block[data-type="core/pullquote"] {
+
+	.wp-block-pullquote {
+		border-width: 2px 0;
+	}
+
+	blockquote {
+		margin: #{ 2 * $size__spacing-unit } 0;
+	}
+
+	blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+	blockquote > .editor-rich-text p,
+	p {
+		font-size: $font__size-lg;
+		font-family: $font__heading;
+		text-align: center;
+
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
+	.wp-block-pullquote__citation {
+		font-family: $font__heading;
+		font-style: italic;
+		text-align: center;
+
+		em,
+		i {
+			font-style: normal;
+		}
+	}
+
+	&[data-align="left"] .wp-block-pullquote,
+	&[data-align="right"] .wp-block-pullquote {
+		margin-top: #{ 1.5 * $size__spacing-unit };
+		margin-bottom: #{ 1.5 * $size__spacing-unit };
+
+		@include media( tablet ) {
+			blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+			blockquote > .editor-rich-text p,
+			p {
+				font-size: $font__size-md;
+				text-align: left;
+			}
+		}
+
+		.wp-block-pullquote__citation {
+			text-align: left;
+		}
+	}
+}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -79,6 +79,48 @@ Newspack Theme Styles - Style Pack 4
 	.wp-block-image figcaption {
 		font-weight: bold;
 	}
+
+	blockquote,
+	cite {
+		font-family: $font__heading;
+		font-style: italic;
+		text-align: center;
+
+		em,
+		i {
+			font-style: normal;
+		}
+	}
+
+	.wp-block-pullquote {
+		border-width: 2px 0;
+
+		blockquote {
+			p {
+				font-size: $font__size-lg;
+
+				@include media( tablet ) {
+					font-size: $font__size-xl;
+				}
+			}
+		}
+
+		cite {
+			font-style: italic;
+		}
+
+		&.alignleft,
+		&.alignright {
+			margin-top: #{ 1.5 * $size__spacing-unit };
+			margin-bottom: #{ 1.5 * $size__spacing-unit };
+
+			@include media( tablet ) {
+				p {
+					font-size: $font__size-lg;
+				}
+			}
+		}
+	}
 }
 
 .single-post {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the pullquote block styles for 'Style E' to both the front-end and the editor.

<details><summary><strong>Screenshots</strong></summary>

**Default settings:**
![image](https://user-images.githubusercontent.com/177561/62903180-bc719000-bd16-11e9-8ff3-f2d8bb529c88.png)

**'Main' colour:**
![image](https://user-images.githubusercontent.com/177561/62903187-c1364400-bd16-11e9-954d-a811061e5f3f.png)

**Solid background style + main color:**
![image](https://user-images.githubusercontent.com/177561/62903198-c5faf800-bd16-11e9-8910-d12d38830a75.png)

**Solid background style + main color + text colour:**
![image](https://user-images.githubusercontent.com/177561/62903205-ca271580-bd16-11e9-8fee-44cf64cc57dd.png)

**Default settings align left:**
![image](https://user-images.githubusercontent.com/177561/62903233-d90dc800-bd16-11e9-8111-7d1d345d9a59.png)

**'Main' colour + align left:**
![image](https://user-images.githubusercontent.com/177561/62903241-ddd27c00-bd16-11e9-96c9-7368fadd6546.png)

**Solid background style + main colour + align left:**
![image](https://user-images.githubusercontent.com/177561/62903245-e1660300-bd16-11e9-9b83-147e35c3ff2a.png)

**Solid background style + main colour + text colour + align left:**
![image](https://user-images.githubusercontent.com/177561/62903252-e75be400-bd16-11e9-9cbd-acaa87a103fd.png)

**Default settings align right:**
![image](https://user-images.githubusercontent.com/177561/62903265-ecb92e80-bd16-11e9-92e0-7fe17ffa5fdb.png)

**'Main' colour + align right:**
![image](https://user-images.githubusercontent.com/177561/62903271-f2167900-bd16-11e9-8e18-4fba4a70005a.png)

**Solid background style + main colour + align right:**
![image](https://user-images.githubusercontent.com/177561/62903281-f80c5a00-bd16-11e9-904d-6cc3b5de87a2.png)

**Solid background style + main colour + text colour + align right:**
![image](https://user-images.githubusercontent.com/177561/62903286-fc387780-bd16-11e9-9060-b0f60684ef21.png)

</details>

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Pack, and switch to Style 4.
3. Copy-paste [this test content](https://cloudup.com/cVjw03uEOuL) into the code editor, to get all the variations of pullquotes.
4. Do a visual review on the front end, and confirm the different variations match the screenshots.
5. Do a visual review in the editor and confirm the different variations match the screenshots. 
6. Try changing the header font and confirm that 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?