### PR TITLE
Style E: Add styles for archive pages

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -125,7 +125,12 @@ function newspack_custom_typography_css() {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
 				font-family: $font_header;
-			}";
+			}
+
+			.taxonomy-description {
+				font-family: $font_header;
+			}
+			";
 		}
 
 		$editor_css_blocks .= "

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -60,54 +60,6 @@ Newspack Theme Styles - Style Pack 4
 	}
 }
 
-// Author bio
-
-.author-bio {
-	display: block;
-	text-align: center;
-
-	h2 {
-		color: $color__text-main;
-		margin: 0 0 #{ 0.5 * $size__spacing-unit };
-		text-align: left;
-	}
-
-	.avatar {
-		height: 60px;
-		margin-left: auto;
-		margin-right: auto;
-		width: 60px;
-
-		@include media( tablet ) {
-			margin-left: 0;
-			margin-right: $size__spacing-unit;
-		}
-	}
-
-	h2 {
-		margin: 0;
-	}
-
-	.author-bio-text {
-		width: 100%;
-
-		@include media( tablet ) {
-			margin-left: auto;
-			margin-right: auto;
-			width: 80%;
-		}
-	}
-
-	.author-bio-header {
-		@include media( tablet ) {
-			align-items: center;
-			display: flex;
-			justify-content: center;
-			text-align: left;
-		}
-	}
-}
-
 .entry-title {
 	font-weight: normal;
 }
@@ -208,5 +160,86 @@ Newspack Theme Styles - Style Pack 4
 
 	.sep {
 		display: none;
+	}
+}
+
+// Author bio
+
+.author-bio {
+	display: block;
+	text-align: center;
+
+	h2 {
+		color: $color__text-main;
+		margin: 0 0 #{ 0.5 * $size__spacing-unit };
+		text-align: left;
+	}
+
+	.avatar {
+		height: 60px;
+		margin-left: auto;
+		margin-right: auto;
+		width: 60px;
+
+		@include media( tablet ) {
+			margin-left: 0;
+			margin-right: $size__spacing-unit;
+		}
+	}
+
+	h2 {
+		margin: 0;
+	}
+
+	.author-bio-text {
+		width: 100%;
+
+		@include media( tablet ) {
+			margin-left: auto;
+			margin-right: auto;
+			width: 80%;
+		}
+	}
+
+	.author-bio-header {
+		@include media( tablet ) {
+			align-items: center;
+			display: flex;
+			justify-content: center;
+			text-align: left;
+		}
+	}
+}
+
+// Archives
+
+.page-title {
+	letter-spacing: 0;
+	text-transform: none;
+
+	@include media( tablet ) {
+		font-size: $font__size_base;
+	}
+
+	.page-description {
+		margin-top: $size__spacing-unit;
+	}
+}
+
+.taxonomy-description {
+	font-family: $font__heading;
+	font-style: normal;
+
+	@include media( tablet ) {
+		margin-bottom: #{ 3 * $size__spacing-unit };
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 85%;
+	}
+}
+
+.archive {
+	.page-header {
+		text-align: center;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the archive header styles for Style E:

![image](https://user-images.githubusercontent.com/177561/62905391-22621580-bd1f-11e9-82a2-1803f98c2f64.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Pack, and switch to Style 4.
3. Navigate to one of the archive pages (author, or category), and confirm the styles match the above.
4. Navigate to Customize > Typography and change the header font; confirm that it changes all three lines of text (the page title, page description, and taxonomy description).

Note: The custom colour does not work on the Archive header; it's a wider bug that doesn't just affect this style pack, so I'll tackle it in a separate PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
