### PR TITLE
Style E: Add image caption styles

### DIFF
--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -48,3 +48,7 @@ Newspack Theme Editor Styles - Style Pack 4
 		padding: 0.4em;
 	}
 }
+
+.wp-block-image figcaption.block-editor-rich-text__editable {
+	font-weight: bold;
+}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -75,6 +75,10 @@ Newspack Theme Styles - Style Pack 4
 		font-size: $font__size-xxl;
 		padding: 0.4em;
 	}
+
+	.wp-block-image figcaption {
+		font-weight: bold;
+	}
 }
 
 .single-post {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the image caption styles for Style E (which is just bolded text):

![image](https://user-images.githubusercontent.com/177561/62906434-81c22480-bd23-11e9-8bbe-f80397f6b509.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and pick Style 4. 
3. Copy paste [this test content](https://cloudup.com/cnGd7pFmIXh) to a post to add image blocks and captions.
4. Confirm that the captions look like the above screenshot on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?