### PR TITLE
Style A, D & E: Correct archive 'page title' custom colour behaviour

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -188,6 +188,7 @@ function newspack_custom_colors_css() {
 		'style-4' === get_theme_mod( 'active_style_pack', 'default' )
 	) {
 		$theme_css .= '
+			.archive .page-title,
 			.entry-meta .byline a,
 			.entry .entry-meta a:hover {
 				color: ' . $primary_color . ';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For the default style, style 3 and style 4, the primary colour should change the 'page title' of the archive page. This PR makes sure it's working. 

**Default:**

![image](https://user-images.githubusercontent.com/177561/62908265-fb5e1080-bd2b-11e9-9d61-8d9083ce845f.png)

**Style 3:**

![image](https://user-images.githubusercontent.com/177561/62908273-087aff80-bd2c-11e9-83e6-a57eec2570ac.png)

**Style 4:**

![image](https://user-images.githubusercontent.com/177561/62908288-16c91b80-bd2c-11e9-972b-9d65d12b0b4a.png)

Style 1 and 2 are still incorrect, but I'll be fixing each of these archive pages in separate PRs.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customize > Style Pack, pick the Default.
3. Change the primary colour.
4. Navigate to an archive page (category or author) and confirm that it looks like the above screenshot.
5. Navigate to Customize > Style Pack, pick Style 3.
6. Navigate to an archive page (category or author) and confirm that it looks like the above screenshot.
5. Navigate to Customize > Style Pack, pick Style 4.
7. Navigate to an archive page (category or author) and confirm that it looks like the above screenshot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
