### PR TITLE
Style B: Update archive header colour

### DIFF
--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -193,6 +193,12 @@
 	}
 }
 
+// Archive
+
+.archive .page-title {
+	color: $color__text-light;
+}
+
 /* Footer */
 
 #colophon {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Style 'B' (1) archive headers were incorrectly inheriting the primary colour; this PR sets them to use the 'light text' colour, to match the designs.

![image](https://user-images.githubusercontent.com/177561/62908992-8bea2000-bd2f-11e9-9198-1ad7ac30ca89.png)

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customize > Style Pack, and pick Style 1.
3. Navigate to an archive page (author, or category) and confirm the first line in the title is light grey, rather than blue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
