### PR TITLE
Style C: Build out styles for archive page headers

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -116,14 +116,16 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.taxonomy-description {
 				font-family: $font_header;
 			}";
 		}
 
 		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.taxonomy-description {
 				font-family: $font_header;
 			}";
 		}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -301,6 +301,34 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
+// Archives
+
+.archive {
+	.page-header {
+		border-bottom: 2px solid $color__text-main;
+		padding-bottom: #{ 2 * $size__spacing-unit };
+
+		@include media( tablet ) {
+			padding-bottom: #{ 4 * $size__spacing-unit };
+		}
+	}
+
+	.page-title {
+		color: $color__text-light;
+		font-size: $font__size-sm;
+	}
+}
+
+.page-description {
+	font-size: $font__size-xxxxxl;
+	margin-top: $size__spacing-unit;
+}
+
+.taxonomy-description {
+	font-family: $font__heading;
+	font-style: normal;
+}
+
 // Footer
 
 .site-footer {

--- a/sass/variables-site/_fonts.scss
+++ b/sass/variables-site/_fonts.scss
@@ -21,6 +21,7 @@ $font__size-xl:    1em * 1.8; // 36px
 $font__size-xxl:   1em * 2.2; // 44px
 $font__size-xxxl:  1em * 2.8; // 56px
 $font__size-xxxxl: 1em * 3.2; // 64px
+$font__size-xxxxxl: 1em * 4.0; // 80px
 
 $font__line-height-body: 1.6;
 $font__line-height-pre: 1.6;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the archive header styles for Style C (2):

![image](https://user-images.githubusercontent.com/177561/62911047-b93acc00-bd37-11e9-973a-ea64e2e1bf8f.png)

It makes the first line of the title smaller and grey, changes the font of the taxonomy description, and adds a bottom border. 

With #176 now merged, you can see the content is really butting up against the top (visible in the screenshot). This happens on multiple pages, and isn't specific to these changes, so I'm going to fix it in a separate PR.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to 'Style 2'.
3. On an archive page (author or category), verify that the styles match the above screenshot.
4. Navigate to Customize > Typography and change the header font.
5. Confirm that this font is used on all three lines of the archive header (both lines of the title, and the description).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
