### PR TITLE
Style D: Update archive header styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -235,6 +235,7 @@ function newspack_custom_colors_css() {
 			.accent-header:before,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title:before,
 			.cat-links:before,
+			.archive .page-title:before,
 			.entry .entry-content .wp-block-image figcaption:after {
 				background-color: ' . $primary_color . ';
 			}

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -123,7 +123,8 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.taxonomy-description {
 				font-family: $font_header;
 			}";
 		}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -11,9 +11,9 @@ Newspack Theme Styles - Style Pack 3
 
 .accent-header,
 .site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-.cat-links {
+.cat-links,
+.archive .page-title {
 	color: $color__primary;
-	font-size: $font__size-xs;
 	margin: 0 0 #{ 2 * $size__spacing-unit };
 	text-transform: uppercase;
 
@@ -25,6 +25,12 @@ Newspack Theme Styles - Style Pack 3
 		margin: 0 0 $size__spacing-unit;
 		width: 32px;
 	}
+}
+
+.accent-header,
+.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.cat-links {
+	font-size: $font__size-xs;
 }
 
 .search .cat-links {
@@ -200,5 +206,17 @@ Newspack Theme Styles - Style Pack 3
 			margin-top: #{ 0.75 * $size__spacing-unit };
 			width: 32px;
 		}
+	}
+}
+
+// Archives
+
+.archive .page-title {
+	font-size: $font__size-sm;
+	margin-bottom: $size__spacing-unit;
+
+	.page-description {
+		font-size: $font__size-xxxxl;
+		margin-top: $size__spacing-unit;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the archive header styles for Style D (3):

<img width="1270" alt="image" src="https://user-images.githubusercontent.com/177561/62914090-85fe3a00-bd43-11e9-8af4-058f4a81d55b.png">

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to 'Style 3'.
3. Navigate to an archive page (author or category), and confirm the header looks like the screenshot above.
4. Navigate to Customize > Colours and change the primary colour; confirm that the top archive header and the accent above it are both changed to that colour.
5. Navigate to Customize > Typography, and change the header colour; confirm that all the archive header text -- the title and archive description -- are changed to the header font.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?