### PR TITLE
Style B: Add pullquote styles to editor

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -364,6 +364,9 @@ function newspack_custom_colors_css() {
 			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
 				background-color: ' . $primary_color . ';
 			}
+			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) blockquote::before {
+				color: ' . $primary_color . ';
+			}
 		';
 	}
 

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -193,7 +193,11 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote::before
 
 			{
 				font-family: $font_header;

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -44,3 +44,122 @@ Newspack Theme Editor Styles - Style Pack 1
 		font-weight: bold;
 	}
 }
+
+.wp-block[data-type="core/pullquote"] {
+
+	.wp-block-pullquote {
+		background-color: $color__background-body;
+		border-width: 0;
+		padding-top: #{ 3 * $size__spacing-unit };
+		position: relative;
+
+		.block-library-pullquote__content {
+			position: relative;
+			z-index: 1;
+		}
+	}
+
+	blockquote {
+		background-color: inherit;
+		border-color: inherit;
+		margin: #{ 2 * $size__spacing-unit } 0;
+		text-align: center;
+
+		&:before {
+			background-color: inherit;
+			color: $color__primary;
+			content: "\201C";
+			display: inline-block;
+			font-family: $font__heading;
+			font-size: calc( 1rem * 5 );
+			font-weight: normal;
+			left: calc( 50% - 0.25em );
+			line-height: 0.75;
+			position: absolute;
+			text-align: center;
+			top: #{ 1.5 * $size__spacing-unit };
+			width: 0.5em;
+			z-index: 1;
+
+			@include media( tablet ) {
+				font-size: calc( 1rem * 7 );
+			}
+		}
+
+		&:after {
+			border-top: 2px solid;
+			border-top-color: inherit;
+			content: "";
+			display: block;
+			position: absolute;
+			opacity: 0.5;
+			left: 15%;
+			right: 15%;
+			top: #{ 2 * $size__spacing-unit };
+		}
+	}
+
+	.wp-block-pullquote.is-style-solid-color {
+		blockquote:before {
+			color: inherit;
+		}
+
+		blockquote:after {
+			border-top-color: currentColor;
+		}
+	}
+
+	blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+	blockquote > .editor-rich-text p,
+	p {
+		font-family: $font__heading;
+		font-size: $font__size-lg;
+		font-weight: bold;
+
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
+	.wp-block-pullquote__citation {
+		font-size: $font__size-sm;
+		font-weight: normal;
+		text-transform: uppercase;
+	}
+
+	&[data-align="left"] .wp-block-pullquote,
+	&[data-align="right"] .wp-block-pullquote {
+		border-width: 0;
+
+		blockquote {
+			padding-top: #{ 3.5 * $size__spacing-unit };
+			text-align: left;
+
+			&:before {
+				font-size: calc( 1rem * 5 );
+				left: 0;
+				text-align: left;
+				width: 0.5em;
+			}
+
+			&:after {
+				left: 0;
+			}
+		}
+
+		&.is-style-solid-color blockquote {
+			padding-top: #{ 0.25 * $size__spacing-unit };
+
+			&:before,
+			&:after {
+				left: #{ 2 * $size__spacing-unit };
+			}
+		}
+
+		blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
+		blockquote > .editor-rich-text p,
+		p {
+			font-size: $font__size-md;
+		}
+	}
+}

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -91,7 +91,7 @@
 	}
 
 	.wp-block-pullquote {
-		background-color: #fff;
+		background-color: $color__background-body;
 		border-width: 0;
 		font-family: $font__heading;
 		font-weight: bold;
@@ -149,9 +149,6 @@
 			font-weight: normal;
 			text-transform: uppercase;
 		}
-
-
-
 
 		&.is-style-solid-color {
 			blockquote:before {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the pullquote styles from Style B to the editor.

I've copied the screenshots from the front-end issue (#168); they may not be a pixel-perfect match, but they're close enough for testing:

<details><summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/177561/62668355-75fbea00-b940-11e9-8fdb-9a9e9f6c82e6.png)

![image](https://user-images.githubusercontent.com/177561/62668363-798f7100-b940-11e9-98e6-5ae6143d5494.png)

![image](https://user-images.githubusercontent.com/177561/62668371-7e542500-b940-11e9-9692-1030a30b3f01.png)

![image](https://user-images.githubusercontent.com/177561/62668379-82804280-b940-11e9-832a-d44d4e5e0ac9.png)

![image](https://user-images.githubusercontent.com/177561/62668383-86ac6000-b940-11e9-866a-2322537e9a7e.png)
![image](https://user-images.githubusercontent.com/177561/62668388-8ad87d80-b940-11e9-89b8-7abd69c9c3b5.png)

![image](https://user-images.githubusercontent.com/177561/62668391-8f049b00-b940-11e9-995e-0f01336a0a98.png)

![image](https://user-images.githubusercontent.com/177561/62668399-92982200-b940-11e9-89d4-2fe0d944fa22.png)

![image](https://user-images.githubusercontent.com/177561/62668405-962ba900-b940-11e9-9e97-877fb18c1b84.png)

![image](https://user-images.githubusercontent.com/177561/62668407-99269980-b940-11e9-83a3-1523758cd215.png)

![image](https://user-images.githubusercontent.com/177561/62668413-9cba2080-b940-11e9-9585-c93a2c820271.png)

![image](https://user-images.githubusercontent.com/177561/62668416-a04da780-b940-11e9-875e-354e7e31f303.png)

![image](https://user-images.githubusercontent.com/177561/62668458-cd9a5580-b940-11e9-8f70-9d8af572861b.png)

![image](https://user-images.githubusercontent.com/177561/62668462-d0954600-b940-11e9-8cdd-3bd94d5f8f30.png)

![image](https://user-images.githubusercontent.com/177561/62668465-d428cd00-b940-11e9-91d3-11f3121335ee.png)

![image](https://user-images.githubusercontent.com/177561/62668467-d723bd80-b940-11e9-80e7-2fd73aae3003.png)

![image](https://user-images.githubusercontent.com/177561/62668476-e30f7f80-b940-11e9-8950-1b836461f07b.png)

![image](https://user-images.githubusercontent.com/177561/62668484-e6a30680-b940-11e9-8398-b8e2038cc3a6.png)

![image](https://user-images.githubusercontent.com/177561/62668488-eacf2400-b940-11e9-9bc3-0387d902e04e.png)

![image](https://user-images.githubusercontent.com/177561/62668490-ee62ab00-b940-11e9-8b72-1d5598817c94.png)

</details>

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to 'Style 1' 
3. Set up multiple pullquote blocks using the different variations, or copy-paste [this test content](https://cloudup.com/cVjw03uEOuL) into the code editor view of a post. The variations are:
    * Default style (centred text, quote icon above which uses the 'primary' colour)
    * With 'main' colour (adds a border to the top that matches this colour)
    * With text colour (changes the text colour)
    * With 'solid' style and 'main' colour changed (has background colour and top border; quote icon and border will inherit the text colour). 
    * Each of the above aligned left, right, wide and full.
     
4. View the pullquote styles in the editor; confirm they match the appearance of the screenshots.
5. Try changing the colour settings of the blocks that are there and verify that they update on the front-end in an expected way.
6. Try changing the primary colour in the Customizer -- it should change the quote colour in all of the blocks but the ones with the solid background.
7. Try changing the header font in the Customizer -- it should change the quote icon, text and citation in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?