### PR TITLE
Style B: Make sure pullquote block inherits custom fonts

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -109,7 +109,9 @@ function newspack_custom_typography_css() {
 
 		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.entry .entry-content .wp-block-pullquote,
+			.entry .entry-content .wp-block-pullquote cite {
 				font-family: $font_header;
 			}";
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you have a custom header font set, the Pullquote blocks in Style B should use them:

<img width="855" alt="image" src="https://user-images.githubusercontent.com/177561/62916121-e42f1b00-bd4b-11e9-9517-469137631a85.png">

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to Customize > Style Packs and pick Style 1.
3. Navigate to Customize > Typography and set a custom ~colour~ font.
4. Copy paste [this test data](https://cloudup.com/cVjw03uEOuL) into the code editor to add multiple pullquotes with different settings.
4. On the front end, confirm that the pullquote blocks are using the custom colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
