### PR TITLE
Reduce size of single post headers on smaller screens.

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -212,8 +212,16 @@ body.page {
 	}
 
 	.entry-title {
-		font-size: $font__size-xxxl;
+		font-size: $font__size-xl;
 		margin: 0 0 0.5em;
+
+		@include media( mobile ) {
+			font-size: $font__size-xxl;
+		}
+
+		@include media( tablet ) {
+			font-size: $font__size-xxxl;
+		}
 
 		@include media(desktop) {
 			font-size: $font__size-xxxxl;

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -34,7 +34,15 @@ body.post-type-post {
 	.editor-post-title__block {
 		max-width: 1200px;
 		.editor-post-title__input {
-			font-size: $font__size-xxxl;
+			font-size: $font__size-xl;
+
+			@include media( mobile ) {
+				font-size: $font__size-xxl;
+			}
+
+			@include media( tablet ) {
+				font-size: $font__size-xxxl;
+			}
 
 			@include media(desktop) {
 				font-size: $font__size-xxxxl;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

More fine tuning is needed for smaller screens, but this PR deals with the biggest glaring issue: the single post titles are way too big on smaller screens.

This PR introduces a couple new breakpoints and knocks them down a bit, so they're less overwhelming.

**Before:**

<img width="342" alt="image" src="https://user-images.githubusercontent.com/177561/62916673-35d8a500-bd4e-11e9-97f4-97e98b2aa33d.png">


**After:**

<img width="342" alt="image" src="https://user-images.githubusercontent.com/177561/62916650-1b063080-bd4e-11e9-86d2-6ba3fe3ea690.png">


### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Navigate to a single post.
3. Scale down the browser window; confirm that the header font size shrinks down a fair bit, similar to the screenshot above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
