### PR TITLE
Mobile menu: Make sure mobile menu inherits the custom colours

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -25,6 +25,7 @@ function newspack_custom_colors_css() {
 		/* Set primary background color */
 
 		.main-navigation .sub-menu,
+		.mobile-sidebar,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
@@ -52,6 +53,10 @@ function newspack_custom_colors_css() {
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
 			color: ' . $primary_color . '; /* base: #0073a8; */
+		}
+
+		.mobile-sidebar {
+			color: ' . $primary_color_contrast . ';
 		}
 
 		/* Set primary border color */
@@ -103,14 +108,14 @@ function newspack_custom_colors_css() {
 
 		/* Set primary variation background color */
 
-		.main-navigation .sub-menu > li > a:hover,
-		.main-navigation .sub-menu > li > a:focus,
-		.main-navigation .sub-menu > li > a:hover:after,
-		.main-navigation .sub-menu > li > a:focus:after,
-		.main-navigation .sub-menu > li > .menu-item-link-return:hover,
-		.main-navigation .sub-menu > li > .menu-item-link-return:focus,
-		.main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
-		.main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
+		.site-header .main-navigation .sub-menu > li > a:hover,
+		.site-header .main-navigation .sub-menu > li > a:focus,
+		.site-header .main-navigation .sub-menu > li > a:hover:after,
+		.site-header .main-navigation .sub-menu > li > a:focus:after,
+		.site-header .main-navigation .sub-menu > li > .menu-item-link-return:hover,
+		.site-header .main-navigation .sub-menu > li > .menu-item-link-return:focus,
+		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
+		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
 		.entry .entry-content > .has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -48,10 +48,20 @@
 		margin-left: $size__spacing-unit;
 	}
 
+	a,
+	a:visited,
+	.main-navigation .sub-menu > li > a {
+		color: inherit;
+	}
+
 	a {
-		color: #fff;
 		display: inline-block;
 		padding: #{ 0.5 * $size__spacing-unit } 0;
+	}
+
+	a:hover {
+		background: transparent;
+		text-decoration: underline;
 	}
 
 	.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the mobile menu uses the custom primary colour as the background, and its links have sufficient contrast against that colour.

<img width="620" alt="image" src="https://user-images.githubusercontent.com/177561/62917084-bea41080-bd4f-11e9-99db-02d5686ca4a1.png">

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Colors, and set a light primary colour, like yellow.
3. Confirm that the mobile menu uses the primary colour as a background.
4. Confirm that the links have turned black instead of white, so they're still legible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?