### PR TITLE
Menu: Simplify menu styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -308,6 +308,9 @@ function newspack_custom_colors_css() {
 			.header-solid-background .site-title a:link,
 			.header-solid-background .site-title a:visited,
 			.header-solid-background .site-description,
+			.header-solid-background.header-simplified .main-navigation .main-menu > li,
+			.header-solid-background.header-simplified .main-navigation ul.main-menu > li > a,
+			.header-solid-background.header-simplified .main-navigation ul.main-menu > li > a:hover,
 			.header-solid-background .top-header-contain,
 			.header-solid-background .middle-header-contain,
 			.main-navigation .sub-menu a {

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -70,7 +70,11 @@ function newspack_custom_colors_css() {
 			color: ' . $primary_color . ';
 		}
 
-		.mobile-sidebar {
+		.mobile-sidebar,
+		.mobile-sidebar a,
+		.mobile-sidebar a:visited,
+		.mobile-sidebar .main-navigation .sub-menu > li > a,
+		.mobile-sidebar .main-navigation ul.main-menu > li > a {
 			color: ' . $primary_color_contrast . ';
 		}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -37,6 +37,7 @@ function newspack_custom_colors_css() {
 
 		.main-navigation .sub-menu,
 		.mobile-sidebar,
+		.site-header .main-navigation .main-menu .sub-menu,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
@@ -74,7 +75,8 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar a,
 		.mobile-sidebar a:visited,
 		.mobile-sidebar .main-navigation .sub-menu > li > a,
-		.mobile-sidebar .main-navigation ul.main-menu > li > a {
+		.mobile-sidebar .main-navigation ul.main-menu > li > a,
+		.site-header .main-navigation .sub-menu > li > a {
 			color: ' . $primary_color_contrast . ';
 		}
 
@@ -139,7 +141,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
-			background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
+			background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . '; /* base: #005177; */
 		}
 
 		/* Set primary variation color */
@@ -306,9 +308,6 @@ function newspack_custom_colors_css() {
 			.header-solid-background .site-title a:link,
 			.header-solid-background .site-title a:visited,
 			.header-solid-background .site-description,
-			.header-solid-background .main-navigation .main-menu > li,
-			.header-solid-background .main-navigation ul.main-menu > li > a,
-			.header-solid-background .main-navigation ul.main-menu > li > a:hover,
 			.header-solid-background .top-header-contain,
 			.header-solid-background .middle-header-contain,
 			.main-navigation .sub-menu a {

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -187,7 +187,8 @@ function newspack_custom_colors_css() {
 	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$theme_css .= '
 			.cat-links a,
-			.cat-links a:visited {
+			.cat-links a:visited,
+			body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -41,23 +41,15 @@
 	}
 
 	.main-menu {
-		margin: 0;
-		overflow: visible;
-		padding: 0;
 		width: 100%;
 
 		> li {
-			color: #555;
-			margin-right: #{0.75 * $size__spacing-unit};
 			position: relative;
 
 			> a {
 				color: inherit;
+				padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 				font-weight: 700;
-
-				+ svg {
-					margin-right: #{0.5 * $size__spacing-unit};
-				}
 
 				&:hover,
 				&:hover + svg {
@@ -70,19 +62,6 @@
 
 				@include media(tablet) {
 					position: relative;
-				}
-
-				> a {
-					margin-right: #{0.125 * $size__spacing-unit};
-				}
-
-				& > a,
-				.menu-item-has-children > a {
-
-					&:after {
-						content: "";
-						display: none;
-					}
 				}
 
 				.submenu-expand {
@@ -105,8 +84,6 @@
 	}
 
 	.sub-menu {
-		list-style: none;
-		padding-left: 0;
 
 		> li {
 			display: block;
@@ -147,8 +124,7 @@
 
 			> a {
 				color: $color__background-body;
-				display: block;
-				line-height: $font__line-height-heading;
+				display: inline-block;
 			}
 
 			> a:empty {
@@ -156,142 +132,7 @@
 			}
 		}
 	}
-
-	/*
-	 * Sub-menu styles
-	 *
-	 * :focus-within needs its own selector so other similar
-	 * selectors don’t get ignored if a browser doesn’t recognize it
-	 */
-	.main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
-
-		display: block;
-		left: 0;
-		margin-top: 0;
-		opacity: 1;
-		width: auto;
-
-		/* Non-mobile position */
-		@include media(tablet) {
-			display: block;
-			margin-top: 0;
-			opacity: 1;
-			position: absolute;
-			left: 0;
-			right: auto;
-			top: 100%;
-			bottom: auto;
-			height: auto;
-			min-width: -moz-max-content;
-			min-width: -webkit-max-content;
-			min-width: max-content;
-			transform: none;
-		}
-
-		&.hidden-links {
-			left: 0;
-			width: 100%;
-			display: table;
-			position: absolute;
-
-			@include media(tablet) {
-				right: 0;
-				left: auto;
-				display: block;
-				width: max-content;
-			}
-		}
-
-		.submenu-expand {
-			display: none;
-		}
-
-		.sub-menu {
-			display: block;
-			margin-top: inherit;
-			position: relative;
-			width: 100%;
-			left: 0;
-			opacity: 1;
-
-			/* Non-mobile position */
-			@include media(tablet) {
-				float: none;
-				max-width: 100%;
-			}
-		}
-
-		/* Nested sub-menu dashes */
-		.sub-menu {
-			counter-reset: submenu;
-		}
-	}
-
-	.main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
-	.main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
-	.main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
-
-		display: block;
-		left: 0;
-		margin-top: 0;
-		opacity: 1;
-		width: auto;
-		min-width: 100%;
-
-
-		/* Non-mobile position */
-		@include media(tablet) {
-			display: block;
-			float: none;
-			margin-top: 0;
-			opacity: 1;
-			position: absolute;
-			left: 0;
-			right: auto;
-			top: 100%;
-			bottom: auto;
-			height: auto;
-			min-width: -moz-max-content;
-			min-width: -webkit-max-content;
-			min-width: max-content;
-			transform: none;
-		}
-
-		&.hidden-links {
-			left: 0;
-			width: 100%;
-			display: table;
-			position: absolute;
-
-			@include media(tablet) {
-				right: 0;
-				left: auto;
-				display: table;
-				width: max-content;
-			}
-		}
-
-		.submenu-expand {
-			display: none;
-		}
-
-		.sub-menu {
-			display: block;
-			margin-top: inherit;
-			position: relative;
-			width: 100%;
-			left: 0;
-			opacity: 1;
-
-			/* Non-mobile position */
-			@include media(tablet) {
-				float: none;
-				max-width: 100%;
-			}
-		}
-	}
 }
-
 
 /* Desktop-specific styles */
 
@@ -303,8 +144,14 @@
 			display: inline-block;
 
 			> li {
+				color: #555;
 				display: inline-block;
-				padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
+				line-height: 1.25;
+				margin-right: #{0.75 * $size__spacing-unit};
+
+				> a {
+					color: inherit;
+				}
 			}
 
 			.sub-menu {
@@ -316,6 +163,8 @@
 				z-index: 99999;
 
 				> li > a {
+					display: block;
+					line-height: $font__line-height-heading;
 					padding: calc( .5 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( .5 * #{$size__spacing-unit} ) $size__spacing-unit;
 
 					&:hover,
@@ -329,10 +178,147 @@
 				}
 			}
 		}
+
+		/*
+		 * Sub-menu styles
+		 *
+		 * :focus-within needs its own selector so other similar
+		 * selectors don’t get ignored if a browser doesn’t recognize it
+		 */
+		.main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+
+			display: block;
+			left: 0;
+			margin-top: 0;
+			opacity: 1;
+			width: auto;
+
+			/* Non-mobile position */
+			@include media(tablet) {
+				display: block;
+				margin-top: 0;
+				opacity: 1;
+				position: absolute;
+				left: 0;
+				right: auto;
+				top: 100%;
+				bottom: auto;
+				height: auto;
+				min-width: -moz-max-content;
+				min-width: -webkit-max-content;
+				min-width: max-content;
+				transform: none;
+			}
+
+			&.hidden-links {
+				left: 0;
+				width: 100%;
+				display: table;
+				position: absolute;
+
+				@include media(tablet) {
+					right: 0;
+					left: auto;
+					display: block;
+					width: max-content;
+				}
+			}
+
+			.submenu-expand {
+				display: none;
+			}
+
+			.sub-menu {
+				display: block;
+				margin-top: inherit;
+				position: relative;
+				width: 100%;
+				left: 0;
+				opacity: 1;
+
+				/* Non-mobile position */
+				@include media(tablet) {
+					float: none;
+					max-width: 100%;
+				}
+			}
+
+			/* Nested sub-menu dashes */
+			.sub-menu {
+				counter-reset: submenu;
+			}
+		}
+
+		.main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+		.main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+		.main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+			display: block;
+			left: 0;
+			margin-top: 0;
+			opacity: 1;
+			width: auto;
+			min-width: 100%;
+
+
+			/* Non-mobile position */
+			@include media(tablet) {
+				display: block;
+				float: none;
+				margin-top: 0;
+				opacity: 1;
+				position: absolute;
+				left: 0;
+				right: auto;
+				top: 100%;
+				bottom: auto;
+				height: auto;
+				min-width: -moz-max-content;
+				min-width: -webkit-max-content;
+				min-width: max-content;
+				transform: none;
+			}
+
+			&.hidden-links {
+				left: 0;
+				width: 100%;
+				display: table;
+				position: absolute;
+
+				@include media(tablet) {
+					right: 0;
+					left: auto;
+					display: table;
+					width: max-content;
+				}
+			}
+
+			.submenu-expand {
+				display: none;
+			}
+
+			.sub-menu {
+				display: block;
+				margin-top: inherit;
+				position: relative;
+				width: 100%;
+				left: 0;
+				opacity: 1;
+
+				/* Non-mobile position */
+				@include media(tablet) {
+					float: none;
+					max-width: 100%;
+				}
+			}
+		}
 	}
 }
 
 .header-center-logo.header-default-height .site-header #site-navigation {
 	flex-basis: 100%;
 	text-align: center;
+}
+
+.header-default-height .site-header .main-navigation .main-menu > li {
+	padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
 }

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -40,12 +40,14 @@
 		padding: 0;
 	}
 
+	li {
+		position: relative;
+	}
+
 	.main-menu {
 		width: 100%;
 
 		> li {
-			position: relative;
-
 			> a {
 				color: inherit;
 				padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
@@ -87,7 +89,6 @@
 
 		> li {
 			display: block;
-			position: relative;
 
 			&.menu-item-has-children {
 
@@ -109,16 +110,6 @@
 
 				.submenu-expand {
 					margin-right: 0;
-				}
-
-				@include media(tablet) {
-
-					.menu-item-has-children > a {
-
-						&:after {
-							content: "\203a";
-						}
-					}
 				}
 			}
 
@@ -170,10 +161,6 @@
 					&:hover,
 					&:focus {
 						background: $color__primary-variation;
-
-						&:after {
-							background: $color__primary-variation;
-						}
 					}
 				}
 			}
@@ -186,7 +173,6 @@
 		 * selectors don’t get ignored if a browser doesn’t recognize it
 		 */
 		.main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
-
 			display: block;
 			left: 0;
 			margin-top: 0;
@@ -208,20 +194,6 @@
 				min-width: -webkit-max-content;
 				min-width: max-content;
 				transform: none;
-			}
-
-			&.hidden-links {
-				left: 0;
-				width: 100%;
-				display: table;
-				position: absolute;
-
-				@include media(tablet) {
-					right: 0;
-					left: auto;
-					display: block;
-					width: max-content;
-				}
 			}
 
 			.submenu-expand {
@@ -278,20 +250,6 @@
 				transform: none;
 			}
 
-			&.hidden-links {
-				left: 0;
-				width: 100%;
-				display: table;
-				position: absolute;
-
-				@include media(tablet) {
-					right: 0;
-					left: auto;
-					display: table;
-					width: max-content;
-				}
-			}
-
 			.submenu-expand {
 				display: none;
 			}
@@ -321,4 +279,8 @@
 
 .header-default-height .site-header .main-navigation .main-menu > li {
 	padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
+}
+
+.header-simplified .site-header .main-navigation .main-menu > li {
+	padding: #{ 0.25 * $size__spacing-unit } 0
 }

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -60,10 +60,6 @@
 		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit }
 	}
 
-	ul ul a {
-		margin: #{ 0.75 * $size__spacing-unit } 0;
-	}
-
 	a:hover {
 		background: transparent;
 		text-decoration: underline;

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -34,7 +34,7 @@
 
 	& > * {
 		clear: both;
-		margin-bottom: #{ 2 * $size__spacing-unit };
+		margin-bottom: #{ 1.5 * $size__spacing-unit };
 	}
 
 	.mobile-menu-toggle {
@@ -51,12 +51,17 @@
 	a,
 	a:visited,
 	.main-navigation .sub-menu > li > a {
-		color: inherit;
+		color: #fff;
 	}
 
 	a {
 		display: inline-block;
-		padding: #{ 0.5 * $size__spacing-unit } 0;
+		margin: #{ 0.25 * $size__spacing-unit } 0;
+		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit }
+	}
+
+	ul ul a {
+		margin: #{ 0.75 * $size__spacing-unit } 0;
 	}
 
 	a:hover {

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -70,6 +70,10 @@
 	.submenu-expand {
 		display: none;
 	}
+
+	.tertiary-menu a {
+		padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+	}
 }
 
 #mobile-sidebar-fallback {

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -8,6 +8,7 @@ nav.secondary-menu {
 
 	a {
 		color: inherit;
+		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit };
 	}
 }
 

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -33,7 +33,7 @@
 
 	li {
 		display: inline-block;
-		font-size: $font__size-sm;
+		font-size: $font__size-xs;
 
 		@include media(tablet) {
 			&:nth-child(n+2) {
@@ -50,11 +50,6 @@
 	.header-simplified & {
 		font-size: $font__size_base;
 		margin-left: $size__spacing-unit;
-		li {
-			a {
-				font-size: $font__size-xs;
-			}
-		}
 	}
 
 	// Centered logo.

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -16,7 +16,7 @@
 	a {
 		color: inherit;
 		display: inline-block;
-		padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+		padding: #{ 0.125 * $size__spacing-unit } 0;
 	}
 
 	#search-toggle {
@@ -27,14 +27,13 @@
 
 // Styles for when menu items appear in the site-header.
 .site-header .tertiary-menu {
-	font-size: $font__size-sm;
-
 	@include media( tablet ) {
 		text-align: right;
 	}
 
 	li {
 		display: inline-block;
+		font-size: $font__size-sm;
 
 		@include media(tablet) {
 			&:nth-child(n+2) {

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -16,6 +16,7 @@
 	a {
 		color: inherit;
 		display: inline-block;
+		padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 	}
 
 	#search-toggle {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -101,10 +101,7 @@ body:not(.header-solid-background) .site-header {
 			padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
 		}
 	}
-
-
 }
-
 
 // Site header
 
@@ -112,10 +109,6 @@ body:not(.header-solid-background) .site-header {
 .tertiary-menu {
 	letter-spacing: 0.05em;
 	text-transform: uppercase;
-}
-
-.site-header .tertiary-menu {
-	font-size: $font__size-xs;
 }
 
 // Accent headers

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -29,11 +29,6 @@ body.header-default-background.header-default-height {
 					color: #fff;
 				}
 			}
-
-			.menu-highlight a {
-				background-color: $color__primary;
-				color: #fff;
-			}
 		}
 	}
 }

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -29,6 +29,11 @@ body.header-default-background.header-default-height {
 					color: #fff;
 				}
 			}
+
+			.menu-highlight a {
+				background-color: $color__primary;
+				color: #fff;
+			}
 		}
 	}
 }

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -59,7 +59,6 @@ h6 {
 }
 
 .site-branding,
-.main-navigation ul.main-menu > li,
 .social-navigation,
 .author-description .author-bio,
 .nav-links {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR cleans up some menu styles, primarily with the goal of only applying certain styles -- the ones that make the dropdowns fly out -- when the menu is not in the 'mobile sidebar', and removing some cruft that's not needed. It also makes the spacing a bit more consistent across the different menus, so there's less to override for the mobile styles.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Test out the different menu settings -- there should not be significant visual changes:
    * Default
    * Solid Background
    * Centred Header
    * Short Header
    * Solid Background + Short Header
    * Solid Background + Centred Logo
    * Short Header + Centred Logo
    * Short Header + Centred Logo + Solid Background

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
