### PR TITLE
Style D: Add footer styles.

### DIFF
--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -220,3 +220,49 @@ Newspack Theme Styles - Style Pack 3
 		margin-top: $size__spacing-unit;
 	}
 }
+
+// Site Footer
+
+.site-footer {
+	background-color: $color__background-dark;
+	color: $color__background-body;
+
+	a,
+	a:hover,
+	a:visited,
+	.widget a,
+	.widget a:hover,
+	.widget a:visited,
+	.widget-title {
+		color: inherit;
+	}
+
+	.widget-title {
+		text-transform: uppercase;
+	}
+}
+
+.footer-branding {
+	margin-bottom: #{ 2 * $size__spacing-unit };
+
+	@include media( tablet ) {
+		padding-top: #{ 2 * $size__spacing-unit };
+	}
+
+	.wrapper {
+		border-bottom: 1px solid rgba( 255, 255, 255, 0.25 );
+	}
+}
+
+.site-info {
+	color: $color__background-body;
+	text-transform: uppercase;
+
+	.wrapper {
+		border: 0;
+	}
+
+	a {
+		color: inherit;
+	}
+}

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -15,6 +15,7 @@ $color__background-button-hover: #111;
 $color__background-pre: #eee;
 $color__background-ins: #fff9c0;
 $color__background_selection: mix( $color__background-body, $color__primary, 75% ); // lighten( salmon, 22.5% ); // lighten( #0999d4, 48% );
+$color__background-dark: #333;
 
 // Text
 $color__text-main: #111;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR builds out the (missing!) footer style for Style D:

![image](https://user-images.githubusercontent.com/177561/62972976-10897c80-bdca-11e9-9b95-1373a7ee6c24.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to Customize > Style Pack and switch to Style 3.
3. Do a visual review of the footer, confirm it looks like the screenshot.
4. Remove all footer widgets and confirm only the bottom line -- the copyright, and social links -- remain.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
