### PR TITLE
Author Bio: Remove placeholder 'Staff Writer' string from author bio

### DIFF
--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -53,7 +53,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 			<div>
 				<h2 class="accent-header">
 					<?php echo esc_html( get_the_author() ); ?>
-					<span><?php esc_html_e( 'Staff Writer', 'newspack-theme' ); ?></span>
+					<span><?php // TODO: Add Job title ?></span>
 				</h2>
 				<div class="author-meta">
 					<a href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the static string 'staff writer' from the author bio. It was used as a placeholder for building out the styles, but now that those are in place, it should be replaced with a dynamic solution (to come). 

**Before:**

![image](https://user-images.githubusercontent.com/177561/62974082-42034780-bdcc-11e9-8f4f-02385a9bbd44.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/62974059-37e14900-bdcc-11e9-8606-efdf8fcfa615.png)

See #236 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. View an author bio at the bottom of a single post, and confirm that the text 'Staff Writer' is gone.

To make author bios visible, you need to add 'Biological Info' to a specific author -- this can be done under WP Admin > Users, and editing a specific user.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
