### PR TITLE
Custom Colours: Make sure essential items have sufficient contrast

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -18,8 +18,21 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 	}
 
+	// Create some variables to use in cases where the colours are against a white background.
+	$primary_color_text   = $primary_color;
+	$secondary_color_text = $secondary_color;
+
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+
+	// Check if each custom colour has sufficient contrast against white; if not, change it to a mid-gray.
+	if ( '#000' === $primary_color_contrast ) {
+		$primary_color_text = '#5a5a5a';
+	}
+
+	if ( '#000' === $secondary_color_contrast ) {
+		$secondary_color_text = '#5a5a5a';
+	}
 
 	$theme_css = '
 		/* Set primary background color */
@@ -37,7 +50,7 @@ function newspack_custom_colors_css() {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		/* Set primary color */
+		/* Set primary color that contrasts against white */
 
 		.main-navigation .main-menu > li,
 		.main-navigation ul.main-menu > li > a,
@@ -45,14 +58,18 @@ function newspack_custom_colors_css() {
 		.main-navigation .main-menu > li > a + svg,
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
-		#colophon .site-info a:hover,
-		.widget a, .widget a:visited,
-		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+		.site-info a:hover,
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+			color: ' . $primary_color_text . ';
+		}
+
+		/* Set primary color */
+
 		.entry .entry-content > .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
-			color: ' . $primary_color . '; /* base: #0073a8; */
+			color: ' . $primary_color . ';
 		}
 
 		.mobile-sidebar {
@@ -182,7 +199,7 @@ function newspack_custom_colors_css() {
 			}
 			.accent-header, .article-section-title,
 			.entry .entry-footer a:hover {
-				color: ' . $primary_color . ';
+				color: ' . $primary_color_text . ';
 			}
 		';
 	}
@@ -196,7 +213,7 @@ function newspack_custom_colors_css() {
 			.archive .page-title,
 			.entry-meta .byline a,
 			.entry .entry-meta a:hover {
-				color: ' . $primary_color . ';
+				color: ' . $primary_color_text . ';
 			}
 		';
 	}
@@ -308,7 +325,7 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
-			color: ' . $primary_color . '; /* base: #0073a8; */
+			color: ' . $primary_color_text . '; /* base: #0073a8; */
 		}
 
 		.editor-block-list__layout .editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
@@ -349,7 +366,7 @@ function newspack_custom_colors_css() {
 	) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .entry-meta .byline a {
-				color: ' . $primary_color . ';
+				color: ' . $primary_color_text . ';
 			}
 		';
 	}
@@ -357,7 +374,7 @@ function newspack_custom_colors_css() {
 	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
-				color: ' . $primary_color . ';
+				color: ' . $primary_color_text . ';
 			}
 		';
 	}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -18,20 +18,18 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 	}
 
-	// Create some variables to use in cases where the colours are against a white background.
-	$primary_color_text   = $primary_color;
-	$secondary_color_text = $secondary_color;
-
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
-	// Check if each custom colour has sufficient contrast against white; if not, change it to a mid-gray.
-	if ( '#000' === $primary_color_contrast ) {
-		$primary_color_text = '#5a5a5a';
-	}
-
-	if ( '#000' === $secondary_color_contrast ) {
-		$secondary_color_text = '#5a5a5a';
+	/**
+	 * Checks if color has sufficient contrast against white; if no, replaces it.
+	 */
+	function newspack_color_with_contrast( $color ) {
+		$contrast = newspack_get_color_contrast( $color );
+		if ( '#000' === $contrast ) {
+			return '#5a5a5a';
+		}
+		return $color;
 	}
 
 	$theme_css = '
@@ -60,7 +58,7 @@ function newspack_custom_colors_css() {
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,
 		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
-			color: ' . $primary_color_text . ';
+			color: ' . newspack_color_with_contrast( $primary_color ) . ';
 		}
 
 		/* Set primary color */
@@ -199,7 +197,7 @@ function newspack_custom_colors_css() {
 			}
 			.accent-header, .article-section-title,
 			.entry .entry-footer a:hover {
-				color: ' . $primary_color_text . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 	}
@@ -213,7 +211,7 @@ function newspack_custom_colors_css() {
 			.archive .page-title,
 			.entry-meta .byline a,
 			.entry .entry-meta a:hover {
-				color: ' . $primary_color_text . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 	}
@@ -325,7 +323,7 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
-			color: ' . $primary_color_text . '; /* base: #0073a8; */
+			color: ' . newspack_color_with_contrast( $primary_color ) . '; /* base: #0073a8; */
 		}
 
 		.editor-block-list__layout .editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
@@ -366,7 +364,7 @@ function newspack_custom_colors_css() {
 	) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .entry-meta .byline a {
-				color: ' . $primary_color_text . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 	}
@@ -374,7 +372,7 @@ function newspack_custom_colors_css() {
 	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
-				color: ' . $primary_color_text . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, it's possible to set any colour as your primary or secondary colour. However, if you pick a really light colour, there are cases where it's used -- like links -- where it won't have a sufficient contrast against the theme's white background.

This PR roughs in one way to approach this: using the existing `newspack_get_color_contrast()` function, check to see if the selected colour has enough contrast against white, and if not, use a mid-grey fallback in cases where it's essential (like text; it's not as dire if decorative elements are low contrast.

This PR in particular just adds this functionality for the accent headers and post meta in the default style pack. If it seems like a good approach, I will work through other areas where this is a problem with additional PRs.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customize > Style Packs and switch to the default.
3. Navigate to Customize > Colors and pick something light for the primary colour -- like yellow.
4. View the homepage blocks; confirm that the accent headers are using grey for the text, rather than yellow. The post meta on the homepage blocks single posts should be doing the same.
5. Switch to a darker custom colour.
6. View the homepage blocks; confirm that the accent headers are using the primary colour for the text.

**Lighter primary colour**

![image](https://user-images.githubusercontent.com/177561/62987469-cff32880-bdf4-11e9-9b14-f46030476855.png)


**Darker primary colour:**

![image](https://user-images.githubusercontent.com/177561/62987448-b05c0000-bdf4-11e9-965b-1deccc015fbf.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
