### PR TITLE
Block Styles: Add style to columns block to reorder columns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -342,6 +342,14 @@ function newspack_editor_customizer_styles() {
 add_action( 'enqueue_block_editor_assets', 'newspack_editor_customizer_styles' );
 
 /**
+ * Enqueue Block Styles Script for the Columns block
+ */
+function newspack_columns_block_style_javascript() {
+	wp_enqueue_script( 'newspack-columns-block-styles-script', get_theme_file_uri( '/js/blocks-columns-style.js' ), array( 'wp-blocks' ), '1.0', true );
+}
+add_action( 'enqueue_block_editor_assets', 'newspack_columns_block_style_javascript' );
+
+/**
  * Determine if current editor page is the static front page.
  */
 function newspack_is_static_front_page() {

--- a/js/blocks-columns-style.js
+++ b/js/blocks-columns-style.js
@@ -1,0 +1,19 @@
+/**
+ * File block-columns-style.js
+ *
+ * Adds block styles to the Columns block, to allow you to reorder columns.
+ */
+
+// Switches the first column to the second spot.
+
+wp.blocks.registerBlockStyle( 'core/columns', {
+	name: 'first-col-to-second',
+	label: 'Move first column to second'
+} );
+
+// Switches the first column to the third spot.
+
+wp.blocks.registerBlockStyle( 'core/columns', {
+	name: 'first-col-to-third',
+	label: 'Move first column to third'
+} );

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -680,6 +680,23 @@
 	.wp-block-columns {
 		@include media(mobile) {
 			flex-wrap: nowrap;
+
+			&[class*='is-style-first-col-to'] .wp-block-column {
+				margin-left: 32px;
+			}
+
+			&[class*='is-style-first-col-to'] .wp-block-column:nth-child(2) {
+				margin-left: 0;
+			}
+
+			&.is-style-first-col-to-second .wp-block-column:nth-child(2) {
+			order: -1;
+			}
+
+			&.is-style-first-col-to-third .wp-block-column:nth-child(2),
+			&.is-style-first-col-to-third .wp-block-column:nth-child(3) {
+				order: -1;
+			}
 		}
 
 		@include media(tablet) {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -179,6 +179,30 @@ figcaption,
 		font-weight: bolder;
 	}
 }
+
+/** === Columns === */
+
+.wp-block-columns {
+	@include media(mobile) {
+		&[class*='is-style-first-col-to'] [data-type="core/column"] {
+			margin-left: 46px;
+		}
+
+		&[class*='is-style-first-col-to'] [data-type="core/column"]:nth-child(2) {
+			margin-left: 0;
+		}
+
+		&.is-style-first-col-to-second [data-type="core/column"]:nth-child(2) {
+		order: -1;
+		}
+
+		&.is-style-first-col-to-third [data-type="core/column"]:nth-child(2),
+		&.is-style-first-col-to-third [data-type="core/column"]:nth-child(3) {
+			order: -1;
+		}
+	}
+}
+
 /** === Paragraph === */
 
 .wp-block-paragraph {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is for [this issue](https://github.com/Automattic/newspack-blocks/issues/40) in the Newspack Block repository -- I think it makes more sense to have in the theme, or its own plugin; I've started with it in the theme for now, but would appreciate a second opinion on this!

Something that came up a few times during the design feedback was how the articles would be ordered on mobile. By default, the columns would stack left to right, meaning the most important story (in theory) would be on the left.

This isn't always the case, though -- there are layouts where the most prominent, important story would actually be placed in the middle on desktop, but should be at the top on mobile/to screenreaders.

I got into it in more detail, along with accessibility considerations, in the original ticket: https://github.com/Automattic/newspack-blocks/issues/40 But the short of it is, the styles this PR adds reorders the columns on desktop sized screens only, so you technically place your most important stories in the first column, but can style that column to appear as the second or third column, to centre it on larger screens.

### How to test the changes in this Pull Request:

1. Apply the patch and run `npm run build`.
2. Copy paste[ this test content](https://cloudup.com/cUZLDreQrup) into the code view of the editor. It has a columns block with three columns, each with an article block.

![image](https://user-images.githubusercontent.com/177561/62988124-07170900-bdf8-11e9-8734-957bae09183e.png)

3. Click the 'Change Block Style or Type' button in the editor for the Columns block; you should now see three options for styles: Default, and the horribly named 'Move first column to second' and 'Move first column to third'; the previews are also not great.

![image](https://user-images.githubusercontent.com/177561/62988173-3594e400-bdf8-11e9-928a-0f8a26d9e4eb.png)

4. Apply 'Move first column to second' -- the larger first column should now appear in the middle:

![image](https://user-images.githubusercontent.com/177561/62988202-50675880-bdf8-11e9-831a-3840719a8446.png)

(Though in the source it's still first; if you shrink down the browser window, it will still be at the top:

![image](https://user-images.githubusercontent.com/177561/62988220-68d77300-bdf8-11e9-98ac-71ab84c0d220.png)
)

5. 'Move first column to third' will move it to the end -- though this would be more realistically used in cases where you have more than three columns:

![image](https://user-images.githubusercontent.com/177561/62988262-90c6d680-bdf8-11e9-83be-e26b74d4162c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
