### PR TITLE
Style E: Update solid background header styles.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -271,7 +271,11 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) && 'style-3' !== get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if (
+		true === get_theme_mod( 'header_solid_background', false ) &&
+		'style-3' !== get_theme_mod( 'active_style_pack', 'default' ) &&
+		'style-4' !== get_theme_mod( 'active_style_pack', 'default' )
+		) {
 
 		$theme_css .= '
 			.header-solid-background .site-header {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -7,6 +7,19 @@ Newspack Theme Styles - Style Pack 4
 @import "variables-style/variables-style";
 @import "../../style-base.scss";
 
+// Header
+
+.header-solid-background {
+	.site-header,
+	.site-header .main-navigation .main-menu .sub-menu {
+		background-color: $color__background-dark;
+	}
+
+	.bottom-header-contain {
+		background-color: darken( $color__background-dark, 5% );
+	}
+}
+
 // Accent headers
 
 .accent-header,
@@ -317,7 +330,7 @@ Newspack Theme Styles - Style Pack 4
 }
 
 .site-info {
-	background-color: $color__text-main;
+	background-color: $color__background-dark;
 
 	.wrapper {
 		border: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #203, this PR makes the header dark grey when you're using the solid background + Style E.

![image](https://user-images.githubusercontent.com/177561/62989961-fae27a00-bdfe-11e9-803b-6c248dd9ec36.png)

It also updates the dark background in the footer to use the same colour, since we have a variable declared for it.

When you have the solid background but no shorter header, the menu bar should use a darker colour:

![image](https://user-images.githubusercontent.com/177561/62989922-e0a89c00-bdfe-11e9-8f9c-dc578fbe9285.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 4.
3. Set the header to use the solid background + short styles; confirm that it looks like the first screenshot above.
4. Set the header to just use the solid background; confirm it looks like the second screenshot above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
