### PR TITLE
Style C: Adjust content padding on the front page.

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -11,7 +11,7 @@ Newspack Theme Styles - Style Pack 2
 
 .site-header,
 .header-solid-background .site-header {
-	padding-bottom: $size__spacing-unit;
+	padding-bottom: #{ 0.5 * $size__spacing-unit };
 
 	@include media(tablet) {
 		padding-bottom: #{ 4 * $size__spacing-unit };
@@ -40,7 +40,7 @@ Newspack Theme Styles - Style Pack 2
 
 .site-content,
 .newspack-front-page.hide-homepage-title .site-content {
-	margin-top: #{ -1 * $size__spacing-unit };
+	margin-top: #{ -0.5 * $size__spacing-unit };
 
 	@include media(tablet) {
 		margin-top: #{ -3.5 * $size__spacing-unit };
@@ -76,7 +76,7 @@ body:not(.header-solid-background) .site-header {
 #primary {
 	background-color: $color__background-body;
 	border-top: 2px solid $color__primary-variation;
-	padding: #{ 2 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+	padding: #{ 2 * $size__spacing-unit } 0;
 
 	@include media(tablet) {
 		border-top-width: 4px;
@@ -92,8 +92,6 @@ body:not(.header-solid-background) .site-header {
 	padding: 0;
 
 	.main-content > article > .entry-content > *:first-child {
-		padding-left: #{ 0.5 * $size__spacing-unit };
-		padding-right: #{ 0.5 * $size__spacing-unit };
 
 		@include media(tablet) {
 			padding: $size__spacing-unit #{ 3 * $size__spacing-unit } 0;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -89,15 +89,22 @@ body:not(.header-solid-background) .site-header {
 }
 
 .newspack-front-page #primary {
-	padding-top: 0;
+	padding: 0;
 
-	@include media(tablet) {
-		padding-top: $size__spacing-unit;
+	.main-content > article > .entry-content > *:first-child {
+		padding-left: #{ 0.5 * $size__spacing-unit };
+		padding-right: #{ 0.5 * $size__spacing-unit };
+
+		@include media(tablet) {
+			padding: $size__spacing-unit #{ 3 * $size__spacing-unit } 0;
+		}
+
+		@include media(desktop) {
+			padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
+		}
 	}
 
-	@include media(desktop) {
-		padding-top: $size__spacing-unit;
-	}
+
 }
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the mockups for style C, only the first part of the page -- the first block of articles, or post header -- is narrower. The rest of the content is 1200px wide. 

This style corrects the spacing on the static front page: only the first article block, or first columns block (whatever is the first immediate child of the content area) will be narrower:

![image](https://user-images.githubusercontent.com/177561/62993664-48fe7a00-be0d-11e9-9e53-16eb72a78e64.png)

![image](https://user-images.githubusercontent.com/177561/62993747-a266a900-be0d-11e9-9454-91151233d531.png)

I'll circle back and address the other pages in separate PRs.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs and switch to Style 2.
3. On the homepage, try a few different settings as the first item -- an article block with a couple settings, a category block, a group block. Make sure it's indented more than the rest of the page, and that the rest of the content is 1200px wide on larger screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
