### PR TITLE
Code simplification: helper function to check the current style pack.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -351,6 +351,19 @@ function newspack_is_static_front_page() {
 }
 
 /**
+ * Check if the current style pack is a particular option.
+ *
+ * Pass in a style pack slug or list of slugs separated by commas (default|style-1|style-2|style-3|style-4)
+ *
+ * @return bool If current style pack is one of the passed options.
+ */
+function newspack_is_active_style_pack() {
+	$args              = func_get_args();
+	$active_style_pack = get_theme_mod( 'active_style_pack', 'default' );
+	return in_array( $active_style_pack, $args );
+}
+
+/**
  * Add body class on editor pages if editing the static front page.
  */
 function newspack_filter_admin_body_class( $classes ) {

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -292,7 +292,6 @@ function newspack_custom_colors_css() {
 	}
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4' ) ) {
-
 		$theme_css .= '
 			.header-solid-background .site-header {
 				background-color: ' . $primary_color . ';

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -192,7 +192,7 @@ function newspack_custom_colors_css() {
 			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
 		}';
 
-	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '
 			.cat-links a,
 			.cat-links a:visited,
@@ -211,11 +211,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if (
-		'default' === get_theme_mod( 'active_style_pack', 'default' ) ||
-		'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ||
-		'style-4' === get_theme_mod( 'active_style_pack', 'default' )
-	) {
+	if ( newspack_is_active_style_pack( 'default', 'style-3', 'style-4' ) ) {
 		$theme_css .= '
 			.archive .page-title,
 			.entry-meta .byline a,
@@ -225,7 +221,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-1' ) ) {
 		$theme_css .= '
 			.accent-header:before,
 			.article-section-title:before,
@@ -240,7 +236,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
 			.site-content #primary {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
@@ -257,7 +253,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$theme_css .= '
 			.cat-links a,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
@@ -275,7 +271,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-4' ) ) {
 		$theme_css .= '
 			.accent-header,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
@@ -295,11 +291,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if (
-		true === get_theme_mod( 'header_solid_background', false ) &&
-		'style-3' !== get_theme_mod( 'active_style_pack', 'default' ) &&
-		'style-4' !== get_theme_mod( 'active_style_pack', 'default' )
-		) {
+	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4' ) ) {
 
 		$theme_css .= '
 			.header-solid-background .site-header {
@@ -375,11 +367,7 @@ function newspack_custom_colors_css() {
 		}
 		';
 
-	if (
-		'default' === get_theme_mod( 'active_style_pack', 'default' ) ||
-		'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ||
-		'style-4' === get_theme_mod( 'active_style_pack', 'default' )
-	) {
+	if ( newspack_is_active_style_pack( 'default', 'style-3', 'style-4' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .entry-meta .byline a {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
@@ -387,7 +375,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'default' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
@@ -395,7 +383,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-1' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header:before,
 			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
@@ -407,7 +395,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				border-color: ' . $primary_color . ';
@@ -415,7 +403,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
@@ -430,7 +418,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+	if ( newspack_is_active_style_pack( 'style-4' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
 			.editor-block-list__layout .editor-block-list__block .article-section-title {

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -107,7 +107,7 @@ function newspack_custom_typography_css() {
 			font-family: $font_header;
 		}";
 
-		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-1' ) ) {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
 			.entry .entry-content .wp-block-pullquote,
@@ -116,7 +116,7 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
-		if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description {
@@ -124,7 +124,7 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
-		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-3' ) ) {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description {
@@ -132,7 +132,7 @@ function newspack_custom_typography_css() {
 			}";
 		}
 
-		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-4' ) ) {
 			$css_blocks .= "
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description,
@@ -195,7 +195,7 @@ function newspack_custom_typography_css() {
 		}
 		";
 
-		if ( 'style-1' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-1' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
@@ -209,7 +209,7 @@ function newspack_custom_typography_css() {
 			";
 		}
 
-		if ( 'style-2' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 
@@ -220,7 +220,7 @@ function newspack_custom_typography_css() {
 		}
 
 
-		if ( 'style-3' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-3' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 
@@ -230,7 +230,7 @@ function newspack_custom_typography_css() {
 			";
 		}
 
-		if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) {
+		if ( newspack_is_active_style_pack( 'style-4' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -9,7 +9,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-bio">
 
 	<?php
-	if ( newspack_is_active_style_pack( 'style-4' ) ) :
+	if ( ! newspack_is_active_style_pack( 'style-4' ) ) :
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 		if ( $author_avatar ) :
 			echo wp_kses(

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -9,7 +9,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 <div class="author-bio">
 
 	<?php
-	if ( 'style-4' !== get_theme_mod( 'active_style_pack', 'default' ) ) :
+	if ( newspack_is_active_style_pack( 'style-4' ) ) :
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 		if ( $author_avatar ) :
 			echo wp_kses(
@@ -31,7 +31,7 @@ if ( (bool) get_the_author_meta( 'description' ) ) : ?>
 	<div class="author-bio-text">
 		<div class="author-bio-header">
 			<?php
-			if ( 'style-4' === get_theme_mod( 'active_style_pack', 'default' ) ) :
+			if ( newspack_is_active_style_pack( 'style-4' ) ) :
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 				if ( $author_avatar ) :
 					echo wp_kses(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces a helper function `newspack_is_active_style_pack()` to check if the current style pack matches a slug (or list of slugs). Meant to replace `if ( 'default' !== get_theme_mod( 'active_style_pack', 'default' ) )` logic, which complicates some of the theme files. There should be no visible changes in this PR—everything should work exactly as before.

### How to test the changes in this Pull Request:

1. Verify that all Style Pack settings continue to function as before. 
2. Keep a particularly careful eye on the cases where multiple slugs are passed in to match, e.g.: https://github.com/Automattic/newspack-theme/blob/28ad20c264cc5cbf84d9f3b52bac33983eb2ced8/inc/color-patterns.php#L190-L198

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
