### PR TITLE
Add styling for Newspack Ads

### DIFF
--- a/header.php
+++ b/header.php
@@ -176,6 +176,6 @@
 
 	</header><!-- #masthead -->
 
-	<div id="content" class="site-content">
-
 	<?php do_action( 'after_header' ); ?>
+
+	<div id="content" class="site-content">

--- a/sass/plugins/newspack-ads.scss
+++ b/sass/plugins/newspack-ads.scss
@@ -6,7 +6,7 @@
 	justify-content: center;
 	align-items: center;
 
-	> div {
+	> * {
 		margin-top: $size__spacing-unit;
 		margin-bottom: $size__spacing-unit;
 	}
@@ -17,15 +17,9 @@
 }
 
 body {
-	// Make the ad background match the bar at the top of the site when default background and default height.
-	&.header-default-background.header-default-height {
-		.newspack_global_ad.global_above_header {
-			background-color: #4a4a4a;
-
-			> div {
-				margin-bottom: #{ 0.7 * $size__spacing-unit }
-			}
-		}
+	// Reduce space on top of the content a bit when there's an ad below the header.
+	&:not(.newspack-front-page) .newspack_global_ad.global_below_header + .site-content {
+		margin-top: #{ 1.5 * $size__spacing-unit };
 	}
 
 	// Style pack 2 can't really support an ad below the header because the content is inset into the header.

--- a/sass/plugins/newspack-ads.scss
+++ b/sass/plugins/newspack-ads.scss
@@ -18,7 +18,7 @@
 
 body {
 	// Reduce space on top of the content a bit when there's an ad below the header.
-	&:not(.newspack-front-page) .newspack_global_ad.global_below_header + .site-content {
+	&:not(.newspack-front-page):not(.style-pack-style-2) .newspack_global_ad.global_below_header + .site-content {
 		margin-top: #{ 1.5 * $size__spacing-unit };
 	}
 

--- a/sass/plugins/newspack-ads.scss
+++ b/sass/plugins/newspack-ads.scss
@@ -1,0 +1,37 @@
+@import "sass/variables-site/variables-site";
+@import "sass/mixins/mixins-master";
+
+.newspack_global_ad {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	> div {
+		margin-top: $size__spacing-unit;
+		margin-bottom: $size__spacing-unit;
+	}
+
+	&.global_above_header {
+		background-color: $color__background-pre;
+	}
+}
+
+body {
+	// Make the ad background match the bar at the top of the site when default background and default height.
+	&.header-default-background.header-default-height {
+		.newspack_global_ad.global_above_header {
+			background-color: #4a4a4a;
+
+			> div {
+				margin-bottom: #{ 0.7 * $size__spacing-unit }
+			}
+		}
+	}
+
+	// Style pack 2 can't really support an ad below the header because the content is inset into the header.
+	&.style-pack-style-2 {
+		.newspack_global_ad.global_below_header {
+			display: none;
+		}
+	}
+}

--- a/sass/style-base.scss
+++ b/sass/style-base.scss
@@ -52,3 +52,6 @@
 /* Media */
 
 @import "media/media";
+
+/* Newspack Ads support */
+@import "plugins/newspack-ads";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds styling for Newspack Ads so that they display nicely on the theme and with style packs. 

Screenshots in details.

Above header:
<details>

<img width="1487" alt="Screen Shot 2019-08-14 at 8 12 42 AM" src="https://user-images.githubusercontent.com/7317227/63036776-96610280-be72-11e9-8199-1977b6e16cfe.png">
<img width="1486" alt="Screen Shot 2019-08-14 at 8 13 12 AM" src="https://user-images.githubusercontent.com/7317227/63036777-96f99900-be72-11e9-9645-8f0bdd634eeb.png">
<img width="1487" alt="Screen Shot 2019-08-14 at 8 13 34 AM" src="https://user-images.githubusercontent.com/7317227/63036778-96f99900-be72-11e9-93b3-14cdf4e9b511.png">
<img width="1486" alt="Screen Shot 2019-08-14 at 8 14 25 AM" src="https://user-images.githubusercontent.com/7317227/63036779-96f99900-be72-11e9-925f-a18d45023d8f.png">

</details>

Below header:
<details>

<img width="1233" alt="Screen Shot 2019-08-14 at 8 18 05 AM" src="https://user-images.githubusercontent.com/7317227/63036814-a7117880-be72-11e9-8596-203dafe0a412.png">
<img width="1230" alt="Screen Shot 2019-08-14 at 8 18 45 AM" src="https://user-images.githubusercontent.com/7317227/63036815-a7117880-be72-11e9-8eb1-050db36c7818.png">
<img width="1235" alt="Screen Shot 2019-08-14 at 8 19 03 AM" src="https://user-images.githubusercontent.com/7317227/63036817-a7aa0f00-be72-11e9-84b6-3692c40af8c3.png">
<img width="1232" alt="Screen Shot 2019-08-14 at 8 19 21 AM" src="https://user-images.githubusercontent.com/7317227/63036818-a7aa0f00-be72-11e9-9e8a-cb160a676a50.png">


</details>

Above footer:
<details>

<img width="1380" alt="Screen Shot 2019-08-14 at 8 50 18 AM" src="https://user-images.githubusercontent.com/7317227/63036827-ae388680-be72-11e9-96cb-ad03002ef24f.png">
<img width="1454" alt="Screen Shot 2019-08-14 at 8 51 06 AM" src="https://user-images.githubusercontent.com/7317227/63036829-ae388680-be72-11e9-809c-f24b2a206b8b.png">

</details>

### How to test the changes in this Pull Request:

1. Install Newspack Ads, create an ad using one of our sample codes. Set it as an above header/below header/above footer ad in the Newspack > Advertising > Global Settings.
2. Try out the different style packs and header settings with the ad.
3. Go to step 1.

To the best of my knowledge, responsiveness of the ads should be handled by the ad itself. We can't make a 900px wide ad responsive on our end since its within an iframe.
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
