### PR TITLE
Centre Logo: Fix alignment

### DIFF
--- a/header.php
+++ b/header.php
@@ -136,11 +136,12 @@
 								newspack_tertiary_menu();
 							}
 							?>
+
 						</div><!-- #tertiary-nav-contain -->
 
 						<?php
-						// Header simplified:
-						if ( true === $header_simplified ) {
+						// Header simplified OR centered logo:
+						if ( true === $header_simplified || true === $header_center_logo ) {
 							get_template_part( 'template-parts/header/header', 'search' );
 						}
 						?>
@@ -169,7 +170,13 @@
 						}
 						?>
 					</div>
-					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+
+					<?php
+					// If logo is not centered.
+					if ( false === $header_center_logo ) {
+						get_template_part( 'template-parts/header/header', 'search' );
+					}
+					?>
 				</div><!-- .wrapper -->
 			</div><!-- .bottom-header-contain -->
 		<?php endif; ?>

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -65,6 +65,10 @@
 				}
 			}
 
+			&:last-child {
+				margin-right: 0;
+			}
+
 			&.menu-item-has-children {
 				position: inherit;
 

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -17,10 +17,6 @@
 		color: inherit;
 		display: inline-block;
 	}
-
-	#search-toggle {
-		margin-left: #{$size__spacing-unit * 0.5}
-	}
 }
 
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -119,6 +119,7 @@
 
 .header-search-contain {
 	display: none;
+	margin-left: #{ 0.75 * $size__spacing-unit };
 	position: relative;
 
 	@include media( tablet ) {
@@ -159,10 +160,20 @@
 
 .header-center-logo {
 	@include media( tablet ) {
+		.site-header .middle-header-contain .wrapper > * {
+			flex: 1 0 0;
+			min-width: calc( 100% / 3 );
+		}
+
 		.site-branding {
-			display: block;
-			flex-grow: 2;
+			flex-wrap: wrap;
+		}
+
+		.custom-logo-link,
+		.site-title,
+		.site-description {
 			text-align: center;
+			width: 100%;
 		}
 	}
 }
@@ -220,7 +231,6 @@
 		display: flex;
 		flex-grow: 2;
 		flex-basis: auto;
-		margin-right: $size__spacing-unit;
 	}
 
 	.custom-logo-link .custom-logo {
@@ -231,37 +241,19 @@
 		margin: 0;
 	}
 
-	&.header-left-logo.hide-site-tagline .main-navigation {
-		flex-grow: 2;
+	&.header-left-logo {
+		.site-branding {
+			margin-right: $size__spacing-unit;
+		}
+
+		&.hide-site-tagline .main-navigation {
+			flex-grow: 2;
+		}
 	}
 
 	.middle-header-contain .wrapper {
 		align-items: center;
 		padding: #{ 0.5 * $size__spacing-unit } 0;
-	}
-
-	.header-search-contain {
-		margin-left: #{ 0.75 * $size__spacing-unit };
-	}
-
-	&.header-center-logo {
-
-		@include media( tablet ) {
-			.site-header .wrapper > * {
-				flex: 1 0 0;
-				min-width: 33%;
-			}
-
-			.site-branding {
-				flex-wrap: wrap;
-			}
-
-			.custom-logo-link,
-			.site-title,
-			.site-description {
-				width: 100%;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the mis-centring of the logo in the header.

Once that was fixed, I also noticed the primary menu wasn't quite centred due to the search being on the same line. So it now sits next to the tertiary nav when you have the logo centred.

![image](https://user-images.githubusercontent.com/177561/63049665-1052b500-be8e-11e9-9994-c2d89f4ef616.png)

Closes #178 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Though the changes target the centred logo, there's always chance for regression elsewhere. So please test the following header settings combos:
     * Centred logo
     * Centred logo + short header
     * Default
     * Short header

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
