### PR TITLE
Centred Logo: Fixes centred dropdowns.

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -335,4 +335,8 @@
 .header-center-logo.header-default-height .site-header #site-navigation {
 	flex-basis: 100%;
 	text-align: center;
+
+	ul ul {
+		text-align: left;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, if you had the logo centred and the header set to be the standard height, the text in the primary menu dropdowns would also be centred.

Closes #249 .

### How to test the changes in this Pull Request:

1. Set to the logo to be centred, and the header not to be short.
2. View the dropdowns in the primary menu; note that their text is centred.
3. Apply the PR and run `npm run build`.
4. Verify that the dropdowns now have the text aligned left.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
