### PR TITLE
Solid Header: Improving vertical spacing, appearance

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -277,6 +277,11 @@ function newspack_custom_colors_css() {
 			.header-solid-background .site-header {
 				background-color: ' . $primary_color . ';
 			}
+			.header-solid-background .top-header-contain {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -10 ) . ';
+				border-bottom-color: ' . newspack_adjust_brightness( $primary_color, -15 ) . ';
+			}
+
 			.header-solid-background .site-header,
 			.header-solid-background .site-title,
 			.header-solid-background .site-title a:link,

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -20,9 +20,12 @@ nav.secondary-menu {
 			flex-wrap: wrap;
 		}
 
+		li {
+			margin-right: #{ $size__spacing-unit }
+		}
+
 		a {
 			font-size: $font__size-xs;
-			margin-right: #{0.5 * $size__spacing-unit};
 		}
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -81,7 +81,7 @@
 	background-color: #4a4a4a;
 	color: #fff;
 
-	.wrapper > * {
+	nav {
 		padding-bottom: #{ 0.3 * $size__spacing-unit };
 		padding-top: #{ 0.3 * $size__spacing-unit };
 	}
@@ -174,6 +174,7 @@
 		background-color: $color__primary;
 		padding-bottom: 0;
 	}
+
 	.site-header,
 	.site-title a,
 	.site-title a:visited,
@@ -185,12 +186,13 @@
 	}
 
 	.top-header-contain {
-		background-color: transparent;
+		background-color: darken( $color__primary, 5% );
+		border-bottom: 1px solid darken( $color__primary, 10% );
 	}
 
 	.middle-header-contain .wrapper {
 		@include media( tablet ) {
-			padding: #{ 1.5 * $size__spacing-unit } 0 #{ 2 * $size__spacing-unit };
+			padding: #{ 3 * $size__spacing-unit } 0;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is related to #248 

Basically, the solid-background header can start looking funky, especially when you use all of the menu locations and centre the logo.

This PR tries to improve that by:

* Increasing and evening out the vertical spacing above and below the centre vertical piece (the logo and menus)
* Adding a visual container around the menus in the top bar (secondary, or secondary + social, depending on the settings) to create some more visual differentiation, and make it look less like things are floating randomly.

![image](https://user-images.githubusercontent.com/177561/63053900-b0f9a280-be97-11e9-80e2-3d06735bbc5b.png)

![image](https://user-images.githubusercontent.com/177561/63054051-f8802e80-be97-11e9-8220-1cf86bbb3928.png)

The only version of the solid background header I originally mocked up was with the logo centred, and without a secondary navigation. I didn't do a great job exploring how the different pieces would fit together when everything was enabled. This is a step towards trying to sort that out, though if we go this route it could use further refinement. 

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Visually review the solid background header and confirm it matches the screenshots above.
3. Visually review the solid background header + centred logo and confirm it matches the screenshots above.
4. Try removing the secondary navigation (and social nav, when the logo isn't centered) and confirm that the top bar is no longer visible. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
