### PR TITLE
Style E: Fix entry title font weight in editor.

### DIFF
--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -7,7 +7,8 @@ Newspack Theme Editor Styles - Style Pack 4
 @import "variables-style/variables-style";
 @import "../../style-editor-base";
 
-.editor-post-title__block .editor-post-title__input {
+.editor-post-title__block .editor-post-title__input,
+.entry-title {
 	font-weight: normal;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed that Style E (Style 4) isn't using the right font weight for the homepage block titles in the editor. This PR fixes that.

**Before:**

![image](https://user-images.githubusercontent.com/177561/63060311-bf02ef80-bea6-11e9-9278-17eadd6310ad.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63060259-97ac2280-bea6-11e9-836b-01f199a8c6a9.png)

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Pack and switch to style 4.
2. View the homepage blocks in the editor; note that the entry titles are bold.
3. Apply the PR and run `npm run build`
4. Confirm that the entry titles in the editor are now the right weight.
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
