### PR TITLE
Adds class to let you 'highlight' a tertiary menu item

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -38,6 +38,7 @@ function newspack_custom_colors_css() {
 		.main-navigation .sub-menu,
 		.mobile-sidebar,
 		.site-header .main-navigation .main-menu .sub-menu,
+		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
@@ -76,7 +77,8 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar a:visited,
 		.mobile-sidebar .main-navigation .sub-menu > li > a,
 		.mobile-sidebar .main-navigation ul.main-menu > li > a,
-		.site-header .main-navigation .sub-menu > li > a {
+		.site-header .main-navigation .sub-menu > li > a,
+		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a {
 			color: ' . $primary_color_contrast . ';
 		}
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -50,7 +50,7 @@
 		> li {
 			> a {
 				color: inherit;
-				padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+				padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 				font-weight: 700;
 
 				&:hover,

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -16,7 +16,30 @@
 	a {
 		color: inherit;
 		display: inline-block;
-		padding: #{ 0.125 * $size__spacing-unit } 0;
+		padding: #{ 0.25 * $size__spacing-unit } 0;
+	}
+
+	.menu-highlight a {
+		border: 1px solid currentColor;
+		font-weight: bold;
+		padding-left: #{$size__spacing-unit * 0.5};
+		padding-right: #{$size__spacing-unit * 0.5};
+	}
+}
+
+
+body.header-default-background.header-default-height .site-header {
+	.tertiary-menu {
+		.menu-highlight a {
+			background-color: $color__primary;
+			border: 0;
+			color: $color__background-body;
+
+			&:hover {
+				background-color: $color__text-main;
+				color: $color__background-body;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the original styles that 'highlighted' the first or last link in the tertiary menu.

They add styles for a class, `menu-highlight`, which can then be used to manually add a link on a specific link, so it makes more sense for the layout a specific site has chosen. 

The default style for this class is bolded with a border. 

If you're using the default header settings, it will add the primary colour as a background colour instead. 

If there's a call for it, we can add styles for this class for the other menus, too. 

Closes #215.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to the Customizer > Menus, and edit the menu you have assigned to the tertiary menu spot. 
3. Edit one of the menu items in the menu -- there is a field, 'CSS Classes' where you can add the class `menu-highlight`:
4. Cycle through the different header options.

* Default header - the menu item with the class should have a primary colour background.

![image](https://user-images.githubusercontent.com/177561/63064329-6e46c300-beb5-11e9-9bd0-beea1a73a05c.png)

![image](https://user-images.githubusercontent.com/177561/63064523-5b80be00-beb6-11e9-8765-24f536fbbd37.png)

* Solid background, or short header - the menu item with the class should be bolded and have a border:

![image](https://user-images.githubusercontent.com/177561/63064410-c7aef200-beb5-11e9-82ad-a54ff191a1df.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
