### PR TITLE
Fix issue with mis-aligned logo in footer

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -169,7 +169,7 @@
 			flex-wrap: wrap;
 		}
 
-		.custom-logo-link,
+		.site-header .custom-logo-link,
 		.site-title,
 		.site-description {
 			text-align: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With the recent fixes to the centred logo in the header, I introduced a new issue: the logo is also getting centred in the footer:

**Before:**

![image](https://user-images.githubusercontent.com/177561/63064941-bfa48180-beb8-11e9-80f2-ff703750654b.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63064963-dfd44080-beb8-11e9-9625-ce4ef5f1b906.png)

### How to test the changes in this Pull Request:

1. Navigate to Customize > Header Settings, and centre the logo.
2. View the logo in the footer; note it's also centred.
3. Apply the PR and run `npm run build`
4. Confirm that the logo in the footer is now sitting in the right spot.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
