### PR TITLE
Minor: Tone down default header borders

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -100,8 +100,8 @@
 .bottom-header-contain {
 	.wrapper {
 		@include media( tablet ) {
-			border-bottom: 1px solid #4a4a4a;
-			border-top: 1px solid #4a4a4a;
+			border-bottom: 1px solid $color__border;
+			border-top: 1px solid $color__border;
 		}
 	}
 }
@@ -225,6 +225,7 @@
 // Simplified Header
 
 .header-simplified {
+
 	.site-header .wrapper {
 		justify-content: flex-start;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In application, the borders used in the default menu started to look a bit heavy handed to me; this PR swaps them out from #494949 to the default border colour, #111 

**Before:**

![image](https://user-images.githubusercontent.com/177561/63065157-db5c5780-beb9-11e9-90d3-bcd3f2ca2e24.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63065132-b667e480-beb9-11e9-8dad-2627a976ff00.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Check the header with the solid background and short options turned off.
3. Do a visual review and confirm that the border uses a lighter grey.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
