### PR TITLE
Minor: Adds bottom border when there is no background on the simplified header

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -225,6 +225,7 @@
 // Simplified Header
 
 .header-simplified {
+
 	.site-header .wrapper {
 		justify-content: flex-start;
 	}
@@ -251,6 +252,10 @@
 		&.hide-site-tagline .main-navigation {
 			flex-grow: 2;
 		}
+	}
+
+	&.header-default-background .site-header {
+		border-bottom: 1px solid $color__border;
 	}
 
 	.middle-header-contain .wrapper {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a minor update to add a bottom border when you have the header set to 'Short Header', but no background set. 

It's to try to make it look less 'floaty' and un-anchored:

**Before:**

![image](https://user-images.githubusercontent.com/177561/63065470-06937680-bebb-11e9-9305-cb36294798f6.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63065494-1ca13700-bebb-11e9-8021-204d28d792c8.png)

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`.
2. Navigate to Customize > Header Settings, check 'Short Header' and uncheck 'Solid Background'.
3. Confirm that the header has a light grey border running the width of the window.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
