### PR TITLE
Style C: Make only single post heading narrow, not whole content area.

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -32,12 +32,6 @@ Newspack Theme Styles - Style Pack 2
 	}
 }
 
-.header-simplified .site-content {
-	@include media( tablet ) {
-		margin-top: #{ -2 * $size__spacing-unit };
-	}
-}
-
 .site-content,
 .newspack-front-page.hide-homepage-title .site-content {
 	margin-top: #{ -0.5 * $size__spacing-unit };
@@ -99,6 +93,23 @@ body:not(.header-solid-background) .site-header {
 
 		@include media(desktop) {
 			padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
+		}
+	}
+}
+
+.single-post #primary {
+	padding-left: 0;
+	padding-right: 0;
+
+	.site-main > .entry-header {
+		@include media(tablet) {
+			padding-left: #{ 3 * $size__spacing-unit };
+			padding-right: #{ 3 * $size__spacing-unit };
+		}
+
+		@include media(desktop) {
+			padding-left: #{ 4.5 * $size__spacing-unit };
+			padding-right: #{ 4.5 * $size__spacing-unit };
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #245, this PR brings the header of the single posts in, and makes the rest of the content area 1200px wide, instead of making all of it narrower to 'fit inside' of the Style C header.

It also fixes a minor issue with Style C, where the content wasn't being 'pulled up' enough when you have the 'short' header set.

**Before:**

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/177561/63066834-ec5c9700-bec0-11e9-9771-c0a1f6fe6717.png">

**After:**

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/177561/63066793-bb7c6200-bec0-11e9-9ad7-f8f9df6b4617.png">

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Pack and set it to Style 2.
2. View a single post. Note the header layout, spacing around the post content.
3. Apply the PR and run `npm run build`
4. Confirm that the 'header' of the post is still narrower, but the rest is wider (1200px wide on larger screens).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?