### PR TITLE
Style C: Make only archive headers narrow, not the whole content area

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -114,6 +114,23 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
+.archive #primary {
+	padding-left: 0;
+	padding-right: 0;
+
+	& > .page-header {
+		@include media(tablet) {
+			padding-left: #{ 3 * $size__spacing-unit };
+			padding-right: #{ 3 * $size__spacing-unit };
+		}
+
+		@include media(desktop) {
+			padding-left: #{ 4.5 * $size__spacing-unit };
+			padding-right: #{ 4.5 * $size__spacing-unit };
+		}
+	}
+}
+
 // Site header
 
 .main-navigation > ul > li,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #245 and #259, this PR makes the header area of the archives page narrower than the content for Style C:

**Before:**

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/177561/63067199-a0aaed00-bec2-11e9-822f-1bc4ff916c6c.png">

**After:**

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/177561/63067163-81ac5b00-bec2-11e9-97b2-48ed53878a7c.png">

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and change to Style 2.
2. View an archive page; note the header appearance and widget. 
3. Apply this PR and run `npm run build`
4. View an archive page again; confirm that the 'page header' is narrower, but the rest of the content is 1200px wide on larger screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?