### PR TITLE
Pages: Restructure markup to match the single posts.

### DIFF
--- a/page.php
+++ b/page.php
@@ -13,24 +13,36 @@ get_header();
 	<section id="primary" class="content-area">
 		<main id="main" class="site-main">
 
+
 			<?php
 
 			/* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
+				?>
 
-				get_template_part( 'template-parts/content/content', 'page' );
+				<header class="entry-header">
+					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+				</header>
 
-				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) {
-					comments_template();
-				}
+				<div class="main-content">
 
+					<?php
+					get_template_part( 'template-parts/content/content', 'page' );
+
+					// If comments are open or we have at least one comment, load up the comment template.
+					if ( comments_open() || get_comments_number() ) {
+						comments_template();
+					}
+					?>
+				</div><!-- .main-content -->
+
+			<?php
 			endwhile; // End of the loop.
+			get_sidebar();
 			?>
 
 		</main><!-- #main -->
-		<?php get_sidebar(); ?>
 	</section><!-- #primary -->
 
 <?php

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -41,7 +41,8 @@
 	margin-top: $size__spacing-unit;
 }
 
-.single {
+.single,
+.page:not(.newspack-front-page) {
 	&.has-sidebar #main {
 		@include media( tablet ) {
 			display: flex;
@@ -53,8 +54,7 @@
 
 .archive,
 .blog,
-.search,
-.page:not(.newspack-front-page) {
+.search {
 	&.has-sidebar #primary {
 		@include media(tablet) {
 			display: flex;
@@ -67,7 +67,7 @@
 .archive #main,
 .blog #main,
 .search #main,
-.page:not(.newspack-front-page) #main,
+.page:not(.newspack-front-page) .main-content,
 .single-post .main-content {
 	@include media(tablet) {
 		width: 65%;

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -22,6 +22,7 @@
 
 .entry-header {
 	position: relative;
+	width: 100%;
 }
 
 .entry-title {
@@ -203,7 +204,6 @@ body.page {
 .single-post {
 	.entry-header {
 		padding: 0 0 $size__spacing-unit;
-		width: 100%;
 	}
 
 	&:not(.has-featured-image) .entry-header,

--- a/template-parts/content/content-page.php
+++ b/template-parts/content/content-page.php
@@ -9,48 +9,42 @@
 
 ?>
 
-<div class="main-content">
-	<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-		<header class="entry-header">
-			<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-		</header>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php newspack_post_thumbnail(); ?>
 
-		<?php newspack_post_thumbnail(); ?>
+	<div class="entry-content">
+		<?php
+		the_content();
 
-		<div class="entry-content">
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . __( 'Pages:', 'newspack' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
+
+	<?php if ( get_edit_post_link() ) : ?>
+		<footer class="entry-footer">
 			<?php
-			the_content();
-
-			wp_link_pages(
-				array(
-					'before' => '<div class="page-links">' . __( 'Pages:', 'newspack' ),
-					'after'  => '</div>',
-				)
+			edit_post_link(
+				sprintf(
+					wp_kses(
+						/* translators: %s: Name of current post. Only visible to screen readers */
+						__( 'Edit <span class="screen-reader-text">%s</span>', 'newspack' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					),
+					get_the_title()
+				),
+				'<span class="edit-link">',
+				'</span>'
 			);
 			?>
-		</div><!-- .entry-content -->
-
-		<?php if ( get_edit_post_link() ) : ?>
-			<footer class="entry-footer">
-				<?php
-				edit_post_link(
-					sprintf(
-						wp_kses(
-							/* translators: %s: Name of current post. Only visible to screen readers */
-							__( 'Edit <span class="screen-reader-text">%s</span>', 'newspack' ),
-							array(
-								'span' => array(
-									'class' => array(),
-								),
-							)
-						),
-						get_the_title()
-					),
-					'<span class="edit-link">',
-					'</span>'
-				);
-				?>
-			</footer><!-- .entry-footer -->
-		<?php endif; ?>
-	</article><!-- #post-<?php the_ID(); ?> -->
-</div>
+		</footer><!-- .entry-footer -->
+	<?php endif; ?>
+</article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I realized working on #245, #259 and #260 (making the top part of the pages narrower for Style C) that I wasn't going to be able to achieve the same thing for the pages and search results with the way that they're structured.

This PR reworks the page template a bit, so the page title is 'outside' of the content area. It should look very similar to how it does now, except the page title will sit above both the content and sidebar areas:

**Before:**

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/177561/63074665-1921a600-bee3-11e9-92a4-49927411ac63.png">

**After**

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/177561/63074680-335b8400-bee3-11e9-8137-7a3208f5e418.png">

### How to test the changes in this Pull Request:

1. View a page.
2. Apply the PR and run `npm run build`
3. View the page again; confirm that, outside of the sidebar looking a bit lower, nothing has changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?