### PR TITLE
Restructure the search results page a bit.

### DIFF
--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -89,3 +89,10 @@
 	font-style: italic;
 }
 
+.search {
+	.page-header {
+		@include media( tablet ) {
+			width: 65%;
+		}
+	}
+}

--- a/search.php
+++ b/search.php
@@ -12,16 +12,16 @@ get_header();
 
 	<section id="primary" class="content-area">
 
+		<header class="page-header">
+			<h1 class="page-title">
+				<?php esc_html_e( 'Search results', 'newspack' ); ?>
+			</h1>
+			<?php get_search_form(); ?>
+		</header><!-- .page-header -->
+
 		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
-
-			<header class="page-header">
-				<h1 class="page-title">
-					<?php esc_html_e( 'Search results', 'newspack' ); ?>
-				</h1>
-				<?php get_search_form(); ?>
-			</header><!-- .page-header -->
 
 			<?php
 			// Start the Loop.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #262, I realized working on #245, #259 and #260 (making the top part of the pages narrower for Style C) that I wasn't going to be able to achieve the same thing for the pages and search results with the way that they're structured.

This PR reworks the search result template a bit, so the search bar is 'outside' of the content area. It should look very similar to how it does now, except the search bar will sit above both the content and sidebar areas:

**Before:**

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/177561/63074781-ae249f00-bee3-11e9-8efe-43382cb645c4.png">

**After**

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/177561/63074796-c7c5e680-bee3-11e9-8605-1d2e71e8efb6.png">

For the search bar, the 'default' look could use some refinement, but for the short-term I just made it the same width as the content area.

### How to test the changes in this Pull Request:

1. View the search results.
2. Apply the PR and run `npm run build`
3. View the search results again; confirm that, outside of the sidebar looking a bit lower, nothing has changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?