### PR TITLE
Menus: Fixes multi-level dropdowns for the primary menu.

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -193,7 +193,7 @@
 			bottom: auto;
 			height: auto;
 			transform: none;
-			min-width: 200px;
+			width: #{ 12.5 * $size__spacing-unit };
 		}
 
 		.main-menu .sub-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
@@ -215,7 +215,7 @@
 			bottom: auto;
 			height: auto;
 			transform: none;
-			min-width: 200px;
+			width: #{ 12.5 * $size__spacing-unit };
 		}
 
 		.main-menu .sub-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -167,6 +167,12 @@
 						background: $color__primary-variation;
 					}
 				}
+
+				.submenu-expand {
+					right: #{ 0.25 * $size__spacing-unit };
+					top: #{ 0.4 * $size__spacing-unit };
+					transform: rotate( -90deg );
+				}
 			}
 		}
 
@@ -178,100 +184,45 @@
 		 */
 		.main-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
 			display: block;
-			left: 0;
 			margin-top: 0;
 			opacity: 1;
-			width: auto;
+			position: absolute;
+			left: 0;
+			right: auto;
+			top: 100%;
+			bottom: auto;
+			height: auto;
+			transform: none;
+			min-width: 200px;
+		}
 
-			/* Non-mobile position */
-			@include media(tablet) {
-				display: block;
-				margin-top: 0;
-				opacity: 1;
-				position: absolute;
-				left: 0;
-				right: auto;
-				top: 100%;
-				bottom: auto;
-				height: auto;
-				min-width: -moz-max-content;
-				min-width: -webkit-max-content;
-				min-width: max-content;
-				transform: none;
-			}
-
-			.submenu-expand {
-				display: none;
-			}
-
-			.sub-menu {
-				display: block;
-				margin-top: inherit;
-				position: relative;
-				width: 100%;
-				left: 0;
-				opacity: 1;
-
-				/* Non-mobile position */
-				@include media(tablet) {
-					float: none;
-					max-width: 100%;
-				}
-			}
-
-			/* Nested sub-menu dashes */
-			.sub-menu {
-				counter-reset: submenu;
-			}
+		.main-menu .sub-menu .menu-item-has-children:not(.off-canvas):focus-within > .sub-menu {
+			left: 100%;
+			top: 0;
 		}
 
 		.main-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
 		.main-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
 		.main-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
 			display: block;
-			left: 0;
+			float: none;
 			margin-top: 0;
 			opacity: 1;
-			width: auto;
-			min-width: 100%;
+			position: absolute;
+			left: 0;
+			right: auto;
+			top: 100%;
+			bottom: auto;
+			height: auto;
+			transform: none;
+			min-width: 200px;
+		}
 
-
-			/* Non-mobile position */
-			@include media(tablet) {
-				display: block;
-				float: none;
-				margin-top: 0;
-				opacity: 1;
-				position: absolute;
-				left: 0;
-				right: auto;
-				top: 100%;
-				bottom: auto;
-				height: auto;
-				min-width: -moz-max-content;
-				min-width: -webkit-max-content;
-				min-width: max-content;
-				transform: none;
-			}
-
-			.submenu-expand {
-				display: none;
-			}
-
-			.sub-menu {
-				display: block;
-				margin-top: inherit;
-				position: relative;
-				width: 100%;
-				left: 0;
-				opacity: 1;
-
-				/* Non-mobile position */
-				@include media(tablet) {
-					float: none;
-					max-width: 100%;
-				}
-			}
+		.main-menu .sub-menu .menu-item-has-children:not(.off-canvas):hover > .sub-menu,
+		.main-menu .sub-menu .menu-item-has-children:not(.off-canvas):focus > .sub-menu,
+		.main-menu .sub-menu .menu-item-has-children.is-focused:not(.off-canvas) > .sub-menu {
+			left: 100%;
+			top: 0;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes it so multi-level menus (3+ levels) are distinguishable -- right now if you nest more than three levels deep, it just looks like one level of dropdowns.

It also simplifies the dropdown styles, removing some CSS that isn't needed.

**My menu settings:**

![image](https://user-images.githubusercontent.com/177561/63113291-0fca2500-bf47-11e9-970b-5735d3e5d5a3.png)

**Before:**

![image](https://user-images.githubusercontent.com/177561/63113247-f923ce00-bf46-11e9-9c97-1e5f987be729.png)

**After:** 
![image](https://user-images.githubusercontent.com/177561/63113180-d691b500-bf46-11e9-812f-9db010b23ff7.png)

### How to test the changes in this Pull Request:

1. Set up a primary menu with three-plus levels.
2. Test on the front-end -- it will look like you just have one level of dropdowns.
3. Apply the PR and run `npm run build`.
4. View the menu again; your different levels should now be visible, and sub-menu items with a dropdown should show an arrow.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?