### PR TITLE
Swap locations of the primary and tertiary navigation in the short header

### DIFF
--- a/header.php
+++ b/header.php
@@ -88,13 +88,17 @@
 				// Centered logo AND short header.
 				if ( true === $header_center_logo && true === $header_simplified ) :
 				?>
-					<div id="tertiary-nav-contain" class="desktop-only">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_tertiary_menu();
-						}
-						?>
-					</div>
+
+					<div class="nav-wrapper desktop-only">
+						<div id="site-navigation">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_primary_menu();
+							}
+							?>
+						</div><!-- #site-navigation -->
+					</div><!-- .nav-wrapper -->
+
 				<?php endif; ?>
 
 
@@ -102,7 +106,7 @@
 
 				<?php
 				// Short header:
-				if ( true === $header_simplified ) :
+				if ( true === $header_simplified && false === $header_center_logo ) :
 				?>
 
 					<div class="nav-wrapper desktop-only">
@@ -125,28 +129,23 @@
 				<?php endif; ?>
 
 
-				<?php
-				// Logo NOT centered and header NOT short:
-				if ( ! ( true === $header_center_logo && true === $header_simplified ) ) :
-				?>
-					<div class="nav-wrapper desktop-only">
-						<div id="tertiary-nav-contain">
-							<?php
-							if ( ! newspack_is_amp() ) {
-								newspack_tertiary_menu();
-							}
-							?>
-
-						</div><!-- #tertiary-nav-contain -->
-
+				<div class="nav-wrapper desktop-only">
+					<div id="tertiary-nav-contain">
 						<?php
-						// Header simplified OR centered logo:
-						if ( true === $header_simplified || true === $header_center_logo ) {
-							get_template_part( 'template-parts/header/header', 'search' );
+						if ( ! newspack_is_amp() ) {
+							newspack_tertiary_menu();
 						}
 						?>
-					</div><!-- .nav-wrapper -->
-				<?php endif; ?>
+					</div><!-- #tertiary-nav-contain -->
+
+					<?php
+						// Header is simplified OR logo is centered:
+						if ( true === $header_simplified || true === $header_center_logo ) :
+							get_template_part( 'template-parts/header/header', 'search' );
+						endif;
+					?>
+				</div><!-- .nav-wrapper -->
+
 
 				<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 					<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -315,6 +315,10 @@
 	justify-content: flex-end;
 }
 
+.header-center-logo.header-simplified .nav-wrapper:first-of-type {
+	justify-content: flex-start;
+}
+
 .desktop-only {
 	display: none;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR switches the locations of the primary and tertiary menus when the header is short, and the logo is centred.

It's to make sure the 'highlighted' menu item is on the more logical right side; as an added bonus, it makes the main menu first, and gives it a little more space (since the search icon is not next to it).

Closes #261 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Run through the different header settings; unfortunately because any header change could affect any of them, it would be ideal to check:
* Default

![image](https://user-images.githubusercontent.com/177561/63115275-ab5d9480-bf4b-11e9-9808-b0ec90a6b034.png)

* Centred Logo

![image](https://user-images.githubusercontent.com/177561/63115310-bfa19180-bf4b-11e9-8157-5d2f9d2d8910.png)

* Short Header

![image](https://user-images.githubusercontent.com/177561/63115364-dcd66000-bf4b-11e9-81c3-e5ad12cb1033.png)

* Centred Logo + Short Header

![image](https://user-images.githubusercontent.com/177561/63115239-97b22e00-bf4b-11e9-88a3-50dd53ccc8b0.png)

* Short Header + Show Tagline (both primary and tertiary menus to the right)

![image](https://user-images.githubusercontent.com/177561/63115405-f4154d80-bf4b-11e9-8ebf-8433b4257514.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
