### PR TITLE
Style C: Fix first homepage block

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -85,7 +85,7 @@ body:not(.header-solid-background) .site-header {
 .newspack-front-page #primary {
 	padding: 0;
 
-	.main-content > article > .entry-content > *:first-child {
+	.site-main > article > .entry-content > *:first-child {
 
 		@include media(tablet) {
 			padding: $size__spacing-unit #{ 3 * $size__spacing-unit } 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In #245, the first block on the Style C homepage was made narrower than the rest of the page... then I went and broke that with #262. This PR fixes it again.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 2 (Style C).
2. View the front page -- note that the first block is now touches the edges:

![image](https://user-images.githubusercontent.com/177561/63130047-1750f480-bf6e-11e9-8874-a5b527b2b548.png)

3. Apply the PR and run `npm run build`
4. View the front page again -- yay!

![image](https://user-images.githubusercontent.com/177561/63130115-410a1b80-bf6e-11e9-9898-3067edb6b862.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?