### PR TITLE
Update secondary colour

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -123,6 +123,7 @@ function newspack_custom_colors_css() {
 		/* Set secondary color with contrast */
 
 		.entry-content a,
+		.entry-content a:visited,
 		.author-bio .author-link,
 		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
 			color:' . newspack_color_with_contrast( $secondary_color ) . ';
@@ -351,7 +352,7 @@ function newspack_custom_colors_css() {
 		 * - pullquote (solid color)
 		 * - buttons
 		 */
-		.editor-block-list__layout .editor-block-list__block a,
+
 		.entry-meta .byline a {
 			color: ' . newspack_color_with_contrast( $primary_color ) . '; /* base: #0073a8; */
 		}
@@ -363,13 +364,6 @@ function newspack_custom_colors_css() {
 
 		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
-		}
-
-		/* Hover colors */
-		.editor-block-list__layout .editor-block-list__block a:hover,
-		.editor-block-list__layout .editor-block-list__block a:active,
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
-			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
 		}
 
 		/* Secondary color */
@@ -390,6 +384,14 @@ function newspack_custom_colors_css() {
 			color: ' . $secondary_color_contrast . '; /* base: #0073a8; */
 		}
 
+		/* Hover colors */
+		.editor-block-list__layout .editor-block-list__block a:hover,
+		.editor-block-list__layout .editor-block-list__block a:active,
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
+			color: ' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #005177; */
+		}
+
+		.editor-block-list__layout .editor-block-list__block a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
 		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -39,8 +39,6 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar,
 		.site-header .main-navigation .main-menu .sub-menu,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
-		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
-		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content > .has-primary-background-color,
 		.entry .entry-content > *[class^="wp-block-"].has-primary-background-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-background-color,
@@ -87,7 +85,51 @@ function newspack_custom_colors_css() {
 		blockquote,
 		.entry .entry-content blockquote,
 		.entry .entry-content .wp-block-quote:not(.is-large),
-		.entry .entry-content .wp-block-quote:not(.is-style-large),
+		.entry .entry-content .wp-block-quote:not(.is-style-large) {
+			border-color: ' . $primary_color . '; /* base: #0073a8; */
+		}
+
+		.gallery-item > div > a:focus {
+			box-shadow: 0 0 0 2px ' . $primary_color . '; /* base: #0073a8; */
+		}
+
+		/* Set secondary background color */
+
+		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
+		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"],
+		.entry .entry-content > .has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-background-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
+			background-color:' . $secondary_color . '; /* base: #666 */
+		}
+
+		/* Set colour that contrasts against the secondary background */
+
+		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
+		.entry .button, button, input[type="button"], input[type="reset"], input[type="submit"] {
+			color: ' . $secondary_color_contrast . ';
+		}
+
+		/* Set secondary color */
+
+		.entry .entry-content > .has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
+		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
+			color:' . $secondary_color . '; /* base: #666 */
+		}
+
+		/* Set secondary color with contrast */
+
+		.entry-content a,
+		.author-bio .author-link,
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+			color:' . newspack_color_with_contrast( $secondary_color ) . ';
+		}
+
+		/* Set secondary border color */
+
 		input[type="text"]:focus,
 		input[type="email"]:focus,
 		input[type="url"]:focus,
@@ -104,29 +146,7 @@ function newspack_custom_colors_css() {
 		input[type="datetime-local"]:focus,
 		input[type="color"]:focus,
 		textarea:focus {
-			border-color: ' . $primary_color . '; /* base: #0073a8; */
-		}
-
-		.gallery-item > div > a:focus {
-			box-shadow: 0 0 0 2px ' . $primary_color . '; /* base: #0073a8; */
-		}
-
-		/* Set secondary background color */
-
-		.entry .entry-content > .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
-			background-color:' . $secondary_color . '; /* base: #666 */
-		}
-
-		/* Set secondary color */
-
-		.entry .entry-content > .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
-			color:' . $secondary_color . '; /* base: #666 */
+			border-color: ' . $secondary_color . '; /* base: #0073a8; */
 		}
 
 		/* Set primary variation background color */
@@ -159,8 +179,7 @@ function newspack_custom_colors_css() {
 		.comment-reply-link:hover,
 		.comment-navigation .nav-previous a:hover,
 		.comment-navigation .nav-next a:hover,
-		#cancel-comment-reply-link:hover,
-		.widget a:hover {
+		#cancel-comment-reply-link:hover {
 			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #0073a8; */
 		}
 
@@ -175,7 +194,9 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary variation color */
 
-		a:hover, a:active,
+		.entry .entry-content a:hover,
+		.widget a:hover,
+		.author-bio .author-link:hover,
 		.entry .entry-content > .has-secondary-variation-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-secondary-variation-color,
 		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
@@ -214,7 +235,8 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'default', 'style-3', 'style-4' ) ) {
 		$theme_css .= '
 			.archive .page-title,
-			.entry-meta .byline a,
+			.entry-meta .byline a, .entry-meta .byline a:visited,
+			.entry .entry-content .entry-meta .byline a, .entry .entry-content .entry-meta .byline a:visited,
 			.entry .entry-meta a:hover {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
@@ -259,6 +281,10 @@ function newspack_custom_colors_css() {
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 			.entry .entry-footer {
 				color: ' . $primary_color . ';
+			}
+
+			.cat-links a:hover {
+				color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}
 
 			.accent-header:before,
@@ -326,12 +352,7 @@ function newspack_custom_colors_css() {
 		 * - buttons
 		 */
 		.editor-block-list__layout .editor-block-list__block a,
-		.entry-meta .byline a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
+		.entry-meta .byline a {
 			color: ' . newspack_color_with_contrast( $primary_color ) . '; /* base: #0073a8; */
 		}
 
@@ -344,19 +365,37 @@ function newspack_custom_colors_css() {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__button,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
-			background-color: ' . $primary_color . '; /* base: #0073a8; */
-		}
-
 		/* Hover colors */
 		.editor-block-list__layout .editor-block-list__block a:hover,
 		.editor-block-list__layout .editor-block-list__block a:active,
 		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
 			color: ' . newspack_adjust_brightness( $primary_color, -40 ) . '; /* base: #005177; */
+		}
+
+		/* Secondary color */
+
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__button,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+			background-color: ' . $secondary_color . '; /* base: #0073a8; */
+		}
+
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__button,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+			color: ' . $secondary_color_contrast . '; /* base: #0073a8; */
+		}
+
+		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
+			color: ' . newspack_color_with_contrast( $secondary_color ) . ';
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -180,12 +180,14 @@
 				color: white;
 			}
 
+			&:not(.has-background):hover,
 			&:hover {
 				color: white;
 				background: $color__background-button-hover;
 				cursor: pointer;
 			}
 
+			&:not(.has-background):focus,
 			&:focus {
 				color: white;
 				background: $color__background-button-hover;

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -26,7 +26,7 @@ a {
 }
 
 a:visited {
-
+	color: $color__link;
 }
 
 a:hover,

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -25,7 +25,7 @@ input[type="submit"] {
 	}
 
 	&:visited {
-		color: $color__background-body;
+		color: inherit;
 		text-decoration: none;
 	}
 

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -25,8 +25,8 @@ textarea {
 	border-radius: 0;
 
 	&:focus {
-		border-color: $color__primary;
-		outline: thin solid rgba( $color__primary, 0.15 );
+		border-color: $color__secondary;
+		outline: thin solid rgba( $color__secondary, 0.15 );
 		outline-offset: -4px;
 	}
 }

--- a/sass/navigation/_links.scss
+++ b/sass/navigation/_links.scss
@@ -1,15 +1,15 @@
 a {
 
 	@include link-transition;
-	color: $color__link;
+	color: $color__text-light;
 
 	&:visited {
-		color: $color__link-visited;
+		color: $color__text-light;
 	}
 
 	&:hover,
 	&:active {
-		color: $color__link-hover;
+		color: $color__text-main;
 		outline: 0;
 		text-decoration: none;
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -94,6 +94,21 @@ body.page {
 			color: $color__primary;
 			font-weight: bold;
 			text-decoration: none;
+
+			&:visited {
+				color: $color__primary;
+			}
+
+			&:hover {
+				color: $color__primary-variation;
+			}
+		}
+	}
+
+	.posted-on {
+		a,
+		a:visited {
+			color: $color__text-light;
 		}
 	}
 }
@@ -163,11 +178,16 @@ body.page {
 	}
 
 	a {
-		text-decoration: underline;
 
-		&.button,
-		&:hover {
-			text-decoration: none;
+		color: $color__link;
+
+		&:visited {
+			color: $color__link-visited;
+		}
+
+		&:hover,
+		&:active {
+			color: $color__link-hover;
 		}
 
 		&.button {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -180,6 +180,7 @@ body.page {
 	a {
 
 		color: $color__link;
+		text-decoration: underline;
 
 		&:visited {
 			color: $color__link-visited;

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -18,7 +18,6 @@
 	}
 
 	a {
-		color: $color__primary;
 
 		&:hover {
 			color: $color__primary-variation;

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -43,8 +43,15 @@
 	}
 }
 
-.entry-meta .byline a {
-	color: $color__text-light;
+.entry-meta .byline {
+	a,
+	a:visited {
+		color: $color__text-light;
+	}
+
+	a:hover {
+		color: $color__text-main;
+	}
 }
 
 .single .entry-meta {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -180,9 +180,20 @@ body:not(.header-solid-background) .site-header {
 
 .entry-meta {
 	.byline a {
-		color: $color__text-light;
 		letter-spacing: 0.05em;
 		text-transform: uppercase;
+	}
+
+	a,
+	a:visited,
+	.byline a,
+	.byline a:visited {
+		color: $color__text-light;
+	}
+
+	a:hover,
+	.byline a:hover {
+		color: $color__text-main;
 	}
 }
 

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -2,7 +2,7 @@
 // Custom Colors - defaults
 $color__primary: #2A7DE1;
 $color__primary-variation: darken( $color__primary, 10% );
-$color__secondary: #666;
+$color__secondary: #555;
 $color__secondary-variation: darken( $color__secondary, 10% );
 
 // Backgrounds
@@ -10,7 +10,7 @@ $color__background-body: #fff;
 $color__background-input: #fff;
 $color__background-screen: #f1f1f1;
 $color__background-hr: #ccc;
-$color__background-button: $color__primary;
+$color__background-button: $color__secondary;
 $color__background-button-hover: #111;
 $color__background-pre: #eee;
 $color__background-ins: #fff9c0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR applies the secondary colour to more elements in the theme -- specifically:

* Links in the content

![image](https://user-images.githubusercontent.com/177561/63131800-c9d78600-bf73-11e9-9abe-d4547237a658.png)

* Hover states on links that aren't technically 'in' the content: 

![image](https://user-images.githubusercontent.com/177561/63131863-07d4aa00-bf74-11e9-8df5-f1539750a138.png)

* Buttons (both the comment submit button, and the default for the button block)

![image](https://user-images.githubusercontent.com/177561/63131558-ffc83a80-bf72-11e9-816d-0952cd4af000.png)

* Outline used for form fields:

![image](https://user-images.githubusercontent.com/177561/63131537-e58e5c80-bf72-11e9-968b-7450d330aa82.png)

It also makes the default secondary colour a bit darker, so it has sufficient contrast against the white background, in terms of accessibility.

### How to test the changes in this Pull Request:

I expect there to be some issues here and there with the links inheriting incorrectly, but didn't want to address them all in this PR because it's already pretty large. 

I'll do an individual sweep of each Style pack and post fixes separately -- in the meantime, the testing steps cover the most important things to check now:

1. Apply the PR and run `npm run build`
2. Navigate to Customize > Style Pack, and pick the default style pack.
3. Change to custom colours so it's easier to spot issues (the default secondary colour is grey, so it's harder to see, but you can also test with it). 
4. Copy paste [this content](https://cloudup.com/cvAh216Fw2D) into a post -- it includes two buttons, and links. 
5. Confirm that the buttons and links are using your secondary colour.
6. View the comment form on the page; confirm the button is using the secondary colour.
7. In the header, open the search; confirm the outline is using the secondary colour. 
8. Hover on a link outside of the standard content area (like in the widget sidebar, or one of the homepage block titles); confirm it's using the secondary colour. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
