### PR TITLE
Style B: Fix category font family

### DIFF
--- a/sass/variables-site/_fonts.scss
+++ b/sass/variables-site/_fonts.scss
@@ -1,7 +1,7 @@
 // Font and typographic variables
 
 $font__body: Georgia, Garamond, "Times New Roman", serif !default;
- $font__heading: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !default;
+$font__heading: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !default;
 
 $font__code: Menlo, monaco, Consolas, Lucida Console, monospace;
 $font__pre: "Courier 10 Pitch", Courier, monospace;

--- a/sass/variables-site/_fonts.scss
+++ b/sass/variables-site/_fonts.scss
@@ -1,7 +1,7 @@
 // Font and typographic variables
 
-$font__body: Georgia, Garamond, "Times New Roman", serif;
-$font__heading: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+$font__body: Georgia, Garamond, "Times New Roman", serif !default;
+ $font__heading: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif !default;
 
 $font__code: Menlo, monaco, Consolas, Lucida Console, monospace;
 $font__pre: "Courier 10 Pitch", Courier, monospace;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For some reason, the category font face in single posts started falling back to the default header typeface when I used Style B and C.

The cause seemed to be something about how the Sass was compiling; the fix I found was to declare the original properties the `! default` value, so they basically act as the fallback, and are only used if the `$font__heading` and `$font_body` variables aren't otherwise set.

**Before:**

![image](https://user-images.githubusercontent.com/177561/63134189-3efb8900-bf7d-11e9-83a9-a08acee08f4f.png)

**After:** 

![image](https://user-images.githubusercontent.com/177561/63134212-5aff2a80-bf7d-11e9-8c6c-9a0d77c33624.png)

I'm not sure if this is happening for anyone else, or if it's just a weird fluke on my machine, but this should at least harden the setup we have in place against weirdness like this.

Closes #264 .

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Pack and set it to Style 1 (Style B).
2. View a single post; confirm that the category font family is not using 'Fira Sans Condensed'.
3. Apply the PR and run `npm run build`.
4. Refresh the single page; see the correct font family.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
