### PR TITLE
Fixes overflow issue with desktop menu when AMP is enabled.

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -45,6 +45,7 @@
 	}
 
 	.main-menu {
+		overflow: visible;
 		width: 100%;
 
 		> li {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you enable AMP and have a menu with dropdowns, you get scrollbars:

![image](https://user-images.githubusercontent.com/177561/63186912-78320880-c012-11e9-9609-83d02fe5bb1c.png)

I thought this was already fixed, but it might've gotten changed with recent menu updates. It should look like:

![image](https://user-images.githubusercontent.com/177561/63186883-5e90c100-c012-11e9-81e0-c444904794a2.png)

Closes #273 .

### How to test the changes in this Pull Request:

1. Set up a menu with dropdowns.
2. View an AMP version of the page; note the menu's getting cut off.
3. Add PR and run `npm run build`
4. Confirm that the menu's no longer getting cut off.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?