### PR TITLE
Remove select colour from customizations.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -183,14 +183,7 @@ function newspack_custom_colors_css() {
 			color:' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #666 */
 		}
 
-		/* Text selection colors */
-
-		::selection {
-			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
-		}
-		::-moz-selection {
-			background-color: ' . newspack_adjust_brightness( $primary_color, 200 ) . '; /* base: #005177; */
-		}';
+		';
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -2,14 +2,6 @@ html {
 	box-sizing: border-box;
 }
 
-::-moz-selection {
-	background-color: $color__background_selection;
-}
-
-::selection {
-	background-color: $color__background_selection;
-}
-
 *,
 *:before,
 *:after {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the `::selection` colour (the colour used when you highlight text) is customized based on a lighter version of the primary colour.

This worked well in Twenty Nineteen, because you could only change the hue (and not the lightness/saturation) but with the Newspack theme, you can pick any colour -- and it's really easy to pick a colour that's too light, and isn't visible when used for the `::selection` colour (making it look like you can't select anything).

This PR removes all customization to the `::selection` value for now. 

Closes #276.

### How to test the changes in this Pull Request:

1. Pick a lighter primary colour (it doesn't need to be super light -- the colour used becomes invisible quicker than you'd expect).
2. Try to select text; note you can't see the selection.
3. Apply the PR and run `npm run build`
4. Try selecting text again; confirm that you're now seeing the browser default.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
