### PR TITLE
Cover Block: Make sure links inherit the white text colour.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -548,8 +548,11 @@
 		a:hover,
 		a:visited,
 		.entry-meta,
-		.entry-meta a {
-			color: inherit;
+		.entry-meta a,
+		.entry-meta a:visited,
+		article .entry-meta a,
+		article .entry-meta a:visited {
+			color: #fff;
 		}
 
 		&.alignleft,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -544,6 +544,14 @@
 			}
 		}
 
+		a,
+		a:hover,
+		a:visited,
+		.entry-meta,
+		.entry-meta a {
+			color: inherit;
+		}
+
 		&.alignleft,
 		&.alignright {
 			width: 100%;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -221,6 +221,14 @@ figcaption,
 		}
 	}
 
+	.entry-meta,
+	.entry-meta a,
+	.entry-meta a:visited,
+	.entry-meta .byline a,
+	.entry-meta .byline a:visited {
+		color: inherit
+	}
+
 	@include media(tablet) {
 		padding-left: 10%;
 		padding-right: 10%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure links in the Cover block inherit the colour used for the text (the block switches it to white). 

**Before**

![image](https://user-images.githubusercontent.com/177561/63302550-31524600-c292-11e9-83e5-372cb8f42ab5.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63302514-1a135880-c292-11e9-8157-48341b893363.png)

### How to test the changes in this Pull Request:

1. Set up a cover block; inside of it add a string of text with a link, and the Newspack block.
2. Note the colour of the links, both in the editor and on the published page.
3. Apply the PR and run `npm run build`. 
4. Test the page with the cover block again; confirm that the text link, and the author titles and entry meta, all inherit the white text colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
