### PR TITLE
Adds option for footer logo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,6 +60,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_theme_support( 'post-thumbnails' );
 		set_post_thumbnail_size( 1568, 9999 );
 
+		add_image_size( 'newspack-footer-logo', 400, 9999, false );
+
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -202,6 +202,44 @@ function newspack_customize_register( $wp_customize ) {
 			'settings'    => 'hide_front_page_title',
 		)
 	);
+
+	// Add option to hide page title on static front page.
+	$wp_customize->add_setting(
+		'hide_front_page_title',
+		array(
+			'default'           => false,
+			'type'              => 'theme_mod',
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+
+	// Add option to upload logo specifically for the footer.
+	$wp_customize->add_setting(
+		'newspack_footer_logo',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Cropped_Image_Control(
+			$wp_customize,
+			'newspack_footer_logo',
+			array(
+				'label'       => esc_html__( 'Footer logo', 'newspack' ),
+				'description' => esc_html__( 'Optional alternative logo to be displayed in the footer.', 'newspack' ),
+				'section'     => 'title_tagline',
+				'settings'    => 'newspack_footer_logo',
+				'priority'    => 8,
+				'flex_width'  => true,
+				'flex_height' => true,
+				'width'       => 800,
+				'height'      => 400,
+			)
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -203,17 +203,6 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Add option to hide page title on static front page.
-	$wp_customize->add_setting(
-		'hide_front_page_title',
-		array(
-			'default'           => false,
-			'type'              => 'theme_mod',
-			'transport'         => 'postMessage',
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-
 	// Add option to upload logo specifically for the footer.
 	$wp_customize->add_setting(
 		'newspack_footer_logo',

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -13,7 +13,11 @@
 		}
 
 		.custom-logo-link {
+			height: auto;
 			margin-bottom: $size__spacing-unit;
+			max-height: 100px;
+			max-width: 200px;
+			width: auto;
 		}
 	}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -14,11 +14,14 @@
 
 		.custom-logo-link,
 		.footer-logo-link {
-			height: auto;
 			margin-bottom: $size__spacing-unit;
-			max-height: 100px;
+			max-height: 75px;
 			max-width: 200px;
-			width: auto;
+
+			img {
+				max-height: 100%;
+				width: auto;
+			}
 		}
 	}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -19,7 +19,7 @@
 			max-width: 200px;
 
 			img {
-				max-height: 100%;
+				max-height: inherit;
 				width: auto;
 			}
 		}

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -12,7 +12,8 @@
 			padding-top: $size__spacing-unit;
 		}
 
-		.custom-logo-link {
+		.custom-logo-link,
+		.footer-logo-link {
 			height: auto;
 			margin-bottom: $size__spacing-unit;
 			max-height: 100px;

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -9,10 +9,24 @@
 if ( is_active_sidebar( 'footer-1' ) && has_custom_logo() ) : ?>
 	<div class="footer-branding">
 		<div class="wrapper">
-			<?php if ( has_custom_logo() ) : ?>
-				<?php the_custom_logo(); ?>
 			<?php
+			if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) :
+			?>
+				<a class="custom-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+					<?php
+					echo wp_get_attachment_image(
+						get_theme_mod( 'newspack_footer_logo', '' ),
+						'newspack-footer-logo',
+						'',
+						array( 'class' => 'custom-logo' )
+					);
+					?>
+				</a>
+			<?php
+			elseif ( has_custom_logo() ) :
+				the_custom_logo();
 			endif;
+
 			newspack_social_menu_footer();
 			?>
 		</div><!-- .wrapper -->

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -5,20 +5,22 @@
  * @package Newspack
  */
 
+$has_footer_logo = false;
+if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) {
+	$has_footer_logo = true;
+}
 
-if ( is_active_sidebar( 'footer-1' ) && has_custom_logo() ) : ?>
+if ( is_active_sidebar( 'footer-1' ) && ( has_custom_logo() || $has_footer_logo ) ) : ?>
 	<div class="footer-branding">
 		<div class="wrapper">
-			<?php
-			if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) :
-			?>
-				<a class="custom-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+			<?php if ( $has_footer_logo ) : ?>
+				<a class="footer-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
 					<?php
 					echo wp_get_attachment_image(
 						get_theme_mod( 'newspack_footer_logo', '' ),
 						'newspack-footer-logo',
 						'',
-						array( 'class' => 'custom-logo' )
+						array( 'class' => 'footer-logo' )
 					);
 					?>
 				</a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a second spot to upload a logo, to be used in the footer. If it's not used, the footer will fallback to using the regular logo.

In some cases, the contrast that would be appropriate for the header won't necessarily work in the footer (for example, if you have a solid background colour header with a dark colour, a white logo may work well, but it would be invisible against a white footer). 

Closes #209.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to Customize > Site Identity, and confirm there's a second option to upload a logo under the main one.
3. Add a footer widget, to make the logo display in the footer.
4. Confirm that it's using the same logo you assigned to the header.
5. Navigate to Customize > Site Identity, and upload a second logo to the Footer logo space. 
6. Confirm that that logo is now displayed in the footer. 
7. Remove the second logo again; confirm that it falls back to the original logo. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
