### PR TITLE
Do not enqueue comment-reply script in AMP context

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -258,16 +258,16 @@ function newspack_scripts() {
 
 	wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 
-	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-		wp_enqueue_script( 'comment-reply' );
-	}
-
-	$newspack_l10n = array(
-		'open_search'  => esc_html__( 'Open Search', 'newspack' ),
-		'close_search' => esc_html__( 'Close Search', 'newspack' ),
-	);
-
 	if ( ! newspack_is_amp() ) {
+		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+			wp_enqueue_script( 'comment-reply' );
+		}
+
+		$newspack_l10n = array(
+			'open_search'  => esc_html__( 'Open Search', 'newspack' ),
+			'close_search' => esc_html__( 'Close Search', 'newspack' ),
+		);
+
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/amp-fallback.js' ), array(), '1.0', true );
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* `comment-reply` script is not enqueued if AMP context.
* The `$newspack_l10n` variable is not unnecessarily computed if AMP context.

Closes #284.