### PR TITLE
Hide footer branding space if the site doesn't have branding

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -16,6 +16,7 @@
 	</div><!-- #content -->
 
 	<footer id="colophon" class="site-footer">
+
 		<?php get_template_part( 'template-parts/footer/footer', 'branding' ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 
@@ -38,7 +39,7 @@
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
 				}
 
-				if ( ! is_active_sidebar( 'footer-1' ) ) {
+				if ( ! is_active_sidebar( 'footer-1' ) || ( ! has_custom_logo() ) ) {
 					newspack_social_menu_footer();
 				}
 				?>

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -211,7 +211,8 @@
 		color: $color__text-main;
 	}
 
-	.footer-branding .wrapper {
+	.footer-branding .wrapper,
+	.widget-area:first-child {
 		border-top: 3px solid currentColor;
 	}
 

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -84,6 +84,9 @@ body.header-default-background.header-default-height {
 
 /* Footer */
 
-#colophon .footer-branding .wrapper {
-	border-top: 4px solid $color__border;
+.site-footer .footer-branding,
+.site-footer .widget-area:first-child {
+	.wrapper {
+		border-top: 4px solid $color__border;
+	}
 }

--- a/template-parts/footer/footer-branding.php
+++ b/template-parts/footer/footer-branding.php
@@ -6,7 +6,7 @@
  */
 
 
-if ( is_active_sidebar( 'footer-1' ) ) : ?>
+if ( is_active_sidebar( 'footer-1' ) && has_custom_logo() ) : ?>
 	<div class="footer-branding">
 		<div class="wrapper">
 			<?php if ( has_custom_logo() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the logic around the footer branding, so the branding container and styles aren't output if you don't actually have a logo.

Closes #287.

Note: this will need to be reworked once #283 is merged.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Switch to Style 2 or 3 -- both have border on the footer branding container, so these'll make it easier to see when it's removed.
3. Run through the following to get the different footer combinations:

* Add a site logo, one footer widget (necessary for the layout) and a social menu (just to make sure it's showing). You should see something like the following, with the logo and social menu, then the widgets, then the site info:

![image](https://user-images.githubusercontent.com/177561/63382327-52c53780-c34f-11e9-9c43-37b7ac0e7992.png)

* Remove the site logo - you should see something like this, with no logo, but with the widget and then the site info with the social menu:

![image](https://user-images.githubusercontent.com/177561/63382200-142f7d00-c34f-11e9-8440-1c90141af0a3.png)

* Remove the footer widget - you should see something like this. It should also look like this with a logo, but not widgets:

![image](https://user-images.githubusercontent.com/177561/63382383-77b9aa80-c34f-11e9-9572-e3680d1f0310.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
