### PR TITLE
Increase size of gaps between widgets.

### DIFF
--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -31,12 +31,12 @@
 
 		@include media( mobile ) {
 			flex: 1 0 0px;
-			margin-right: $size__spacing-unit;
-			min-width: calc( 50% - #{ $size__spacing-unit } );
+			margin-right: #{ 2 * $size__spacing-unit };
+			min-width: calc( 50% - #{ 2 * $size__spacing-unit } );
 		}
 
 		@include media( tablet ) {
-			min-width: calc( 25% - #{ $size__spacing-unit } );
+			min-width: calc( 25% - #{ 2 * $size__spacing-unit } );
 		}
 
 		&:last-child {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR doubles the space between widgets in the footer when you have more than one. 

**Before:**

![image](https://user-images.githubusercontent.com/177561/63383504-c8320780-c351-11e9-8365-0642b1d6878b.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63383437-a46ec180-c351-11e9-8f3d-4c4112e6958a.png)

Closes #288 .

### How to test the changes in this Pull Request:

1. Add 2+ text widgets to the footer (they're the easiest to see how wide they actually are. 
2. Note the spacing between.
3. Apply PR and run `npm run build`.
4. Confirm that the footer appears to have better spacing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
