### PR TITLE
Add hover styles to the top-level of menu.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -169,8 +169,6 @@ function newspack_custom_colors_css() {
 
 		/* Set primary variation color */
 
-		.main-navigation .main-menu > li > a:hover,
-		.main-navigation .main-menu > li > a:hover + svg,
 		.author-bio .author-description .author-link:hover,
 		.entry .entry-content > .has-primary-variation-color,
 		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-color,

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -54,9 +54,8 @@
 				padding: #{ 0.25 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
 				font-weight: 700;
 
-				&:hover,
-				&:hover + svg {
-					color: $color__primary-variation;
+				&:hover {
+					opacity: 0.75;
 				}
 			}
 

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -9,6 +9,10 @@ nav.secondary-menu {
 	a {
 		color: inherit;
 		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit };
+
+		&:hover {
+			opacity: 0.75;
+		}
 	}
 }
 

--- a/sass/navigation/_menu-social-navigation.scss
+++ b/sass/navigation/_menu-social-navigation.scss
@@ -26,12 +26,12 @@
 
 			&:hover,
 			&:active {
-				opacity: 0.6;
+				opacity: 0.7;
 			}
 
 			&:focus {
 				opacity: 1;
-				border-bottom: 1px solid $color__text-main;
+				border-bottom: 1px solid currentColor;
 			}
 
 			svg {

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -17,6 +17,10 @@
 		color: inherit;
 		display: inline-block;
 		padding: #{ 0.25 * $size__spacing-unit } 0;
+
+		&:hover {
+			opacity: 0.75;
+		}
 	}
 
 	.menu-highlight a {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -115,6 +115,10 @@
 	.search-icon {
 		display: none;
 	}
+
+	&:hover {
+		opacity: 0.7;
+	}
 }
 
 .header-search-contain {

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -24,9 +24,11 @@ body.header-default-background.header-default-height {
 				font-weight: 700;
 				padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
 
-				&:hover {
+				&:hover,
+				&:focus {
 					background-color: $color__text-main;
 					color: #fff;
+					opacity: 1.0;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a hover style to the top level of each of the menus (primary, secondary, tertiary), and the search toggle.

I was trying to find a way to style these that didn't require a ton of CSS to get around the different colour options, header options, and style packs.

This approach is to add a slight opacity change on hover (so the links become a bit lighter). 

If it doesn't seem noticeable enough, another option would be to use a bottom border, either a text decoration, or a box-shadow if we want a bolder line. 

Open to thoughts about how this looks, and if it would be better to go with something bolder.

Closes #254.

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`
2. Hover over items from each menu; the top level of the primary menu, and links from the secondary, tertiary, social and search toggle should all get slightly lighter on hover.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
