### PR TITLE
Separators: Adding styles the separator blocks.

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -572,13 +572,12 @@
 	//! Separator
 	.wp-block-separator,
 	hr {
-		background-color: $color__text-light;
+		background-color: transparent;
 		border: 0;
-		height: 2px;
-		margin-bottom: (2 * $size__spacing-unit);
-		margin-top: (2 * $size__spacing-unit);
-		max-width: 2.25em;
-		text-align: left;
+		border-top: 1px solid $color__border;
+		height: 1px;
+		margin: (2 * $size__spacing-unit) auto;
+		max-width: #{ 5 * $size__spacing-unit };
 
 		&.is-style-wide {
 			max-width: 100%;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -561,12 +561,15 @@ figcaption,
 .wp-block-separator {
 
 	&:not(.is-style-dots) {
-		border-bottom: 2px solid $color__text-light;
+		border: 0;
+		border-top: 1px solid $color__border;
+		background-color: transparent;
 	}
 
 	&:not(.is-style-wide):not(.is-style-dots) {
-		width: $font__size-xl;
-		margin-left: 0;
+		max-width: #{ 5 * $size__spacing-unit };
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	&.is-style-dots:before {

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -114,3 +114,7 @@ Newspack Theme Editor Styles - Style Pack 2
 		}
 	}
 }
+
+.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+	border-top: 5px solid $color__text-main;
+}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -325,6 +325,10 @@ body:not(.header-solid-background) .site-header {
 			}
 		}
 	}
+
+	.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+		border-top: 5px solid $color__text-main;
+	}
 }
 
 // Author Bio

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -134,3 +134,8 @@ Newspack Theme Editor Styles - Style Pack 3
 
 	}
 }
+
+.wp-block-separator:not(.is-style-dots),
+hr {
+	border-top: 1px dotted $color__text-main;
+}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -220,6 +220,11 @@ Newspack Theme Styles - Style Pack 3
 			width: 32px;
 		}
 	}
+
+	.wp-block-separator,
+	hr {
+		border-top: 1px dotted $color__text-main;
+	}
 }
 
 // Archives


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR sets up the 'default' styles for the separator block, as well as some slightly different style for style packs 2 and 3.

**Default:** 

![image](https://user-images.githubusercontent.com/177561/63393910-1e16a780-c372-11e9-8fcf-1a136b954755.png)

**Style 2** (chunkier 'default' separator styles):

![image](https://user-images.githubusercontent.com/177561/63393922-28d13c80-c372-11e9-8648-755ae64b6d0c.png)

**Style 3** (lightly dotted line for default, wide styles)

![image](https://user-images.githubusercontent.com/177561/63393939-38508580-c372-11e9-9d5a-a17870b3a611.png)

Closes #291.

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/c1JumUobaDY) into the Code editor.
2. With either the default stylepack, or style packs 1 or 4, view the post on the front end and in the editor, and confirm the blocks look like the first screenshot.
3. Switch to style 2, and confirm that the blocks look like the second screenshot on the front-end and in the editor.
4. Switch to style 3, and confirm that the blocks look like the third screenshot on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?