### PR TITLE
Reduce minimum height of cover blocks when nested in columns blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -554,6 +554,13 @@
 		}
 	}
 
+	.wp-block-columns {
+		.wp-block-cover,
+		.wp-block-cover-image {
+			min-height: 330px;
+		}
+	}
+
 	//! Galleries
 	.wp-block-gallery {
 		list-style-type: none;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -286,6 +286,13 @@ figcaption,
 	}
 }
 
+.wp-block-columns {
+	.wp-block-cover,
+	.wp-block-cover-image {
+		min-height: 330px;
+	}
+}
+
 /** === Image === */
 
 .wp-block-image {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reduces the minimum height of the cover block when it's nested inside of the columns block. Otherwise, the minimum height makes it about square. 

Closes #292.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cCDS8IUGlL2) into the code editor.
2. View the blocks in the editor and on the front end -- the minimum height for the cover block is 430px:

![image](https://user-images.githubusercontent.com/177561/63398833-a487b500-c383-11e9-8190-b592aba4d3cd.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the cover blocks now have a minimum height of 330px -- should still be enough for a few lines of content, but short enough to appear more rectangular.

![image](https://user-images.githubusercontent.com/177561/63398821-96399900-c383-11e9-8457-279f643c9de8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
