### PR TITLE
Make sure the homepage block doesn't inherit the custom link colour

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -393,7 +393,9 @@ function newspack_custom_colors_css() {
 
 		/* Do not overwrite solid color pullquote or cover links */
 		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-cover a {
+		.editor-block-list__layout .editor-block-list__block .wp-block-cover a,
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a,
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover {
 			color: inherit;
 		}
 		';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR prevents the Newspack homepage block from inheriting the custom link colour.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Colors and change it to 'Custom' colours, and pick a secondary colour.
2. Add a Homepage article block to the editor.
3. Note that the post title is inheriting your custom colour in the editor: 

![image](https://user-images.githubusercontent.com/177561/63400577-29c19880-c389-11e9-87e1-9d8b4a307f5a.png)

4. Apply the PR.
5. Check the editor again; confirm that the entry title now matches the front-end (very dark grey). 

![image](https://user-images.githubusercontent.com/177561/63400523-f4b54600-c388-11e9-806f-61bb0b2d6d2f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
