### PR TITLE
Fix contrast issue with the Style 3 accent headers

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -271,8 +271,9 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.cat-links a,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-			.entry .entry-footer {
-				color: ' . $primary_color . ';
+			.entry .entry-footer,
+			.accent-header {
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
 			.cat-links a:hover {
@@ -438,7 +439,7 @@ function newspack_custom_colors_css() {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
-				color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
 			.editor-block-list__layout .editor-block-list__block .accent-header:before,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes contrast issues in the style 3 'accent headers' when you're using custom colours.

These headers, specifically, are:

* The Homepage Block headers
* The sidebar widget headers
* The category links at the top of single posts

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Style Packs, and switch to Style 3.
2. Navigate to Customizer > Colours, and pick a light primary colour. 
3. View a Homepage Block on the front-end of the site and in the editor, and note the Section Header colour: 

![image](https://user-images.githubusercontent.com/177561/63401540-7d81b100-c38c-11e9-9789-bdf40a946c11.png)

4. View a single post and note the category colour at the top:

![image](https://user-images.githubusercontent.com/177561/63401553-8b373680-c38c-11e9-93fd-b70515b814a3.png)

5. View a sidebar widget title -- it won't have a contrast colour, because it won't be using your custom colour at all:

![image](https://user-images.githubusercontent.com/177561/63401561-9a1de900-c38c-11e9-9897-7d9d63d36def.png)

6. Apply the PR.
7. View the Homepage blocks on the front-end and in the editor; the section title should now be a mid-grey: 

![image](https://user-images.githubusercontent.com/177561/63401603-c0438900-c38c-11e9-98f7-6c71defccf38.png)

8. View a single post; note the category colour how has contrast:

![image](https://user-images.githubusercontent.com/177561/63401618-d2252c00-c38c-11e9-883f-9b51f2750580.png)

9. Lastly, check the sidebar widget and confirm it has sufficient contrast, and isn't falling back to the default blue:

![image](https://user-images.githubusercontent.com/177561/63401640-e23d0b80-c38c-11e9-8778-218bea4e42f7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
