### PR TITLE
Add release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 # Compiled CSS
 styles/
 *.css
+
+# Release folder
+release/

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build:print": "node-sass sass/print.scss styles/print.css --output-style expanded && postcss -r styles/print.css",
     "build": "run-p \"build:*\"",
     "prebuild": "run-p \"prebuild:*\"",
-    "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial"
+    "watch": "chokidar \"**/*.scss\" -c \"npm run build\" --initial",
+    "release:archive": "run-p \"build\" && mkdir -p release && zip -r release/newspack-theme.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*"
   }
 }


### PR DESCRIPTION
1. `npm run release:archive`
2. In the `release` folder there should be a `newspack-theme.zip` which is a complete, ready-to-go zip of the theme and can be installed like a regular theme.