### PR TITLE
Cover Blocks: Remove/override default cover block font styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -396,7 +396,8 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-cover a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover {
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover,
+		.editor-block-list__layout .editor-block-list__block .wp-block-cover .article-section-title {
 			color: inherit;
 		}
 		';

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -528,22 +528,6 @@
 			padding: $size__spacing-unit 10%;
 		}
 
-		.wp-block-cover-image-text,
-		.wp-block-cover-text,
-		h2 {
-			font-family: $font__heading;
-			font-size: $font__size-lg;
-			font-weight: bold;
-			line-height: 1.25;
-			padding: 0;
-			color: #fff;
-
-			@include media(tablet) {
-				font-size: $font__size-xl;
-				max-width: 100%;
-			}
-		}
-
 		a,
 		a:hover,
 		a:visited,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -524,6 +524,10 @@
 		min-height: 430px;
 		padding: $size__spacing-unit;
 
+		h2 {
+			max-width: 100%;
+		}
+
 		@include media(tablet) {
 			padding: $size__spacing-unit 10%;
 		}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -526,6 +526,8 @@
 
 		h2 {
 			max-width: 100%;
+			padding-left: 0;
+			text-align: left;
 		}
 
 		@include media(tablet) {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -211,6 +211,8 @@ figcaption,
 
 	h2 {
 		max-width: 100%;
+		padding-left: 0;
+		text-align: left;
 	}
 
 	@include media(tablet) {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -201,26 +201,6 @@ figcaption,
 
 .wp-block-cover {
 
-	h2,
-	.wp-block-cover-text {
-		font-family: $font__heading;
-		font-size: $font__size-lg;
-		font-weight: bold;
-		line-height: 1.4;
-		padding-left: $size__spacing-unit;
-		padding-right: $size__spacing-unit;
-
-		strong {
-			font-weight: bolder;
-		}
-
-		@include media(tablet) {
-			margin-left: auto;
-			margin-right: auto;
-			padding: 0;
-		}
-	}
-
 	.entry-meta,
 	.entry-meta a,
 	.entry-meta a:visited,

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -209,14 +209,13 @@ figcaption,
 		color: inherit
 	}
 
+	h2 {
+		max-width: 100%;
+	}
+
 	@include media(tablet) {
 		padding-left: 10%;
 		padding-right: 10%;
-
-		h2,
-		.wp-block-cover-text {
-			font-size: $font__size-xl;
-		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The cover block originally only let you nest a header, body text, and a button. Because of that, the theme's original styles (and the block's own default styles) reflect that -- and caused some issues.

This PR makes sure blocks inside of the cover block use standard font sizes, and make sure h2s don't have a max-width. 

### How to test the changes in this Pull Request:

1. Copy paste [this content](https://cloudup.com/c9Pq7o_IDhB) into the editor (a cover block, with one Newspack article block inside of it).
2. View in the editor and on the front end; note that the section header is narrower than the rest of the content, and weirdly large:

![image](https://user-images.githubusercontent.com/177561/63481763-6b1a7c80-c44b-11e9-89c9-b2f5d6ada5b8.png)

... and the editor, it's also not white and has a max-width of 610px:

![image](https://user-images.githubusercontent.com/177561/63482035-34913180-c44c-11e9-8f40-e9bca2fcbd13.png)

3. Apply the PR and run `npm run build`
4. Confirm that the section header is using the right font size, and in the editor uses the right colour and is the same width:

![image](https://user-images.githubusercontent.com/177561/63481814-9b621b00-c44b-11e9-8ee6-49cdf63da137.png)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
