### PR TITLE
Add 'all-caps' option to the Typography settings, so it's optional.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -321,7 +321,7 @@ function newspack_editor_customizer_styles() {
 		$theme_customizations .= newspack_custom_colors_css();
 	}
 
-	if ( get_theme_mod( 'font_body', '' ) || get_theme_mod( 'font_header', '' ) ) {
+	if ( get_theme_mod( 'font_body', '' ) || get_theme_mod( 'font_header', '' ) || get_theme_mod( 'accent_allcaps', true ) ) {
 		$theme_customizations .= newspack_custom_typography_css();
 	}
 
@@ -431,7 +431,7 @@ add_action( 'wp_head', 'newspack_colors_css_wrap' );
  */
 function newspack_typography_css_wrap() {
 
-	if ( is_admin() || ( ! get_theme_mod( 'font_body', '' ) && ! get_theme_mod( 'font_header', '' ) ) ) {
+	if ( is_admin() || ( ! get_theme_mod( 'font_body', '' ) && ! get_theme_mod( 'font_header', '' ) && ! get_theme_mod( 'accent_allcaps', true ) ) ) {
 		return;
 	}
 	?>

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -324,6 +324,23 @@ function newspack_customize_typography_register( $wp_customize ) {
 			'choices' => $font_stacks,
 		)
 	);
+
+	// Typography - use optional uppercase styles
+	$wp_customize->add_setting(
+		'accent_allcaps',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'accent_allcaps',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Use all-caps for accent text.', 'newspack' ),
+			'section' => 'newspack_typography',
+		)
+	);
 }
 
 add_action( 'customize_register', 'newspack_customize_typography_register' );

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -268,6 +268,30 @@ function newspack_custom_typography_css() {
 		";
 	}
 
+	if ( true === get_theme_mod( 'accent_allcaps', true ) ) {
+		$css_blocks .= '
+			.tags-links span:first-child,
+			.page-title {
+				text-transform: uppercase;
+			}
+		';
+
+		if ( newspack_is_active_style_pack( 'default' ) ) {
+			$css_blocks        .= '
+				.accent-header,
+				.article-section-title,
+				.cat-links a {
+					text-transform: uppercase;
+				}
+			';
+			$editor_css_blocks .= '
+				.article-section-title {
+					text-transform: uppercase;
+				}
+			';
+		}
+	}
+
 	if ( '' !== $css_blocks ) {
 		$theme_css = $css_blocks;
 	} else {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -68,7 +68,6 @@ body.page {
 		font-weight: bold;
 		font-size: $font__size-sm;
 		margin-right: $size__spacing-unit;
-		text-transform: uppercase;
 	}
 
 	a {

--- a/sass/styles/style-default/style-default-editor.scss
+++ b/sass/styles/style-default/style-default-editor.scss
@@ -4,5 +4,4 @@
 	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
 	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
-	text-transform: uppercase;
 }

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -7,7 +7,6 @@
 	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
 	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
-	text-transform: uppercase;
 }
 
 /* Navigation */
@@ -44,7 +43,6 @@ body.header-default-background.header-default-height {
 		display: inline-block;
 		margin: 0 #{ 0.25 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit } 0;
 		padding: 0.5em 0.75em;
-		text-transform: uppercase;
 
 		&:visited {
 			color: #fff;

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -159,7 +159,6 @@ blockquote {
 
 .page-title {
 	letter-spacing: 0.01em;
-	text-transform: uppercase;
 }
 
 .page-description {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to set some of the accent letters to all-caps, rather than having it as the default. 

This is because all-caps can be difficult to read, espeicially in some font faces. 

To start, it adds an option under the Customizer, and only makes changes to the default style pack. 

See #280.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and pick 'Default'.
3. Check the following situations (all the elements that are all-caps):

* Article block with section header 

![image](https://user-images.githubusercontent.com/177561/63482255-15df6a80-c44d-11e9-9fdf-82980b35e091.png)

* Single Post - category on top

![image](https://user-images.githubusercontent.com/177561/63482289-360f2980-c44d-11e9-876b-80e1fdf9d8d1.png)

* Single post - tag label at bottom: 

![image](https://user-images.githubusercontent.com/177561/63482321-4fb07100-c44d-11e9-88c5-f59a917b2e0c.png)

* Single post - author bio:

![image](https://user-images.githubusercontent.com/177561/63482329-59d26f80-c44d-11e9-9a7d-e08cf5c9df02.png)

* Sidebar widget title: 

![image](https://user-images.githubusercontent.com/177561/63482305-44f5dc00-c44d-11e9-84b0-8860b73ecdec.png)

* One of the 'page titles' -- like the top line in the header of the archives: 

![image](https://user-images.githubusercontent.com/177561/63482356-75d61100-c44d-11e9-86e2-e33f578a74d2.png)

4. Apply the PR and run `npm run build`
5. Navigate to Customize > Typography and uncheck 'Use all-caps for accent text.'
6. Loop through the above items, and confirm that they're now title case:

* Article block with section header 

![image](https://user-images.githubusercontent.com/177561/63482501-f8f76700-c44d-11e9-912d-8f986b538c2e.png)

* Single Post - category on top

![image](https://user-images.githubusercontent.com/177561/63482505-0280cf00-c44e-11e9-8e7d-267bbfb06db7.png)

* Single post - tag label at bottom: 

![image](https://user-images.githubusercontent.com/177561/63482520-0d3b6400-c44e-11e9-951e-e4b5a7a68dd4.png)

* Single post - author bio:

![image](https://user-images.githubusercontent.com/177561/63482534-19272600-c44e-11e9-9bd3-7100ef1cfa1d.png)

* Sidebar widget title: 

![image](https://user-images.githubusercontent.com/177561/63482549-20e6ca80-c44e-11e9-88df-ef75e681ad32.png)

* One of the 'page titles' -- like the top line in the header of the archives: 

![image](https://user-images.githubusercontent.com/177561/63482487-ed0ba500-c44d-11e9-82c3-51b700f59f19.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
