### PR TITLE
Add additional colours to the theme palette.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -185,6 +185,21 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 						newspack_adjust_brightness( get_theme_mod( 'secondary_color_hex', $secondary_color ), -40 ),
 				),
 				array(
+					'name'  => __( 'Dark Gray', 'newspack' ),
+					'slug'  => 'dark-gray',
+					'color' => '#111', // color__text-main
+				),
+				array(
+					'name'  => __( 'Medium Gray', 'newspack' ),
+					'slug'  => 'medium-gray',
+					'color' => '#767676', // color__text-light
+				),
+				array(
+					'name'  => __( 'Light Gray', 'newspack' ),
+					'slug'  => 'light-gray',
+					'color' => '#eee', // color__background-pre
+				),
+				array(
 					'name'  => __( 'White', 'newspack' ),
 					'slug'  => 'white',
 					'color' => '#FFF',

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -794,6 +794,21 @@
 		background-color: $color__secondary-variation;
 	}
 
+	.has-dark-gray-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color {
+		background-color: #111;
+	}
+
+	.has-medium-gray-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-medium-gray-background-color {
+		background-color: #767676;
+	}
+
+	.has-light-gray-background-color,
+	.wp-block-pullquote.is-style-solid-color.has-light-gray-background-color {
+		background-color: #eee;
+	}
+
 	.has-white-background-color,
 	.wp-block-pullquote.is-style-solid-color.has-white-background-color {
 		background-color: #FFF;
@@ -822,6 +837,21 @@
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
 		color: $color__secondary-variation;
+	}
+
+	.has-dark-gray-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color {
+		color: #111;
+	}
+
+	.has-medium-gray-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color {
+		color: #767676;
+	}
+
+	.has-light-gray-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
+		color: #eee;
 	}
 
 	.has-white-color,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds three greys to the editor colour palette, matching colours used in the theme: a dark grey (same colour as the text), a medium grey (same colour as the 'light' text) and a light grey (same colour as the `pre` tag background). 

I wanted to build out some more colours outside of the four generated from the custom colours, to use for backgrounds, etc. 

Closes #310.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm you see three new greys in the colour picker in the editor (you can get to it using the paragraph block or pullquote block)

![image](https://user-images.githubusercontent.com/177561/63556064-344e7000-c4f8-11e9-95b5-4362c8ed27ca.png)

3. Copy paste [this test content](https://cloudup.com/cAU4fvc-gIM) into the code editor.
4. Confirm that the styles match the descriptions in the editor and on the front-end -- it should be three paragraphs in varying shades of grey, and three paragraphs with varying shades of grey background.

![image](https://user-images.githubusercontent.com/177561/63556074-416b5f00-c4f8-11e9-94da-e54dc77ee173.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
