### PR TITLE
Cover Block: Remove width restriction on content width when nested inside of columns

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -570,6 +570,10 @@
 		.wp-block-cover-image {
 			min-height: 330px;
 		}
+
+		.wp-block-cover__inner-container {
+			width: 100%;
+		}
 	}
 
 	//! Galleries

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -299,6 +299,10 @@ figcaption,
 	.wp-block-cover-image {
 		min-height: 330px;
 	}
+
+	.wp-block-cover__inner-container {
+		width: 100%;
+	}
 }
 
 /** === Image === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to the minimum height, when you nest a cover block inside of a columns block, you don't need the width restriction that the block has for its content by default.

Closes #309.

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/cioCwGWKKgs) into the code editor.
2. View in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/63556763-e129ec80-c4fa-11e9-976e-406172ee1e09.png)

The block 'inner container' is 70px narrower than the space available, not leaving much room for content: 

![image](https://user-images.githubusercontent.com/177561/63556809-07e82300-c4fb-11e9-9891-cb43bf86a01b.png)

3. Apply the PR and run `npm run build`.
4. Confirm that there's now more space for content:

![image](https://user-images.githubusercontent.com/177561/63556826-18000280-c4fb-11e9-9082-e5344b4b3c99.png)

![image](https://user-images.githubusercontent.com/177561/63556840-21896a80-c4fb-11e9-89f5-fce3453511ac.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
