### PR TITLE
Set a specific size for the featured image on single posts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,6 +60,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_theme_support( 'post-thumbnails' );
 		set_post_thumbnail_size( 1568, 9999 );
 
+		add_image_size( 'newspack-featured-image', 1200, 9999 );
 		add_image_size( 'newspack-footer-logo', 400, 9999, false );
 
 		// This theme uses wp_nav_menu() in two locations.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,7 +158,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			?>
 
 			<figure class="post-thumbnail">
-				<?php the_post_thumbnail(); ?>
+				<?php the_post_thumbnail( 'newspack-featured-image' ); ?>
 			</figure><!-- .post-thumbnail -->
 
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a specific image size for the featured image; it's to fix an issue with images  not resizing properly on the staging sites.

Unfortunately I couldn't recreate this locally; the steps mostly focus on making sure nothing changes. I did confirm it works by editing the code on one of the staging sites with this problem though. 

### How to test the changes in this Pull Request:

1. Set up two posts with featured images; make sure one is larger than 1200 (so it appears above the content) and one is smaller than 1200 (so it uses the fallback behaviour, and appears in the content)
2. Apply the PR.
3. Confirm that images look the same. 

Once the theme is updated on the staging sites, then we can confirm that this is totally fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
