### PR TITLE
Improve styles for post thumbnail on single posts

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -137,6 +137,7 @@ body.page {
 }
 
 .post-thumbnail {
+	width: 100%;
 	margin: 0;
 
 	&:focus {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you have a large featured image, but there's an issue with it (eg. for some reason the site doesn't scale it up correctly, so it's displaying small, or it's missing), the flexbox styles on the single post page can fall apart.

This PR adds a width to the .post-thumbnail container, making sure the content and sidebar always sit below it, rather than beside, no matter how large the image is.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Check the featured image styles in a few spots: single post, page, archive and homepage block. Confirm that nothing has changed.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
