### PR TITLE
Adds a logo resizer to the theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -523,6 +523,11 @@ require get_template_directory() . '/inc/template-tags.php';
 require get_template_directory() . '/inc/customizer.php';
 
 /**
+ * Logo Resizer.
+ */
+require get_template_directory() . '/inc/logo-resizer.php';
+
+/**
  * Load Jetpack compatibility file.
  */
 if ( defined( 'JETPACK__VERSION' ) ) {

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -221,7 +221,7 @@ function newspack_customize_register( $wp_customize ) {
 				'description' => esc_html__( 'Optional alternative logo to be displayed in the footer.', 'newspack' ),
 				'section'     => 'title_tagline',
 				'settings'    => 'newspack_footer_logo',
-				'priority'    => 8,
+				'priority'    => 9,
 				'flex_width'  => true,
 				'flex_height' => true,
 				'width'       => 800,

--- a/inc/logo-resizer.php
+++ b/inc/logo-resizer.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Newspack Theme: Add Logo Size option in the customizer.
+ *
+ * @package Newspack
+ */
+
+/**
+ * Registers customizer controls for the logo resizer.
+ */
+function newspack_logo_resizer_customize_register( $wp_customize ) {
+	// Logo Resizer additions
+	$wp_customize->add_setting(
+		'logo_size',
+		array(
+			'default'              => 50,
+			'type'                 => 'theme_mod',
+			'theme_supports'       => 'custom-logo',
+			'transport'            => 'postMessage',
+			'sanitize_callback'    => 'absint',
+			'sanitize_js_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'logo_size',
+		array(
+			'label'       => esc_html__( 'Logo Size', 'newspack' ),
+			'section'     => 'title_tagline',
+			'priority'    => 8,
+			'type'        => 'range',
+			'settings'    => 'logo_size',
+			'input_attrs' => array(
+				'step'             => 5,
+				'min'              => 0,
+				'max'              => 100,
+				'aria-valuemin'    => 0,
+				'aria-valuemax'    => 100,
+				'aria-valuenow'    => 50,
+				'aria-orientation' => 'horizontal',
+			),
+		)
+	);
+}
+add_action( 'customize_register', 'newspack_logo_resizer_customize_register' );
+
+/**
+ * Add support for logo resizing by filtering `get_custom_logo`.
+ */
+function newspack_customize_logo_resize( $html ) {
+	$size           = get_theme_mod( 'logo_size' );
+	$custom_logo_id = get_theme_mod( 'custom_logo' );
+	// set the short side minimum
+	$min = 48;
+
+	// don't use empty() because we can still use a 0
+	if ( is_numeric( $size ) && is_numeric( $custom_logo_id ) ) {
+
+		// we're looking for $img['width'] and $img['height'] of original image
+		$logo = wp_get_attachment_metadata( $custom_logo_id );
+		if ( ! $logo ) {
+			return $html;
+		}
+
+		// get the logo support size
+		$sizes = get_theme_support( 'custom-logo' );
+
+		// Check for max height and width, default to image sizes if none set in theme
+		$max['height'] = isset( $sizes[0]['height'] ) ? $sizes[0]['height'] : $logo['height'];
+		$max['width']  = isset( $sizes[0]['width'] ) ? $sizes[0]['width'] : $logo['width'];
+
+		// landscape or square
+		if ( $logo['width'] >= $logo['height'] ) {
+			$output = newspack_logo_resize_min_max(
+				$logo['height'],
+				$logo['width'],
+				$max['height'],
+				$max['width'],
+				$size,
+				$min
+			);
+			$img    = array(
+				'height' => $output['short'],
+				'width'  => $output['long'],
+			);
+		// portrait
+		} elseif ( $logo['width'] < $logo['height'] ) {
+			$output = newspack_logo_resize_min_max( $logo['width'], $logo['height'], $max['width'], $max['height'], $size, $min );
+			$img    = array(
+				'height' => $output['long'],
+				'width'  => $output['short'],
+			);
+		}
+
+		// add the CSS
+		$css = '
+		<style>
+		.site-header .custom-logo {
+			height: ' . $img['height'] . 'px;
+			max-height: ' . $max['height'] . 'px;
+			max-width: ' . $max['width'] . 'px;
+			width: ' . $img['width'] . 'px;
+		}
+		</style>';
+
+		$html = $css . $html;
+	}
+
+	return $html;
+}
+add_filter( 'get_custom_logo', 'newspack_customize_logo_resize' );
+
+/**
+ * Helper function to determine the max size of the logo
+ */
+function newspack_logo_resize_min_max( $short, $long, $short_max, $long_max, $percent, $min ) {
+	$ratio        = ( $long / $short );
+	$max['long']  = ( $long_max >= $long ) ? $long : $long_max;
+	$max['short'] = ( $short_max >= ( $max['long'] / $ratio ) ) ? floor( $max['long'] / $ratio ) : $short_max;
+
+	$ppp = ( $max['short'] - $min ) / 100;
+
+	$size['short'] = round( $min + ( $percent * $ppp ) );
+	$size['long']  = round( $size['short'] / ( $short / $long ) );
+
+	return $size;
+}
+
+/**
+ * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+function newspack_logo_resizer_customize_preview_js() {
+	wp_enqueue_script( 'newspack-logo-resizer-customizer', get_template_directory_uri() . '/js/logo/customize-preview.js', array( 'jquery', 'customize-preview' ), '1.0', true );
+}
+add_action( 'customize_preview_init', 'newspack_logo_resizer_customize_preview_js' );
+
+/**
+ * JS handlers for Customizer Controls
+ */
+function newspack_logo_resizer_customize_controls_js() {
+	wp_enqueue_script( 'newspack-logo-resizer-customizer-controls', get_template_directory_uri() . '/js/logo/customize-controls.js', array( 'jquery', 'customize-controls' ), '1.0', true );
+}
+add_action( 'customize_controls_enqueue_scripts', 'newspack_logo_resizer_customize_controls_js' );
+
+/**
+ * Adds CSS to the Customizer controls.
+ */
+function newspack_logo_resizer_customize_css() {
+	wp_add_inline_style( 'customize-controls', '#customize-control-logo_size input[type="range"] { width: 100%; }' );
+}
+add_action( 'customize_controls_enqueue_scripts', 'newspack_logo_resizer_customize_css' );

--- a/js/logo/customize-controls.js
+++ b/js/logo/customize-controls.js
@@ -1,0 +1,34 @@
+/**
+ * File customize-controls.js.
+ *
+ * Brings logo resizing technology to the Customizer.
+ *
+ * Contains handlers to change Customizer controls.
+ */
+( function( $ ) {
+	'use strict';
+
+	var api = wp.customize;
+
+	api.bind( 'ready', function() {
+		$( window ).load( function() {
+			if ( false == api.control( 'custom_logo' ).setting() ) {
+				$( '#customize-control-logo_size' ).hide();
+			}
+		} );
+	} );
+
+	// Check logo changes
+	api( 'custom_logo', function( value ) {
+		value.bind ( function ( to ) {
+			if ( '' === to ) {
+				api.control( 'logo_size' ).deactivate();
+			} else {
+				$( '#customize-control-logo_size' ).show();
+				api.control( 'logo_size' ).activate();
+				api.control( 'logo_size' ).setting( 50 );
+				api.control( 'logo_size' ).setting.preview();
+			}
+		} );
+	} );
+} )( jQuery );

--- a/js/logo/customize-preview.js
+++ b/js/logo/customize-preview.js
@@ -1,0 +1,155 @@
+/**
+ * File customize-preview.js.
+ *
+ * Brings logo resizing technology to the Customizer.
+ *
+ * Contains handlers to make Customizer preview changes asynchronously.
+ */
+( function( $ ) {
+
+	var api = wp.customize;
+	var Logo = new photoBlogLogo();
+	var initial = null;
+	var resizeTimer;
+
+	api( 'custom_logo', function( value ) {
+		handleLogoDetection( value() );
+		value.bind( handleLogoDetection );
+	} );
+
+	api( 'logo_size', function( value ) {
+		Logo.resize( value() );
+		value.bind( Logo.resize );
+	} );
+
+	api( 'ready', function() {
+		initial = api( 'custom_logo' )._value;
+	} );
+
+	function handleLogoDetection( to, initial ) {
+		if ( '' === to ) {
+			Logo.remove();
+		} else if ( undefined === initial ) {
+			Logo.add();
+		} else {
+			Logo.change();
+		}
+		initial = to;
+	}
+
+	function photoBlogLogo() {
+		var intId = 0;
+		var hasLogo = null;
+		var min = 48;
+
+		var self = {
+			resize: function( to ) {
+				if ( hasLogo ) {
+					var img = new Image();
+					var logo = $( '.custom-logo' );
+
+					var size = {
+						width: parseInt( logo.attr( 'width' ), 10 ),
+						height: parseInt( logo.attr( 'height' ), 10 ),
+					}
+
+					var cssMax = {
+						width: parseInt( logo.css( 'max-width' ), 10 ),
+						height: parseInt( logo.css( 'max-height' ), 10 ),
+					}
+
+					var max = new Object();
+					max.width = $.isNumeric( cssMax.width ) ? cssMax.width : size.width;
+					max.height = $.isNumeric( cssMax.height ) ? cssMax.height : size.height;
+
+					img.onload = function() {
+						var output = new Object();
+
+						if ( size.width >= size.height ) {
+							// landscape or square, calculate height as short side
+							output = logo_min_max( size.height, size.width, max.height, max.width, to, min );
+							size = {
+								height: output.a,
+								width: output.b,
+							}
+						} else if ( size.width < size.height ){
+							// portrait, calculate height as long side
+							output = logo_min_max( size.width, size.height, max.width, max.height, to, min );
+							size = {
+								height: output.b,
+								width: output.a,
+							}
+						}
+
+ 						logo.css( {
+							width: size.width,
+							height: size.height,
+						} );
+					}
+
+					img.src = logo.attr( 'src' );
+
+					clearTimeout( resizeTimer );
+					resizeTimer = setTimeout( function() {
+						$( document.body ).resize();
+					}, 500 );
+				}
+			},
+
+			add: function() {
+				intID = setInterval( function() {
+					var logo = $( '.custom-logo[src]' );
+					if ( logo.length ) {
+						clearInterval( intID );
+						hasLogo = true;
+					}
+				}, 500 );
+			},
+
+			change: function() {
+				var oldlogo = $( '.custom-logo' ).attr( 'src' );
+				intID = setInterval( function() {
+					var logo = $( '.custom-logo' ).attr( 'src' );
+					if ( logo != oldlogo ) {
+						clearInterval( intID );
+						hasLogo = true;
+						self.resize( 50 );
+					}
+				}, 100 );
+			},
+
+			remove: function() {
+				hasLogo = null;
+			}
+
+		}
+
+		return self;
+
+	}
+
+	// a is short side, b is long side
+	// x is short css max, y is long css max
+	// p is percent, m is minimum short side
+	function logo_min_max( a, b, amax, bmax, p, m ){
+		var ppp,
+			ratio,
+			max = new Object(),
+			size = new Object();
+
+		ratio = ( b / a );
+		max.b = ( bmax >= b ) ? b : bmax;
+		max.a = ( amax >= ( max.b / ratio ) ) ? Math.floor( max.b / ratio ) : amax;
+
+		// number of pixels per percentage point
+		ppp = ( max.a - m ) / 100;
+
+		// at 0%, the minimum is set, scale up from there
+		size.a = Math.floor( m + ( p * ppp ) );
+		// long side is calculated from the image ratio
+		size.b = Math.floor( size.a * ratio );
+
+		return size;
+	}
+
+} )( jQuery );

--- a/sass/mixins/_utilities.scss
+++ b/sass/mixins/_utilities.scss
@@ -6,6 +6,12 @@
 		}
 	}
 
+	@if tabletonly == $res {
+		@media only screen and (max-width: #{ $tablet_width - 1 } ) {
+			@content;
+		}
+	}
+
 	@if tablet == $res {
 		@media only screen and (min-width: $tablet_width) {
 			@content;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -25,14 +25,7 @@
 
 	.custom-logo {
 		height: auto;
-		min-height: inherit;
-		max-height: 75px;
-		max-width: 200px;
 		width: auto;
-
-		@include media( tablet ) {
-			max-height: 150px;
-		}
 	}
 }
 
@@ -237,10 +230,6 @@
 	.site-branding {
 		display: flex;
 		flex-basis: auto;
-	}
-
-	.custom-logo-link .custom-logo {
-		max-height: 50px;
 	}
 
 	.site-description {

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -22,9 +22,14 @@
 	line-height: 1;
 	margin: 0 $size__spacing-unit 0 0;
 	overflow: hidden;
+}
 
-	.custom-logo {
+.site-header .custom-logo-link .custom-logo {
+
+	@include media( tabletonly ) {
 		height: auto;
+		max-height: 75px;
+		max-width: 175px;
 		width: auto;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a logo resizer to the customizer that's been used in a few WordPress.com theme (Radcliffe 2, Photos, Photo Blog). 

This opens up options for different logo sizes, especially on sites that want larger, more detailed logos.

One known issue with it is if you upload a very small logo, the resizer acts wonky (often sizing down will size the logo up and vis versa). 

Closes #5. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Site Identity. If you have a logo uploaded, you should see a slider below it. 

![image](https://user-images.githubusercontent.com/177561/63625910-fca5fd80-c5b5-11e9-8b7e-5773a2583ebe.png)

3. Try scaling up and down your logo; confirm that it previews in the customizer, and displays at the same size on the front end.
4. Try logos with a few different aspect ratios: wide, tall, and square. 
5. Try scaling down the browser window to tablet size, and confirm that the logo is scaled down, regardless what size you've set it at (the maximum for smaller screens right now is 175px wide and 75px tall). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
