### PR TITLE
Update caption styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -696,16 +696,6 @@
 				}
 			}
 		}
-
-		&.is-style-borders .wp-block-column {
-			&:not(:first-child) {
-				margin-left: 64px;
-			}
-
-			&:after {
-				right: -32px;
-			}
-		}
 	}
 
 	//! Latest Comments

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -495,6 +495,10 @@
 		.aligncenter {
 			margin: 0 auto;
 		}
+
+		figcaption {
+			padding: ( $size__spacing-unit * .5 );
+		}
 	}
 
 	//! Cover Image

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -110,20 +110,6 @@
 		padding: 20px 30px;
 	}
 
-	//! Captions
-	.wp-block-audio figcaption,
-	.wp-block-video figcaption,
-	.wp-block-image figcaption,
-	.wp-block-gallery .blocks-gallery-image figcaption,
-	.wp-block-gallery .blocks-gallery-item figcaption {
-		font-family: $font__heading;
-		font-size: $font__size-xs;
-		line-height: $font__line-height-pre;
-		margin: 0;
-		padding: ( $size__spacing-unit * .5 );
-		text-align: center;
-	}
-
 	//! Audio
 	.wp-block-audio {
 
@@ -509,12 +495,6 @@
 		.aligncenter {
 			margin: 0 auto;
 		}
-
-		figcaption {
-			border-bottom: 1px solid $color__border;
-			margin: auto;
-			max-width: 780px;
-		}
 	}
 
 	//! Cover Image
@@ -712,6 +692,16 @@
 				}
 			}
 		}
+
+		&.is-style-borders .wp-block-column {
+			&:not(:first-child) {
+				margin-left: 64px;
+			}
+
+			&:after {
+				right: -32px;
+			}
+		}
 	}
 
 	//! Latest Comments
@@ -745,6 +735,13 @@
 
 		&.has-excerpts {
 
+		}
+	}
+
+	//! Newspack Block
+	.wp-block-newspack-blocks-homepage-articles {
+		figcaption {
+			max-width: 100%;
 		}
 	}
 

--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -21,12 +21,15 @@
 	margin-right: auto;
 }
 
+figcaption,
 .wp-caption-text {
+	border-bottom: 1px solid $color__border;
 	color: $color__text-light;
 	font-size: $font__size-xs;
 	font-family: $font__heading;
 	line-height: $font__line-height-pre;
 	margin: 0;
-	padding: ( $size__spacing-unit * .5 );
+	max-width: 780px;
+	padding: 0 ( $size__spacing-unit * .5 ) ( $size__spacing-unit * .5 );
 	text-align: center;
 }

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -131,8 +131,17 @@ figcaption,
 .gallery-caption {
 	font-family: $font__heading;
 	font-size: $font__size-xs;
-	line-height: 1.6;
+	line-height: $font__line-height-pre;
 	color: $color__text-light;
+}
+
+figcaption {
+	border-bottom: 1px solid $color__border;
+	color: $color__text-light;
+	margin: 0;
+	max-width: 780px;
+	padding: 0 ( $size__spacing-unit * .5 ) ( $size__spacing-unit * .5 );
+	text-align: center;
 }
 
 /** === Post Title === */
@@ -289,11 +298,8 @@ figcaption,
 /** === Image === */
 
 .wp-block-image {
-	.block-editor-rich-text__editable {
-		border-bottom: 1px solid $color__border;
-		padding-bottom: $size__spacing-unit;
-		margin: auto;
-		max-width: 780px;
+	figcaption {
+		margin-top: 0;
 	}
 }
 
@@ -309,18 +315,6 @@ figcaption,
 	.wp-block-image > div > div {
 		max-width: 100%;
 		width: 100% !important; // !important to override inline styles.
-	}
-}
-
-/** === Gallery === */
-
-.wp-block-gallery {
-
-	.blocks-gallery-image figcaption,
-	.blocks-gallery-item figcaption,
-	.gallery-item .gallery-caption {
-		font-size: $font__size-xs;
-		line-height: 1.6;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR simplifies the theme's caption styles, and applies the style used for images consistently for audio and video captions, without being inherited by Gallery captions. With this approach, we don't have to apply the caption styles to the `figcaption` on a block by block basis -- they're used for all instances of that tag.

This will also ultimately be applied to the homepage article blocks when https://github.com/Automattic/newspack-blocks/pull/87 is merged.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Copy paste this [test content](https://cloudup.com/cFQ9Bk3kBXw) into the edit view of a post. It includes an image, gallery, audio and video file, all with captions; there's also an article block, but you'll have to apply https://github.com/Automattic/newspack-blocks/pull/87 and make sure you have an article with an image and caption to test it. 
3. Verify the appearance of the captions in the editor and on the front end; for most, they should be slightly smaller, grey, with a border on the bottom. For the gallery, they should be white text (since they sit on top of the image):

**Article block:**
![image](https://user-images.githubusercontent.com/177561/63642194-b661a480-c670-11e9-8ca0-79f154f7fe87.png)

**Image block:**
![image](https://user-images.githubusercontent.com/177561/63642198-be214900-c670-11e9-9aa5-a1121b42c5e5.png)

**Gallery block:**
![image](https://user-images.githubusercontent.com/177561/63642200-c4afc080-c670-11e9-8286-9124bfce78cf.png)

**Audio block:** 
![image](https://user-images.githubusercontent.com/177561/63642201-cd07fb80-c670-11e9-958a-4354f9577205.png)

**Video block:** 
![image](https://user-images.githubusercontent.com/177561/63642204-d4c7a000-c670-11e9-82bf-970e3e0f97cb.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
