### PR TITLE
Correct font weights, uses, in style 2, to better match the designs

### DIFF
--- a/inc/style-packs.php
+++ b/inc/style-packs.php
@@ -34,7 +34,7 @@ new Newspack_Style_Packs_Core(
 				'Fira Sans Condensed' => 'https://fonts.googleapis.com/css?family=Fira+Sans+Condensed:400,400i,600,600i',
 			),
 			'style-2' => array(
-				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:500,700,900',
+				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:500,700,800',
 			),
 			'style-3' => array(
 				'Barlow' => 'https://fonts.googleapis.com/css?family=Barlow:400,400i,700,700i&display=swap',

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -118,6 +118,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$css_blocks .= "
+			blockquote,
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description {
 				font-family: $font_header;
@@ -211,6 +212,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$editor_css_blocks .= "
+			.editor-block-list__layout .editor-block-list__block blockquote,
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 
 			{

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -13,7 +13,8 @@ h1,
 h2,
 h3,
 h4,
-blockquote p {
+blockquote p,
+.editor-post-title__block .editor-post-title__input {
 	font-weight: 800;
 }
 

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -7,11 +7,30 @@ Newspack Theme Editor Styles - Style Pack 2
 @import "variables-style/variables-style";
 @import "../../style-editor-base";
 
+// Elements
+
+h1,
+h2,
+h3,
+h4,
+blockquote p {
+	font-weight: 800;
+}
+
+blockquote {
+	font-family: $font__heading;
+}
+
+// Accent Headers
+
 .accent-header,
 .article-section-title {
 	color: $color__text-light;
 	font-family: $font__heading;
 	font-size: $font__size-xs;
+	font-weight: bold;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
 }
 
 .article-section-title {
@@ -47,7 +66,7 @@ Newspack Theme Editor Styles - Style Pack 2
 	&.has-drop-cap:not(:focus)::first-letter {
 		border: 7px solid $color__primary;
 		font-family: $font__heading;
-		font-weight: bold;
+		font-weight: 800;
 		font-size: $font__size-xxl;
 		padding: 0.4em;
 	}

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -30,8 +30,6 @@ blockquote {
 	font-family: $font__heading;
 	font-size: $font__size-xs;
 	font-weight: bold;
-	letter-spacing: 0.05em;
-	text-transform: uppercase;
 }
 
 .article-section-title {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -131,6 +131,22 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
+// Site header
+
+.main-navigation > ul > li,
+.tertiary-menu {
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+h4,
+.comments-title {
+	font-weight: 800;
+}
+
 // Accent headers
 
 .accent-header,
@@ -139,6 +155,9 @@ body:not(.header-solid-background) .site-header {
 	color: $color__text-light;
 	font-family: $font__heading;
 	font-size: $font__size-xs;
+	font-weight: bold;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
 }
 
 .site-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
@@ -227,6 +246,14 @@ body:not(.header-solid-background) .site-header {
 
 // Blocks
 
+blockquote {
+	font-family: $font__heading;
+
+	p {
+		font-weight: 800;
+	}
+}
+
 .entry .entry-content {
 
 	.wp-block-newspack-blocks-homepage-articles {
@@ -247,7 +274,7 @@ body:not(.header-solid-background) .site-header {
 	.has-drop-cap:not(:focus)::first-letter {
 		border: 7px solid $color__primary;
 		font-family: $font__heading;
-		font-weight: bold;
+		font-weight: 800;
 		font-size: $font__size-xxl;
 		padding: 0.4em;
 	}
@@ -261,7 +288,6 @@ body:not(.header-solid-background) .site-header {
 			p {
 				font-size: $font__size-lg;
 				font-style: normal;
-				font-weight: bold;
 
 				@include media( tablet ) {
 					font-size: $font__size-xl;
@@ -321,6 +347,7 @@ body:not(.header-solid-background) .site-header {
 	h2 {
 		color: inherit;
 		font-size: $font__size-md;
+		font-weight: 800;
 		letter-spacing: 0;
 		margin: 0 0 #{ 0.5 * $size__spacing-unit };
 		text-transform: none;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -131,13 +131,7 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-// Site header
-
-.main-navigation > ul > li,
-.tertiary-menu {
-	letter-spacing: 0.05em;
-	text-transform: uppercase;
-}
+// HTML Elements
 
 h1,
 h2,
@@ -156,8 +150,6 @@ h4,
 	font-family: $font__heading;
 	font-size: $font__size-xs;
 	font-weight: bold;
-	letter-spacing: 0.05em;
-	text-transform: uppercase;
 }
 
 .site-content .wp-block-newspack-blocks-homepage-articles .article-section-title {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects some font weights/uses in Style 2, to better match the mockup -- specifically:

* Increases the font weight of h1-h4s (h5, h6 still use bold; it's easier to read at that size)
* Uses the header font for quotes, and increases the font weight. 
* Increases the font weight of dropcaps.
* Switch the heaviest Montserrat weight from 900 (black) to 800 (extra-bold).

**Before:**

![image](https://user-images.githubusercontent.com/177561/63713891-606a3980-c7f5-11e9-872b-7fc1b5b14575.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63713857-4fb9c380-c7f5-11e9-8e15-64e724b6a9e8.png)

### How to test the changes in this Pull Request:

1. Copy this [test content](https://cloudup.com/c6xh8Vb6GKs) into the code editor.
2. Navigate to Customize > Style Packs and switch to Style 2.
3. Apply the PR and run `npm run build`.
4. View the example post in the editor and on the front end, and confirm:
    * That the h1-h4 use the font weight 800
    * That the dropcap uses the font weight 800
    * That the quotes (blockquote and pullquote) use the header font Montserrat, and the font-weight 800.
     * That the title in the editor uses the font weight 800.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
