### PR TITLE
Update column spacing when the border style is used

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -703,12 +703,21 @@
 					margin-bottom: 0;
 				}
 			}
+		}
 
-			&[class*='has-'] > * {
-				margin-right: $size__spacing-unit;
+		&.is-style-borders {
+			.wp-block-column {
 
-				&:last-child {
-					margin-right: 0;
+				@include media(tablet) {
+					flex-basis: calc(50% - 32px);
+
+					&:not(:first-child) {
+						margin-left: 64px;
+					}
+
+					&:after {
+						right: -32px;
+					}
 				}
 			}
 		}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -703,13 +703,13 @@
 					margin-bottom: 0;
 				}
 			}
-		}
 
-		&[class*='has-'] > * {
-			margin-right: $size__spacing-unit;
+			&[class*='has-'] > * {
+				margin-right: $size__spacing-unit;
 
-			&:last-child {
-				margin-right: 0;
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -705,6 +705,14 @@
 			}
 		}
 
+		&[class*='has-'] > * {
+			margin-right: $size__spacing-unit;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
 		&.is-style-borders {
 			.wp-block-column {
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -286,6 +286,25 @@ figcaption,
 	}
 }
 
+/** === Columns === */
+
+.wp-block-columns.is-style-borders {
+	[data-type="core/column"] {
+
+		@include media(tablet) {
+			flex-basis: calc(50% - 32px);
+
+			&:not(:first-child) {
+				margin-left: 64px;
+			}
+
+			&:after {
+				right: -42px;
+			}
+		}
+	}
+}
+
 /** === Image === */
 
 .wp-block-image {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR increases the spacing between columns when you have the border style turned on.

From the front-end styles I also removed some styles from the columns (the `&[class*='has-'] > *` stuff) -- the columns block used to add classes to determine how many columns  

Note: there's an issue if you have custom widths set for your columns, where the columns wrap oddly at the tablet breakpoint where it seems like they shouldn't. I could recreate it without this PR, and using Twenty Nineteen, so it's not related to this PR or anything in the theme. I need to follow up on it.

### How to test the changes in this Pull Request:

1. Copy-paste this [test code](https://cloudup.com/cEATJk284YX) into the editor.
2. You should see something like this on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/63715622-f6539380-c7f8-11e9-98c3-2036f0cece17.png)

3. Apply the PR and run `npm run build`; confirm the columns are more spaced out on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/63715676-1be09d00-c7f9-11e9-8708-fced790c9ed5.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
