### PR TITLE
Override the background colour for styles 3 and 4

### DIFF
--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -11,8 +11,13 @@ Newspack Theme Styles - Style Pack 3
 
 .header-solid-background {
 	.site-header,
+	.top-header-contain,
 	.site-header .main-navigation .main-menu .sub-menu {
 		background-color: $color__background-dark;
+	}
+
+	.top-header-contain {
+		border-color: lighten( $color__background-dark, 5% );
 	}
 
 	.bottom-header-contain {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -11,8 +11,13 @@ Newspack Theme Styles - Style Pack 4
 
 .header-solid-background {
 	.site-header,
+	.top-header-contain,
 	.site-header .main-navigation .main-menu .sub-menu {
 		background-color: $color__background-dark;
+	}
+
+	.top-header-contain {
+		border-color: lighten( $color__background-dark, 5% );
 	}
 
 	.bottom-header-contain {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The solid background header style is currently using a blue background behind the secondary navigation; it was intended to be dark grey as well.

This PR fixes that.

**Before:**

![image](https://user-images.githubusercontent.com/177561/63727131-3e33e400-c814-11e9-8903-6186a58b5e8d.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/63727095-23616f80-c814-11e9-89fc-c2b7be1789d5.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. In the Customizer > Header Settings, pick 'Solid Background'
3. In Customizer > Style Packs, pick Style 3. 
4. Make sure you have a seconday menu assigned.
5. Confirm the background colour is correct.
6. Switch to Style 4 and confirm the background is correct.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
