### PR TITLE
Fix some custom typography inheritance issues

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -125,6 +125,9 @@ function newspack_custom_typography_css() {
 			$css_blocks .= "
 			blockquote,
 			.has-drop-cap:not(:focus)::first-letter,
+			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+			.accent-header,
+			.cat-links,
 			.taxonomy-description {
 				font-family: $font_header;
 			}";
@@ -254,7 +257,8 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$editor_css_blocks .= "
 			.editor-block-list__layout .editor-block-list__block blockquote,
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.editor-block-list__layout .editor-block-list__block .entry-meta
 
 			{
 				font-family: $font_header;

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -32,6 +32,7 @@ function newspack_custom_typography_css() {
 		.no-comments,
 		.not-found .page-title,
 		.error-404 .page-title,
+		.author-bio .author-link,
 		.page-links,
 		.page-description,
 		.pagination .nav-links,
@@ -106,7 +107,10 @@ function newspack_custom_typography_css() {
 		.widget_tag_cloud .tagcloud,
 
 		/* _copy.scss */
-		blockquote cite
+		blockquote cite,
+
+		/* _blocks.scss */
+		.entry .entry-content .wp-block-button .wp-block-button__link
 
 		{
 			font-family: $font_header;

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -41,6 +41,7 @@ function newspack_custom_typography_css() {
 		.site-info,
 		#cancel-comment-reply-link,
 		.entry .entry-content .jp-relatedposts-i2 a,
+		.accent-header,
 		h1,
 		h2,
 		h3,
@@ -94,6 +95,9 @@ function newspack_custom_typography_css() {
 		.comment-form label,
 		.comment-form .comment-notes,
 
+		/* _posts-and-pages.scss */
+		.cat-links,
+
 		/* _widgets.scss */
 		.widget_archive ul li,
 		.widget_categories ul li,
@@ -110,8 +114,8 @@ function newspack_custom_typography_css() {
 		blockquote cite,
 
 		/* _blocks.scss */
-		.entry .entry-content .wp-block-button .wp-block-button__link
-
+		.entry .entry-content .wp-block-button .wp-block-button__link,
+		.wp-block-newspack-blocks-homepage-articles .article-section-title
 		{
 			font-family: $font_header;
 		}";
@@ -128,10 +132,14 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$css_blocks .= "
 			blockquote,
+<<<<<<< HEAD
 			.has-drop-cap:not(:focus)::first-letter,
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 			.accent-header,
 			.cat-links,
+=======
+			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+>>>>>>> Make typography fixes more general.
 			.taxonomy-description {
 				font-family: $font_header;
 			}";
@@ -234,6 +242,9 @@ function newspack_custom_typography_css() {
 		/* Jetpack blocks */
 		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 a,
 		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 strong,
+
+		/* Newspack Block */
+		.editor-block-list__layout .editor-block-list__block .entry-meta,
 
 		/* Classic Editor */
 		.editor-block-list__layout .editor-block-list__block .wp-caption dd,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When setting custom typography header font should be used for the 'accent' headers, article block section titles, categories and post meta (like author name and published date). A few of these weren't working; this PR fixes them.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to Customize > Style Pack and pick Style 2 or Style 4; this PR affects all the style packs, but these two are the only ones that either use sans-serif for both the header and body, or serif for both the header and footer -- it makes this easier to test.
3. Navigate to Customize > Typography, and change the header font to something noticeably different than the default (eg. Georgia for Style 2, and Arial/Helvetica for Style 4).
4. Confirm that it's applied to the following spots on the front-end:

* Article Block - section header - before:

![image](https://user-images.githubusercontent.com/177561/63730646-0717ff80-c821-11e9-866b-e46eef41aa66.png)

* Article Block - section header - after:

![image](https://user-images.githubusercontent.com/177561/63730923-2f542e00-c822-11e9-8291-2b05eec8c907.png)

* Single Post - catgory link (at top) - before:
![image](https://user-images.githubusercontent.com/177561/63730662-15feb200-c821-11e9-8828-e9739d65fa89.png)

* Single Post - catgory link (at top) - after:

![image](https://user-images.githubusercontent.com/177561/63731015-a4bffe80-c822-11e9-9303-a9f837d4dc2f.png)

* Author bio title and text link - before:

![image](https://user-images.githubusercontent.com/177561/63731183-4ba49a80-c823-11e9-9d04-2d6907b208eb.png)

* Author bio title and text link - after:

![image](https://user-images.githubusercontent.com/177561/63731067-ec468a80-c822-11e9-90f5-c98366ced8d7.png)

* Button Block - before:

![image](https://user-images.githubusercontent.com/177561/63731174-45162300-c823-11e9-907d-d0177d40f194.png)

* Button block - after:

![image](https://user-images.githubusercontent.com/177561/63731010-9f62b400-c822-11e9-8bec-a0772b9bc1e5.png)

5. And in the editor:

* Article Block - post meta (author name and publish date) - before:

![image](https://user-images.githubusercontent.com/177561/63730865-e7350b80-c821-11e9-8a19-04aca0e6a79d.png)

* Article Block - post meta (author name and publish date) - after:

![image](https://user-images.githubusercontent.com/177561/63730898-0a5fbb00-c822-11e9-9a2d-1231b5c684f6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?