### PR TITLE
Cover Block: Fix section header contrast issue with homepage block

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -270,7 +270,7 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$theme_css .= '
 			.cat-links a,
-			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+			.article-section-title,
 			.entry .entry-footer,
 			.accent-header {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
@@ -294,7 +294,7 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-4' ) ) {
 		$theme_css .= '
 			.accent-header,
-			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+			.article-section-title,
 			.cat-links,
 			.entry .entry-footer {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -284,6 +284,13 @@ figcaption {
 	}
 }
 
+.wp-block-cover {
+	.accent-header,
+	.article-section-title {
+		color: inherit;
+	}
+}
+
 .wp-block-columns {
 	.wp-block-cover,
 	.wp-block-cover-image {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -134,7 +134,7 @@ body:not(.header-solid-background) .site-header {
 // Accent headers
 
 .accent-header,
-.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.article-section-title,
 .cat-links {
 	color: $color__text-light;
 	font-family: $font__heading;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -28,7 +28,7 @@ Newspack Theme Styles - Style Pack 3
 // Accent headers
 
 .accent-header,
-.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.article-section-title,
 .cat-links,
 .archive .page-title {
 	color: $color__primary;

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -123,3 +123,12 @@ cite {
 		}
 	}
 }
+
+.wp-block-cover h2.article-section-title {
+	&:before {
+		width: 70%;
+	}
+	&:after {
+		display: none;
+	}
+}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -28,14 +28,14 @@ Newspack Theme Styles - Style Pack 4
 // Accent headers
 
 .accent-header,
-.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.article-section-title,
 .cat-links {
 	color: $color__primary;
 	font-size: $font__size-xs;
 	text-align: center;
 }
 
-.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.article-section-title,
 .widget-title.accent-header {
 	margin-bottom: $size__spacing-unit;
 	overflow: hidden;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a contrast issue that happens when you nest the homepage block into the cover block -- the section header of the homepage block isn't white on the front end for Style Packs 1-4. 

Thankfully the fix is just making the selectors less specific. 

Style 1:

![image](https://user-images.githubusercontent.com/177561/63733903-09815600-c82f-11e9-8c90-27f08de2b31c.png)

Style 2:

![image](https://user-images.githubusercontent.com/177561/63733949-3cc3e500-c82f-11e9-8b74-fb21db511339.png)

Style 3:

![image](https://user-images.githubusercontent.com/177561/63733967-4ea58800-c82f-11e9-90c8-872ccef57a5f.png)

Style 4:

![image](https://user-images.githubusercontent.com/177561/63733987-61b85800-c82f-11e9-8752-4d3910d74106.png)


### How to test the changes in this Pull Request:

1. Copy this [test content](https://cloudup.com/cmGhyEkvMGg) into a post.
2. Apply the PR and run `npm run build.`
3. Cycle through the style packs and confirm the 'section header' text is white on the front-end (it's already working as expected in the editor). For Style packs 1 and 3, the accents (the blocks before or above) should still use your primary colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
