### PR TITLE
Fix accent header styles for the default style pack.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -413,7 +413,8 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .article-section-title {
+			.editor-block-list__layout .editor-block-list__block .article-section-title,
+			.editor-block-list__layout .editor-block-list__block .accent-header {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -285,7 +285,8 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.article-section-title {
+				.article-section-title,
+				.accent-header {
 					text-transform: uppercase;
 				}
 			';

--- a/sass/styles/style-default/style-default-editor.scss
+++ b/sass/styles/style-default/style-default-editor.scss
@@ -1,3 +1,4 @@
+.accent-header,
 .article-section-title {
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the `.accent-header` styles to the editor for the default style pack, and makes sure it respects the colour and font settings. 

**Before:**

Front-end:

![image](https://user-images.githubusercontent.com/177561/63735914-3edd7200-c836-11e9-92ff-9bc96b2fc2e5.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/63735932-4ef55180-c836-11e9-8d93-8f93fb07f40f.png)

Front-end - custom colour: 

![image](https://user-images.githubusercontent.com/177561/63735883-2705ee00-c836-11e9-8efb-05225c57589e.png)

Editor - custom colour: 

![image](https://user-images.githubusercontent.com/177561/63735982-764c1e80-c836-11e9-82b1-33ce46c82c4e.png)

**After:**

Front-end:
![image](https://user-images.githubusercontent.com/177561/63735540-038e7380-c835-11e9-9449-4eaca587b804.png)

Editor:
![image](https://user-images.githubusercontent.com/177561/63735569-1b65f780-c835-11e9-9cec-ce22f8f4f6db.png)

Front-end - custom colour:

![image](https://user-images.githubusercontent.com/177561/63735648-59631b80-c835-11e9-9190-a26cba13baca.png)

Editor - custom colour:

![image](https://user-images.githubusercontent.com/177561/63735675-6b44be80-c835-11e9-895d-c831e0876fba.png)

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and pick the default style.
2. Navigate to Customize > Typography, and check 'Use all-caps for accent text.'
3. Copy paste [this test content](https://cloudup.com/c7euMkswBWL) into the code view of the editor (it's a heading block with the `accent-header` class added in the Advanced Options. 
4. View it in the editor and on the front-end.
5. Apply the PR and run `npm run build`.
6. Confirm that the font size and style now matches the screenshots.
7. Try a lighter and a darker custom primary colour; for the former, it should use a grey for the lighter colour, and the actual darker custom colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
