### PR TITLE
Update accent-header styles for style 1.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -237,7 +237,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-1' ) ) {
 		$theme_css .= '
-			.accent-header:before,
+			.accent-header:not(.widget-title):before,
 			.article-section-title:before,
 			.cat-links:before,
 			.page-title:before {
@@ -421,7 +421,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-1' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .accent-header:before,
+			.editor-block-list__layout .editor-block-list__block .accent-header:not(.widget-title):before,
 			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
 				background-color: ' . $primary_color . ';
 			}

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -11,6 +11,7 @@ Newspack Theme Editor Styles - Style Pack 1
 .article-section-title {
 	color: #666;
 	font-family: $font__heading;
+	font-size: $font__size-sm;
 
 	&:before {
 		background-color: $color__primary;

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -8,6 +8,7 @@
 .cat-links,
 .page-title {
 	color: #666;
+	font-size: $font__size-sm;
 
 	&:before {
 		background-color: $color__primary;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the .accent-header styles to the editor for the Style 1 style pack, and makes sure it respects the colour and font settings.

**Before:**

Front-end:

![image](https://user-images.githubusercontent.com/177561/63740210-f24d6300-c844-11e9-9e7d-75d51e298cae.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/63740192-e366b080-c844-11e9-9321-f9b2776e2a95.png)

Front-end (custom colour):

![image](https://user-images.githubusercontent.com/177561/63740247-0f823180-c845-11e9-9e9a-e1d06ce547d2.png)

Editor (custom colour):

![image](https://user-images.githubusercontent.com/177561/63740261-23c62e80-c845-11e9-9594-b594d0e2cc2f.png)

**After:** 

Front-end:

![image](https://user-images.githubusercontent.com/177561/63740130-b1554e80-c844-11e9-8177-5dfcbabae5c3.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/63740139-bf0ad400-c844-11e9-8587-7ace1bdee5bd.png)

Front-end (custom colour):

![image](https://user-images.githubusercontent.com/177561/63740086-85d26400-c844-11e9-948a-7798833e98ae.png)

Editor (custom colour):

![image](https://user-images.githubusercontent.com/177561/63740094-8ec33580-c844-11e9-9bda-85b5570ed60b.png)


### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and pick Style 1.
2. Navigate to Customize > Typography, and check 'Use all-caps for accent text.'
3. Copy paste [this test content](https://cloudup.com/c7euMkswBWL) into the code view of the editor (it's a heading block with the `accent-header` class added in the Advanced Options. 
4. View it in the editor and on the front-end.
5. Apply the PR and run `npm run build`.
6. Confirm that the font size and style now matches the screenshots.
7. Try a lighter and a darker custom primary colour; both should be applied to the 'accent' block in front of the text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
