### PR TITLE
Update accent-header styles for style 4

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -297,7 +297,7 @@ function newspack_custom_colors_css() {
 			.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 			.cat-links,
 			.entry .entry-footer {
-				color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
 			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
@@ -306,7 +306,7 @@ function newspack_custom_colors_css() {
 			}
 
 			.site-footer .widget .widget-title {
-				color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 	}
@@ -460,7 +460,7 @@ function newspack_custom_colors_css() {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
 			.editor-block-list__layout .editor-block-list__block .article-section-title {
-				color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -285,8 +285,8 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.article-section-title,
-				.accent-header {
+				.accent-header,
+				.article-section-title {
 					text-transform: uppercase;
 				}
 			';

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -15,13 +15,13 @@ Newspack Theme Editor Styles - Style Pack 4
 .accent-header,
 .article-section-title {
 	color: $color__primary;
+	font-size: $font__size-xs;
 	text-align: center;
 }
 
 .article-section-title {
 	margin-bottom: #{ 1.5 * $size__spacing-unit };
 	overflow: hidden;
-
 
 	&:before,
 	&:after {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -31,6 +31,7 @@ Newspack Theme Styles - Style Pack 4
 .site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 .cat-links {
 	color: $color__primary;
+	font-size: $font__size-xs;
 	text-align: center;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the .accent-header styles to the editor for Style 4, and makes sure it respects the colour and font settings.

(Unfortunately I haven't found a good way to add the border on each side without having to edit HTML and add a span, like the markup for the widget title/homepage article title. I plan to circle back to that and sort it out). 

**Before:**

Front-end:

![image](https://user-images.githubusercontent.com/177561/63741296-56722600-c849-11e9-8572-47fe5301d045.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/63741308-6d187d00-c849-11e9-8851-d18df2dd6b05.png)

Front-end - custom colour:

![image](https://user-images.githubusercontent.com/177561/63741317-743f8b00-c849-11e9-8acf-37bd03960e32.png)

Editor - custom colour:

![image](https://user-images.githubusercontent.com/177561/63741342-8a4d4b80-c849-11e9-9c6a-2c99cbc48836.png)

**After:**

Front-end:

![image](https://user-images.githubusercontent.com/177561/63741278-478b7380-c849-11e9-9f94-8195ada78f76.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/63741268-33e00d00-c849-11e9-8c8b-194eda50169e.png)

Front-end - custom colour:

![image](https://user-images.githubusercontent.com/177561/63741203-ea8fbd80-c848-11e9-8837-2efe005cdc49.png)

Editor - custom colour:

![image](https://user-images.githubusercontent.com/177561/63741216-fc716080-c848-11e9-9f55-b70698ed0873.png)


### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and pick Style 4.
2. Navigate to Customize > Typography, and check 'Use all-caps for accent text.'
3. Copy paste this test content into the code view of the editor (it's a heading block with the `accent-header` class added in the Advanced Options.
4. View it in the editor and on the front-end.
5. Apply the PR and run npm run build.
6. Confirm that the font size and style now matches the screenshots.
7. Try a lighter and a darker custom primary colour; for the former, it should use a grey for the lighter colour, and the actual darker custom colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
