### PR TITLE
Adds image size for the non-single views (archive, search, blog index).

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -61,7 +61,8 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		set_post_thumbnail_size( 1568, 9999 );
 
 		add_image_size( 'newspack-featured-image', 1200, 9999 );
-		add_image_size( 'newspack-footer-logo', 400, 9999, false );
+		add_image_size( 'newspack-archive-image', 800, 600, true );
+		add_image_size( 'newspack-footer-logo', 400, 9999, true );
 
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -167,7 +167,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 		<figure class="post-thumbnail">
 			<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-				<?php the_post_thumbnail( 'post-thumbnail' ); ?>
+				<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
 			</a>
 		</figure>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a specific image size for the archives, search and blog post index page. It's to fix issues on sites where the original image isn't as large as the theme's thumbnail image, so it doesn't resize (it just stays at whatever the thumbnail size is, usually 150).

Unfortunately this is tricky to test locally, but you can edit files on one of the staging sites to test the fix (no thumbnail regenerating required). Locally, it's just important to make sure the archive pages look the same before and after the PR.

Closes #294 .

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Install Regenerate thumbnails (if you don't have it already), and run it (it doesn't appear to be needed on the problem sites, but it could help rule out issues locally).
3. View an archive page and confirm things look okay; confirm that the images are 800x600 or smaller.
4. Do the same on the blog posts index page.
5. Do the same on the search results page. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?