### PR TITLE
Cover Block: Improve styles for cover blocks when floated left or right

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -535,10 +535,34 @@
 
 		&.alignleft,
 		&.alignright {
-			width: 100%;
+			min-height: 250px;
+			max-width: 100%;
+
+			@include media(mobile) {
+				width: 50%;
+			}
 
 			@include media(tablet) {
 				padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
+			}
+
+			blockquote,
+			.wp-block-pullquote:not(.is-style-solid-color) blockquote {
+				padding-left: 0;
+			}
+
+			.wp-block-cover__inner-container {
+				width: 100%;
+
+				[class*="wp-block-"]:first-child {
+					margin-top: 0;
+					padding-top: 0;
+				}
+
+				[class*="wp-block-"]:last-child {
+					margin-bottom: 0;
+					padding-bottom: 0;
+				}
 			}
 		}
 	}
@@ -547,10 +571,6 @@
 		.wp-block-cover,
 		.wp-block-cover-image {
 			min-height: 330px;
-		}
-
-		.wp-block-cover__inner-container {
-			width: 100%;
 		}
 	}
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -225,22 +225,20 @@ figcaption {
 	}
 
 	@include media(tablet) {
-		padding-left: 10%;
-		padding-right: 10%;
+		padding-left: 5%;
+		padding-right: 5%;
 	}
 }
 
 .wp-block[data-type="core/cover"][data-align="left"],
 .wp-block[data-type="core/cover"][data-align="right"] {
-
-	.editor-block-list__block-edit {
-		width: calc(4 * (100vw / 12));
-	}
-
 	.wp-block-cover {
-		width: 100%;
-		max-width: 100%;
+		min-height: 250px;
 		padding: calc(1.375 * #{$size__spacing-unit});
+
+		@include media( tablet ) {
+			max-width: 405px;
+		}
 
 		p {
 			padding-left: 0;
@@ -248,9 +246,32 @@ figcaption {
 		}
 
 		@include media(tablet) {
-			padding: calc(2.75 * #{$size__spacing-unit}) calc(2.75 * #{$size__spacing-unit}) calc(3.125 * #{$size__spacing-unit});
+			padding: calc(2 * #{$size__spacing-unit});
+		}
+
+		.wp-block-cover__inner-container {
+			width: 100%;
+		}
+
+		.block-editor-block-list__block-edit {
+			float: none;
+			margin-left: 0;
+			margin-right: 0;
+		}
+
+		.wp-block {
+			&:first-child {
+				margin-top: 0;
+				padding-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+				padding-bottom: 0;
+			}
 		}
 	}
+
 }
 
 .wp-block[data-type="core/cover"][data-align="wide"],

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -259,7 +259,7 @@ figcaption {
 			margin-right: 0;
 		}
 
-		.wp-block {
+		[class*="wp-block-"] {
 			&:first-child {
 				margin-top: 0;
 				padding-top: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is intended to improve the appearance of the Cover block when it's aligned left or right. 

It doesn't fix all cases of possible weirdness (for example, citations still won't have sufficient contrast), but it should at least make pullquotes, quotes, and paragraphs nested in cover blocks and then aligned left or right fit in the available space.

Closes #338

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/cKXWmuncLky) into the code view of a post.
2. View the post on the front end and in the editor; note the visual issues (like excess padding and text getting cut off):

**Front end:**

![image](https://user-images.githubusercontent.com/177561/63820000-6eef4880-c8fc-11e9-92a5-d14cd75fa33a.png)

![image](https://user-images.githubusercontent.com/177561/63820002-744c9300-c8fc-11e9-8ec0-32a3a7b0a8c7.png)

**Editor:** 

![image](https://user-images.githubusercontent.com/177561/63820019-83334580-c8fc-11e9-9713-07cf1e9d7224.png)

![image](https://user-images.githubusercontent.com/177561/63820024-875f6300-c8fc-11e9-9236-0cea2c25b61e.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the vertical spacing is improved (decreased), and the text is no longer getting cut off in the editor:

**Front end:**

![image](https://user-images.githubusercontent.com/177561/63819971-46ffe500-c8fc-11e9-8acd-3736924c6cd1.png)

![image](https://user-images.githubusercontent.com/177561/63819976-4bc49900-c8fc-11e9-827d-8ad7389ecb6a.png)

**Editor:**

![image](https://user-images.githubusercontent.com/177561/63819942-2c2d7080-c8fc-11e9-986c-bb804dafd000.png)

![image](https://user-images.githubusercontent.com/177561/63819947-30f22480-c8fc-11e9-9074-553616988e10.png)

4. Edit the post and switch from the default template to the Article Feature template; confirm the cover blocks pull out of the content area:

![image](https://user-images.githubusercontent.com/177561/63819924-14ee8300-c8fc-11e9-9a56-0cc6562dad47.png)

![image](https://user-images.githubusercontent.com/177561/63819926-19b33700-c8fc-11e9-983a-cf469f0d3d43.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
