### PR TITLE
Cover block: Update widths to display correctly on the static front page

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -55,26 +55,22 @@
 	.entry .entry-content {
 		.alignwide {
 			@include media(tablet) {
-				margin-left: auto;
-				margin-right: auto;
-				max-width: 1400px;
+				margin-left: calc(25% - 25vw);
+				margin-right: calc(25% - 25vw);
+				max-width: 100vw;
+
+				&.wp-block-cover {
+					width: auto;
+				}
 			}
 		}
 		.alignfull {
 			margin-left: calc(50% - 50vw);
 			margin-right: calc(50% - 50vw);
 			max-width: 100vw;
-		}
 
-		//! Group Block
-		.wp-block-group {
-			&.alignfull,
-			&.alignwide {
-				> *:not(.alignfull):not(.alignwide) {
-					margin-left: auto;
-					margin-right: auto;
-					max-width: 1200px;
-				}
+			&.wp-block-cover {
+				width: 100vw;
 			}
 		}
 	}

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -16,8 +16,12 @@ body.newspack-static-front-page {
 		max-width: 1230px; // 1200px + 30px to offset padding
 	}
 
-	[data-type="core/group"][data-align="wide"],
-	[data-type="core/group"][data-align="full"] {
+	.wp-block[data-align="wide"] {
+		max-width: 1430px; // 1400px + 30px to offset padding
+	}
+
+	.wp-block[data-type="core/group"][data-align="wide"],
+	.wp-block[data-type="core/group"][data-align="full"] {
 		.wp-block:not([data-align="wide"]):not([data-align="full"]) {
 			max-width: 1230px; // 1200px + 30px to offset padding
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the full-width cover block doesn't display at full width on the static front page, and the wide width blocks are the same width as the regular content. 

Closes #326 .

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cwHPromTa6x) into the code editor on the static front page. It includes a cover block with the normal, wide and full width, and the group block with the normal, wide and full widths. 
2. In the editor, note the appearance of the blocks -- the wide width blocks are not any wider than the regular width blocks:

![image](https://user-images.githubusercontent.com/177561/63821130-b4157980-c900-11e9-9d31-f22840f1b06f.png)

3. On the front-end, the same wide block issue exists; the full-width cover block also doesn't extend the full width of the window:

![image](https://user-images.githubusercontent.com/177561/63821161-c8f20d00-c900-11e9-91ab-24545d8d13be.png)

On the front-end, the group block only has the wide-width issue; the full-width block displays correctly:

![image](https://user-images.githubusercontent.com/177561/63821191-e3c48180-c900-11e9-8148-ef5e6d24a73d.png)

4. Apply the PR and run `npm run build`.

5. Confirm the blocks now match their width description in the editor:

![image](https://user-images.githubusercontent.com/177561/63821259-271ef000-c901-11e9-848f-7192c0a69742.png)

![image](https://user-images.githubusercontent.com/177561/63821264-2ede9480-c901-11e9-9fc8-ad4543c881fd.png)

6. ... and ditto with the front-end:

![image](https://user-images.githubusercontent.com/177561/63821282-3f8f0a80-c901-11e9-859a-095c27cf4115.png)

![image](https://user-images.githubusercontent.com/177561/63821289-461d8200-c901-11e9-861c-09183a8c92c9.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
