### PR TITLE
Centred Logo: Allow for larger logos when centred

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,8 +96,6 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_theme_support(
 			'custom-logo',
 			array(
-				'height'      => 400,
-				'width'       => 800,
 				'flex-width'  => true,
 				'flex-height' => true,
 				'header-text' => array( 'site-title' ),

--- a/inc/logo-resizer.php
+++ b/inc/logo-resizer.php
@@ -65,9 +65,11 @@ function newspack_customize_logo_resize( $html ) {
 		// get the logo support size
 		$sizes = get_theme_support( 'custom-logo' );
 
+		$logo_max_width = ( $logo['width'] > 600 ) ? 600 : $logo['width'];
+
 		// Check for max height and width, default to image sizes if none set in theme
 		$max['height'] = isset( $sizes[0]['height'] ) ? $sizes[0]['height'] : $logo['height'];
-		$max['width']  = isset( $sizes[0]['width'] ) ? $sizes[0]['width'] : $logo['width'];
+		$max['width']  = isset( $sizes[0]['width'] ) ? $sizes[0]['width'] : $logo_max_width;
 
 		// landscape or square
 		if ( $logo['width'] >= $logo['height'] ) {

--- a/js/logo/customize-preview.js
+++ b/js/logo/customize-preview.js
@@ -8,7 +8,7 @@
 ( function( $ ) {
 
 	var api = wp.customize;
-	var Logo = new photoBlogLogo();
+	var Logo = new NewspackLogo();
 	var initial = null;
 	var resizeTimer;
 
@@ -37,13 +37,15 @@
 		initial = to;
 	}
 
-	function photoBlogLogo() {
+	function NewspackLogo() {
+
 		var intId = 0;
 		var hasLogo = null;
 		var min = 48;
 
 		var self = {
 			resize: function( to ) {
+
 				if ( hasLogo ) {
 					var img = new Image();
 					var logo = $( '.custom-logo' );
@@ -59,7 +61,7 @@
 					}
 
 					var max = new Object();
-					max.width = $.isNumeric( cssMax.width ) ? cssMax.width : size.width;
+					max.width = $.isNumeric( cssMax.width ) ? cssMax.width : 600;
 					max.height = $.isNumeric( cssMax.height ) ? cssMax.height : size.height;
 
 					img.onload = function() {

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -74,12 +74,4 @@ body.header-default-background.header-default-height .site-header {
 		font-size: $font__size_base;
 		margin-left: $size__spacing-unit;
 	}
-
-	// Centered logo.
-	.header-center-logo & {
-		margin-left: 0;
-		@include media(tablet) {
-			text-align: center;
-		}
-	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -163,12 +163,13 @@
 .header-center-logo {
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > * {
-			flex: 1 0 0;
-			min-width: calc( 100% / 3 );
+			flex-basis: 1;
 		}
 
 		.site-branding {
+			flex-basis: 2;
 			flex-wrap: wrap;
+			max-width: 40%
 		}
 
 		.site-header .custom-logo-link,
@@ -176,6 +177,20 @@
 		.site-description {
 			text-align: center;
 			width: 100%;
+		}
+
+		.site-header .custom-logo-link {
+			margin-right: 0;
+			img {
+				height: auto;
+				max-width: 100%;
+			}
+		}
+	}
+
+	@include media( desktop ) {
+		.site-branding {
+			max-width: 50%
 		}
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -163,16 +163,16 @@
 .header-center-logo {
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
-			border: 1px solid red;
-			flex-basis: 30%;
-			justify-content: space-between;
+			justify-content: center;
+			width: 35%;
 
 			&.site-branding {
-				flex-basis: 40%;
+				width: 30%;
 			}
 		}
 
 		.site-branding {
+			flex-basis: unset;
 			flex-wrap: wrap;
 		}
 
@@ -196,9 +196,8 @@
 	@include media( desktop ) {
 		.site-header .middle-header-contain .wrapper > div {
 			flex: 1;
-			flex-basis: auto;
 			display: flex;
-			justify-content: center;
+			width: auto;
 
 			&:first-of-type > * {
 				margin-right: auto;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -318,26 +318,6 @@
 			margin-right: auto;
 		}
 	}
-
-	&.header-center-logo {
-
-		@include media( tablet ) {
-			.site-header .wrapper > * {
-				flex: 1 0 0;
-				min-width: 33%;
-			}
-
-			.site-branding {
-				flex-wrap: wrap;
-			}
-
-			.custom-logo-link,
-			.site-title,
-			.site-description {
-				width: 100%;
-			}
-		}
-	}
 }
 
 // Wrapper used to align search with menus.

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -199,6 +199,10 @@
 			display: flex;
 			width: auto;
 
+			&.site-branding {
+				width: auto;
+			}
+
 			&:first-of-type > * {
 				margin-right: auto;
 			}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -162,14 +162,18 @@
 
 .header-center-logo {
 	@include media( tablet ) {
-		.site-header .middle-header-contain .wrapper > * {
-			flex-basis: 1;
+		.site-header .middle-header-contain .wrapper > div {
+			border: 1px solid red;
+			flex-basis: 30%;
+			justify-content: space-between;
+
+			&.site-branding {
+				flex-basis: 40%;
+			}
 		}
 
 		.site-branding {
-			flex-basis: 2;
 			flex-wrap: wrap;
-			max-width: 40%
 		}
 
 		.site-header .custom-logo-link,
@@ -181,6 +185,7 @@
 
 		.site-header .custom-logo-link {
 			margin-right: 0;
+
 			img {
 				height: auto;
 				max-width: 100%;
@@ -189,8 +194,23 @@
 	}
 
 	@include media( desktop ) {
-		.site-branding {
-			max-width: 50%
+		.site-header .middle-header-contain .wrapper > div {
+			flex: 1;
+			flex-basis: auto;
+			display: flex;
+			justify-content: center;
+
+			&:first-of-type > * {
+				margin-right: auto;
+			}
+
+			&:last-of-type {
+				justify-content: flex-end;
+			}
+		}
+
+		.site-header .custom-logo-link img {
+			max-width: inherit;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, when you add a wider logo to the header and centre it, it gets cut off (as @claudiulodro noted in #319.

This PR tries to improve that behaviour, to allow for wider, more banner-like logos. 

There are some limits -- larger logos will squish out the menu to the right, for example, and even when you use small logos, the menus only get so much space. So some thought needs to go in what header to use, how many links to put in the header, and how large the logo should be set to be, depending on what's needed. 

### How to test the changes in this Pull Request:

1. Upload the below logo as your site logo, and size it up to be larger.

![WordPress-logotype-standard](https://user-images.githubusercontent.com/177561/63822323-dd380900-c904-11e9-95d9-4c184cc997e7.png)

2. Under Customize > Header Settings, pick 'Center Logo'

2. View on the front-end; note that the logo gets cut-off.

![image](https://user-images.githubusercontent.com/177561/63828388-2430f900-c91b-11e9-85fd-8c91dcd6e5a5.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the logo now doesn't get cut off (though if it was set quite large, it may be squishing out the tertiary menu now). 

![image](https://user-images.githubusercontent.com/177561/63828423-3dd24080-c91b-11e9-9d7a-f14603024ea4.png)

This is partially because I removed the fixed logo size in the theme as part of these updates, since you can resize it. If it's too large now, it just needs to be scaled down again using the Logo Resizer:

![image](https://user-images.githubusercontent.com/177561/63828474-76721a00-c91b-11e9-96d8-dd0debb2cebc.png)

5. Try resizing the browser window and confirm things behave fairly well -- this is approximately tablet-sized, before the mobile menu appears:

![image](https://user-images.githubusercontent.com/177561/63828483-7ffb8200-c91b-11e9-8e7c-a1d575e9b7de.png)

6. Try a smaller square-shaped logo as well (you can crop the one I attached above for this effect) -- when a smaller logo is in place, each section of the header will be the same width: 

![image](https://user-images.githubusercontent.com/177561/63828586-e1bbec00-c91b-11e9-94f1-3b717390d0f2.png)

It's only when you have a larger logo that it starts eating into the menu space.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
