### PR TITLE
Footer: Fix 'site info' spacing

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -36,7 +36,7 @@
 
 				<?php
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
-					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+					the_privacy_policy_link( '', '' );
 				}
 
 				if ( ! is_active_sidebar( 'footer-1' ) || ( ! has_custom_logo() ) ) {

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -63,20 +63,30 @@
 
 	.wrapper {
 		border-top: 1px solid $color__border;
-		justify-content: space-between;
+		display: block;
 		padding: $size__spacing-unit 0;
+
+		@include media( tablet ) {
+
+			display: flex;
+			justify-content: flex-start;
+
+			& > * {
+				margin-left: $size__spacing-unit;
+			}
+
+			& > *:last-child {
+				margin-left: auto;
+			}
+		}
 	}
 
 	a {
 		color: inherit;
+		display: block;
 
 		&:hover {
 			text-decoration: none;
-			color: $color__primary-variation;
 		}
-	}
-
-	.privacy-policy-link {
-		margin-right: $size__spacing-unit;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the 'site info' part of the footer (the very bottom bar) spaces out elements in it evenly. Depending on what you have, this can look good, or dang weird.

Just the copyright and WordPress credit:

![image](https://user-images.githubusercontent.com/177561/63961213-1aa3b000-ca45-11e9-81b9-4a7e9f4a4bee.png)

Copyright, credit + social menu:

![image](https://user-images.githubusercontent.com/177561/63961240-31e29d80-ca45-11e9-9aef-8f68dcae5408.png)

Copyright, credit, social menu + privacy policy link:

![image](https://user-images.githubusercontent.com/177561/63961272-44f56d80-ca45-11e9-943f-a14539802238.png)

Copyright, credit + privacy policy link:

![image](https://user-images.githubusercontent.com/177561/63961332-6e15fe00-ca45-11e9-8f72-92d097d242e0.png)

This PR makes it so all but the last element sit on the left:

Just the copyright and WordPress credit:

![image](https://user-images.githubusercontent.com/177561/63961213-1aa3b000-ca45-11e9-81b9-4a7e9f4a4bee.png)

Just the copyright and WordPress credit:

Copyright, credit + social menu:

![image](https://user-images.githubusercontent.com/177561/63961443-addce580-ca45-11e9-969f-ba5bab9ce57c.png)

Copyright, credit, social menu + privacy policy link:

![image](https://user-images.githubusercontent.com/177561/63961408-9bfb4280-ca45-11e9-941d-3cb3ed891920.png)

Copyright, credit + privacy policy link:

![image](https://user-images.githubusercontent.com/177561/63961386-8d149000-ca45-11e9-9c73-d65d24449ff1.png)

Closes #347.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Run through the different footer variations, and verify they look like the second set of screenshots: 
   * Nothing set up (just the copyright and WordPress credit)
   * With just the social menu in the bottom bar (to get it there, add a social menu but don't add any footer widgets -- otherwise it will appear higher up in the footer).
   * With just the privacy policy link (to enable, navigate to WP Admin > Settings > Privacy, and pick a published page to be your Privacy Policy page, or publish the draft Privacy Policy page).
   * With both the privacy policy link and social menu links.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
