### PR TITLE
Make sure blocks nested in wide and full blocks don't get too wide

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -73,6 +73,18 @@
 				width: 100vw;
 			}
 		}
+
+		.wp-block-cover,
+		.wp-block-group {
+			&.alignfull,
+			&.alignwide {
+				> *:not(.alignfull):not(.alignwide) {
+					margin-left: auto;
+					margin-right: auto;
+					max-width: 1200px;
+				}
+			}
+		}
 	}
 }
 
@@ -971,6 +983,24 @@
 
 		&.alignwide {
 			width: auto;
+		}
+	}
+
+	//! Group & Cover Block
+	.entry .entry-content > .wp-block-cover,
+	.entry .entry-content > .wp-block-group {
+		&.alignfull,
+		&.alignwide {
+			> div > .alignwide {
+				margin-left: auto;
+				margin-right: auto;
+				max-width: 1200px;
+			}
+			> div >  *:not(.alignfull):not(.alignwide) {
+				margin-left: auto;
+				margin-right: auto;
+				max-width: 780px;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure blocks nested in full and wide cover and group blocks maintain their usual default width (780px) unless they are also set to wide and full.

Some examples of what it should look like:

Normal Cover block + pullquote:

![image](https://user-images.githubusercontent.com/177561/63968632-02d42800-ca55-11e9-83a5-24fd86455def.png)

Wide Cover block + pullquote:

![image](https://user-images.githubusercontent.com/177561/63981584-99641180-ca74-11e9-8099-44c5198c6649.png)

Wide cover block + wide pullquote: 

![image](https://user-images.githubusercontent.com/177561/63981594-a123b600-ca74-11e9-95bf-378bb56bb1d1.png)

Full cover block + pullquote: 
![image](https://user-images.githubusercontent.com/177561/63981602-aa148780-ca74-11e9-993c-83d5f5832655.png)

Full cover block + wide pullquote:

![image](https://user-images.githubusercontent.com/177561/63981625-b3055900-ca74-11e9-9a9f-7ad08277b020.png)

Full cover block + full pullquote: 
![image](https://user-images.githubusercontent.com/177561/63981640-bc8ec100-ca74-11e9-95ad-aa467e2fe711.png)

Closes #346

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Switch to anything but style pack 1 (to temporarily avoid some unrelated issues with the cover block + pullquote block) -- edited to correct the step. 
3. Copy paste [this test content](https://cloudup.com/cwb7fcjZI12) into a post.
4. Set the post to use the 'Article Feature' template.
5. Review the post on the front-end -- it includes a mix of cover and group blocks, with the Newspack article block and the pullquote block nested inside. Note: There's a bit more padding on the cover block, so the nested blocks won't quite be as wide as they are in the group block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
