### PR TITLE
Fix issue where captioned images were pulled out of the content area.

### DIFF
--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -1,18 +1,5 @@
 .wp-caption {
 	margin-bottom: calc(1.5 * #{$size__spacing-unit});
-
-	&.aligncenter {
-
-		@include media(tablet) {
-			position: relative;
-			left: calc( #{$size__site-tablet-content} / 2 );
-			transform: translateX( -50% );
-		}
-
-		@include media(desktop) {
-			left: calc( #{$size__site-desktop-content} / 2 );
-		}
-	}
 }
 
 .wp-caption img[class*="wp-image-"] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The class `.wp-caption` shows up in some older WordPress content; the styles for it in the theme currently pull it out of the content area; you can still end up with this class using the Classic block, so we should remove the problematic styles. This PR fixes that. 

Closes #306.

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/cswqky3w7uS) into the code view of the editor.
2. View on the front-end; note it hangs out of the side:

<img width="920" alt="image" src="https://user-images.githubusercontent.com/177561/64138249-0f3be600-cdb1-11e9-9678-82d8d0a39585.png">

3. Apply the PR and run `npm run build`
4. Confirm that the image is fully visible:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/177561/64138274-31cdff00-cdb1-11e9-8c4c-f8ea2759d887.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
