### PR TITLE
Add a 'no sidebar' and wide template option to the theme

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -50,8 +50,10 @@
 	}
 }
 
-// Wide and full widths need adjustment for the homepage
-.newspack-front-page {
+// Wide and full widths need adjustment for the wider templates
+.newspack-front-page,
+.post-template-single-wide,
+.page-template-single-wide {
 	.entry .entry-content {
 		.alignwide {
 			@include media(tablet) {

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -68,7 +68,8 @@
 .blog #main,
 .search #main,
 .page .main-content,
-.single-post .main-content {
+.single-post .main-content,
+.newspack-front-page.page-template-single-feature .site-main {
 	@include media(tablet) {
 		width: 65%;
 	}
@@ -92,12 +93,11 @@
 }
 
 // Single-column layouts
-.post-template-single-feature,
-.page-template-single-feature {
-	.main-content {
-		margin-left: auto;
-		margin-right: auto;
-	}
+.post-template-single-feature .main-content,
+.page-template-single-feature .main-content,
+.newspack-front-page.page-template-single-feature .site-main {
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .page-template-single-feature {
@@ -115,5 +115,14 @@
 .page-template-single-wide {
 	.main-content {
 		width: 100%;
+	}
+
+	@include media( tablet ) {
+		.author-bio,
+		.comments-area {
+			margin-left: auto;
+			margin-right: auto;
+			width: 65%;
+		}
 	}
 }

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -67,7 +67,7 @@
 .archive #main,
 .blog #main,
 .search #main,
-.page:not(.newspack-front-page) .main-content,
+.page .main-content,
 .single-post .main-content {
 	@include media(tablet) {
 		width: 65%;
@@ -77,7 +77,7 @@
 .archive #secondary,
 .blog #secondary,
 .search #secondary,
-.page:not(.newspack-front-page) #secondary,
+.page #secondary,
 .single-post #secondary {
 	@include media(tablet) {
 		width: calc( 35% - #{ 2 * $size__spacing-unit } );
@@ -89,4 +89,31 @@
 
 .hide {
 	display: none;
+}
+
+// Single-column layouts
+.post-template-single-feature,
+.page-template-single-feature {
+	.main-content {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+.page-template-single-feature {
+	@include media(tablet) {
+		.entry-header {
+			margin-left: auto;
+			margin-right: auto;
+			width: 65%;
+		}
+	}
+}
+
+.newspack-front-page,
+.post-template-single-wide,
+.page-template-single-wide {
+	.main-content {
+		width: 100%;
+	}
 }

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -250,13 +250,6 @@ body.page {
 		}
 	}
 
-	&.post-template-single-feature {
-		.main-content {
-			margin-left: auto;
-			margin-right: auto;
-		}
-	}
-
 	.main-content {
 		.post-thumbnail:first-child {
 			margin-top: #{ 2 * $size__spacing-unit };

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -82,7 +82,7 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-.newspack-front-page #primary {
+.newspack-front-page:not(.page-template-single-feature) #primary {
 	padding: 0;
 
 	.site-main > article > .entry-content > *:first-child {

--- a/single-feature.php
+++ b/single-feature.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Article feature
+ * Template Name: One column
  * Template Post Type: post, page
  *
  * The template for displaying all single posts

--- a/single-wide.php
+++ b/single-wide.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Article feature
+ * Template Name: Article wide
  * Template Post Type: post, page
  *
  * The template for displaying all single posts

--- a/single-wide.php
+++ b/single-wide.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Article wide
+ * Template Name: One column wide
  * Template Post Type: post, page
  *
  * The template for displaying all single posts


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new template to the theme -- One column wide -- and renames the Article feature to One column. It also makes both template available on both posts and pages (not just posts). 

The default: 780px wide content area, plus sidebar.

![image](https://user-images.githubusercontent.com/177561/64208995-4b745280-ce54-11e9-9181-62960fb30f4e.png)

![image](https://user-images.githubusercontent.com/177561/64209246-d8b7a700-ce54-11e9-9811-60b61ec159c9.png)


One column: 780px wide content area, centred.

![image](https://user-images.githubusercontent.com/177561/64208978-41eaea80-ce54-11e9-9ccb-3fd66bf2e1f1.png)

![image](https://user-images.githubusercontent.com/177561/64209162-a3ab5480-ce54-11e9-9e9d-40b34bab2f52.png)

One column wide: 1200px wide content area, taking up all available space (not intended for regular content but to create a homepage-like page on other pages in the site. The width makes for a too-long line width for straight text):

![image](https://user-images.githubusercontent.com/177561/64208956-3697bf00-ce54-11e9-8c2c-6a3d363c6194.png)

![image](https://user-images.githubusercontent.com/177561/64209286-f553df00-ce54-11e9-9af8-7ad0061bb6fd.png)

There are a couple things I'm unsure about still:

1. The static front page still displays at 1200px wide by default with no sidebar, so it makes it a bit of an 'odd one out' with the template options. There are a couple ways we could handle it: 

* Keep it as is (always force a one column wide layout on the static front page).
* Remove the front-page.php; make the front-page use the two column default layout and have to switch to the wide version to get the current behaviour. Switch to that wide template on site setup using the plugin.
* Keep the default (wide styles), and allow switching between the two other templates -- this way, the front-page.php default styles and the wide one-column will look the same, but the regular one column would be narrower. 

2. For the one-column wide template, should the author bio and comments also be wide? Or should they respect the 780px column width? 

![image](https://user-images.githubusercontent.com/177561/64208915-1cf67780-ce54-11e9-8b59-cb564963284e.png)

Closes #351.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a new post, try switching to the 'One column' template.
3. [Copy-paste this test content](https://cloudup.com/cKHrYoUSnTW) to have a regular-width, wide-width and full-width group block. 
4. Confirm that the regular content is 780px wide at the most, and that the wide and full-width blocks are wider.
5. Switch the post to the 'One column wide' template; confirm that the regular content is 1200px wide, and the wide and full width blocks still appear wider than the content area. 
6. Create a new page, and switch it to the 'One column' template.
7. [Copy-paste this test content](https://cloudup.com/cKHrYoUSnTW) to have a regular-width, wide-width and full-width group block. 
8. Confirm that the regular content is 780px wide at the most, and that the wide and full-width blocks are wider.
9. Switch the post to the 'One column wide' template; confirm that the regular content is 1200px wide, and the wide and full width blocks still appear wider than the content area. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
