### PR TITLE
Style 1: Rework Pullquote styles so they work in Cover Blocks

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -39,11 +39,11 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar,
 		.site-header .main-navigation .main-menu .sub-menu,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
-		.entry .entry-content > .has-primary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-primary-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-primary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
+		.entry .entry-content .has-primary-background-color,
+		.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
+		.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 		.entry .entry-content .wp-block-file .wp-block-file__button {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
@@ -63,10 +63,10 @@ function newspack_custom_colors_css() {
 
 		/* Set primary color */
 
-		.entry .entry-content > .has-primary-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-primary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
+		.entry .entry-content .has-primary-color,
+		.entry .entry-content *[class^="wp-block-"] .has-primary-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
 			color: ' . $primary_color . ';
 		}
 
@@ -97,10 +97,10 @@ function newspack_custom_colors_css() {
 
 		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
 		.button, button, input[type="button"], input[type="reset"], input[type="submit"],
-		.entry .entry-content > .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
+		.entry .entry-content .has-secondary-background-color,
+		.entry .entry-content *[class^="wp-block-"].has-secondary-background-color,
+		.entry .entry-content *[class^="wp-block-"] .has-secondary-background-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
 			background-color:' . $secondary_color . '; /* base: #666 */
 		}
 
@@ -113,10 +113,10 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary color */
 
-		.entry .entry-content > .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
+		.entry .entry-content .has-secondary-color,
+		.entry .entry-content *[class^="wp-block-"] .has-secondary-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
 			color:' . $secondary_color . '; /* base: #666 */
 		}
 
@@ -160,20 +160,20 @@ function newspack_custom_colors_css() {
 		.site-header .main-navigation .sub-menu > li > .menu-item-link-return:focus,
 		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
 		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
-		.entry .entry-content > .has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
+		.entry .entry-content .has-primary-variation-background-color,
+		.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
+		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
 			background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . '; /* base: #005177; */
 		}
 
 		/* Set primary variation color */
 
 		.author-bio .author-description .author-link:hover,
-		.entry .entry-content > .has-primary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-primary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color p,
+		.entry .entry-content .has-primary-variation-color,
+		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color p,
 		.comment .comment-author .fn a:hover,
 		.comment-reply-link:hover,
 		.comment-navigation .nav-previous a:hover,
@@ -184,10 +184,10 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary variation background color */
 
-		.entry .entry-content > .has-secondary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].has-secondary-variation-ackground-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-variation-background-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color {
+		.entry .entry-content .has-secondary-variation-background-color,
+		.entry .entry-content *[class^="wp-block-"].has-secondary-variation-ackground-color,
+		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-background-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color {
 			background-color:' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #666 */
 		}
 
@@ -196,10 +196,10 @@ function newspack_custom_colors_css() {
 		.entry .entry-content a:hover,
 		.widget a:hover,
 		.author-bio .author-link:hover,
-		.entry .entry-content > .has-secondary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"] .has-secondary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
-		.entry .entry-content > *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p {
+		.entry .entry-content .has-secondary-variation-color,
+		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p {
 			color:' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #666 */
 		}
 
@@ -244,7 +244,7 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.entry .entry-content .wp-block-pullquote blockquote:before {
+			.entry .entry-content .wp-block-pullquote blockquote p:first-of-type:before {
 				color: ' . $primary_color . ';
 			}
 		';
@@ -426,7 +426,7 @@ function newspack_custom_colors_css() {
 			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
 				background-color: ' . $primary_color . ';
 			}
-			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) blockquote::before {
+			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) .block-library-pullquote__content:before {
 				color: ' . $primary_color . ';
 			}
 		';

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -202,7 +202,7 @@ function newspack_custom_typography_css() {
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote::before
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .block-library-pullquote__content::before
 
 			{
 				font-family: $font_header;

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -48,7 +48,6 @@ Newspack Theme Editor Styles - Style Pack 1
 .wp-block[data-type="core/pullquote"] {
 
 	.wp-block-pullquote {
-		background-color: $color__background-body;
 		border-width: 0;
 		padding-top: #{ 3 * $size__spacing-unit };
 		position: relative;
@@ -60,13 +59,41 @@ Newspack Theme Editor Styles - Style Pack 1
 	}
 
 	blockquote {
-		background-color: inherit;
 		border-color: inherit;
 		margin: #{ 2 * $size__spacing-unit } 0;
 		text-align: center;
 
+		&:before,
+		&:after {
+			border-top: 2px solid;
+			border-top-color: inherit;
+			content: "";
+			display: block;
+			position: absolute;
+			opacity: 0.8;
+			top: #{ 2 * $size__spacing-unit };
+		}
+
 		&:before {
-			background-color: inherit;
+			left: 15%;
+			right: calc( 50% + 2em);
+		}
+
+		&:after {
+			left: calc( 50% + 2em);
+			right: 15%;
+		}
+	}
+
+	.wp-block-pullquote.is-style-solid-color {
+		blockquote:before,
+		blockquote:after {
+			border-top-color: currentColor;
+		}
+	}
+
+	.block-library-pullquote__content {
+		&:before {
 			color: $color__primary;
 			content: "\201C";
 			display: inline-block;
@@ -77,7 +104,7 @@ Newspack Theme Editor Styles - Style Pack 1
 			line-height: 0.75;
 			position: absolute;
 			text-align: center;
-			top: #{ 1.5 * $size__spacing-unit };
+			top: #{ -3.5 * $size__spacing-unit };
 			width: 0.5em;
 			z-index: 1;
 
@@ -85,28 +112,10 @@ Newspack Theme Editor Styles - Style Pack 1
 				font-size: calc( 1rem * 7 );
 			}
 		}
-
-		&:after {
-			border-top: 2px solid;
-			border-top-color: inherit;
-			content: "";
-			display: block;
-			position: absolute;
-			opacity: 0.5;
-			left: 15%;
-			right: 15%;
-			top: #{ 2 * $size__spacing-unit };
-		}
 	}
 
-	.wp-block-pullquote.is-style-solid-color {
-		blockquote:before {
-			color: inherit;
-		}
-
-		blockquote:after {
-			border-top-color: currentColor;
-		}
+	.wp-block-pullquote.is-style-solid-color .block-library-pullquote__content:before {
+		color: inherit;
 	}
 
 	blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
@@ -135,23 +144,31 @@ Newspack Theme Editor Styles - Style Pack 1
 			text-align: left;
 
 			&:before {
-				font-size: calc( 1rem * 5 );
-				left: 0;
-				text-align: left;
-				width: 0.5em;
+				left: 2em;
+				right: 0;
 			}
 
 			&:after {
+				display: none;
+			}
+		}
+
+		.block-library-pullquote__content {
+			&:before {
+				font-size: calc( 1rem * 5 );
 				left: 0;
+				text-align: left;
+				top: #{ -2.5 * $size__spacing-unit };
+				width: 0.5em;
 			}
 		}
 
 		&.is-style-solid-color blockquote {
 			padding-top: #{ 0.25 * $size__spacing-unit };
 
-			&:before,
-			&:after {
-				left: #{ 2 * $size__spacing-unit };
+			&:before {
+				left: #{ 4 * $size__spacing-unit };
+				right: #{ 2 * $size__spacing-unit };
 			}
 		}
 

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -97,26 +97,44 @@
 	.wp-block-pullquote {
 		background-color: $color__background-body;
 		border-width: 0;
+		border-color: transparent;
 		font-family: $font__heading;
 		font-weight: bold;
 		padding-top: #{ 4 * $size__spacing-unit };
 		position: relative;
 
 		p {
-			position: relative;
-			z-index: 1;
 			@include media( tablet ) {
 				font-size: $font__size-xl;
 			}
 		}
 
 		blockquote {
-			background-color: inherit;
 			border-color: inherit;
 			text-align: center;
 
+			&:before,
+			&:after {
+				border-top: 2px solid;
+				border-color: inherit;
+				content: "";
+				display: block;
+				position: absolute;
+				opacity: 0.8;
+				top: #{ 2 * $size__spacing-unit };
+			}
+
 			&:before {
-				background-color: inherit;
+				left: 15%;
+				right: calc( 50% + 2em);
+			}
+
+			&:after {
+				left: calc( 50% + 2em);
+				right: 15%;
+			}
+
+			p:first-of-type:before {
 				color: $color__primary;
 				content: "\201C";
 				display: inline-block;
@@ -134,17 +152,16 @@
 					font-size: calc( 1rem * 7 );
 				}
 			}
+		}
 
-			&:after {
-				border-top: 2px solid;
-				border-top-color: inherit;
-				content: "";
-				display: block;
-				position: absolute;
-				opacity: 0.5;
-				left: 15%;
-				right: 15%;
-				top: #{ 2 * $size__spacing-unit };
+		&.is-style-solid-color {
+			blockquote:before,
+			blockquote:after {
+				border-top-color: currentColor;
+			}
+
+			p:first-of-type:before {
+				color: inherit;
 			}
 		}
 
@@ -172,23 +189,42 @@
 
 			p {
 				font-size: $font__size-md;
+
+					&:first-of-type:before {
+					font-size: calc( 1rem * 5 );
+					left: 0;
+					text-align: left;
+					width: 0.5em;
+				}
 			}
 
-			blockquote:before {
-				font-size: calc( 1rem * 5 );
-				left: 0;
-				text-align: left;
-				width: 0.5em;
+			blockquote {
+				&:before {
+					left: 3em;
+					right: 15%;
+				}
+
+				&:after {
+					display: none;
+				}
 			}
 
-			blockquote:after {
-				left: 0;
-			}
+			&.is-style-solid-color {
+				p:first-of-type:before {
+					left: #{ 1.5 * $size__spacing-unit };
+				}
 
-			&.is-style-solid-color blockquote:before,
-			&.is-style-solid-color blockquote:after {
-				left: #{ 2 * $size__spacing-unit };
+				blockquote:before {
+					left: 4em;
+				}
 			}
+		}
+	}
+
+	.wp-block-cover,
+	.wp-block-group {
+		.wp-block-pullquote {
+			background-color: transparent;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I originally managed to get the Style 1 Pullquote styles to properly inherit the colour settings by giving them a white background. However, this doesn't work well when nesting the pullquote inside of a group or pullquote.

This PR reworks how those styles are set up, so it doesn't rely on a white background to inherit the colour styles properly.

As part of this PR, I also simplified one of the selectors in the colour settings, since it wasn't being applied correctly.

Closes #370 .

Regular pullquotes: 

![image](https://user-images.githubusercontent.com/177561/64459636-39412100-d0ad-11e9-8fc6-3a35c4702f00.png)

Nested inside of a Cover block:

![image](https://user-images.githubusercontent.com/177561/64459657-45c57980-d0ad-11e9-8d39-eedcc8208432.png)

![image](https://user-images.githubusercontent.com/177561/64459661-49f19700-d0ad-11e9-8c61-c083cd874b36.png)

Nested inside of a Group block:

![image](https://user-images.githubusercontent.com/177561/64459688-57a71c80-d0ad-11e9-9940-546c6e11ad83.png)

Aligned left:

![image](https://user-images.githubusercontent.com/177561/64459708-62fa4800-d0ad-11e9-98cd-102510c649de.png)

Aligned right:

![image](https://user-images.githubusercontent.com/177561/64459714-6988bf80-d0ad-11e9-8987-851a9870eec8.png)


### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Style Packs, and switch to Style 1.
3. Copy paste [this test content](https://cloudup.com/cCabjWZ7BMJ) into the code view of the editor -- it has a mix of regular pullquotes with the different colour settings, with backgrounds, and nested in cover and group blocks. 

_Note: There's a Gutenberg issue where the pullquotes just using the border styles will error out when you navigate back to the editor. If you click the `...` menu, then pick "Attempt Block Recovery", it will fix it:_ 

![image](https://user-images.githubusercontent.com/177561/64458903-73a9be80-d0ab-11e9-9f94-5cce3dde3e21.png)

4. View the pullquotes in the editor and on the front-end; confirm that they match the screenshots in appearance.
5. Change your colour settings -- if you're using the default colours, change them to custom colours, and vis versa -- confirm that the 'quote' is still using your colours, except when the pullquote is using the solid background style.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
