### PR TITLE
Style 3: Remove 'overlap' style when the block is in a group or cover block

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -30,14 +30,22 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) {
-	.post-has-image .entry-title {
-		background-color: $color__background-body;
-		margin-top: -1.75em;
-		padding: 0.5em 0.25em 0 0;
-		position: relative;
-		width: 85%;
-		z-index: 1;
+.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+	background-color: $color__background-body;
+	margin-top: -1.75em;
+	padding: 0.5em 0.25em 0 0;
+	position: relative;
+	width: 85%;
+	z-index: 1;
+}
+
+.wp-block-cover,
+.wp-block-group {
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+		background-color: transparent;
+		margin-top: 0;
+		padding: 0;
+		width: auto;
 	}
 }
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -141,14 +141,22 @@ figcaption,
 }
 
 .entry .entry-content {
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) {
-		.post-has-image .entry-title {
-			background-color: $color__background-body;
-			margin-top: -1.5em;
-			padding: 0.5em 0.25em 0 0;
-			position: relative;
-			width: 85%;
-			z-index: 1;
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+		background-color: $color__background-body;
+		margin-top: -1.5em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
+	}
+
+	.wp-block-cover,
+	.wp-block-group {
+		.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+			background-color: transparent;
+			margin-top: 0;
+			padding: 0;
+			width: auto;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Style 3, the article block titles are 'pulled up' over the featured images.

To do this, we have to add a white background to the titles, which doesn't work well when they're nested inside of the cover or group blocks.

This PR removes that particular style in those cases, so the titles sit below the images. 

**Before:** 

![image](https://user-images.githubusercontent.com/177561/64461149-39432000-d0b1-11e9-9fd0-ce38e15f1e6c.png)

**After:** 

![image](https://user-images.githubusercontent.com/177561/64461128-27617d00-d0b1-11e9-888f-8963b9e9e374.png)

Closes #301  .

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Style Packs, and change to Style 3.
2. Copy-paste [this test content](https://cloudup.com/cpl3NU08Mab) into the code editor.
3. Update the article block settings to make sure at least one article per block has an image.
4. View on the front end and in the editor; note the odd white block.
5. Apply the PR and run `npm run build`
6. Confirm that the titles now sit below the images, and don't have white backgrounds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
