### PR TITLE
Fix alignment in comment count in footer

### DIFF
--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -50,6 +50,7 @@
 			@include media(tablet) {
 				flex: 0 0 calc(2 * (100vw / 12));
 				margin-left: #{$size__spacing-unit};
+				text-align: right;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a minor issue with the comment count, where it doesn't fully align to the right.

Before:

![image](https://user-images.githubusercontent.com/177561/64491386-ff8f2800-d21c-11e9-9176-1adb447fa8d5.png)

After:

![image](https://user-images.githubusercontent.com/177561/64491376-ed14ee80-d21c-11e9-899b-31ca709fd017.png)

Closes #372 .

### How to test the changes in this Pull Request:

1. Navigate to a post with a comment count and note the alignment of the comment count
2. Apply the PR and run `npm run build`
3. Confirm that the comment count is aligned right.
4. Scale down the browser window and confirm the comment count aligns left when it wraps to a new line.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
