### PR TITLE
Fix issue with custom colours in entry footer.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -54,6 +54,7 @@ function newspack_custom_colors_css() {
 		.main-navigation ul.main-menu > li > a,
 		.entry .entry-content .more-link:hover,
 		.main-navigation .main-menu > li > a + svg,
+		.entry-footer a,
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue with the entry footer links not picking up the primary custom colour in the default style pack, and style 1.

It should not change  styles 2 and 4 (which already worked) or style 3 (which doesn't use the custom colour in the tags). 

Here are screenshots with the primary colour set to red: 

**Default style - before:**

![image](https://user-images.githubusercontent.com/177561/64493028-c44a2480-d22f-11e9-89f6-f4738479bae4.png)

**Default style - after:**

![image](https://user-images.githubusercontent.com/177561/64493022-b72d3580-d22f-11e9-8a42-3fc350c7adae.png)

**Style 1 - before:**

![image](https://user-images.githubusercontent.com/177561/64493036-d926b800-d22f-11e9-9f43-cf8d7512803b.png)

**Style 1 - after:**

![image](https://user-images.githubusercontent.com/177561/64493014-ada3cd80-d22f-11e9-969b-5d960c7914dc.png)

**Style 2 - before:**

![image](https://user-images.githubusercontent.com/177561/64493039-e774d400-d22f-11e9-93cb-514a6fc54595.png)

**Style 2 - after:**

![image](https://user-images.githubusercontent.com/177561/64493008-a41a6580-d22f-11e9-88bf-48aa3f1efa71.png)

**Style 3 - before:**

![image](https://user-images.githubusercontent.com/177561/64493050-03787580-d230-11e9-8227-8168ee57c6d4.png)

**Style 3 - after:**

![image](https://user-images.githubusercontent.com/177561/64493002-982ea380-d22f-11e9-9743-fd6d0b416c0f.png)

**Style 4 - before:**

![image](https://user-images.githubusercontent.com/177561/64493068-391d5e80-d230-11e9-8727-8b2194edaad6.png)

**Style 4 - after:**

![image](https://user-images.githubusercontent.com/177561/64492995-85b46a00-d22f-11e9-8aff-8028465d6008.png)

Closes #367 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Set a custom primary colour that's darker (lighter colours, when used for text, will switch to grey for legibility).
3. Navigate to a post with at least one tag.
4. Cycle through the style packs and confirm they pick up the correct colours, as per the screenshots above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
