### PR TITLE
Fix button padding when nested in a floated cover block

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -566,12 +566,10 @@
 
 				[class*="wp-block-"]:first-child {
 					margin-top: 0;
-					padding-top: 0;
 				}
 
 				[class*="wp-block-"]:last-child {
 					margin-bottom: 0;
-					padding-bottom: 0;
 				}
 			}
 		}

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -262,12 +262,10 @@ figcaption {
 		[class*="wp-block-"] {
 			&:first-child {
 				margin-top: 0;
-				padding-top: 0;
 			}
 
 			&:last-child {
 				margin-bottom: 0;
-				padding-bottom: 0;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In an attempt to remove extra space from floated Cover Blocks, I removed the padding from the first and last item. But this caused some weirdness with the button block, so this PR removes it. 

Closes #369 .

### How to test the changes in this Pull Request:

1. Copy [this test content](https://cloudup.com/c616VScV4Ja) into a post.
2. View on the front end and in the editor; note the lack of padding on the button.

![image](https://user-images.githubusercontent.com/177561/64554782-ed7eb980-d2f0-11e9-9946-739fc6f165f6.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the button now looks correct on the front-end and in the editor.

![image](https://user-images.githubusercontent.com/177561/64554592-91b43080-d2f0-11e9-92b5-841ff59853ff.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
