### PR TITLE
Make accent header class more consistent with article block section headers

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -713,10 +713,6 @@
 		@include media(tablet) {
 			.wp-block-column > * {
 
-				&:first-child {
-					margin-top: 0;
-				}
-
 				&:last-child {
 					margin-bottom: 0;
 				}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -144,7 +144,7 @@ h4,
 // Accent headers
 
 .accent-header,
-.article-section-title,
+.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 .cat-links {
 	color: $color__text-light;
 	font-family: $font__heading;
@@ -152,6 +152,7 @@ h4,
 	font-weight: bold;
 }
 
+.accent-header,
 .site-content .wp-block-newspack-blocks-homepage-articles .article-section-title {
 	margin-bottom: $size__spacing-unit;
 	@include media( tablet ) {

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -11,7 +11,7 @@ Newspack Theme Editor Styles - Style Pack 3
 .article-section-title {
 	color: $color__primary;
 	font-size: $font__size-xs;
-	margin: 0 0 #{ 2 * $size__spacing-unit };
+	margin: 0 0 #{ 1.5 * $size__spacing-unit };
 
 	&:before {
 		background-color: $color__primary;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -47,7 +47,7 @@ Newspack Theme Styles - Style Pack 3
 .site-content .wp-block-newspack-blocks-homepage-articles  .article-section-title,
 .cat-links,
 .archive .page-title {
-	margin: 0 0 #{ 2 * $size__spacing-unit };
+	margin: 0 0 #{ 1.5 * $size__spacing-unit };
 }
 
 .accent-header,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -32,7 +32,6 @@ Newspack Theme Styles - Style Pack 3
 .cat-links,
 .archive .page-title {
 	color: $color__primary;
-	margin: 0 0 #{ 2 * $size__spacing-unit };
 
 	&:before {
 		background-color: $color__primary;
@@ -42,6 +41,13 @@ Newspack Theme Styles - Style Pack 3
 		margin: 0 0 $size__spacing-unit;
 		width: 32px;
 	}
+}
+
+.accent-header,
+.site-content .wp-block-newspack-blocks-homepage-articles  .article-section-title,
+.cat-links,
+.archive .page-title {
+	margin: 0 0 #{ 2 * $size__spacing-unit };
 }
 
 .accent-header,

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -31,13 +31,18 @@ Newspack Theme Styles - Style Pack 4
 .article-section-title,
 .cat-links {
 	color: $color__primary;
+}
+
+.accent-header,
+.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
+.cat-links {
 	font-size: $font__size-xs;
+	margin-bottom: $size__spacing-unit;
 	text-align: center;
 }
 
 .article-section-title,
 .widget-title.accent-header {
-	margin-bottom: $size__spacing-unit;
 	overflow: hidden;
 
 	span {

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -164,3 +164,12 @@ blockquote {
 .page-description {
 	text-transform: none;
 }
+
+.accent-header {
+	margin-bottom: 0.5em;
+
+	& + * {
+		margin-top: 0;
+	}
+}
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the sizing and spacing for the `.accent-header` and article block section headers more consistent. 

Closes #361 

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Copy-paste [this test content](https://cloudup.com/ckrXMoFajyS) into a post or page. It includes a column block with two article blocks (the first and second column), and one column that has the `.accent-header` class, a header block and a paragraph block.
3. Cycle through the different style packs; confirm that the section header from the block, and the `.accent-header` class on the header, are the same size and have the same vertical spacing in the editor and on the front-end. 

**Default**
![image](https://user-images.githubusercontent.com/177561/64570721-4a409b00-d316-11e9-8440-20b66bb62504.png)

**Style 1**
![image](https://user-images.githubusercontent.com/177561/64570764-71976800-d316-11e9-9a13-b31ba0cf74ab.png)

**Style 2**
![image](https://user-images.githubusercontent.com/177561/64570789-7f4ced80-d316-11e9-8444-bdfabd292945.png)

**Style 3**

![image](https://user-images.githubusercontent.com/177561/64570906-ee2a4680-d316-11e9-8dec-cee17b2f4c7b.png)

**Style 4**

![image](https://user-images.githubusercontent.com/177561/64570658-1cf3ed00-d316-11e9-8ee2-f7c5518bb20e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
