### PR TITLE
Fix donation block custom colours

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -44,7 +44,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
-		.entry .entry-content .wp-block-file .wp-block-file__button {
+		.entry .entry-content .wp-block-file .wp-block-file__button,
+		.main-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
@@ -76,7 +77,8 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar .main-navigation .sub-menu > li > a,
 		.mobile-sidebar .main-navigation ul.main-menu > li > a,
 		.site-header .main-navigation .sub-menu > li > a,
-		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a {
+		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
+		.main-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
 		}
 
@@ -355,8 +357,13 @@ function newspack_custom_colors_css() {
 			border-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
+		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
+		}
+
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+			color: ' . $primary_color_contrast . ';
 		}
 
 		/* Secondary color */
@@ -365,7 +372,8 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			background-color: ' . $secondary_color . '; /* base: #0073a8; */
 		}
 
@@ -373,7 +381,8 @@ function newspack_custom_colors_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
 		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover {
+		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			color: ' . $secondary_color_contrast . '; /* base: #0073a8; */
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The donation block wasn't picking up the primary colour for the current selection, or the secondary custom colour for the button; this PR fixes that.
 
Closes #339.

### How to test the changes in this Pull Request:

1. Change your site to use two custom colours.
2. Add a donation block to a post or page.
3. Confirm its appearance in the editor and on the front end; it should be using all blue in the editor, and blue and your primary colour on the front end.

Front end: 
<img width="706" alt="image" src="https://user-images.githubusercontent.com/177561/64665873-0d090580-d409-11e9-8934-17bbfdf1178a.png">

4. Apply the PR and run `npm run build`
5. Confirm that in the editor and on the front end, both your primary and secondary colours are used, not the Newspack blue:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/177561/64665901-2c079780-d409-11e9-9e0d-cec02b431fd0.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
