### PR TITLE
Fix issue where cover block collapses when focused on in editor.

### DIFF
--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -237,7 +237,7 @@ figcaption {
 		padding: calc(1.375 * #{$size__spacing-unit});
 
 		@include media( tablet ) {
-			max-width: 405px;
+			max-width: 400px;
 		}
 
 		p {
@@ -250,7 +250,8 @@ figcaption {
 		}
 
 		.wp-block-cover__inner-container {
-			width: 100%;
+			width: 450px;
+			max-width: 100%;
 		}
 
 		.block-editor-block-list__block-edit {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you float a cover block to the right or left and then give it focus, it 'collapses', and becomes really narrow:

Before focusing: 

<img width="893" alt="image" src="https://user-images.githubusercontent.com/177561/64666099-e7c8c700-d409-11e9-9db6-ce758d0a4d4b.png">

After focusing: 

<img width="931" alt="image" src="https://user-images.githubusercontent.com/177561/64666138-0af37680-d40a-11e9-893b-c335fdc52f04.png">

Closes #368.

### How to test the changes in this Pull Request:

1. Add a cover block to a post, and float it left.
2. In the editor, click inside of the cover block, to add a block or edit what's there. Note that it 'collapses'.
3. Apply the PR and run `npm run build`.
4. Repeat step two; confirm that the cover block maintains its width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?