### PR TITLE
Update font sizes to be relative to the base size.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -125,25 +125,25 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'      => __( 'Small', 'newspack' ),
 					'shortName' => __( 'S', 'newspack' ),
-					'size'      => 19.5,
+					'size'      => 16,
 					'slug'      => 'small',
 				),
 				array(
 					'name'      => __( 'Normal', 'newspack' ),
 					'shortName' => __( 'M', 'newspack' ),
-					'size'      => 22,
+					'size'      => 20,
 					'slug'      => 'normal',
 				),
 				array(
 					'name'      => __( 'Large', 'newspack' ),
 					'shortName' => __( 'L', 'newspack' ),
-					'size'      => 36.5,
+					'size'      => 36,
 					'slug'      => 'large',
 				),
 				array(
 					'name'      => __( 'Huge', 'newspack' ),
 					'shortName' => __( 'XL', 'newspack' ),
-					'size'      => 49.5,
+					'size'      => 44,
 					'slug'      => 'huge',
 				),
 			)

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -796,15 +796,15 @@
 	}
 
 	.has-normal-font-size {
-		font-size: $font__size-md;
+		font-size: $font__size_base;
 	}
 
 	.has-large-font-size {
-		font-size: $font__size-lg;
+		font-size: $font__size-xl;
 	}
 
 	.has-huge-font-size {
-		font-size: $font__size-xl;
+		font-size: $font__size-xxl;
 	}
 
 	.has-primary-background-color,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Gutenberg includes a font-size picker for blocks like the paragraph block; right now, the 'small' and 'normal' sizes are practically identical; this PR fixes that and makes the other size more 'standard' with what's used in the theme.

Before:

<img width="716" alt="image" src="https://user-images.githubusercontent.com/177561/64666403-0d0a0500-d40b-11e9-85d8-9a9944afc9c8.png">

After:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/177561/64666365-e8ae2880-d40a-11e9-9a8d-a740d3216c48.png">

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/cPNsqohmlcQ) into the code editor.
2. View how the different font sizes look.
3. Apply the PR and run `npm run build`.
4. Confirm that the font sizes (especially the first and second lines) look distinctly different.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?