### PR TITLE
Style 3: Make sure post meta (author and published date) aren't large…

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -23,6 +23,11 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
+.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.entry-meta {
+	font-size: $font__size-xs;
+}
+
 .wp-block-paragraph {
 	&.has-drop-cap:not(:focus)::first-letter {
 		font-family: $font__heading;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -89,6 +89,11 @@ Newspack Theme Styles - Style Pack 3
 
 // Posts & Pages
 
+.entry-meta,
+.entry .wp-block-newspack-blocks-homepage-articles article .entry-meta {
+	font-size: $font__size-xs;
+}
+
 .single-post:not(.has-featured-image) .entry-header,
 .single-post.has-large-featured-image .entry-header {
 	border-bottom: 1px dotted $color__text-main;


### PR DESCRIPTION
…r than the category/accent header.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the post meta (author name and published date) do not display larger than the section title in the article block when using 'Style 3'. 

Before:

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/177561/64666871-a4238c80-d40c-11e9-8c3c-fa6042f9c156.png">

After:

<img width="1273" alt="image" src="https://user-images.githubusercontent.com/177561/64666751-3b3c1480-d40c-11e9-9943-42709896422c.png">

Closes #221 .

### How to test the changes in this Pull Request:

1. Navigate to the Customizer > Style Packs and switch to Style 3.
2. Add an article block to a page, and add a 'section header'.
3. Compare the font size between the section header and author and publish date; note that the post meta is larger than the section header.
4. Apply the PR and run `npm run build`
5. Confirm that the section header and post meta is the same size. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->
