### PR TITLE
Style 2: Make sure the menu toggle uses the all-caps

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -320,6 +320,7 @@ function newspack_custom_typography_css() {
 			$css_blocks        .= '
 				.main-navigation ul li,
 				.tertiary-menu,
+				.mobile-menu-toggle,
 				.accent-header,
 				.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
 				.cat-links,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Style 2 mobile menu toggle uses all caps, when the site is set to use all caps for accent text; this makes it match the mockups.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 2.
2. Navigate to Customize > Typography and confirm that "Use all-caps for accent text." is checked.
3. View the front end of the site; make the browser window narrow so you can see the menu toggle button; it should be all caps but it won't be. 

<img width="137" alt="image" src="https://user-images.githubusercontent.com/177561/64667093-712dc880-d40d-11e9-9308-75963258a8e0.png">

4. Apply the PR and run `npm run build`.
5. View on the front end; both the 'Menu' button and the 'Close' button when you open it should use all-caps:

<img width="159" alt="image" src="https://user-images.githubusercontent.com/177561/64667084-66733380-d40d-11e9-8445-1aa075dc558f.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
