### PR TITLE
Style 2: Remove overlap styles from header on smaller screens.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -252,6 +252,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
+			.site-header,
 			.site-content #primary {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -11,8 +11,6 @@ Newspack Theme Styles - Style Pack 2
 
 .site-header,
 .header-solid-background .site-header {
-	padding-bottom: #{ 0.5 * $size__spacing-unit };
-
 	@include media(tablet) {
 		padding-bottom: #{ 4 * $size__spacing-unit };
 	}
@@ -34,8 +32,6 @@ Newspack Theme Styles - Style Pack 2
 
 .site-content,
 .newspack-front-page.hide-homepage-title .site-content {
-	margin-top: #{ -0.5 * $size__spacing-unit };
-
 	@include media(tablet) {
 		margin-top: #{ -3.5 * $size__spacing-unit };
 	}
@@ -46,6 +42,13 @@ Newspack Theme Styles - Style Pack 2
 }
 
 // Header
+
+.site-header {
+	border-bottom: 2px solid $color__primary-variation;
+	@include media( tablet ) {
+		border-bottom: 0;
+	}
+}
 
 .bottom-header-contain .wrapper {
 	border: 0;
@@ -69,11 +72,10 @@ body:not(.header-solid-background) .site-header {
 
 #primary {
 	background-color: $color__background-body;
-	border-top: 2px solid $color__primary-variation;
-	padding: #{ 2 * $size__spacing-unit } 0;
+	padding: $size__spacing-unit 0;
 
 	@include media(tablet) {
-		border-top-width: 4px;
+		border-top: 4px solid $color__primary-variation;
 		padding: #{ 3 * $size__spacing-unit } #{ 3 * $size__spacing-unit } 0;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Style 2 has a pretty bold overlap style that is currently styled to stay that way on smaller screens... but it looks a bit odd there. This PR removes the style from smaller screens, keeping the coloured border, but smoothing out the jig-jagginess.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 2.
2. View the front end of the site; scale down the browser window until you see the mobile styles (when the menu is replaced with a button toggle).

<img width="580" alt="image" src="https://user-images.githubusercontent.com/177561/64667515-e64dcd80-d40e-11e9-95aa-a3ca3824ff8e.png">

3. Apply the PR and run `npm run build`
4. View the front-end again; confirm that the seperation between the content and header is now smooth, but the border (using a darker shade of the primary colour) is still there:

<img width="579" alt="image" src="https://user-images.githubusercontent.com/177561/64667490-cdddb300-d40e-11e9-9aa2-b3e90de7542d.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
