### PR TITLE
Captions: Make captions on article blocks left-aligned

### DIFF
--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -20,3 +20,9 @@ figcaption,
 	padding: 0 ( $size__spacing-unit * .5 ) ( $size__spacing-unit * .5 );
 	text-align: center;
 }
+
+.wp-block-newspack-blocks-homepage-articles figcaption {
+	padding-left: 0;
+	padding-right: 0;
+	text-align: left;
+}

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -144,6 +144,12 @@ figcaption {
 	text-align: center;
 }
 
+.wp-block-newspack-blocks-homepage-articles figcaption {
+	padding-left: 0;
+	padding-right: 0;
+	text-align: left;
+}
+
 /** === Post Title === */
 
 .editor-post-title__block {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
### Changes proposed in this Pull Request:

This PR makes the image captions left-aligned when displayed on the article blocks. 

It needs to be test with https://github.com/Automattic/newspack-blocks/pull/87 applied, or after its been merged into the block itself.

Closes #391

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-blocks/pull/87 if it hasn't been merged yet, and run `npm run build:webpack`.
2. Add an article block to a page; make sure it's showing a post with a featured image, and that featured image has a caption.
3. Under the Featured Image Settings for the block, make sure the caption is set to be on:

<img width="267" alt="image" src="https://user-images.githubusercontent.com/177561/64888626-740d0100-d639-11e9-8057-e223d10b9b4c.png">

4. View on the front-end and in the editor; confirm that the caption is displaying, and is centred:

<img width="381" alt="image" src="https://user-images.githubusercontent.com/177561/64888722-a9195380-d639-11e9-864f-f4c0e5398908.png">

5. Apply this PR and run `npm run build`
6. View the block in the editor and on the front-end again; confirm that the caption text is now left-aligned:

<img width="406" alt="image" src="https://user-images.githubusercontent.com/177561/64888690-969f1a00-d639-11e9-927b-a5151d4a4b90.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
