### PR TITLE
Rework caption styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -511,7 +511,7 @@
 		}
 
 		figcaption {
-			padding: ( $size__spacing-unit * .5 );
+			text-align: left;
 		}
 	}
 
@@ -911,6 +911,10 @@
 			max-width: 100vw;
 			position: relative;
 			width: 100vw;
+
+			figcaption {
+	g			padding: 0 $size__spacing-unit;
+			}
 		}
 
 		&.alignleft,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -142,6 +142,10 @@
 				max-width: (0.33 * $desktop_width);
 			}
 		}
+
+		figcaption {
+			text-align: left;
+		}
 	}
 
 	//! Video
@@ -149,6 +153,10 @@
 
 		video {
 			width: 100%;
+		}
+
+		figcaption {
+			text-align: left;
 		}
 	}
 
@@ -911,10 +919,6 @@
 			max-width: 100vw;
 			position: relative;
 			width: 100vw;
-
-			figcaption {
-	g			padding: 0 $size__spacing-unit;
-			}
 		}
 
 		&.alignleft,

--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -14,8 +14,19 @@ figcaption,
 	font-size: $font__size-xs;
 	font-family: $font__heading;
 	line-height: $font__line-height-pre;
-	margin: 0;
+	margin: 0 auto;
 	max-width: 780px;
 	padding: 0;
 	text-align: left;
 }
+
+.newspack-front-page,
+.post-template-single-wide,
+.page-template-single-wide {
+	figcaption,
+	.wp-caption-text {
+		max-width: 1200px;
+	}
+}
+
+

--- a/sass/media/_captions.scss
+++ b/sass/media/_captions.scss
@@ -10,13 +10,12 @@
 
 figcaption,
 .wp-caption-text {
-	border-bottom: 1px solid $color__border;
 	color: $color__text-light;
 	font-size: $font__size-xs;
 	font-family: $font__heading;
 	line-height: $font__line-height-pre;
 	margin: 0;
 	max-width: 780px;
-	padding: 0 ( $size__spacing-unit * .5 ) ( $size__spacing-unit * .5 );
-	text-align: center;
+	padding: 0;
+	text-align: left;
 }

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -10,6 +10,10 @@ body {
 	.wp-block[data-align="full"] {
 		max-width: 100vw;
 		width: auto;
+
+		figcaption {
+			padding: 0 $size__spacing-unit;
+		}
 	}
 
 	@include media(desktop) {
@@ -128,20 +132,18 @@ table th {
 }
 
 figcaption,
-.gallery-caption {
+.gallery-caption,
+.wp-caption-text {
 	font-family: $font__heading;
-	font-size: $font__size-xs;
+	font-size: $font__size-xxs;
 	line-height: $font__line-height-pre;
 	color: $color__text-light;
+	margin: 0 0 #{ 0.5 * $size__spacing-unit }	;
 }
 
-figcaption {
-	border-bottom: 1px solid $color__border;
-	color: $color__text-light;
-	margin: 0;
+figcaption,
+.wp-caption-text {
 	max-width: 780px;
-	padding: 0 ( $size__spacing-unit * .5 ) ( $size__spacing-unit * .5 );
-	text-align: center;
 }
 
 /** === Post Title === */
@@ -347,6 +349,7 @@ figcaption {
 .wp-block-image {
 	figcaption {
 		margin-top: 0;
+		text-align: left;
 	}
 }
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -134,15 +134,11 @@ table th {
 figcaption,
 .gallery-caption,
 .wp-caption-text {
+	color: $color__text-light;
 	font-family: $font__heading;
 	font-size: $font__size-xxs;
 	line-height: $font__line-height-pre;
-	color: $color__text-light;
-	margin: 0 0 #{ 0.5 * $size__spacing-unit }	;
-}
-
-figcaption,
-.wp-caption-text {
+	margin: 0 auto #{ 0.5 * $size__spacing-unit };
 	max-width: 780px;
 }
 
@@ -366,6 +362,19 @@ figcaption,
 		max-width: 100%;
 		width: 100% !important; // !important to override inline styles.
 	}
+}
+
+/** === Gallery === */
+
+.wp-block-gallery figcaption {
+	margin-bottom: 0;
+}
+
+/** === Audio & Video === */
+
+.wp-block-audio figcaption,
+.wp-block-video figcaption {
+	text-align: left;
 }
 
 /** === Button === */

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -30,6 +30,10 @@ body.newspack-static-front-page {
 			max-width: 1430px; // 1400px + 30px to offset padding
 		}
 	}
+
+	figcaption {
+		max-width: 1230px;
+	}
 }
 
 /** === Single Posts === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reworks the caption styles; it:

* Removes the bottom border, to visually simplify things, and
* Makes all captions left-aligned, so they line up better with all of the left-aligned elements.

This improves the appearance of https://github.com/Automattic/newspack-blocks/pull/87, and I think it works better for the captions in general.

Closes #392, closes #391.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. To test on article blocks, apply https://github.com/Automattic/newspack-blocks/pull/87 and run `npm run build:webpack` if it hasn't been merged yet (otherwise, make sure the blocks are up-to-date).
3. Copy-paste [this captions test data](https://cloudup.com/cClKjAzLiZ6) to a post.
4. If testing the Homepage Article blocks captions, adjust settings to make sure you have posts with featured images to display, and that those featured images have captions.
5. Do a visual review on the front-end and in the editor and look for any weirdness. The captions should no longer have bottom borders, and should be aligned left (excluding in the gallery block). When the block is set to wide or full, the caption should be no wider than the content (780px, or 1200px with the 'wide' template or on the static front page).

Image:

<img width="839" alt="image" src="https://user-images.githubusercontent.com/177561/64891848-fd740180-d640-11e9-8742-1dcbb2d1c24e.png">

Align-full image:

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/177561/64891867-08c72d00-d641-11e9-8c73-20c067e7cafb.png">

Article Block:

<img width="833" alt="image" src="https://user-images.githubusercontent.com/177561/64892057-74a99580-d641-11e9-8af9-0d308c78c506.png">

Gallery: 

<img width="816" alt="image" src="https://user-images.githubusercontent.com/177561/64892084-7f642a80-d641-11e9-9a05-26d33ca4345d.png">

Audio & Video:

<img width="819" alt="image" src="https://user-images.githubusercontent.com/177561/64892097-8854fc00-d641-11e9-812d-bcff1e7f8b0f.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
