### PR TITLE
Fixes excessive spacing on top of articles

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -250,10 +250,8 @@ body.page {
 		}
 	}
 
-	.main-content {
-		.post-thumbnail:first-child {
-			margin-top: #{ 2 * $size__spacing-unit };
-		}
+	.main-content > .post-thumbnail:first-child {
+		margin-top: #{ 2 * $size__spacing-unit };
 	}
 
 	@include media(mobile) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The featured images in the article blocks were (wrongly!) inheriting a top margin when they were added to a regular post. This PR makes the style more specific.

Fixes #320.

### How to test the changes in this Pull Request:

1. On a post, add the article block and set it to display as grid.
2. Make sure at least one article has a featured image; if all do, add a 'section header' so you can see the issue easier.
3. Publish; on the front-end, note the spacing on top of the articles -- the articles with featured images will be pushed down:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/177561/64893272-a2dca480-d644-11e9-8888-7a4630f64a48.png">

4. Apply the PR and run `npm run build`
5. Confirm that the articles now appear to be lined up along the top:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/177561/64893331-c56ebd80-d644-11e9-8d3f-288b25f79590.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
