### PR TITLE
Editor: Make sure wide template editor preview is correct

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -410,6 +410,18 @@ function newspack_is_active_style_pack() {
 }
 
 /**
+ * Check for specific templates.
+ */
+function newspack_check_current_template() {
+	global $post;
+
+	$post_id       = $post->ID;
+	$template_file = $post_id ? get_post_meta( $post_id, '_wp_page_template', true ) : '';
+
+	return $template_file;
+}
+
+/**
  * Add body class on editor pages if editing the static front page.
  */
 function newspack_filter_admin_body_class( $classes ) {
@@ -420,6 +432,10 @@ function newspack_filter_admin_body_class( $classes ) {
 
 	if ( 'default' !== get_theme_mod( 'active_style_pack', 'default' ) ) {
 		$classes .= ' style-pack-' . get_theme_mod( 'active_style_pack', 'default' );
+	}
+
+	if ( 'single-wide.php' === newspack_check_current_template() ) {
+		$classes .= ' newspack-single-wide-template';
 	}
 
 	return $classes;

--- a/functions.php
+++ b/functions.php
@@ -415,8 +415,7 @@ function newspack_is_active_style_pack() {
 function newspack_check_current_template() {
 	global $post;
 
-	$post_id       = $post->ID;
-	$template_file = $post_id ? get_post_meta( $post_id, '_wp_page_template', true ) : '';
+	$template_file = ( $post && $post->ID ) ? get_post_meta( $post->ID, '_wp_page_template', true ) : '';
 
 	return $template_file;
 }

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -11,7 +11,8 @@
 
 /** === Static Front Page === */
 
-body.newspack-static-front-page {
+body.newspack-static-front-page,
+body.newspack-single-wide-template {
 	.wp-block {
 		max-width: 1230px; // 1200px + 30px to offset padding
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the ability to add a class to the Gutenberg editor based on the current template, so the preview can be styled correctly.

It specific deals with making sure the 'One column wide' template content previews at 1200px wide; I'll build on it further to make sure wide and full align content doesn't display as such when you're using the default (two column) template.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a new post and add some content; click publish.
3. Confirm that the content doesn't exceed 780px wide in the editor.
4. Switch to the 'One col wide template', click 'Update', then refresh the page (unfortunately this approach requires a full page refresh, but if problematic we can look into adding the body tag via JS on template change).
5. Confirm that the post content in the editor now previews at 1200px wide.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
