### PR TITLE
Make sure you can't "tab into" a closed mobile menu

### DIFF
--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -86,8 +86,16 @@
 	transition: right 0.2s;
 	z-index: 999999;
 
-	.menu-opened & {
-		right: 0;
+	& > * {
+		display: none;
+	}
+}
+
+.menu-opened #mobile-sidebar-fallback {
+	right: 0;
+
+	& > * {
+		display: block;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When using the non-AMP version of the site, you can "tab into" the mobile menu when closed -- meaning, if you start tabbing through the site from the top, the links in that menu grab focus, and you tab through multiple hidden

Closes #371.

### How to test the changes in this Pull Request:

1. Turn off AMP.
2. Focus your cursor in the browser's address bar, and use the tab key to move the cursor focus down the page.
3. When you focus on a link, it should have a dotted outline. Note that once you hit the content area of the site, the "focus" is not visible -- it doesn't seem to 'hit' the visible links. But in the lower left corner, you'll probably see that it's still hitting links - these are in the hidden mobile sidebar.
4. Apply the PR and run `npm run build`
5. Repeat steps 2 and 3; note that you will now see the focused elements when you tab into the site, and you're no longer hitting 'invisible' links.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
