### PR TITLE
Only define newspack_is_amp if it's not already defined

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,13 +15,15 @@ if ( version_compare( $GLOBALS['wp_version'], '4.7', '<' ) ) {
 	return;
 }
 
-/**
- * Determine whether it is an AMP response.
- *
- * @return bool Whether AMP.
- */
-function newspack_is_amp() {
-	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+if ( ! function_exists( 'newspack_is_amp' ) ) {
+	/**
+	 * Determine whether it is an AMP response.
+	 *
+	 * @return bool Whether AMP.
+	 */
+	function newspack_is_amp() {
+		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	}
 }
 
 if ( ! function_exists( 'newspack_setup' ) ) :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I'm going to be adding `newspack_is_amp` into the Newspack plugin, as that also needs to check whether we're on an AMP page for stuff. Since plugins are loaded before themes, we need a `function_exists` check in the theme. This tweak should prevent issues from having the same function defined multiple times.

### How to test the changes in this Pull Request:

1. Any existing usage of `newspack_is_amp` in this theme shouldn't break or do anything different.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
