### PR TITLE
Moves the keyboard focus to the 'close' button when mobile menu is opened

### DIFF
--- a/js/amp-fallback.js
+++ b/js/amp-fallback.js
@@ -40,11 +40,20 @@
 	// Mobile menu fallback.
 
 	var menuToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
-		body = document.getElementsByTagName( 'body' )[0];
+		body = document.getElementsByTagName( 'body' )[0],
+		mobileSidebar = document.getElementById( 'mobile-sidebar-fallback' ),
+		menuOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[0],
+		menuCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[0];
 
 	for ( var i = 0; i < menuToggle.length; i++ ) {
 		menuToggle[i].addEventListener( 'click', function() {
-			body.classList.toggle( 'menu-opened' );
+			if ( body.classList.contains( 'menu-opened' ) ) {
+				body.classList.remove( 'menu-opened' );
+				menuOpenButton.focus();
+			} else {
+				body.classList.add( 'menu-opened' );
+				menuCloseButton.focus();
+			}
 		}, false );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the keyboard focus into the mobile menu when opened when not using AMP.

### How to test the changes in this Pull Request:

1. Make the browser window narrow enough to see the mobile menu toggle, and turn off AMP.
2. Tab to focus on the Menu toggle (this will be easier to test once #397 is merged; otherwise you can tab _through_ the hidden menu before getting to the toggle). 

<img width="714" alt="image" src="https://user-images.githubusercontent.com/177561/64909720-d9b2c900-d6dd-11e9-84c2-452325e9d082.png">
 
3. Hit 'Enter/Return' to open the mobile menu.
4. Try to tab through the mobile menu; note the focus is still on the page behind the menu (like this screenshot, where you can see the focus on one of the articles):

<img width="698" alt="image" src="https://user-images.githubusercontent.com/177561/64909736-08c93a80-d6de-11e9-8854-d9f6c0ad1a58.png">

5. Apply the PR and run `npm run build`.
6. Repeat steps 1 - 3. 
7. Confirm that the 'Close' button gains focus when you open the menu:

<img width="699" alt="image" src="https://user-images.githubusercontent.com/177561/64909765-31513480-d6de-11e9-8ecf-01a8731d10ca.png">

8. Confirm you can tab up and down the links in the menu.
9. Confirm when you tab back to 'Close' and hit Enter/Return, the menu closes and focus returns to the Menu button:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/177561/64909720-d9b2c900-d6dd-11e9-84c2-452325e9d082.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
