### PR TITLE
Fixes issue with disappeared homepage title

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -17,7 +17,13 @@ get_header();
 			/* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
+				?>
 
+				<header class="entry-header">
+					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+				</header>
+
+				<?php
 				get_template_part( 'template-parts/content/content', 'page' );
 
 				// If comments are open or we have at least one comment, load up the comment template.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This came up in the review of #400: there is no longer a `the_title()` function in the front-page.php. I believe this is from when I reorganized the page.php, and removed it from the page content template part into the page template itself.

This PR re-adds the title function to front-page.php.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customize > Homepage Settings, and uncheck 'Hide Homepage Title'.
3. Confirm that the title on the static front page previews in the Customizer and now appears on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
