### PR TITLE
Fix focus contrast issues with search, text inputs

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -55,6 +55,7 @@ function newspack_custom_colors_css() {
 		.main-navigation ul.main-menu > li > a,
 		.entry .entry-content .more-link:hover,
 		.main-navigation .main-menu > li > a + svg,
+		.search-form button:active, .search-form button:hover, .search-form button:focus,
 		.entry-footer a,
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
@@ -130,27 +131,6 @@ function newspack_custom_colors_css() {
 		.author-bio .author-link,
 		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
 			color:' . newspack_color_with_contrast( $secondary_color ) . ';
-		}
-
-		/* Set secondary border color */
-
-		input[type="text"]:focus,
-		input[type="email"]:focus,
-		input[type="url"]:focus,
-		input[type="password"]:focus,
-		input[type="search"]:focus,
-		input[type="number"]:focus,
-		input[type="tel"]:focus,
-		input[type="range"]:focus,
-		input[type="date"]:focus,
-		input[type="month"]:focus,
-		input[type="week"]:focus,
-		input[type="time"]:focus,
-		input[type="datetime"]:focus,
-		input[type="datetime-local"]:focus,
-		input[type="color"]:focus,
-		textarea:focus {
-			border-color: ' . $secondary_color . '; /* base: #0073a8; */
 		}
 
 		/* Set primary variation background color */

--- a/sass/forms/_fields.scss
+++ b/sass/forms/_fields.scss
@@ -25,8 +25,8 @@ textarea {
 	border-radius: 0;
 
 	&:focus {
-		border-color: $color__secondary;
-		outline: thin solid rgba( $color__secondary, 0.15 );
+		border-color: $color__text-main;
+		outline: thin solid rgba( $color__text-main, 0.25 );
 		outline-offset: -4px;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR switches the search (and other text inputs) from using the secondary custom colour on focus, to using a much darker grey on focus. 

The secondary colour doesn't always provide sufficient contrast, making it kind of useless as an indicator in most cases.

It also makes sure the search icon picks up the primary colour on focus (if the contrast is sufficient) or grey if it is not -- it was stuck on blue.

**Before:**

Focus on input: 

<img width="362" alt="image" src="https://user-images.githubusercontent.com/177561/64910631-72e5dd80-d6e6-11e9-8986-a1b2d50d9c24.png">

Focus on button:

<img width="340" alt="image" src="https://user-images.githubusercontent.com/177561/64910636-7d07dc00-d6e6-11e9-9d8e-f3b0b084cdfd.png">

**After:**

Focus on input: 

<img width="348" alt="image" src="https://user-images.githubusercontent.com/177561/64910609-3619e680-d6e6-11e9-976e-85b364c44660.png">

Focus on button:

<img width="334" alt="image" src="https://user-images.githubusercontent.com/177561/64910612-3c0fc780-d6e6-11e9-8354-d30b9f183747.png">

Closes #389.

### How to test the changes in this Pull Request:

1. Open the search and tab to the input and button; note their appearance on focus.
2. Apply the PR and run `npm run build`
3. Repeat step one; confirm that the input now turns dark grey on focus, and the search button either picks up your primary colour, or, if it's insufficient contrast against while, a grey.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?