### PR TITLE
Improve appearance of mobile menu

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -92,6 +92,10 @@ function newspack_custom_colors_css() {
 			border-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
+		.mobile-sidebar nav.main-navigation + nav.secondary-menu {
+			border-color: ' . $primary_color_contrast . ';
+		}
+
 		.gallery-item > div > a:focus {
 			box-shadow: 0 0 0 2px ' . $primary_color . '; /* base: #0073a8; */
 		}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -73,6 +73,7 @@ function newspack_custom_colors_css() {
 		}
 
 		.mobile-sidebar,
+		.mobile-sidebar button:hover,
 		.mobile-sidebar a,
 		.mobile-sidebar a:visited,
 		.mobile-sidebar .main-navigation .sub-menu > li > a,

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -29,7 +29,7 @@
 	background-color: $color__primary;
 	color: #fff;
 	font-size: $font__size-sm;
-	width: 80vw;
+	width: 90vw;
 	padding: $size__spacing-unit;
 
 	@include media(tablet) {

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -35,7 +35,7 @@
 
 	& > * {
 		clear: both;
-		margin-bottom: #{ 1.5 * $size__spacing-unit };
+		margin-bottom: $size__spacing-unit;
 	}
 
 	.mobile-menu-toggle {
@@ -57,13 +57,24 @@
 
 	a {
 		display: inline-block;
-		margin: #{ 0.25 * $size__spacing-unit } 0;
-		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit }
+		margin: #{ 0.125 * $size__spacing-unit } 0;
+		padding: #{ 0.125 * $size__spacing-unit } #{ 0.25 * $size__spacing-unit };
 	}
 
 	a:hover {
 		background: transparent;
 		text-decoration: underline;
+	}
+
+	nav.secondary-menu a,
+	.main-navigation .main-menu > li > a {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	nav.main-navigation + nav.secondary-menu {
+		border-top: 1px solid #fff;
+		padding-top: #{ 0.75 * $size__spacing-unit };
 	}
 
 	.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg,
@@ -72,8 +83,15 @@
 		display: none;
 	}
 
-	.tertiary-menu a {
-		padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+	.tertiary-menu {
+		li {
+			display: inline-block;
+			margin-right: #{ 0.5 * $size__spacing-unit };
+		}
+
+		a {
+			padding: #{ 0.125 * $size__spacing-unit } #{ 0.5 * $size__spacing-unit };
+		}
 	}
 }
 

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -16,6 +16,9 @@
 }
 
 .site-header .mobile-menu-toggle {
+	&:hover {
+		color: inherit
+	}
 	@include media(tablet) {
 		display: none;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR cleans up some of the mobile menu styles, including:

* Reducing vertical spacing
* Adding a divider between the primary and secondary menus
* Updating the tertiary menu to match the mockups, with the links side-by-side
* Increasing the width from 80% to 90% of the available screen size.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65267740-7dc7b600-daca-11e9-91f2-90828a763bbe.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65267675-5cff6080-daca-11e9-9a81-f76654467b25.png)

With custom colour: 

![image](https://user-images.githubusercontent.com/177561/65268132-5de4c200-dacb-11e9-8a7d-49174cb62afe.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Confirm the appearance matches the 'after' mockup above.
3. Under Customize > Colors, switch the primary colour to something lighter; confirm that the new border is black (and has sufficient contrast) rather than white.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
