### PR TITLE
Improve appearance of featured image when set as background

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -82,7 +82,7 @@ function newspack_body_classes( $classes ) {
 
 	// Adds a class if singular post has a large featured image
 	$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-	if ( is_single() && has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+	if ( is_single() && has_post_thumbnail() && 1200 < (int) $thumbnail_info['width'] ) {
 		$classes[] = 'has-large-featured-image';
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -362,7 +362,7 @@ body.page {
 
 /* Featured Image - special styles */
 
-.single-featured-image-behind {
+.has-large-featured-image.single-featured-image-behind {
 	.site-content {
 		margin-top: 0;
 	}
@@ -371,13 +371,29 @@ body.page {
 .featured-image-behind {
 	background-color: $color__text-main;
 	margin: 0 calc(50% - 50vw);
-	min-height: 50vh;
+	min-height: calc( 90vh - 60px );
 	overflow: hidden;
 	position: relative;
 	width: 100vw;
 
-	@include media( tablet ) {
-		min-height: 80vh;
+	.admin-bar & {
+		min-height: calc( 100vh - 106px );
+	}
+
+	@media screen and (min-height: 700px) and (min-width: 768px) {
+		min-height: calc( 100vh - 220px );
+
+		.admin-bar & {
+			min-height: calc( 100vh - 250px );
+		}
+
+		.header-simplified & {
+			min-height: calc( 100vh - 110px );
+		}
+
+		.header-simplified.admin-toolbar & {
+			min-height: calc( 100vh - 142px );
+		}
 	}
 
 	&:before,

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -422,6 +422,7 @@ body.page {
 		align-self: flex-end;
 		color: #fff;
 		margin: 0 auto #{ 2 * $size__spacing-unit };
+		max-width: 90%;
 		position: relative;
 		z-index: 2;
 
@@ -429,15 +430,15 @@ body.page {
 			display: none;
 		}
 
-		a,
 		.entry-meta,
 		.entry-meta .byline a,
 		.entry-meta .byline a:visited,
 		.entry-meta .posted-on a,
 		.entry-meta .posted-on a:visited,
+		.cat-links,
 		.cat-links a,
 		.cat-links a:visited {
-			color: inherit;
+			color: #fff;
 		}
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -369,9 +369,9 @@ body.page {
 
 .featured-image-behind {
 	background-color: $color__text-main;
+	display: flex;
 	margin: 0 calc(50% - 50vw);
 	min-height: calc( 90vh - 60px );
-	overflow: hidden;
 	position: relative;
 	width: 100vw;
 
@@ -379,7 +379,7 @@ body.page {
 		min-height: calc( 100vh - 106px );
 	}
 
-	@media screen and (min-height: 700px) and (min-width: 768px) {
+	@media screen and (min-width: 768px) {
 		min-height: calc( 100vh - 220px );
 
 		.admin-bar & {
@@ -395,19 +395,29 @@ body.page {
 		}
 	}
 
-	&:before,
-	.wrapper {
+	&:before {
+		background-color: rgba(0,0,0,0.5);
+		content: '';
 		bottom: 0;
 		left: 0;
 		position: absolute;
 		right: 0;
 		top: 0;
+		z-index: 1;
 	}
 
-	&:before {
-		background-color: rgba(0,0,0,0.5);
-		content: '';
-		z-index: 1;
+	.wrapper {
+		margin-top: auto;
+		margin-bottom: 0;
+	}
+
+	.post-thumbnail {
+		bottom: 0;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+		overflow: hidden;
 	}
 
 	.wp-post-image {
@@ -421,7 +431,7 @@ body.page {
 	.entry-header {
 		align-self: flex-end;
 		color: #fff;
-		margin: 0 auto #{ 2 * $size__spacing-unit };
+		margin: #{ 4 * $size__spacing-unit } auto #{ 2 * $size__spacing-unit };
 		max-width: 90%;
 		position: relative;
 		z-index: 2;

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -228,8 +228,7 @@ body.page {
 		padding: 0 0 $size__spacing-unit;
 	}
 
-	&:not(.has-featured-image) .entry-header,
-	&.has-large-featured-image .entry-header {
+	&:not(.has-large-featured-image) .entry-header {
 		border-bottom: 1px solid #ddd;
 	}
 
@@ -422,13 +421,9 @@ body.page {
 	.entry-header {
 		align-self: flex-end;
 		color: #fff;
-		margin: 0 auto;
+		margin: 0 auto #{ 2 * $size__spacing-unit };
 		position: relative;
 		z-index: 2;
-
-		.entry-title {
-			margin-bottom: #{ 0.25 * $size__spacing-unit };
-		}
 
 		.author-avatar {
 			display: none;
@@ -439,8 +434,15 @@ body.page {
 		.entry-meta .byline a,
 		.entry-meta .byline a:visited,
 		.entry-meta .posted-on a,
-		.entry-meta .posted-on a:visited	 {
-			color: #fff;
+		.entry-meta .posted-on a:visited,
+		.cat-links a,
+		.cat-links a:visited {
+			color: inherit;
 		}
+	}
+
+	.entry-meta .byline {
+		display: inline-block;
+		margin-right: $size__spacing-unit;
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -116,6 +116,23 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
+.single-featured-image-behind {
+	#primary {
+		padding-top: 0;
+	}
+
+	@include media( tablet ) {
+		.site-header {
+			padding: 0;
+		}
+
+		#primary {
+			border-top: 0;
+
+		}
+	}
+}
+
 .archive #primary {
 	padding-left: 0;
 	padding-right: 0;

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -95,6 +95,17 @@ figcaption,
 	font-weight: bold;
 }
 
+.single-featured-image-behind {
+	.featured-image-behind {
+		.entry-subhead {
+			border: 0;
+			display: block;
+			padding: 0;
+			text-align: center;
+		}
+	}
+}
+
 .entry .entry-content {
 	.has-drop-cap:not(:focus)::first-letter {
 		background-color: $color__primary;

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -70,6 +70,21 @@ body.header-default-background.header-default-height {
 	}
 }
 
+.featured-image-behind {
+	.cat-links {
+		font-size: $font__size-sm;
+		a,
+		a:hover {
+			background-color: transparent;
+			margin: 0;
+			padding: 0;
+		}
+		.sep {
+			display: inline;
+		}
+	}
+}
+
 /* Archives */
 
 .blog,

--- a/single-feature.php
+++ b/single-feature.php
@@ -26,19 +26,19 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-				if ( 'behind' === $featured_image_position ) :
+
+				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
 				?>
 
 					<div class="featured-image-behind">
-
 						<?php newspack_post_thumbnail(); ?>
-
 						<div class="wrapper">
 							<header class="entry-header">
 								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 							</header>
 						</div><!-- .wrapper -->
 					</div><!-- .featured-image-behind -->
+
 				<?php else : ?>
 
 					<header class="entry-header">
@@ -47,10 +47,9 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 
 					<?php
 					// Place larger featured images above content area.
-					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'default' === $featured_image_style ) {
+					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
 						newspack_post_thumbnail();
 					}
-
 				endif;
 				?>
 

--- a/single-wide.php
+++ b/single-wide.php
@@ -24,19 +24,19 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-				if ( 'behind' === $featured_image_position ) :
+
+				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
 				?>
 
 					<div class="featured-image-behind">
-
 						<?php newspack_post_thumbnail(); ?>
-
 						<div class="wrapper">
 							<header class="entry-header">
 								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 							</header>
 						</div><!-- .wrapper -->
 					</div><!-- .featured-image-behind -->
+
 				<?php else : ?>
 
 					<header class="entry-header">
@@ -45,7 +45,7 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 
 					<?php
 					// Place larger featured images above content area.
-					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'default' === $featured_image_style ) {
+					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
 						newspack_post_thumbnail();
 					}
 				endif;

--- a/single.php
+++ b/single.php
@@ -22,20 +22,18 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 
 				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
-				if ( 'behind' === $featured_image_position ) :
+				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
 				?>
 
-
 					<div class="featured-image-behind">
-
 						<?php newspack_post_thumbnail(); ?>
-
 						<div class="wrapper">
 							<header class="entry-header">
 								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 							</header>
 						</div><!-- .wrapper -->
 					</div><!-- .featured-image-behind -->
+
 				<?php else : ?>
 
 					<header class="entry-header">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR improves the styles applied when the featured image is set as a background, to try to make sure the post title is not cut off. 

If you have a very tall logo you can still cut it off, but I would consider that an extreme case; most logo sizes should allow for the post title to appear, if not the byline and share icons.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a new post and add a featured image that's at least 1200px wide.
3. Under the featured image, pick the 'Behind Article Title' option.

![image](https://user-images.githubusercontent.com/177561/65351086-03676680-db9c-11e9-90d7-3ee49487eadd.png)

4. View on front-end; confirm that the post title is visible on different screen sizes. 

![image](https://user-images.githubusercontent.com/177561/65351165-39a4e600-db9c-11e9-880a-2f9d3b2de46d.png)

5. Navigate to Customize > Header Settings and pick the 'Short Header'; repeat step 4. 
6. Edit the post again and pick a featured image that's narrower than 1200px wide. 
7. View on the front-end; regardless of option selection, the featured image should display in the content area.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
