### PR TITLE
Fix button focus colour

### DIFF
--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -33,6 +33,7 @@ input[type="submit"] {
 
 	&:focus {
 		background: $color__background-button-hover;
+		color: $color__background-body;
 		outline: thin dotted;
 		outline-offset: -4px;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR sets a text colour for buttons on `:focus`. I noticed while testing an unrelated Donate block PR that the button in that block had black text on a black background when focused if you used a lighter secondary colour.

### How to test the changes in this Pull Request:


1. In Customize > Colours, set the secondary colour to use a light colour -- this is the background colour that's used on buttons.
2. Add a donation block to the page.
3. Tab through the page until you focus on the button -- note that it's black text on a black background: 

![image](https://user-images.githubusercontent.com/177561/65377627-a6cf7e80-dc63-11e9-8a19-3219e0534a5d.png)

4. Apply the PR and run `npm run build`
5. Repeat step 3; confirm that the button now has white text on a black background when focused:

![image](https://user-images.githubusercontent.com/177561/65377642-c4044d00-dc63-11e9-9422-577691ff0536.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
