### PR TITLE
Fixes donate block custom colours on homepage

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -79,7 +79,7 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar .main-navigation ul.main-menu > li > a,
 		.site-header .main-navigation .sub-menu > li > a,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
-		.main-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
 		}
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -45,7 +45,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 		.entry .entry-content .wp-block-file .wp-block-file__button,
-		.main-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the donate block is picking up custom colours.

I did fix this already, but the selector I used only appeared on the subpages, not the homepage.

Closes #339

### How to test the changes in this Pull Request:

1. Add the donate block to the homepage and to a subpage/post.
2. Navigate to Customize > Colours, and pick two custom colours.
3. Confirm that your custom colours are working on the block on the subpage/post but not on the homepage.
4. Apply the PR and run `npm run build`.
5. Confirm that the custom colours are being used by the donate block when on the homepage and the subpage/post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
