### PR TITLE
Cover Block: Reduce the amount of padding on the cover block further

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -579,6 +579,11 @@
 		.wp-block-cover,
 		.wp-block-cover-image {
 			min-height: 330px;
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
+			.wp-block-cover__inner-container {
+				width: 100%;
+			}
 		}
 	}
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -315,6 +315,8 @@ figcaption {
 	.wp-block-cover,
 	.wp-block-cover-image {
 		min-height: 330px;
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	.wp-block-cover__inner-container {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the padding on columns block even further when they're nested in columns; otherwise there's really not a lot of room.

(I'll be tackling the issue with the too-tall final column in a separate PR).

**Before:**

![image](https://user-images.githubusercontent.com/177561/65378284-0715ee80-dc6b-11e9-900a-d33eb27ba475.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65378255-c74f0700-dc6a-11e9-9364-4830a693420a.png)

Closes #365.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cXdf3ez2rSd) into a post.
2. View in the editor and on the front-end; note how much space in on the right and left for the content.
3. Apply the PR and run `npm run build`.
4. Confirm that there's less space on the right and left of the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
