### PR TITLE
Remove top and bottom no margin from nested blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -5,14 +5,6 @@
 	margin: 32px 0;
 	max-width: 100%;
 
-	> *:first-child {
-		margin-top: 0;
-	}
-
-	> *:last-child {
-		margin-bottom: 0;
-	}
-
 	// When the image block is aligned left or right, the markup changes,
 	// making a slighly different selector necessary.
 	&.wp-block-image .alignleft,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a style that was removing the top margin of a first child element, and the bottom margin of a last child element.

Overall this would be reducing some extra spacing when elements are nested in the content, and was a style brought over from Twenty Nineteen.

In application -- especially as block nesting is becoming more complex -- it was causing unexpected visual issues, like making the last column taller than the rest:
 
![image](https://user-images.githubusercontent.com/177561/65379006-19e1f080-dc76-11e9-8082-97433b283866.png)

I think removing the style will cause fewer issues than keeping it in. 

### How to test the changes in this Pull Request:

1. Copy paste [this test content](https://cloudup.com/cXdf3ez2rSd) into a post.
2. View on the front-end -- note that the last column appears taller than the rest.
3. Apply the PR and run `npm run build`
4. Confirm that the issue is now fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
