### PR TITLE
Update styles to work better with hidden avatars

### DIFF
--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -170,16 +170,11 @@
 		.children {
 			padding-left: 0;
 		}
-
-		&.depth-1 {
-			margin-left: calc(3.25 * #{$size__spacing-unit});
-		}
 	}
 
 	.comment-body {
 		margin: calc(2 * #{$size__spacing-unit}) 0 0;
 	}
-
 
 	.comment-meta {
 		position: relative;
@@ -191,14 +186,6 @@
 			float: left;
 			margin-right: $size__spacing-unit;
 			position: relative;
-
-			@include media(tablet) {
-				float: inherit;
-				margin-right: inherit;
-				position: absolute;
-				top: 0;
-				right: calc(100% + #{$size__spacing-unit});
-			}
 		}
 
 		.fn {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -81,7 +81,7 @@ body.page {
 }
 
 .entry-meta {
-	.author-avatar {
+	.author-avatar:not(:empty) {
 		float: left;
 		margin-right: #{ $size__spacing-unit * 0.5 };
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#275 was originally about adding an option to the theme to hide the gravatars... but WordPress already includes one! So this PR updates the styles to make sure they work well when the avatar is hidden.

Closes #275 

### How to test the changes in this Pull Request:

1. Navigate to WP Admin > Settings > Discussion; scroll near the bottom and uncheck 'Show Avatars'

![image](https://user-images.githubusercontent.com/177561/65379274-8b23a280-dc7a-11e9-8c46-0434b9e66091.png)

2. Check the following points: 
* The homepage article block (should look okay out-of-the-box)

![image](https://user-images.githubusercontent.com/177561/65379300-d2aa2e80-dc7a-11e9-9e31-042c32d4c301.png)

* A single post's byline (slight space to the left)

![image](https://user-images.githubusercontent.com/177561/65379291-bdcd9b00-dc7a-11e9-9249-254c56d69567.png)

* A author bio in the footer (should look okay out-of-the-box)

![image](https://user-images.githubusercontent.com/177561/65379295-c7ef9980-dc7a-11e9-920d-1bcb481645d0.png)

* Comments (too much space on left)

![image](https://user-images.githubusercontent.com/177561/65379318-fa999200-dc7a-11e9-852f-d97439d5295a.png)

3. Apply the PR and run `npm run build`
4. Confirm the issues above are fixed:

* A single post's byline (slight space to the left)

![image](https://user-images.githubusercontent.com/177561/65379339-44827800-dc7b-11e9-956b-9bb8c98326af.png)

* Comments:

![image](https://user-images.githubusercontent.com/177561/65379334-37fe1f80-dc7b-11e9-9ed1-88f5340b2a48.png)

5. Turn back on Avatars and make sure the above spots still look okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
