### PR TITLE
Remove hyphenated styles on titles

### DIFF
--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -142,15 +142,7 @@ h6 {
 .entry-title,
 .comments-title,
 blockquote {
-	hyphens: auto;
 	word-break: break-word;
-}
-
-/* Do not hyphenate entry title on tablet view and bigger. */
-.entry-title {
-	@include media(tablet) {
-		hyphens: none;
-	}
 }
 
 .page-header {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme's `hyphen: auto` on post titles causes odd word breaking on smaller screens when paired with WordPress's `widont` filter; this PR removes it. There's still a `word-wrap: break-word` that will prevent too-long words from causing side-scrolling.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65391532-23736300-dd1f-11e9-94af-252a029ce740.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65391527-08a0ee80-dd1f-11e9-8ab0-10d28bf704cc.png)

### How to test the changes in this Pull Request:

1. Make the browser window narrower than a tablet screen; find a post title that includes a hyphen (or copy the post title from my example from a new post, "Featured Image behind title".
2. Apply the PR and run `npm run build`
3. Confirm that the unneeded hyphen and word break is removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
