### PR TITLE
Fix vertical spacing in site footer on smaller screens

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -24,7 +24,7 @@
 			<div class="wrapper">
 				<?php $blog_info = get_bloginfo( 'name' ); ?>
 				<?php if ( ! empty( $blog_info ) ) : ?>
-					&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>.
+					<span class="copyright">&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>.</span>
 				<?php endif; ?>
 
 				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'newspack' ) ); ?>" class="imprint">

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -59,7 +59,7 @@
 }
 
 .site-info {
-	color: $color__text-light;
+	color: $color__text-light;}
 
 	.wrapper {
 		border-top: 1px solid $color__border;
@@ -83,7 +83,8 @@
 
 	a {
 		color: inherit;
-		display: block;
+		display: inline-block;
+		margin: #{ 0.25 * $size__spacing-unit };
 
 		&:hover {
 			text-decoration: none;

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -59,7 +59,7 @@
 }
 
 .site-info {
-	color: $color__text-light;}
+	color: $color__text-light;
 
 	.wrapper {
 		border-top: 1px solid $color__border;
@@ -83,11 +83,15 @@
 
 	a {
 		color: inherit;
-		display: inline-block;
-		margin: #{ 0.25 * $size__spacing-unit };
+		display: block;
 
 		&:hover {
 			text-decoration: none;
 		}
+	}
+
+	a,
+	.copyright {
+		margin: #{ 0.25 * $size__spacing-unit } 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes up some crowding in the 'site info' (copyright, 'Powered By' and social links) section of the footer when displayed on small screens.

### How to test the changes in this Pull Request:

1. Remove the footer widgets (makes the social links menu appear in the site info section).
2. Make sure you have a social links section setup.
3. View on the front-end and make the browser window narrow; note how close the elements are together:

![image](https://user-images.githubusercontent.com/177561/65391941-e6f63600-dd23-11e9-8bb6-7e63c42fd589.png)

4. Apply the PR and run `npm run build`
5. Refresh the page; confirm that things look more spaced out:

![image](https://user-images.githubusercontent.com/177561/65392144-510fda80-dd26-11e9-9bf8-17fbc567dd7f.png)

6. Make the browser window full-width and confirm there's no visual weirdness.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
