### PR TITLE
Tighten up the spacing on the primary menu when using the short header

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -241,5 +241,12 @@
 }
 
 .header-simplified .site-header .main-navigation .main-menu > li {
-	padding: #{ 0.25 * $size__spacing-unit } 0
+	margin-right: #{ 0.25 * $size__spacing-unit };
+	padding: #{ 0.25 * $size__spacing-unit } 0;
+
+	@include media( tablet ) {
+		&.menu-item-has-children > a {
+			padding-right: 0;
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tightens up the spacing between links in the primary menu on sites using the 'short header', to buy a bit more real estate.

**Before (menu on left)**

![image](https://user-images.githubusercontent.com/177561/65464543-e25a7c00-de0e-11e9-9649-89ee92a506a6.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65464374-737d2300-de0e-11e9-986c-71fccba4d89c.png)

### How to test the changes in this Pull Request:

1. Under Customize > Header Settings, pick the short header.
2. Set up a primary menu; make sure at least one item has a dropdown.
3. Review spacing between links in the primary menu, and spacing between the link and down arrow on menu items that have dropdowns.
4. Apply the PR and run `npm run build`
5. Confirm that the menu items have less spacing between them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
