### PR TITLE
Reduce vertical spacing on solid-background headers

### DIFF
--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -241,9 +241,10 @@
 		border-bottom: 1px solid darken( $color__primary, 10% );
 	}
 
+
 	.middle-header-contain .wrapper {
 		@include media( tablet ) {
-			padding: #{ 3 * $size__spacing-unit } 0;
+			padding: #{ 2 * $size__spacing-unit } 0;
 		}
 	}
 
@@ -251,7 +252,6 @@
 		background-color: #4a4a4a;
 		.wrapper {
 			border: 0;
-			padding: #{ 0.15 * $size__spacing-unit } 0;
 		}
 
 		.main-navigation .main-menu > li,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR knocks down the amount of padding added to the middle of the header when you select a solid background. It was edging on too much, and eating up a lot of screen space for no good reason (especially noticeable as I've been working on the featured image behind the article title styles).

In all this change reduces the height of the header by at little more than the height of the primary menu (the dark grey bar at the bottom), without crowding things.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65465804-04093280-de12-11e9-9393-28c2137480f0.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65465775-f5bb1680-de11-11e9-8f25-7749d357e6c9.png)

### How to test the changes in this Pull Request:

1. Under Customizer > Header Settings, select a solid background header, and turn off the 'Short Header' option.
2. View on the front end and note the vertical spacing.
3. Apply the PR and run `npm run build`.
4. Confirm that the header now has less vertical spacing, but still feels spaced out enough (if it feels claustrophobic due to this change, let me know!).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
