### PR TITLE
Remove bottom spacing from blocks nested inside of column or group blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -705,12 +705,13 @@
 	//! Columns
 	.wp-block-columns {
 
-		@include media(tablet) {
-			.wp-block-column > * {
+		.wp-block-column > * :last-child {
+			margin-bottom: 0;
+		}
 
-				&:last-child {
-					margin-bottom: 0;
-				}
+		@include media(tablet) {
+			.wp-block-column {
+				margin-bottom: 0;
 			}
 
 			&[class*='has-'] > * {
@@ -739,6 +740,14 @@
 			}
 		}
 	}
+
+	//! Group
+	.wp-block-group {
+		.wp-block-group__inner-container > *:last-child {
+			margin-bottom: 0;
+		}
+	}
+
 
 	//! Latest Comments
 	.wp-block-latest-comments {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This fixes a similar issue that code removed in #412 was suppose to help with, but with a bit more focus on specific blocks, and making sure it wasn't introducing new issues (like the different heights in the columns block that #412 fixed).

It removes the bottom margin from the last element inside of a group block and each individual columns blocks, and, on larger screens, removes the bottom margin from the bottom of each individual column.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65468974-a4635500-de1a-11e9-8162-f1a1133ac990.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65468964-8eee2b00-de1a-11e9-8a95-1555c86c0ae0.png)

### How to test the changes in this Pull Request:

1. Copy-paste [this test code](https://cloudup.com/cH8sR1XhC4S) into the editor -- it has a group block, with a columns block inside; each column contains a cover block so you can easier see the height.
2. Save and publish.
3. Note the bottom spacing on the front-end -- there is quite a bit more grey than there is on the top.
4. Apply the PR and run `npm run build`.
5. View the page on the front-end again; confirm that the top and bottom spacing in the group block is now consistent. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
