### PR TITLE
Cover Block: Override `height: 100%` when nested in columns block

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -570,6 +570,7 @@
 	.wp-block-columns {
 		.wp-block-cover,
 		.wp-block-cover-image {
+			height: auto;
 			min-height: 330px;
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, when you nest a cover block inside of a columns block, it will fill the available vertical space on the front end (it displays as expected in the editor). This is fine, except when the other column is very long -- then you end up with an oddly tall cover block. Or, if you have more than one thing in the column with the cover block, it will still be 100% of the column's height, and hang out the end. 

I think this was introduced with the height option for the Cover block.

This PR overrides the `height: 100%` in that case, resulting in a more predictable height.

Closes #420 

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cX7lzYzU15E) into the editor
2. View on the front-end; note that the cover block on the right is very tall:

![image](https://user-images.githubusercontent.com/177561/65472045-74ba4a00-de26-11e9-9f87-7c834103fdb8.png)

3. Apply the PR and run `npm run build`
4. Confirm that the cover block is now displaying at a more standard height on the front-end:
![image](https://user-images.githubusercontent.com/177561/65472017-5c4a2f80-de26-11e9-976d-8cd872f52ba0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
