### PR TITLE
Add bottom border to mobile header

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -241,6 +241,8 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
 			.site-header,
+			.header-default-background .site-header,
+			.header-simplified.header-default-background .site-header,
 			.site-content #primary {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -1,8 +1,3 @@
-// Site header
-.site-header {
-
-}
-
 // Site branding
 .site-branding {
 	align-items: center;
@@ -158,9 +153,22 @@
  * Header options.
  */
 
+ // Default Header
+
+.header-default-background {
+	.site-header {
+		border-bottom: 1px solid $color__border;
+
+		@include media(tablet) {
+			border-bottom: 0;
+		}
+	}
+}
+
 // Centred Logo
 
 .header-center-logo {
+
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
 			justify-content: center;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -43,7 +43,9 @@ Newspack Theme Styles - Style Pack 2
 
 // Header
 
-.site-header {
+.site-header,
+.header-default-background .site-header,
+.header-simplified.header-default-background .site-header {
 	border-bottom: 2px solid $color__primary-variation;
 	@include media( tablet ) {
 		border-bottom: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a light grey bottom border to the mobile header when it doesn't have a solid background. This helps differentiate it from the rest of the content.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65480863-e787ed00-de47-11e9-87e5-02c43b2b59dc.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65480792-ac85b980-de47-11e9-8ba0-1620116fc27c.png)

### How to test the changes in this Pull Request:

1. Under Customizer > Style Pack, pick any style pack but 'style 2' (the header behaves differently)
2. Under Customizer > Header settings, make sure to have both 'short header' and 'solid background' unchecked.
3. On the front-end, shrink down the browser window until you see the mobile menu; confirm there's no border.
4. Apply the PR and run `npm run build`.
5. Confirm that there's now a bottom border.
6 Navigate to Customizer > Style Packs and switch to style 2.
7. Confirm that the mobile-sized header still has a 2px wide border using the site's primary colour like in the screenshot below, and not a 1px wide grey border.

![image](https://user-images.githubusercontent.com/177561/65480940-57967300-de48-11e9-99a4-2d98c730990f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
