### PR TITLE
Only show featured image option on posts

### DIFF
--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -2,7 +2,7 @@
 
 import { addFilter } from '@wordpress/hooks';
 import { RadioControl } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { withDispatch, withSelect, select } from '@wordpress/data';
 import { Component, createElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -47,12 +47,20 @@ const ComposedRadio = compose( [
 ] )( RadioCustom );
 
 const wrapPostFeaturedImage = OriginalComponent => {
-	return props => (
-		<Fragment>
-			<OriginalComponent { ...props } />
-			<ComposedRadio />
-		</Fragment>
-	);
+	return props => {
+		const post_type = select( 'core/editor' ).getCurrentPostType();
+
+        if (post_type !== "post") {
+            return <OriginalComponent {...props} />;
+        }
+
+        return (
+			<Fragment>
+				<OriginalComponent { ...props } />
+				<ComposedRadio />
+			</Fragment>
+		);
+	};
 };
 
 addFilter(

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -50,11 +50,11 @@ const wrapPostFeaturedImage = OriginalComponent => {
 	return props => {
 		const post_type = select( 'core/editor' ).getCurrentPostType();
 
-        if (post_type !== "post") {
-            return <OriginalComponent {...props} />;
-        }
+		if ( "post" !== post_type ) {
+			return <OriginalComponent {...props} />;
+		}
 
-        return (
+		return (
 			<Fragment>
 				<OriginalComponent { ...props } />
 				<ComposedRadio />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Featured Image placement options only appear on posts, not pages. 

![image](https://user-images.githubusercontent.com/177561/65544856-08dced80-dec9-11e9-940c-0cb9053d5477.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Edit a page; confirm that the 'Featured Image Position' radio buttons do not appear below the Featured Image in the sidebar.
3. Edit a page; confirm that the 'Featured Image Position' radio buttons do appear. 
4. Toggle the featured image option to 'behind' and confirm it works on the front end.
5. Return to the editor; confirm that the 'behind' option is still selected; switch to 'default' and confirm that it also works on the front-end.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
