### PR TITLE
Make sure the author bio is not displayed on single posts and pages.

### DIFF
--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -5,7 +5,7 @@
  * @package Newspack
  */
 
-if ( (bool) get_the_author_meta( 'description' ) ) : ?>
+if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 <div class="author-bio">
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure that the author bio won't show up on pages when you use the one-column and one-column wide templates. 

### How to test the changes in this Pull Request:

1. Set a page using an author with an author description in their profile (the criteria to have the author profile display at the bottom). Publish with the default template.
2. Set a second page; apply the 'one column' template and publish.
3. Set a third page; apply the 'one wide column' template and publish.
4. View all three on the front end; note that the first one doesn't have an author bio on the bottom, but the second and third ones do:

![image](https://user-images.githubusercontent.com/177561/65550057-a0dfd480-ded3-11e9-94ca-e1da4a8afdbd.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the second and third test pages no longer display the author bio.
7. Double-check a post and confirm that the author bio still displays.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
