### PR TITLE
Single Article: Add style to place featured image and article title side by side

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -335,7 +335,7 @@ add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
  * Enqueue Block Styles Javascript
  */
 function newspack_extend_featured_image_script() {
-	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks' ) );
+	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_extend_featured_image_script' );
 

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -49,7 +49,7 @@ function newspack_custom_colors_css() {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		@media only screen and (min-width: 1168px) {
+		@media only screen and (min-width: 782px) {
 			.header-default-background .featured-image-beside {
 				background-color: ' . $primary_color . ';
 			}
@@ -91,7 +91,7 @@ function newspack_custom_colors_css() {
 			color: ' . $primary_color_contrast . ';
 		}
 
-		@media only screen and (min-width: 1168px) {
+		@media only screen and (min-width: 782px) {
 			.header-default-background .featured-image-beside .entry-header {
 				color: ' . $primary_color_contrast . ';
 			}
@@ -248,7 +248,7 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color . ';
 			}
 
-			@media only screen and (min-width: 1168px) {
+			@media only screen and (min-width: 782px) {
 				.header-default-background .featured-image-beside .cat-links:before {
 					background-color: ' . $primary_color_contrast . ';
 				}
@@ -285,16 +285,6 @@ function newspack_custom_colors_css() {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			@media only screen and (min-width: 1168px) {
-				.header-default-background .featured-image-beside .cat-links {
-					color: ' . $primary_color_contrast . ';
-				}
-
-				.header-default-background .featured-image-beside .cat-links:before {
-					background-color: ' . $primary_color_contrast . ';
-				}
-			}
-
 			.cat-links a:hover {
 				color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}
@@ -306,6 +296,22 @@ function newspack_custom_colors_css() {
 			figcaption:after,
 			.wp-caption-text:after {
 				background-color: ' . $primary_color . ';
+			}
+
+			@media only screen and (min-width: 782px) {
+				.header-solid-background .featured-image-beside {
+					background-color: ' . $primary_color . ';
+				}
+
+				.header-solid-background .featured-image-beside .entry-header,
+				.header-default-background .featured-image-beside .entry-header {
+					color: ' . $primary_color_contrast . ';
+				}
+
+				.header-solid-background .featured-image-beside .cat-links:before,
+				.header-default-background .featured-image-beside .cat-links:before {
+					background-color: ' . $primary_color_contrast . ';
+				}
 			}
 		';
 	}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -49,6 +49,12 @@ function newspack_custom_colors_css() {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
+		@media only screen and (min-width: 1168px) {
+			.header-default-background .featured-image-beside {
+				background-color: ' . $primary_color . ';
+			}
+		}
+
 		/* Set primary color that contrasts against white */
 
 		.main-navigation .main-menu > li,
@@ -83,6 +89,12 @@ function newspack_custom_colors_css() {
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
+		}
+
+		@media only screen and (min-width: 1168px) {
+			.header-default-background .featured-image-beside .entry-header {
+				color: ' . $primary_color_contrast . ';
+			}
 		}
 
 		/* Set primary border color */
@@ -235,6 +247,12 @@ function newspack_custom_colors_css() {
 			.entry .entry-content .wp-block-pullquote blockquote p:first-of-type:before {
 				color: ' . $primary_color . ';
 			}
+
+			@media only screen and (min-width: 1168px) {
+				.header-default-background .featured-image-beside .cat-links:before {
+					background-color: ' . $primary_color_contrast . ';
+				}
+			}
 		';
 	}
 
@@ -265,6 +283,16 @@ function newspack_custom_colors_css() {
 			.entry .entry-footer,
 			.accent-header {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
+			}
+
+			@media only screen and (min-width: 1168px) {
+				.header-default-background .featured-image-beside .cat-links {
+					color: ' . $primary_color_contrast . ';
+				}
+
+				.header-default-background .featured-image-beside .cat-links:before {
+					background-color: ' . $primary_color_contrast . ';
+				}
 			}
 
 			.cat-links a:hover {

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -261,7 +261,8 @@ function newspack_custom_colors_css() {
 			.site-header,
 			.header-default-background .site-header,
 			.header-simplified.header-default-background .site-header,
-			.site-content #primary {
+			.site-content #primary,
+			#page .site-header {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -90,6 +90,10 @@ function newspack_body_classes( $classes ) {
 	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 	if ( 'behind' === $current_featured_image_style ) {
 		$classes[] = 'single-featured-image-behind';
+	} elseif ( 'beside' === $current_featured_image_style ) {
+		$classes[] = 'single-featured-image-beside';
+	} else {
+		$classes[] = 'single-featured-image-default';
 	}
 
 	return $classes;

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -18,6 +18,7 @@ class RadioCustom extends Component {
 				options={ [
 					{ label: __( 'Default' ), value: '' },
 					{ label: __( 'Behind article title' ), value: 'behind' },
+					{ label: __( 'Beside article title' ), value: 'beside' },
 				] }
 				onChange={ value => {
 					this.setState( { value } );

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -127,6 +127,7 @@
 		position: absolute;
 		top: calc( 100% + 4px );
 		width: 300px;
+		z-index: 5;
 
 		@include media (tablet) {
 			right: 0;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -250,10 +250,9 @@
 		border-bottom: 1px solid darken( $color__primary, 10% );
 	}
 
-
 	.middle-header-contain .wrapper {
 		@include media( tablet ) {
-			padding: #{ 2 * $size__spacing-unit } 0;
+			padding: #{ 1.5 * $size__spacing-unit } 0 $size__spacing-unit;
 		}
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -530,6 +530,7 @@ body.page {
 			padding-right: 0;
 
 			a,
+			a:hover,
 			.cat-links,
 			.entry-meta,
 			.entry-meta .byline a,

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -543,13 +543,17 @@ body.page {
 				display: block;
 			}
 
-			.entry-meta .byline {
-				display: inline-block;
+			.entry-meta {
+				margin-bottom: $size__spacing-unit;
 
-				&:after {
-					content: "|";
+				.byline {
 					display: inline-block;
-					margin: 0 $size__spacing-unit;
+
+					&:after {
+						content: "|";
+						display: inline-block;
+						margin: 0 #{ 0.75 * $size__spacing-unit } 0 $size__spacing-unit;
+					}
 				}
 			}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -535,10 +535,6 @@ body.page {
 			margin-left: auto;
 			max-width: 600px;
 
-			.author-avatar {
-				display: none;
-			}
-
 			a,
 			.cat-links,
 			.entry-meta,
@@ -551,6 +547,20 @@ body.page {
 
 			.entry-subhead {
 				display: block;
+			}
+
+			.entry-meta .byline {
+				display: inline-block;
+
+				&:after {
+					content: "|";
+					display: inline-block;
+					margin: 0 $size__spacing-unit;
+				}
+			}
+
+			.author-avatar {
+				display: none;
 			}
 		}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -381,7 +381,7 @@ body.page {
 		min-height: calc( 100vh - 106px );
 	}
 
-	@media screen and (min-width: 768px) {
+	@include media( tablet ) {
 		min-height: calc( 100vh - 220px );
 
 		.admin-bar & {
@@ -482,28 +482,20 @@ body.page {
 	.featured-image-beside {
 		display: flex;
 		margin: 0 calc(50% - 50vw);
-		min-height: calc( 90vh - 60px );
+		min-height: calc( 100vh - 220px );
 		position: relative;
 		width: 100vw;
 
 		.admin-bar & {
-			min-height: calc( 100vh - 106px );
+			min-height: calc( 100vh - 250px );
 		}
 
-		@media screen and (min-height: 700px) and (min-width: 768px) {
-			min-height: calc( 100vh - 220px );
+		.header-simplified & {
+			min-height: calc( 100vh - 110px );
+		}
 
-			.admin-bar & {
-				min-height: calc( 100vh - 250px );
-			}
-
-			.header-simplified & {
-				min-height: calc( 100vh - 110px );
-			}
-
-			.header-simplified.admin-toolbar & {
-				min-height: calc( 100vh - 142px );
-			}
+		.header-simplified.admin-toolbar & {
+			min-height: calc( 100vh - 142px );
 		}
 
 		.post-thumbnail,
@@ -534,6 +526,8 @@ body.page {
 			color: #fff;
 			margin-left: auto;
 			max-width: 600px;
+			padding-left: 0;
+			padding-right: 0;
 
 			a,
 			.cat-links,

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -466,7 +466,7 @@ body.page {
 	width: 100%;
 }
 
-@include media( desktop ) {
+@include media( tablet ) {
 	.single-featured-image-beside .site-content {
 		margin-top: 0;
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -81,6 +81,8 @@ body.page {
 }
 
 .entry-meta {
+	margin-bottom: #{ 0.25 * $size__spacing-unit };
+
 	.author-avatar:not(:empty) {
 		float: left;
 		margin-right: #{ $size__spacing-unit * 0.5 };
@@ -455,5 +457,105 @@ body.page {
 	.entry-meta .byline {
 		display: inline-block;
 		margin-right: $size__spacing-unit;
+	}
+}
+
+
+.featured-image-beside > .wrapper {
+	max-width: 100%;
+	width: 100%;
+}
+
+@include media( desktop ) {
+	.single-featured-image-beside .site-content {
+		margin-top: 0;
+	}
+
+	.header-default-background .featured-image-beside {
+		background-color: $color__primary;
+	}
+
+	.header-solid-background .featured-image-beside {
+		background-color: #333;
+	}
+
+	.featured-image-beside {
+		display: flex;
+		margin: 0 calc(50% - 50vw);
+		min-height: calc( 90vh - 60px );
+		position: relative;
+		width: 100vw;
+
+		.admin-bar & {
+			min-height: calc( 100vh - 106px );
+		}
+
+		@media screen and (min-height: 700px) and (min-width: 768px) {
+			min-height: calc( 100vh - 220px );
+
+			.admin-bar & {
+				min-height: calc( 100vh - 250px );
+			}
+
+			.header-simplified & {
+				min-height: calc( 100vh - 110px );
+			}
+
+			.header-simplified.admin-toolbar & {
+				min-height: calc( 100vh - 142px );
+			}
+		}
+
+		.post-thumbnail,
+		& > .wrapper {
+			width: 50%;
+		}
+
+		.post-thumbnail {
+			margin: 0;
+			overflow: hidden;
+			position: relative;
+		}
+
+		& > .wrapper {
+			padding: 0 #{ 2 * $size__spacing-unit };
+			margin: auto 0;
+		}
+
+		.wp-post-image {
+			min-height: 100%;
+			object-fit: cover;
+			object-position: 50% 50%;
+			position: absolute;
+			width: 100%;
+		}
+
+		.entry-header {
+			color: #fff;
+			margin-left: auto;
+			max-width: 600px;
+
+			.author-avatar {
+				display: none;
+			}
+
+			a,
+			.cat-links,
+			.entry-meta,
+			.entry-meta .byline a,
+			.entry-meta .byline a:visited,
+			.entry-meta .posted-on a,
+			.entry-meta .posted-on a:visited	 {
+				color: inherit;
+			}
+
+			.entry-subhead {
+				display: block;
+			}
+		}
+
+		.entry-title {
+			font-size: $font__size-xxl;
+		}
 	}
 }

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -53,16 +53,19 @@
 	}
 }
 
-.single .entry-meta {
+.single {
 	@include media( tablet ) {
-		align-items: center;
-		display: flex;
+		.entry-meta {
+			align-items: center;
+			display: flex;
+		}
 
-		.posted-on {
+		&.single-featured-image-default	.posted-on {
 			margin-left: #{ 1.5 * $size__spacing-unit };
 		}
 	}
 }
+
 
 /* Avatar */
 .avatar,

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -31,6 +31,12 @@
 
 /* Posts & Pages */
 
+@include media( tablet ) {
+	.featured-image-beside .cat-links:before {
+		background-color: $color__background-body;
+	}
+}
+
 .single .cat-links {
 	font-size: $font__size_base;
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -45,7 +45,12 @@ Newspack Theme Styles - Style Pack 2
 
 .site-header,
 .header-default-background .site-header,
-.header-simplified.header-default-background .site-header {
+.header-simplified.header-default-background .site-header,
+body:not(.header-solid-background) .site-header {
+	background-color: #efefef;
+}
+
+#page .site-header {
 	border-bottom: 2px solid $color__primary-variation;
 	@include media( tablet ) {
 		border-bottom: 0;
@@ -64,10 +69,6 @@ Newspack Theme Styles - Style Pack 2
 	#search-toggle {
 		color: inherit;
 	}
-}
-
-body:not(.header-solid-background) .site-header {
-	background-color: #efefef;
 }
 
 // Content Area
@@ -137,7 +138,7 @@ body:not(.header-solid-background) .site-header {
 @include media( tablet ) {
 	.single-featured-image-beside {
 		.site-header {
-			padding: 0 0 #{ 0.5 * $size__spacing-unit };
+			padding: 0;
 		}
 
 		#primary {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -105,8 +105,7 @@ body:not(.header-solid-background) .site-header {
 	padding-left: 0;
 	padding-right: 0;
 
-	.site-main > .entry-header,
-	.featured-image-beside .entry-header {
+	.site-main > .entry-header {
 		@include media(tablet) {
 			padding-left: #{ 3 * $size__spacing-unit };
 			padding-right: #{ 3 * $size__spacing-unit };
@@ -144,6 +143,11 @@ body:not(.header-solid-background) .site-header {
 		#primary {
 			border-top: 0;
 			padding-top: 0;
+		}
+
+		.entry-header {
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
 		}
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -119,7 +119,6 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-
 .single-featured-image-behind {
 	#primary {
 		padding-top: 0;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -105,7 +105,8 @@ body:not(.header-solid-background) .site-header {
 	padding-left: 0;
 	padding-right: 0;
 
-	.site-main > .entry-header {
+	.site-main > .entry-header,
+	.featured-image-beside .entry-header {
 		@include media(tablet) {
 			padding-left: #{ 3 * $size__spacing-unit };
 			padding-right: #{ 3 * $size__spacing-unit };
@@ -117,6 +118,7 @@ body:not(.header-solid-background) .site-header {
 		}
 	}
 }
+
 
 .single-featured-image-behind {
 	#primary {
@@ -130,7 +132,19 @@ body:not(.header-solid-background) .site-header {
 
 		#primary {
 			border-top: 0;
+		}
+	}
+}
 
+@include media( desktop ) {
+	.single-featured-image-beside {
+		.site-header {
+			padding: 0 0 #{ 0.5 * $size__spacing-unit };
+		}
+
+		#primary {
+			border-top: 0;
+			padding-top: 0;
 		}
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -135,7 +135,7 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-@include media( desktop ) {
+@include media( tablet ) {
 	.single-featured-image-beside {
 		.site-header {
 			padding: 0 0 #{ 0.5 * $size__spacing-unit };

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -95,9 +95,9 @@ Newspack Theme Styles - Style Pack 3
 
 // Posts & Pages
 
-@include media( desktop ) {
-	.header-solid-background .featured-image-beside {
-
+@include media( tablet ) {
+	.featured-image-beside .cat-links:before {
+		background-color: $color__background-body;
 	}
 }
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -107,7 +107,7 @@ Newspack Theme Styles - Style Pack 3
 }
 
 .single-post:not(.has-featured-image) .entry-header,
-.single-post.has-large-featured-image .entry-header {
+.single-post:not(.has-large-featured-image) .entry-header {
 	border-bottom: 1px dotted $color__text-main;
 }
 
@@ -136,11 +136,13 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
-.header-solid-background .featured-image-beside {
-	background-color: $color__primary;
+@include media( tablet ) {
+	.header-solid-background .featured-image-beside {
+		background-color: $color__primary;
 
-	.cat-links:before {
-		background-color: $color__background-body;
+		.cat-links:before {
+			background-color: $color__background-body;
+		}
 	}
 }
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -95,6 +95,12 @@ Newspack Theme Styles - Style Pack 3
 
 // Posts & Pages
 
+@include media( desktop ) {
+	.header-solid-background .featured-image-beside {
+
+	}
+}
+
 .entry-meta,
 .entry .wp-block-newspack-blocks-homepage-articles article .entry-meta {
 	font-size: $font__size-xs;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -136,6 +136,14 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
+.header-solid-background .featured-image-beside {
+	background-color: $color__primary;
+
+	.cat-links:before {
+		background-color: $color__background-body;
+	}
+}
+
 figcaption,
 .wp-caption-text {
 	border: none;

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -90,6 +90,23 @@ Newspack Theme Styles - Style Pack 4
 
 // Posts & Pages
 
+@include media( desktop ) {
+	.header-solid-background .featured-image-beside {
+		background-color: $color__background-pre;
+	}
+
+	.featured-image-beside {
+		.entry-header {
+			color: $color__text-main;
+		}
+	}
+
+	.single-post .featured-image-beside .entry-subhead {
+		border: 0;
+		padding: 0;
+	}
+}
+
 figcaption,
 .wp-caption-text {
 	font-weight: bold;

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -90,23 +90,6 @@ Newspack Theme Styles - Style Pack 4
 
 // Posts & Pages
 
-@include media( desktop ) {
-	.header-solid-background .featured-image-beside {
-		background-color: $color__background-pre;
-	}
-
-	.featured-image-beside {
-		.entry-header {
-			color: $color__text-main;
-		}
-	}
-
-	.single-post .featured-image-beside .entry-subhead {
-		border: 0;
-		padding: 0;
-	}
-}
-
 figcaption,
 .wp-caption-text {
 	font-weight: bold;
@@ -226,6 +209,31 @@ figcaption,
 	&.has-large-featured-image {
 		.entry-header {
 			border-bottom: 0;
+		}
+	}
+}
+
+@include media( tablet ) {
+	.header-solid-background .featured-image-beside {
+		background-color: $color__background-pre;
+
+		.entry-header {
+			color: $color__text-main;
+		}
+
+		.cat-links {
+			color: $color__primary;
+		}
+	}
+
+	.single-post .featured-image-beside .entry-subhead {
+		border: 0;
+		margin-bottom: 0;
+		padding: 0;
+		text-align: center;
+
+		.author-avatar {
+			display: none;
 		}
 	}
 }

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -60,8 +60,10 @@ body.header-default-background.header-default-height {
 	.featured-image-beside {
 		.cat-links {
 			a,
-			a:hover {
+			a:hover,
+			a:visited {
 				background-color: transparent;
+				color: inherit;
 				margin: 0;
 				padding: 0;
 			}

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -55,21 +55,32 @@ body.header-default-background.header-default-height {
 	}
 }
 
-@include media( desktop ) {
-	.featured-image-behind,
-	.featured-image-beside {
-		.cat-links {
-			a,
-			a:hover,
-			a:visited {
-				background-color: transparent;
-				color: inherit;
-				margin: 0;
-				padding: 0;
-			}
-			.sep {
-				display: inline;
-			}
+.featured-image-behind .cat-links {
+	a,
+	a:hover,
+	a:visited {
+		background-color: transparent;
+		color: inherit;
+		margin: 0;
+		padding: 0;
+	}
+	.sep {
+		display: inline;
+	}
+}
+
+@include media( tablet ) {
+	.featured-image-beside .cat-links {
+		a,
+		a:hover,
+		a:visited {
+			background-color: transparent;
+			color: inherit;
+			margin: 0;
+			padding: 0;
+		}
+		.sep {
+			display: inline;
 		}
 	}
 }

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -55,6 +55,23 @@ body.header-default-background.header-default-height {
 	}
 }
 
+@include media( desktop ) {
+	.featured-image-behind,
+	.featured-image-beside {
+		.cat-links {
+			a,
+			a:hover {
+				background-color: transparent;
+				margin: 0;
+				padding: 0;
+			}
+			.sep {
+				display: inline;
+			}
+		}
+	}
+}
+
 .tags-links {
 	a {
 		background-color: #f1f1f1;

--- a/single-feature.php
+++ b/single-feature.php
@@ -26,8 +26,14 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				// Template part for large featured images.
-				get_template_part( 'template-parts/post/large-featured-image' );
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+					get_template_part( 'template-parts/post/large-featured-image' );
+				else :
 				?>
+					<header class="entry-header">
+						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+					</header>
+				<?php endif; ?>
 
 				<div class="main-content">
 

--- a/single-feature.php
+++ b/single-feature.php
@@ -25,32 +25,8 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 			while ( have_posts() ) :
 				the_post();
 
-				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-
-				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
-				?>
-
-					<div class="featured-image-behind">
-						<?php newspack_post_thumbnail(); ?>
-						<div class="wrapper">
-							<header class="entry-header">
-								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-							</header>
-						</div><!-- .wrapper -->
-					</div><!-- .featured-image-behind -->
-
-				<?php else : ?>
-
-					<header class="entry-header">
-						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-					</header>
-
-					<?php
-					// Place larger featured images above content area.
-					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
-						newspack_post_thumbnail();
-					}
-				endif;
+				// Template part for large featured images.
+				get_template_part( 'template-parts/post/large-featured-image' );
 				?>
 
 				<div class="main-content">

--- a/single-wide.php
+++ b/single-wide.php
@@ -24,8 +24,14 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				// Template part for large featured images.
-				get_template_part( 'template-parts/post/large-featured-image' );
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+					get_template_part( 'template-parts/post/large-featured-image' );
+				else :
 				?>
+					<header class="entry-header">
+						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+					</header>
+				<?php endif; ?>
 
 				<div class="main-content">
 

--- a/single-wide.php
+++ b/single-wide.php
@@ -23,32 +23,8 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 			while ( have_posts() ) :
 				the_post();
 
-				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-
-				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
-				?>
-
-					<div class="featured-image-behind">
-						<?php newspack_post_thumbnail(); ?>
-						<div class="wrapper">
-							<header class="entry-header">
-								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-							</header>
-						</div><!-- .wrapper -->
-					</div><!-- .featured-image-behind -->
-
-				<?php else : ?>
-
-					<header class="entry-header">
-						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-					</header>
-
-					<?php
-					// Place larger featured images above content area.
-					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
-						newspack_post_thumbnail();
-					}
-				endif;
+				// Template part for large featured images.
+				get_template_part( 'template-parts/post/large-featured-image' );
 				?>
 
 				<div class="main-content">

--- a/single.php
+++ b/single.php
@@ -34,6 +34,19 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 						</div><!-- .wrapper -->
 					</div><!-- .featured-image-behind -->
 
+				<?php elseif ( 'beside' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) : ?>
+
+					<div class="featured-image-beside">
+
+						<div class="wrapper">
+							<header class="entry-header">
+								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+							</header>
+						</div><!-- .wrapper -->
+
+						<?php newspack_post_thumbnail(); ?>
+
+					</div><!-- .featured-image-behind -->
 				<?php else : ?>
 
 					<header class="entry-header">

--- a/single.php
+++ b/single.php
@@ -14,14 +14,22 @@ get_header();
 		<main id="main" class="site-main">
 
 			<?php
-
 			/* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
 
+				// Get the post thumbnail.
+				$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+
 				// Template part for large featured images.
-				get_template_part( 'template-parts/post/large-featured-image' );
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+					get_template_part( 'template-parts/post/large-featured-image' );
+				else :
 				?>
+					<header class="entry-header">
+						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+					</header>
+				<?php endif; ?>
 
 				<div class="main-content">
 

--- a/single.php
+++ b/single.php
@@ -8,7 +8,6 @@
  */
 
 get_header();
-$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 ?>
 
 	<section id="primary" class="content-area">
@@ -20,45 +19,8 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 			while ( have_posts() ) :
 				the_post();
 
-				$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-
-				if ( 'behind' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
-				?>
-
-					<div class="featured-image-behind">
-						<?php newspack_post_thumbnail(); ?>
-						<div class="wrapper">
-							<header class="entry-header">
-								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-							</header>
-						</div><!-- .wrapper -->
-					</div><!-- .featured-image-behind -->
-
-				<?php elseif ( 'beside' === $featured_image_position && has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) : ?>
-
-					<div class="featured-image-beside">
-
-						<div class="wrapper">
-							<header class="entry-header">
-								<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-							</header>
-						</div><!-- .wrapper -->
-
-						<?php newspack_post_thumbnail(); ?>
-
-					</div><!-- .featured-image-behind -->
-				<?php else : ?>
-
-					<header class="entry-header">
-						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-					</header>
-
-					<?php
-					// Place larger featured images above content area.
-					if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) {
-						newspack_post_thumbnail();
-					}
-				endif;
+				// Template part for large featured images.
+				get_template_part( 'template-parts/post/large-featured-image' );
 				?>
 
 				<div class="main-content">

--- a/template-parts/post/large-featured-image.php
+++ b/template-parts/post/large-featured-image.php
@@ -5,44 +5,38 @@
  * @package Newspack
  */
 
-// Get the post thumbnail.
-$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
-// Make sure we have a featured image, and it's larger than 1200 wide before continuing.
-if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+if ( 'behind' === $featured_image_position ) :
+?>
 
-	$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+	<div class="featured-image-behind">
+		<?php newspack_post_thumbnail(); ?>
+		<div class="wrapper">
+			<header class="entry-header">
+				<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+			</header>
+		</div><!-- .wrapper -->
+	</div><!-- .featured-image-behind -->
 
-	if ( 'behind' === $featured_image_position ) :
-	?>
+<?php elseif ( 'beside' === $featured_image_position ) : ?>
 
-		<div class="featured-image-behind">
-			<?php newspack_post_thumbnail(); ?>
-			<div class="wrapper">
-				<header class="entry-header">
-					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-				</header>
-			</div><!-- .wrapper -->
-		</div><!-- .featured-image-behind -->
+	<div class="featured-image-beside">
+		<div class="wrapper">
+			<header class="entry-header">
+				<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+			</header>
+		</div><!-- .wrapper -->
+		<?php newspack_post_thumbnail(); ?>
+	</div><!-- .featured-image-behind -->
 
-	<?php elseif ( 'beside' === $featured_image_position ) : ?>
+<?php else : ?>
 
-		<div class="featured-image-beside">
-			<div class="wrapper">
-				<header class="entry-header">
-					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-				</header>
-			</div><!-- .wrapper -->
-			<?php newspack_post_thumbnail(); ?>
-		</div><!-- .featured-image-behind -->
+	<header class="entry-header">
+		<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+	</header>
 
-	<?php else : ?>
-
-		<header class="entry-header">
-			<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-		</header>
-
-		<?php
-		newspack_post_thumbnail();
-	endif;
+	<?php
+	newspack_post_thumbnail();
 endif;
+

--- a/template-parts/post/large-featured-image.php
+++ b/template-parts/post/large-featured-image.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * The template part for displaying large featured images on posts.
+ *
+ * @package Newspack
+ */
+
+// Get the post thumbnail.
+$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+
+// Make sure we have a featured image, and it's larger than 1200 wide before continuing.
+if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+
+	$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+
+	if ( 'behind' === $featured_image_position ) :
+	?>
+
+		<div class="featured-image-behind">
+			<?php newspack_post_thumbnail(); ?>
+			<div class="wrapper">
+				<header class="entry-header">
+					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+				</header>
+			</div><!-- .wrapper -->
+		</div><!-- .featured-image-behind -->
+
+	<?php elseif ( 'beside' === $featured_image_position ) : ?>
+
+		<div class="featured-image-beside">
+			<div class="wrapper">
+				<header class="entry-header">
+					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+				</header>
+			</div><!-- .wrapper -->
+			<?php newspack_post_thumbnail(); ?>
+		</div><!-- .featured-image-behind -->
+
+	<?php else : ?>
+
+		<header class="entry-header">
+			<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+		</header>
+
+		<?php
+		newspack_post_thumbnail();
+	endif;
+endif;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an additional featured image option, to place the featured image beside the article title.

It also moves all of the featured image PHP -- for both this style, the behind-the-title style and the default style -- into a separate template part, to limit repetition.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a new post; add a featured image, and underneath that, pick 'Beside article title' for placement:

![image](https://user-images.githubusercontent.com/177561/65556698-61ba7f00-dee5-11e9-883d-d591d75ae659.png)

3. View on the front-end -- the featured image should be sitting to the left of the article title; if you scale down the browser window, the two will stack for tablet-sized screens. 
4. The exact appearance of this featured image style will depend a bit on style pack and header settings; please cycle through the following to make sure it's all right:

**Default style pack, default header background:**

![image](https://user-images.githubusercontent.com/177561/65556773-b231dc80-dee5-11e9-9540-3128157aac71.png)

**Default style pack, default header background, custom primary colour:**

![image](https://user-images.githubusercontent.com/177561/65556823-dee5f400-dee5-11e9-8c42-4984726cd7ac.png)

**Default style pack, solid header background:** 

![image](https://user-images.githubusercontent.com/177561/65556797-c4ac1600-dee5-11e9-9542-b712153c8e1c.png)

---

**Style 1, default header background**

![image](https://user-images.githubusercontent.com/177561/65557090-e0fc8280-dee6-11e9-9f52-ca9286d105a8.png)

**Style 1, solid header background**

![image](https://user-images.githubusercontent.com/177561/65557111-f2458f00-dee6-11e9-84a2-2b67c1d4f747.png)

**Style 1, default header background, custom colour**

![image](https://user-images.githubusercontent.com/177561/65557161-1d2fe300-dee7-11e9-9bc0-8e3330b94462.png)

---

**Style 2, default header background** (Note the overlap style is overridden when the side-by-side style is used):

![image](https://user-images.githubusercontent.com/177561/65557696-173b0180-dee9-11e9-9f88-1e27f4dd1642.png)

**Style 2, soild header background**

![image](https://user-images.githubusercontent.com/177561/65557731-346fd000-dee9-11e9-9379-d28a58ece4fc.png)

**Style 2, default header background, custom colour**

![image](https://user-images.githubusercontent.com/177561/65557749-4487af80-dee9-11e9-8a6d-9bf5d650f024.png)

---

**Style 3, default header background**

![image](https://user-images.githubusercontent.com/177561/65557824-79940200-dee9-11e9-8a68-a6f24388d190.png)

**Style 3, soild header background** (Still uses primary behind the title, because the solid header is dark grey)

![image](https://user-images.githubusercontent.com/177561/65557847-8fa1c280-dee9-11e9-9d52-bb3d8e8349c8.png)

**Style 3, default header background, custom colour**

![image](https://user-images.githubusercontent.com/177561/65557874-a9430a00-dee9-11e9-95ff-2ebef313fd6a.png)

---

**Style 4, default header background**

![image](https://user-images.githubusercontent.com/177561/65557917-caa3f600-dee9-11e9-9685-d2fc330e03e5.png)

**Style 4, soild header background** (Uses light grey rather than the primary colour as a background)

![image](https://user-images.githubusercontent.com/177561/65557934-dc859900-dee9-11e9-8561-34cf7af1a727.png)

**Style 4, default header background, custom colour**

![image](https://user-images.githubusercontent.com/177561/65557956-f32bf000-dee9-11e9-8cd1-94eb25de719c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
