### PR TITLE
Fix issue where floated image inside of a column pops out of the side

### DIFF
--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -28,6 +28,10 @@ body {
 		}
 	}
 
+	.block-editor-inner-blocks .wp-block[data-align="left"] {
+		left: auto;
+	}
+
 	.wp-block[data-align="right"] {
 		@include media( desktop ) {
 			right: #{-2 * $size__spacing-unit };
@@ -35,6 +39,10 @@ body {
 		@include media( wide ) {
 			right: #{-4 * $size__spacing-unit };
 		}
+	}
+
+	.block-editor-inner-blocks .wp-block[data-align="right"] {
+		right: auto;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you nest an image block inside of a column and float it right or left, it will pop outside of the edge of the column block in the editor (but display correctly on the front-end). This PR corrects that.

**Before:**

![image](https://user-images.githubusercontent.com/177561/65563041-30e64400-defd-11e9-8035-ea6154e6c47f.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65562982-01cfd280-defd-11e9-95f4-1a65645477d0.png)

Closes #366.

### How to test the changes in this Pull Request:

1. Copy-paste[ this test content](https://cloudup.com/cm1wyOLCp_V) into the editor.
2. Note how the images pop out of the sides.
3. Apply the PR and run `npm run build`
4. Confirm that the images no longer pop out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
