### PR TITLE
Make sure editor correctly reflects widths, and block widths/alignments.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -443,8 +443,12 @@ function newspack_filter_admin_body_class( $classes ) {
 		$classes .= ' style-pack-' . get_theme_mod( 'active_style_pack', 'default' );
 	}
 
-	if ( 'single-wide.php' === newspack_check_current_template() ) {
+	if ( 'single-feature.php' === newspack_check_current_template() ) {
+		$classes .= ' newspack-single-column-template';
+	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {
 		$classes .= ' newspack-single-wide-template';
+	} else {
+		$classes .= ' newspack-default-template';
 	}
 
 	return $classes;
@@ -456,7 +460,7 @@ add_filter( 'admin_body_class', 'newspack_filter_admin_body_class', 10, 1 );
  * Enqueue CSS styles for the editor that use the <body> tag.
  */
 function newspack_enqueue_editor_override_assets( $classes ) {
-		wp_enqueue_style( 'newspack-editor-overrides', get_theme_file_uri( '/styles/style-editor-overrides.css' ), false, '1.1', 'all' );
+	wp_enqueue_style( 'newspack-editor-overrides', get_theme_file_uri( '/styles/style-editor-overrides.css' ), false, '1.1', 'all' );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_editor_override_assets' );
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -6,48 +6,6 @@
 
 body {
 	background-color: $color__background-body;
-
-	.wp-block[data-align="full"] {
-		max-width: 100vw;
-		width: auto;
-
-		figcaption {
-			padding: 0 $size__spacing-unit;
-		}
-	}
-
-	@include media(desktop) {
-
-		.wp-block[data-align="wide"] {
-			max-width: 1230px;
-		}
-	}
-
-	.wp-block[data-align="left"] {
-		@include media( desktop ) {
-			left: #{-2 * $size__spacing-unit };
-		}
-		@include media( wide ) {
-			left: #{-4 * $size__spacing-unit };
-		}
-	}
-
-	.block-editor-inner-blocks .wp-block[data-align="left"] {
-		left: auto;
-	}
-
-	.wp-block[data-align="right"] {
-		@include media( desktop ) {
-			right: #{-2 * $size__spacing-unit };
-		}
-		@include media( wide ) {
-			right: #{-4 * $size__spacing-unit };
-		}
-	}
-
-	.block-editor-inner-blocks .wp-block[data-align="right"] {
-		right: auto;
-	}
 }
 
 /** === Content Width === */
@@ -276,39 +234,8 @@ figcaption,
 			}
 		}
 	}
-
 }
 
-.wp-block[data-type="core/cover"][data-align="wide"],
-.wp-block[data-type="core/cover"][data-align="full"] {
-
-	@include media(tablet) {
-
-		h2,
-		.wp-block-cover-text {
-			max-width: calc(8 * (100vw / 12));
-		}
-	}
-
-	@include media(desktop) {
-
-		h2,
-		.wp-block-cover-text {
-			max-width: calc(6 * (100vw / 12));
-		}
-	}
-}
-
-.wp-block[data-type="core/cover"][data-align="full"] {
-
-	@include media(tablet) {
-
-		.wp-block-cover {
-			padding-left: calc(10% + 64px);
-			padding-right: calc(10% + 64px);
-		}
-	}
-}
 
 .wp-block-cover {
 	.accent-header,

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -9,7 +9,25 @@
 @import "variables-site/variables-site";
 @import "mixins/mixins-master";
 
-/** === Static Front Page === */
+/** === Default Template === */
+
+@include media( mobile ) {
+	body.newspack-default-template .wp-block[data-align=full] {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 780px;
+	}
+}
+
+/** === One Column Templates === */
+
+@include media(desktop) {
+	body.newspack-single-column-template .wp-block[data-align="wide"] {
+		max-width: 1230px;
+	}
+}
+
+/** === Wide Templates === */
 
 body.newspack-static-front-page,
 body.newspack-single-wide-template {
@@ -34,6 +52,47 @@ body.newspack-single-wide-template {
 
 	figcaption {
 		max-width: 1230px;
+	}
+}
+
+/** === Wide Blocks === */
+
+body.newspack-static-front-page,
+body.newspack-single-wide-template,
+body.newspack-single-column-template {
+	.wp-block[data-align="full"] {
+		max-width: 100vw;
+		width: auto;
+
+		figcaption {
+			padding: 0 $size__spacing-unit;
+		}
+	}
+
+	.wp-block[data-align="left"] {
+		@include media( desktop ) {
+			left: #{-2 * $size__spacing-unit };
+		}
+		@include media( wide ) {
+			left: #{-4 * $size__spacing-unit };
+		}
+	}
+
+	.block-editor-inner-blocks .wp-block[data-align="left"] {
+		left: auto;
+	}
+
+	.wp-block[data-align="right"] {
+		@include media( desktop ) {
+			right: #{-2 * $size__spacing-unit };
+		}
+		@include media( wide ) {
+			right: #{-4 * $size__spacing-unit };
+		}
+	}
+
+	.block-editor-inner-blocks .wp-block[data-align="right"] {
+		right: auto;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the editor preview for the different blocks widths accurately reflects the front-end:

* On a regular post or page with the default template, wide and full width blocks will display at the same width as everything else, and left and right aligned blocks will stay within the content area.
* On a regular post or page with the one column template, the content will display at 780px, but wide and full blocks will display at wider widths, and left and right aligned blocks will pop out of the content area.
* On a regular post or page with the one column wide template, or on the static front page with the default template, the content will display at 1200px, but wide and full blocks will display at wider widths, and left and right aligned blocks will pop out of the content area.

Closes #147 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Copy-paste [this test content](https://cloudup.com/cGdP0kGUH8Y) into the editor of a new post or page-- it includes wide and full group blocks, and two image blocks - one aligned left and the other aligned right.
3. Confirm that everything is displaying within the content area:

![image](https://user-images.githubusercontent.com/177561/65566391-86bfe980-df07-11e9-86f8-b0f73ada3daf.png)

4. Change the page to use the One Column template; save and refresh the editor (so the proper class will be added).
5. Confirm that the wide and full blocks display at the expected width, and the left and right aligned blocks peek out of the content area (which should be 780px wide):

![image](https://user-images.githubusercontent.com/177561/65566421-a1925e00-df07-11e9-9689-a72589a45813.png)

4. Change the page to use the One Column Wide template; save and refresh the editor (so the proper class will be added).
5. Confirm that the wide and full blocks display at the expected width, and the left and right aligned blocks peek out of the content area (which should be 1200px wide):

![image](https://user-images.githubusercontent.com/177561/65566448-bc64d280-df07-11e9-9f30-4c1e9860d781.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?