### PR TITLE
Make sure git only ignores files in the root styles directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ Thumbs.db
 /vendor/
 
 # Compiled CSS
-styles/
+/styles/
 *.css
 
 # Compiled Javascript


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure that only files in the /styles/ directory in the root of the theme are ignored, and not ones in the /sass/styles/ directory (which needs to be editable to add new style packs). 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Try adding a new file to the `/sass/styles/` directory, and run `git status`; confirm it shows up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
