### PR TITLE
Take another pass at improving the dropdown menu styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -298,20 +298,9 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			@media only screen and (min-width: 782px) {
-				.header-solid-background .featured-image-beside {
-					background-color: ' . $primary_color . ';
-				}
-
-				.header-solid-background .featured-image-beside .entry-header,
-				.header-default-background .featured-image-beside .entry-header {
-					color: ' . $primary_color_contrast . ';
-				}
-
-				.header-solid-background .featured-image-beside .cat-links:before,
-				.header-default-background .featured-image-beside .cat-links:before {
-					background-color: ' . $primary_color_contrast . ';
-				}
+			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:hover,
+			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:focus {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
 	}
@@ -332,6 +321,11 @@ function newspack_custom_colors_css() {
 
 			.site-footer .widget .widget-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
+			}
+
+			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:hover,
+			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:focus {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
 	}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -35,9 +35,7 @@ function newspack_custom_colors_css() {
 	$theme_css = '
 		/* Set primary background color */
 
-		.main-navigation .sub-menu,
 		.mobile-sidebar,
-		.site-header .main-navigation .main-menu .sub-menu,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
 		.entry .entry-content .has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
@@ -57,8 +55,6 @@ function newspack_custom_colors_css() {
 
 		/* Set primary color that contrasts against white */
 
-		.main-navigation .main-menu > li,
-		.main-navigation ul.main-menu > li > a,
 		.entry .entry-content .more-link:hover,
 		.main-navigation .main-menu > li > a + svg,
 		.search-form button:active, .search-form button:hover, .search-form button:focus,
@@ -85,7 +81,10 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar a:visited,
 		.mobile-sidebar .main-navigation .sub-menu > li > a,
 		.mobile-sidebar .main-navigation ul.main-menu > li > a,
-		.site-header .main-navigation .sub-menu > li > a,
+		.site-header .main-navigation .sub-menu a:hover,
+		.site-header .main-navigation .sub-menu a:focus,
+		.site-header .main-navigation .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
+		.site-header .main-navigation .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -258,13 +258,23 @@
 	padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
 }
 
-.header-simplified .site-header .main-navigation .main-menu > li {
-	margin-right: #{ 0.25 * $size__spacing-unit };
-	padding: #{ 0.25 * $size__spacing-unit } 0;
+.header-simplified {
+	.site-header .main-navigation .main-menu > li {
+		margin-right: #{ 0.25 * $size__spacing-unit };
+		padding: #{ 0.25 * $size__spacing-unit } 0;
 
-	@include media( tablet ) {
-		&.menu-item-has-children > a {
-			padding-right: 0;
+		@include media( tablet ) {
+			&.menu-item-has-children > a {
+				padding-right: 0;
+			}
+		}
+
+		> .sub-menu {
+			padding-top: 20px;
+
+			&:before {
+				top: 12px;
+			}
 		}
 	}
 }

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -147,20 +147,38 @@
 				> a {
 					color: inherit;
 				}
+
+				> .sub-menu {
+					padding-top: 12px;
+
+					&:before {
+						border-style: solid;
+						border-width: 0 8px 8px 8px;
+						border-color: transparent transparent $color__background-dark transparent;
+						content: '';
+						display: inline-block;
+						height: 0;
+						left: 10px;
+						position: absolute;
+						top: 4px;
+						width: 0;
+					}
+				}
 			}
 
 			.sub-menu {
-				background-color: $color__primary;
 				color: $color__background-body;
 				position: absolute;
 				opacity: 0;
+				transition: opacity 0.2s;
 				left: -9999px;
 				z-index: 99999;
 
-				> li > a {
+				a {
+					background-color: $color__background-dark;
 					display: block;
 					line-height: $font__line-height-heading;
-					padding: calc( .5 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( .5 * #{$size__spacing-unit} ) $size__spacing-unit;
+					padding: calc( 0.75 * #{$size__spacing-unit} ) calc( 24px + #{$size__spacing-unit} ) calc( 0.75 * #{$size__spacing-unit} ) $size__spacing-unit;
 
 					&:hover,
 					&:focus {
@@ -170,7 +188,7 @@
 
 				.submenu-expand {
 					right: #{ 0.25 * $size__spacing-unit };
-					top: #{ 0.4 * $size__spacing-unit };
+					top: #{ 0.65 * $size__spacing-unit };
 					transform: rotate( -90deg );
 				}
 			}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -24,6 +24,23 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
+.header-solid-background.header-simplified {
+	.site-header .main-navigation .main-menu .sub-menu {
+		a {
+			background-color: $color__text-main;
+
+			&:hover,
+			&:focus {
+				background-color: $color__primary
+			}
+		}
+
+		&:before {
+			border-color: transparent transparent $color__text-main transparent;
+		}
+	}
+}
+
 // Accent headers
 
 .accent-header,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -11,8 +11,7 @@ Newspack Theme Styles - Style Pack 3
 
 .header-solid-background {
 	.site-header,
-	.top-header-contain,
-	.site-header .main-navigation .main-menu .sub-menu {
+	.top-header-contain {
 		background-color: $color__background-dark;
 	}
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -11,8 +11,7 @@ Newspack Theme Styles - Style Pack 4
 
 .header-solid-background {
 	.site-header,
-	.top-header-contain,
-	.site-header .main-navigation .main-menu .sub-menu {
+	.top-header-contain {
 		background-color: $color__background-dark;
 	}
 
@@ -22,6 +21,23 @@ Newspack Theme Styles - Style Pack 4
 
 	.bottom-header-contain {
 		background-color: darken( $color__background-dark, 5% );
+	}
+}
+
+.header-solid-background.header-simplified {
+	.site-header .main-navigation .main-menu .sub-menu {
+		a {
+			background-color: $color__text-main;
+
+			&:hover,
+			&:focus {
+				background-color: $color__primary
+			}
+		}
+
+		&:before {
+			border-color: transparent transparent $color__text-main transparent;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR takes another swing at styling the theme's dropdown menus on desktop. Rather than using the custom colours, they only use them on hover and otherwise have a dark background.

They also have a small triangle at the top, to help separate the link from the dropdown a bit, and make them a bit more free-floating (so the dropdown position is less problematic).

This PR will replace #268 if it seems like a better approach.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Cycle through the different style packs and header settings (notable ones listed below) -- what do you think about this approach? Do you see any issues?

(Personally I'm not 100% solid on the grey + grey for style packs 3 and 4 when they have solid headers, but if this otherwise seems okay I can explore an alternative for those in that case -- perhaps primary colour?)

**Default**

![image](https://user-images.githubusercontent.com/177561/65644350-defaf800-dfa8-11e9-8782-49e58971682b.png)

**Default + solid header**

![image](https://user-images.githubusercontent.com/177561/65644375-ea4e2380-dfa8-11e9-9dae-1005b4fb60af.png)

**Default + short header**

![image](https://user-images.githubusercontent.com/177561/65644395-f6d27c00-dfa8-11e9-952d-621756c927fc.png)

**Default + Centred Logo**

![image](https://user-images.githubusercontent.com/177561/65644415-081b8880-dfa9-11e9-812a-3697296187bd.png)


**Style 2**

![image](https://user-images.githubusercontent.com/177561/65644325-d1457280-dfa8-11e9-8548-15ed7d8304c4.png)

**Style 2 + solid header**

![image](https://user-images.githubusercontent.com/177561/65644313-c5f24700-dfa8-11e9-9092-cc26071ba1c1.png)


**Style 3/4 + solid header (which is already dark grey) + short header** 

![image](https://user-images.githubusercontent.com/177561/65644282-b410a400-dfa8-11e9-8bfa-121ab8e911e5.png)

![image](https://user-images.githubusercontent.com/177561/65644221-93484e80-dfa8-11e9-9b93-91afbde32c47.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
