### PR TITLE
Improve appearance of style 3 + captions for the article blocks.

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -35,13 +35,19 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
-	background-color: $color__background-body;
-	margin-top: -1.75em;
-	padding: 0.5em 0.25em 0 0;
-	position: relative;
-	width: 85%;
-	z-index: 1;
+.wp-block-newspack-blocks-homepage-articles {
+	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+		background-color: $color__background-body;
+		margin-top: -1.75em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
+	}
+
+	figcaption:after {
+		display: none;
+	}
 }
 
 .wp-block-cover,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -152,13 +152,19 @@ figcaption,
 }
 
 .entry .entry-content {
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
-		background-color: $color__background-body;
-		margin-top: -1.5em;
-		padding: 0.5em 0.25em 0 0;
-		position: relative;
-		width: 85%;
-		z-index: 1;
+	.wp-block-newspack-blocks-homepage-articles {
+		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+			background-color: $color__background-body;
+			margin-top: -1.5em;
+			padding: 0.5em 0.25em 0 0;
+			position: relative;
+			width: 85%;
+			z-index: 1;
+		}
+
+		figcaption:after {
+			display: none;
+		}
 	}
 
 	.wp-block-cover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Style 3 includes a visual accent underneath photo captions, and in the article block, displays the article title partially over the featured image.

None of this works well together with captions on the article block; this PR fixes that.

Note: needs to be tested with https://github.com/Automattic/newspack-blocks/pull/126, or after it's merged.

**Before:**

(This actually looks okay, but it's because the accent after the caption is pushing down the title far enough not to overlap it. But the overlap may cause other issues -- we should just remove it.)
![image](https://user-images.githubusercontent.com/177561/65650074-2475f000-dfbe-11e9-9e56-f9b4bcfa99cf.png)

![image](https://user-images.githubusercontent.com/177561/65650071-1e800f00-dfbe-11e9-8b6a-6c7b60191eb2.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/65649980-a580b780-dfbd-11e9-8f62-9d9f07620dc2.png)

![image](https://user-images.githubusercontent.com/177561/65649987-b16c7980-dfbd-11e9-97f3-29a84b4e38c7.png)


### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to style 3.
2. On a page, add two article blocks, one with the image aligned left/right, and the other with it aligned to the top. Turn on "Show Featured Image Captions" for both.
3. Make sure at least one article in each block has a featured image, and that image has a caption.
4. Note the visual appearance in the editor and on the front-end.
5. Apply the PR and run `npm run build`.
6. Confirm that the little accent under the caption when the image is aligned left/right is not there, and that the title does not have a negative top margin when the image is sitting above it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
