### PR TITLE
Make it possible to add the 'secondary' menu, even when you're using the short header

### DIFF
--- a/header.php
+++ b/header.php
@@ -40,8 +40,8 @@
 		?>
 
 		<?php
-		// Header is NOT short:
-		if ( false === $header_simplified ) :
+		// Header is NOT short, or if it is, there's a secondary menu assigned.
+		if ( false === $header_simplified || ( true === $header_simplified && has_nav_menu( 'secondary-menu' ) ) ) :
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -274,7 +274,7 @@
 
 .header-simplified {
 
-	.site-header .wrapper {
+	.middle-header-contain .wrapper {
 		justify-content: flex-start;
 	}
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -20,13 +20,20 @@ Newspack Theme Styles - Style Pack 2
 	}
 }
 
-.header-simplified .site-header {
-	@include media( tablet ) {
-		padding-top: #{ 0.5 * $size__spacing-unit };
+.header-simplified {
+	.middle-header-contain {
+		@include media( tablet ) {
+			padding-top: #{ 0.5 * $size__spacing-unit };
+		}
+		@include media( desktop ) {
+			padding-top: $size__spacing-unit;
+		}
 	}
 
-	@include media( desktop ) {
-		padding: $size__spacing-unit 0 #{ 10 * $size__spacing-unit };
+	.site-header {
+		@include media( desktop ) {
+			padding: 0 0 #{ 10 * $size__spacing-unit };
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you use the short header, the secondary menu doesn't display, and the social menu doesn't display in the header (it does display in the footer, though). 

This PR makes it so if you have the secondary menu assigned, it will appear with the social menu, and if you don't, neither will appear. 

This was requested in some charter feedback; along with visual feedback, I'd love to get a second opinion whether this addition makes sense. 

Closes #437.

**Regular 'short' header:** 

![image](https://user-images.githubusercontent.com/177561/65910875-6cab5e80-e380-11e9-9851-ab0d4d88e42a.png)

**Short header when the secondary menu is added:**

![image](https://user-images.githubusercontent.com/177561/65910797-4259a100-e380-11e9-8d39-4fb432b4a283.png)

**Regular 'short' header with style 2** (which has some style pack-specific header spacing):

![image](https://user-images.githubusercontent.com/177561/65910911-851b7900-e380-11e9-89c7-b582163996f4.png)

**'Short' header with style 2 and the secondary menu:** 

![image](https://user-images.githubusercontent.com/177561/65910977-a9775580-e380-11e9-9d28-fd86ac0636c7.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Header Settings, and pick 'Short Header'
3. If you don't already have one assigned, assign a menu to the 'secondary location'.
4. Confirm the appearance on the front end matches the second screenshot above.
5. Navigate to Customize > Style Packs, and switch to Style 2.
6. Confirm the appearance on the front end matches the fourth screenshot above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
