### PR TITLE
Adjust mobile menu breakpoint

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -224,7 +224,7 @@ function newspack_primary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 1099px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 900px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -247,7 +247,7 @@ function newspack_secondary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 1099px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 900px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -271,7 +271,7 @@ function newspack_tertiary_menu() {
 		return;
 	}
 	?>
-		<nav toolbar="(min-width: 1099px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+		<nav toolbar="(min-width: 900px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
 			<?php
 			wp_nav_menu(
 				array(
@@ -310,7 +310,7 @@ function newspack_social_menu_header() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 1099px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 900px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
 		<?php newspack_social_menu_settings(); ?>
 	</nav><!-- .social-navigation -->
 <?php

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -224,7 +224,7 @@ function newspack_primary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 900px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -247,7 +247,7 @@ function newspack_secondary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 900px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -271,7 +271,7 @@ function newspack_tertiary_menu() {
 		return;
 	}
 	?>
-		<nav toolbar="(min-width: 900px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+		<nav toolbar="(min-width: 767px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
 			<?php
 			wp_nav_menu(
 				array(
@@ -310,7 +310,7 @@ function newspack_social_menu_header() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 900px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 767px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
 		<?php newspack_social_menu_settings(); ?>
 	</nav><!-- .social-navigation -->
 <?php

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -224,7 +224,7 @@ function newspack_primary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 1099px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -247,7 +247,7 @@ function newspack_secondary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 1099px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(
@@ -271,7 +271,7 @@ function newspack_tertiary_menu() {
 		return;
 	}
 	?>
-		<nav toolbar="(min-width: 767px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+		<nav toolbar="(min-width: 1099px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
 			<?php
 			wp_nav_menu(
 				array(
@@ -310,7 +310,7 @@ function newspack_social_menu_header() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 1099px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
 		<?php newspack_social_menu_settings(); ?>
 	</nav><!-- .social-navigation -->
 <?php

--- a/sass/mixins/_utilities.scss
+++ b/sass/mixins/_utilities.scss
@@ -18,6 +18,12 @@
 		}
 	}
 
+	@if narrowdesktop == $res {
+		@media only screen and (min-width: $narrow_desktop_width) {
+			@content;
+		}
+	}
+
 	@if desktop == $res {
 		@media only screen and (min-width: $desktop_width) {
 			@content;

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -19,7 +19,16 @@
 	&:hover {
 		color: inherit
 	}
-	@include media(narrowdesktop) {
+}
+
+@include media( tablet ) {
+	.header-default-height .site-header .mobile-menu-toggle {
+		display: none;
+	}
+}
+
+@include media( narrowdesktop ) {
+	.header-simplified .site-header .mobile-menu-toggle {
 		display: none;
 	}
 }

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -19,7 +19,7 @@
 	&:hover {
 		color: inherit
 	}
-	@include media(tablet) {
+	@include media(desktop) {
 		display: none;
 	}
 }

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -19,7 +19,7 @@
 	&:hover {
 		color: inherit
 	}
-	@include media(desktop) {
+	@include media(narrowdesktop) {
 		display: none;
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -343,11 +343,20 @@
 	justify-content: flex-start;
 }
 
+// Hide desktop menus at specific breakpoints.
+
 .desktop-only {
 	display: none;
+}
 
-	@include media( narrowdesktop ) {
+@include media( tablet ) {
+	.header-default-height .desktop-only {
 		display: inherit;
 	}
 }
 
+@include media( narrowdesktop ) {
+	.header-simplified .desktop-only {
+		display: inherit;
+	}
+}

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -346,7 +346,7 @@
 .desktop-only {
 	display: none;
 
-	@include media( tablet ) {
+	@include media( desktop ) {
 		display: inherit;
 	}
 }

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -346,7 +346,7 @@
 .desktop-only {
 	display: none;
 
-	@include media( desktop ) {
+	@include media( narrowdesktop ) {
 		display: inherit;
 	}
 }

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -11,7 +11,7 @@ $size__site-desktop-content: 65%;
 
 $mobile_width: 600px;
 $tablet_width: 782px;
-$narrow_desktop_width: 882px;
+$narrow_desktop_width: 960px;
 $desktop_width: 1168px;
 $wide_width: 1379px;
 

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -11,6 +11,7 @@ $size__site-desktop-content: 65%;
 
 $mobile_width: 600px;
 $tablet_width: 782px;
-$desktop_width: 1100px;
+$narrow_desktop_width: 900px;
+$desktop_width: 1168px;
 $wide_width: 1379px;
 

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -11,7 +11,7 @@ $size__site-desktop-content: 65%;
 
 $mobile_width: 600px;
 $tablet_width: 782px;
-$narrow_desktop_width: 900px;
+$narrow_desktop_width: 882px;
 $desktop_width: 1168px;
 $wide_width: 1379px;
 

--- a/sass/variables-site/_structure.scss
+++ b/sass/variables-site/_structure.scss
@@ -11,6 +11,6 @@ $size__site-desktop-content: 65%;
 
 $mobile_width: 600px;
 $tablet_width: 782px;
-$desktop_width: 1168px;
+$desktop_width: 1100px;
 $wide_width: 1379px;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR increases the breakpoint at which the site will switch to the mobile menu, from a smaller tablet size (782px) to a size that should cover larger tablets (1100px) and also allow for longer menus, since it will switch to the mobile version rather than starting to wrap.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that the menu toggle appears on screens narrower than 1100px.
3. Confirm that the menu toggle works when AMP is enabled.
4. Confirm that the menu toggle works when AMP is disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?