### PR TITLE
Hide Jetpack-specific comments header

### DIFF
--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -54,6 +54,12 @@
 			}
 		}
 	}
+
+	// Hide Jetpack comments' title.
+	.comments-title-wrap + .comment-respond .comment-reply-title {
+		display: none;
+	}
+
 }
 
 #comment {

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -16,11 +16,6 @@
 	& > * {
 		margin-top: calc(2 * #{$size__spacing-unit});
 		margin-bottom: calc(2 * #{$size__spacing-unit});
-
-		@include media(tablet) {
-			margin-top: calc(3 * #{$size__spacing-unit});
-			margin-bottom: calc(3 * #{$size__spacing-unit});
-		}
 	}
 
 	/* Add extra margin when the comments section is located immediately after the


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the second comments headed when you have Jetpack comments enabled.

Closes #445.

### How to test the changes in this Pull Request:

1. Navigate to WP Admin > Jetpack > Settings > Discussion, and check "Let visitors use a WordPress.com, Twitter, Facebook, or Google account to comment"

![image](https://user-images.githubusercontent.com/177561/66004900-c2eecf00-e45e-11e9-84bc-ed807e5b7b5b.png)

(You need to use a site that can fully connect to Jetpack -- not just in developer mode -- to enable this).

2. View a post with comments enabled; note the double-header:

![image](https://user-images.githubusercontent.com/177561/66004987-ffbac600-e45e-11e9-9644-b51638767843.png)

3. Apply the PR and run `npm run build`
4. Confirm that the second header is now gone:

![image](https://user-images.githubusercontent.com/177561/66005049-32fd5500-e45f-11e9-8ca2-c28f75983041.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
