### PR TITLE
Widgets: Fix issue with "top post" image width

### DIFF
--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -85,6 +85,17 @@
 	}
 }
 
+
+.widgets-list-layout {
+	.widgets-list-layout-blavatar {
+		width: auto;
+	}
+
+	.widgets-list-layout-links {
+		width: calc( 100% - 60px)
+	}
+}
+
 #secondary {
 	section:first-child,
 	section:first-child > div {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Jetpack's "Top Posts and Pages" widget, the author image was displaying too wide -- this PR fixes that.

Closes #442.

### How to test the changes in this Pull Request:

1. Start on a test site that has a full Jetpack connection (not just debug mode).
2. Navigate to WP Admin > Jetpack > Settings > Writing.
3. Under "Widgets", turn on "Make extra widgets available for use on your site..."

![image](https://user-images.githubusercontent.com/177561/66006668-42cb6800-e464-11e9-9b97-dbbd278fb717.png)

4. Navigate to Customizer > Widgets, and add the "Top Posts & Pages (Jetpack)" widget to a widget area; in its options, select "Image List".
5. Hopefully you'll get a widget out of the gate that will look like:

![image](https://user-images.githubusercontent.com/177561/66006840-f6ccf300-e464-11e9-8bbc-76c048a97447.png)

6. Apply the PR and run `npm run build`
7. Confirm that the image and text are more reasonable widths:

![image](https://user-images.githubusercontent.com/177561/66006912-3bf12500-e465-11e9-99ce-792b4c13983a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
