### PR TITLE
Fix up styles for related posts block

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -38,7 +38,7 @@ function newspack_custom_typography_css() {
 		.site-title,
 		.site-info,
 		#cancel-comment-reply-link,
-		.entry .entry-content .jp-relatedposts-i2,
+		.entry .entry-content .jp-relatedposts-i2 a,
 		h1,
 		h2,
 		h3,
@@ -189,7 +189,8 @@ function newspack_custom_typography_css() {
 		.editor-block-list__layout .editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 
 		/* Jetpack blocks */
-		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2,
+		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 a,
+		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 strong,
 
 		/* Classic Editor */
 		.editor-block-list__layout .editor-block-list__block .wp-caption dd,

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -38,6 +38,7 @@ function newspack_custom_typography_css() {
 		.site-title,
 		.site-info,
 		#cancel-comment-reply-link,
+		.jp-relatedposts-i2,
 		h1,
 		h2,
 		h3,
@@ -186,6 +187,9 @@ function newspack_custom_typography_css() {
 
 		/* Latest Comments blocks */
 		.editor-block-list__layout .editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,
+
+		/* Jetpack blocks */
+		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2,
 
 		/* Classic Editor */
 		.editor-block-list__layout .editor-block-list__block .wp-caption dd,

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -38,7 +38,7 @@ function newspack_custom_typography_css() {
 		.site-title,
 		.site-info,
 		#cancel-comment-reply-link,
-		.jp-relatedposts-i2,
+		.entry .entry-content .jp-relatedposts-i2,
 		h1,
 		h2,
 		h3,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -803,16 +803,17 @@
 	.jp-relatedposts-i2 {
 		border-top: 1px solid $color__border;
 		border-bottom: 1px solid $color__border;
+		padding: $size__spacing-unit 0;
 		font-family: $font__heading;
 		a {
-			font-size: $font__size-md;
+			font-size: $font__size-sm;
 			font-weight: bold;
 			text-decoration: none;
 		}
 
 		.jp-related-posts-i2__post-date,
 		.jp-related-posts-i2__post-context {
-			font-size: $font__size-sm;
+			font-size: $font__size-xxs;
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -801,6 +801,8 @@
 
 	// Jetpack Blocks
 	.jp-relatedposts-i2 {
+		border-top: 1px solid $color__border;
+		border-bottom: 1px solid $color__border;
 		font-family: $font__heading;
 		a {
 			font-size: $font__size-md;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -799,6 +799,21 @@
 		}
 	}
 
+	// Jetpack Blocks
+	.jp-relatedposts-i2 {
+		font-family: $font__heading;
+		a {
+			font-size: $font__size-md;
+			font-weight: bold;
+			text-decoration: none;
+		}
+
+		.jp-related-posts-i2__post-date,
+		.jp-related-posts-i2__post-context {
+			font-size: $font__size-sm;
+		}
+	}
+
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -804,8 +804,8 @@
 		border-top: 1px solid $color__border;
 		border-bottom: 1px solid $color__border;
 		padding: $size__spacing-unit 0;
-		font-family: $font__heading;
 		a {
+			font-family: $font__heading;
 			font-size: $font__size-base;
 			font-weight: bold;
 			text-decoration: none;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -806,14 +806,14 @@
 		padding: $size__spacing-unit 0;
 		font-family: $font__heading;
 		a {
-			font-size: $font__size-sm;
+			font-size: $font__size-base;
 			font-weight: bold;
 			text-decoration: none;
 		}
 
 		.jp-related-posts-i2__post-date,
 		.jp-related-posts-i2__post-context {
-			font-size: $font__size-xxs;
+			font-size: $font__size-xs;
 		}
 	}
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -752,8 +752,9 @@ ul.wp-block-archives,
 	border-bottom: 1px solid $color__border;
 	padding: $size__spacing-unit 0;
 	font-family: $font__heading;
-	a {
-		font-size: $font__size-sm;
+	a,
+	strong {
+		font-size: $font__size-md;
 		font-weight: bold;
 		text-decoration: none;
 	}

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -746,19 +746,21 @@ ul.wp-block-archives,
 
 /** === Jetpack Blocks === */
 
+// Jetpack Blocks
 .jp-relatedposts-i2 {
 	border-top: 1px solid $color__border;
 	border-bottom: 1px solid $color__border;
+	padding: $size__spacing-unit 0;
 	font-family: $font__heading;
 	a {
-		font-size: $font__size-md;
+		font-size: $font__size-sm;
 		font-weight: bold;
 		text-decoration: none;
 	}
 
 	.jp-related-posts-i2__post-date,
 	.jp-related-posts-i2__post-context {
-		font-size: $font__size-sm;
+		font-size: $font__size-xxs;
 	}
 }
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -754,14 +754,14 @@ ul.wp-block-archives,
 	font-family: $font__heading;
 	a,
 	strong {
-		font-size: $font__size-md;
+		font-size: $font__size-base;
 		font-weight: bold;
 		text-decoration: none;
 	}
 
 	.jp-related-posts-i2__post-date,
 	.jp-related-posts-i2__post-context {
-		font-size: $font__size-xxs;
+		font-size: $font__size-xs;
 	}
 }
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -747,6 +747,8 @@ ul.wp-block-archives,
 /** === Jetpack Blocks === */
 
 .jp-relatedposts-i2 {
+	border-top: 1px solid $color__border;
+	border-bottom: 1px solid $color__border;
 	font-family: $font__heading;
 	a {
 		font-size: $font__size-md;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -751,9 +751,9 @@ ul.wp-block-archives,
 	border-top: 1px solid $color__border;
 	border-bottom: 1px solid $color__border;
 	padding: $size__spacing-unit 0;
-	font-family: $font__heading;
 	a,
 	strong {
+		font-family: $font__heading;
 		font-size: $font__size-base;
 		font-weight: bold;
 		text-decoration: none;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -744,6 +744,22 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Jetpack Blocks === */
+
+.jp-relatedposts-i2 {
+	font-family: $font__heading;
+	a {
+		font-size: $font__size-md;
+		font-weight: bold;
+		text-decoration: none;
+	}
+
+	.jp-related-posts-i2__post-date,
+	.jp-related-posts-i2__post-context {
+		font-size: $font__size-sm;
+	}
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -193,3 +193,9 @@ hr {
 		}
 	}
 }
+
+// Jetpack Blocks
+.jp-relatedposts-i2 {
+	border-top: 1px dotted $color__text-main;
+	border-bottom: 1px dotted $color__text-main;
+}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -296,12 +296,12 @@ figcaption,
 			}
 		}
 	}
-}
 
-// Jetpack Blocks
-.jp-relatedposts-i2 {
-	border-top: 1px dotted $color__text-main;
-	border-bottom: 1px dotted $color__text-main;
+	// Jetpack Blocks
+	.jp-relatedposts-i2 {
+		border-top: 1px dotted $color__text-main;
+		border-bottom: 1px dotted $color__text-main;
+	}
 }
 
 // Archives

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -298,6 +298,12 @@ figcaption,
 	}
 }
 
+// Jetpack Blocks
+.jp-relatedposts-i2 {
+	border-top: 1px dotted $color__text-main;
+	border-bottom: 1px dotted $color__text-main;
+}
+
 // Archives
 
 .archive .page-title {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes borders from Jetpack's Related Posts block, and tidies up the general appearance by adding better font scaling, and adding borders.

Closes #434.

### How to test the changes in this Pull Request:

1. Start with a test site fully connected to Jetpack (not in dev mode) so you have access to the Related Posts block.
2. On an existing post, add the block (this hopefully will make sure at least one real post will appear.
3. Note the appearance on the front-end and in the editor:

Editor:

![image](https://user-images.githubusercontent.com/177561/66010216-dc017b00-e472-11e9-85a4-e221b6fc742d.png)

Front-end: (On my test site I only managed to get one post displaying two related articles, so it's a bit large:)

![image](https://user-images.githubusercontent.com/177561/66010209-d1df7c80-e472-11e9-86be-d2314338a46d.png)


4. Apply the PR and run `npm run build`.
5. Confirm that the block looks better:

Editor:
![image](https://user-images.githubusercontent.com/177561/66010177-b4121780-e472-11e9-8275-5102cffc0ada.png)

Front-end:

![image](https://user-images.githubusercontent.com/177561/66010161-a6f52880-e472-11e9-8f2a-005fd68ba2b9.png)

6. Try switching to "Style 3" and confirm the borders are dotted on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/66010128-87f69680-e472-11e9-9c30-6e45c4458c5c.png)

7. Navigate to Customizer > Typography, and try changing the header font; confirm it updates on the front-end and the editor (all text should use it):

![image](https://user-images.githubusercontent.com/177561/66010319-57632c80-e473-11e9-8f83-3669d33bcac8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
