### PR TITLE
Tweaks to the comment templates for Renaming Comments

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -28,13 +28,9 @@ $discussion = newspack_get_discussion_data();
 		<?php
 		if ( comments_open() ) {
 			if ( have_comments() ) {
-				echo ( function_exists('\Rename_Comments\get_text') )
-					? \Rename_Comments\get_text( 'rc_comments_title' )
-					: __( 'Join the Conversation', 'newspack' );
+				echo apply_filters( 'newspack_comment_section_title_nocomments', __( 'Join the Conversation', 'newspack' ) );
 			} else {
-				echo ( function_exists('\Rename_Comments\get_text') )
-					? \Rename_Comments\get_text( 'rc_no_comments_title' )
-					: __( 'Leave a comment', 'newspack' );
+				echo apply_filters( 'newspack_comment_section_title', __( 'Leave a comment', 'newspack' ) );
 			}
 		} else {
 			if ( '1' == $discussion->responses ) {
@@ -91,7 +87,7 @@ $discussion = newspack_get_discussion_data();
 		if ( have_comments() ) :
 			$prev_icon     = newspack_get_icon_svg( 'chevron_left', 22 );
 			$next_icon     = newspack_get_icon_svg( 'chevron_right', 22 );
-			$comments_text = ( function_exists('\Rename_Comments\get_text') ) ? \Rename_Comments\get_text( 'rc_comments_name_plural' ) : __( 'Comments', 'newspack' );
+			$comments_text = apply_filters( 'newspack_comments_name_plural', __( 'Comments', 'newspack' ) );
 			the_comments_navigation(
 				array(
 					'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'newspack' ), $comments_text ),
@@ -102,9 +98,7 @@ $discussion = newspack_get_discussion_data();
 
 		// Show comment form at bottom if showing newest comments at the bottom.
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
-			$leave_comment_text = ( function_exists('\Rename_Comments\get_text') )
-				? \Rename_Comments\get_text( 'rc_comments_leave_comment' )
-				: __( 'Leave a comment', 'newspack' );
+			$leave_comment_text = apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) );
 			?>
 			<div class="comment-form-flex">
 				<span class="screen-reader-text"><?php echo $leave_comment_text; ?></span>
@@ -119,9 +113,7 @@ $discussion = newspack_get_discussion_data();
 			?>
 			<p class="no-comments">
 				<?php
-					echo ( function_exists('\Rename_Comments\get_text') )
-						? \Rename_Comments\get_text( 'rc_comments_closed' )
-						: esc_html__( 'Comments are closed.', 'newspack' );
+					echo apply_filters( 'newspack_comments_closed', __( 'Comments are closed.', 'newspack' ) );
 				?>
 			</p>
 			<?php

--- a/comments.php
+++ b/comments.php
@@ -28,9 +28,13 @@ $discussion = newspack_get_discussion_data();
 		<?php
 		if ( comments_open() ) {
 			if ( have_comments() ) {
-				_e( 'Join the Conversation', 'newspack' );
+				echo ( function_exists('\Rename_Comments\get_text') )
+					? \Rename_Comments\get_text( 'rc_comments_title' )
+					: __( 'Join the Conversation', 'newspack' );
 			} else {
-				_e( 'Leave a comment', 'newspack' );
+				echo ( function_exists('\Rename_Comments\get_text') )
+					? \Rename_Comments\get_text( 'rc_no_comments_title' )
+					: __( 'Leave a comment', 'newspack' );
 			}
 		} else {
 			if ( '1' == $discussion->responses ) {
@@ -73,7 +77,7 @@ $discussion = newspack_get_discussion_data();
 			<?php
 			wp_list_comments(
 				array(
-					'walker'      => new Newspack_Walker_Comment(),
+					'walker'      => new newspack_Walker_Comment(),
 					'avatar_size' => newspack_get_avatar_size(),
 					'short_ping'  => true,
 					'style'       => 'ol',
@@ -87,22 +91,25 @@ $discussion = newspack_get_discussion_data();
 		if ( have_comments() ) :
 			$prev_icon     = newspack_get_icon_svg( 'chevron_left', 22 );
 			$next_icon     = newspack_get_icon_svg( 'chevron_right', 22 );
-			$comments_text = __( 'Comments', 'newspack' );
+			$comments_text = ( function_exists('\Rename_Comments\get_text') ) ? \Rename_Comments\get_text( 'rc_comments_name_plural' ) : __( 'Comments', 'newspack' );
 			the_comments_navigation(
 				array(
-					'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'newspack' ), __( 'Comments', 'newspack' ) ),
-					'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'newspack' ), __( 'Comments', 'newspack' ), $next_icon ),
+					'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'newspack' ), $comments_text ),
+					'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'newspack' ), $comments_text, $next_icon ),
 				)
 			);
 		endif;
 
 		// Show comment form at bottom if showing newest comments at the bottom.
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
+			$leave_comment_text = ( function_exists('\Rename_Comments\get_text') )
+				? \Rename_Comments\get_text( 'rc_comments_leave_comment' )
+				: __( 'Leave a comment', 'newspack' );
 			?>
 			<div class="comment-form-flex">
-				<span class="screen-reader-text"><?php _e( 'Leave a comment', 'newspack' ); ?></span>
+				<span class="screen-reader-text"><?php echo $leave_comment_text; ?></span>
 				<?php newspack_comment_form( 'asc' ); ?>
-				<h2 class="comments-title" aria-hidden="true"><?php _e( 'Leave a comment', 'newspack' ); ?></h2>
+				<h2 class="comments-title" aria-hidden="true"><?php echo $leave_comment_text; ?></h2>
 			</div>
 			<?php
 		endif;
@@ -111,7 +118,11 @@ $discussion = newspack_get_discussion_data();
 		if ( ! comments_open() ) :
 			?>
 			<p class="no-comments">
-				<?php _e( 'Comments are closed.', 'newspack' ); ?>
+				<?php
+					echo ( function_exists('\Rename_Comments\get_text') )
+						? \Rename_Comments\get_text( 'rc_comments_closed' )
+						: esc_html__( 'Comments are closed.', 'newspack' );
+				?>
 			</p>
 			<?php
 		endif;

--- a/comments.php
+++ b/comments.php
@@ -28,9 +28,9 @@ $discussion = newspack_get_discussion_data();
 		<?php
 		if ( comments_open() ) {
 			if ( have_comments() ) {
-				echo apply_filters( 'newspack_comment_section_title_nocomments', __( 'Join the Conversation', 'newspack' ) );
+				echo esc_html( apply_filters( 'newspack_comment_section_title_nocomments', __( 'Join the Conversation', 'newspack' ) ) );
 			} else {
-				echo apply_filters( 'newspack_comment_section_title', __( 'Leave a comment', 'newspack' ) );
+				echo esc_html( apply_filters( 'newspack_comment_section_title', __( 'Leave a comment', 'newspack' ) ) );
 			}
 		} else {
 			if ( '1' == $discussion->responses ) {
@@ -101,9 +101,9 @@ $discussion = newspack_get_discussion_data();
 			$leave_comment_text = apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) );
 			?>
 			<div class="comment-form-flex">
-				<span class="screen-reader-text"><?php echo $leave_comment_text; ?></span>
+				<span class="screen-reader-text"><?php echo esc_html( $leave_comment_text ); ?></span>
 				<?php newspack_comment_form( 'asc' ); ?>
-				<h2 class="comments-title" aria-hidden="true"><?php echo $leave_comment_text; ?></h2>
+				<h2 class="comments-title" aria-hidden="true"><?php echo esc_html( $leave_comment_text ); ?></h2>
 			</div>
 			<?php
 		endif;
@@ -113,7 +113,7 @@ $discussion = newspack_get_discussion_data();
 			?>
 			<p class="no-comments">
 				<?php
-					echo apply_filters( 'newspack_comments_closed', __( 'Comments are closed.', 'newspack' ) );
+					echo esc_html( apply_filters( 'newspack_comments_closed', __( 'Comments are closed.', 'newspack' ) ) );
 				?>
 			</p>
 			<?php

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -11,11 +11,11 @@ $has_responses = $discussion->responses > 0;
 
 if ( $has_responses ) {
 	/* translators: %1(X comments)$s */
-	$meta_label = sprintf( _n(
+	$meta_label = apply_filters( 'newspack_number_comments', sprintf( _n(
 		'%d Comment',
 		'%d Comments',
 		$discussion->responses, 'newspack'
-	), $discussion->responses );
+	), $discussion->responses ) );
 
 } else {
 	$meta_label = esc_html( apply_filters( 'newspack_no_comments', __( 'No comments', 'newspack' ) ) );

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -11,20 +11,14 @@ $has_responses = $discussion->responses > 0;
 
 if ( $has_responses ) {
 	/* translators: %1(X comments)$s */
-	$meta_label = sprintf( _n( '%d Comment', '%d Comments', $discussion->responses, 'newspack' ), $discussion->responses );
+	$meta_label = sprintf( _n(
+		'%d Comment',
+		'%d Comments',
+		$discussion->responses, 'newspack'
+	), $discussion->responses );
 
-	if ( function_exists('\Rename_Comments\get_text') ) {
-		$rc_name = ( $discussion->responses > 1 )
-			? \Rename_Comments\get_text('rc_comments_name_plural')
-			: \Rename_Comments\get_text('rc_comments_name');
-		$meta_label = sprintf( '%d %s', $discussion->responses, $rc_name );
-	}
 } else {
-	$meta_label = __( 'No comments', 'newspack' );
-
-	if ( function_exists('\Rename_Comments\get_text') ) {
-		$meta_label = sprintf( esc_html__( 'No %s', 'newspack' ), \Rename_Comments\get_text('rc_comments_name_plural') );
-	}
+	$meta_label = apply_filters( 'newspack_no_comments', __( 'No comments', 'newspack' ) );
 }
 ?>
 

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -12,8 +12,19 @@ $has_responses = $discussion->responses > 0;
 if ( $has_responses ) {
 	/* translators: %1(X comments)$s */
 	$meta_label = sprintf( _n( '%d Comment', '%d Comments', $discussion->responses, 'newspack' ), $discussion->responses );
+
+	if ( function_exists('\Rename_Comments\get_text') ) {
+		$rc_name = ( $discussion->responses > 1 )
+			? \Rename_Comments\get_text('rc_comments_name_plural')
+			: \Rename_Comments\get_text('rc_comments_name');
+		$meta_label = sprintf( '%d %s', $discussion->responses, $rc_name );
+	}
 } else {
 	$meta_label = __( 'No comments', 'newspack' );
+
+	if ( function_exists('\Rename_Comments\get_text') ) {
+		$meta_label = sprintf( esc_html__( 'No %s', 'newspack' ), \Rename_Comments\get_text('rc_comments_name_plural') );
+	}
 }
 ?>
 

--- a/template-parts/post/discussion-meta.php
+++ b/template-parts/post/discussion-meta.php
@@ -18,7 +18,7 @@ if ( $has_responses ) {
 	), $discussion->responses );
 
 } else {
-	$meta_label = apply_filters( 'newspack_no_comments', __( 'No comments', 'newspack' ) );
+	$meta_label = esc_html( apply_filters( 'newspack_no_comments', __( 'No comments', 'newspack' ) ) );
 }
 ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes the comments templates to use the helper from the new [Rename Comments plugin](https://github.com/Automattic/newspack-rename-comments) to enable publishers to rename the comments section if they so wish.

### How to test the changes in this Pull Request:

1. Install and activate the [Rename Comments plugin](https://github.com/Automattic/newspack-rename-comments)
2.Apply the PR
3.Configure the Rename Comments plugin
4. Check the comments section is appropriately renamed on the front end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
