### PR TITLE
Make sure the special featured image classes are only applied to single posts

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -88,12 +88,14 @@ function newspack_body_classes( $classes ) {
 
 	// Adds a class to single artcles, if they're using a special featured image style.
 	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-	if ( 'behind' === $current_featured_image_style ) {
-		$classes[] = 'single-featured-image-behind';
-	} elseif ( 'beside' === $current_featured_image_style ) {
-		$classes[] = 'single-featured-image-beside';
-	} else {
-		$classes[] = 'single-featured-image-default';
+	if ( is_single() ) {
+		if ( 'behind' === $current_featured_image_style ) {
+			$classes[] = 'single-featured-image-behind';
+		} elseif ( 'beside' === $current_featured_image_style ) {
+			$classes[] = 'single-featured-image-beside';
+		} else {
+			$classes[] = 'single-featured-image-default';
+		}
 	}
 
 	return $classes;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the classes used for the special featured image placements (behind or beside the content) are applied pretty liberally, meaning styles for them can also affect other spots that these posts show up, like the archive pages. This PR makes them a bit more specific. 

See #436.

### How to test the changes in this Pull Request:

1. Create or edit a post; add a featured image and select the 'Featured image behind' or 'Featured image beside' styles.
2. View an archive page where that post shows up; note there's no space at the top after header:

![image](https://user-images.githubusercontent.com/177561/66139964-2b03f900-e5b6-11e9-9448-9b0d74b6e5ad.png)

3. Apply the PR.
4. Confirm that the spacing is now correct on the archive page:

![image](https://user-images.githubusercontent.com/177561/66139933-1b84b000-e5b6-11e9-8546-b46d5f7a6df1.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
