### PR TITLE
Remove extra spacing from bottom of homepage

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -5,6 +5,10 @@
 	margin: 32px 0;
 	max-width: 100%;
 
+	&:last-child {
+		margin-bottom: 0;
+	}
+
 	// When the image block is aligned left or right, the markup changes,
 	// making a slighly different selector necessary.
 	&.wp-block-image .alignleft,

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -297,6 +297,10 @@ body.page {
 			margin-top: #{ 0.5 * $size__spacing-unit };
 		}
 	}
+
+	.entry-footer {
+		margin-bottom: 0;
+	}
 }
 
 /* Author description */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The homepage can have a lot of space at the bottom on mobile, primarily when viewed when logged in (the edit link styles add a lot). This PR tightens that up.

Closes #449.

### How to test the changes in this Pull Request:

1. Make your browser window narrow, to the point where everything displays as one column.
2. View the bottom of the page; note the extra space: 

![image](https://user-images.githubusercontent.com/177561/66172657-6d9ef300-e601-11e9-987e-65279db1a85f.png)

![image](https://user-images.githubusercontent.com/177561/66172660-71cb1080-e601-11e9-8746-345b162410b1.png)

3. Apply the PR and run `npm run build`
4. Confirm that the vertical spacing on small screens is lessened:

![image](https://user-images.githubusercontent.com/177561/66172692-932bfc80-e601-11e9-9038-7b40ebe54998.png)

![image](https://user-images.githubusercontent.com/177561/66172696-9921dd80-e601-11e9-818e-339d73886b64.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
