### PR TITLE
Recent Posts widget: Fix up vertical spacing, colours

### DIFF
--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -52,8 +52,8 @@
 
 .widget_recent_comments,
 .widget_recent_entries {
-	li {
-		margin-bottom: #{ 0.5 * $size__spacing-unit };
+	ul li {
+		margin-bottom: #{ 0.75 * $size__spacing-unit };
 	}
 }
 
@@ -66,9 +66,10 @@
 	}
 
 	.post-date {
-		color: $color__text-light;
+		color: inherit;
 		font-size: $font__size-sm;
 		display: block;
+		opacity: 0.8;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes up two issues with the Recent Posts widget: It increases the vertical spacing between items, and updates the colour used on the date so it works against the possible dark background in the footer, instead of disappearing into it.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Pack, and pick style 3. (Style 2 also can have a dark background, if you pick it plus a darker primary colour).
2. Navigate to Customize > Widgets, and add a Recent Posts widget to the footer; check off 'Show Date'.
3. View on front end:

![image](https://user-images.githubusercontent.com/177561/66172967-cf139180-e602-11e9-8023-98b707be5fda.png)

4. Apply the PR and run `npm run build`
5. Confirm the widget now has better spacing, and the date is legible:

![image](https://user-images.githubusercontent.com/177561/66172957-bf944880-e602-11e9-8995-8b9c60bb9a31.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
