### PR TITLE
Add option to hide entire Author Bio

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -229,6 +229,35 @@ function newspack_customize_register( $wp_customize ) {
 			)
 		)
 	);
+
+	/**
+	 * Author Bio options
+	 */
+	$wp_customize->add_section(
+		'author_bio_options',
+		array(
+			'title' => esc_html__( 'Author Bio Settings', 'newspack' ),
+		)
+	);
+
+	// Add option to hide the whole author bio.
+	$wp_customize->add_setting(
+		'show_author_bio',
+		array(
+			'default'           => true,
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'show_author_bio',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display Author Bio', 'newspack' ),
+			'description' => esc_html__( 'Display Author Bio under individual posts.', 'newspack' ),
+			'section'     => 'author_bio_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -96,6 +96,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'single-featured-image-default';
 	}
 
+	// Adds a class if the author bio is hidden.
+	$display_author_bio = get_theme_mod( 'show_author_bio', true );
+	if ( false === $display_author_bio ) {
+		$classes[] = 'hide-author-bio';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/js/src/customize-preview.js
+++ b/js/src/customize-preview.js
@@ -28,4 +28,15 @@
 			}
 		});
 	});
+
+	// Hide Author Bio
+	wp.customize( 'show_author_bio', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( 'body' ).addClass( 'hide-author-bio' );
+			} else {
+				$( 'body' ).removeClass( 'hide-author-bio' );
+			}
+		});
+	});
 })( jQuery );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -361,6 +361,10 @@ body.page {
 	}
 }
 
+.hide-author-bio .author-bio {
+	display: none;
+}
+
 /* Featured Image - special styles */
 
 .has-large-featured-image.single-featured-image-behind {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to the Customizer to turn off Author Bios, site-wide. 

See #433

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`
2. Navigate to Customize > Author Bio; confirm that that panel is actually there, and it includes a 'Display Author Bio' checkbox.
3. Within the Customizer preview, navigate to a post, and scroll down to where the Author Bio displays.
4. Uncheck the 'Display Author Bio' checkbox, and confirm the preview reflects the change.
5. Publish the Customizer settings; confirm that the author bios are hidden on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
