### PR TITLE
Style 3: Fix issue with category customizer inheritance

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -278,6 +278,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$theme_css .= '
+			.cat-links,
 			.cat-links a,
 			.article-section-title,
 			.entry .entry-footer,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Style 3, when you have a custom colour, the divider used between categories on single posts was not inheriting the custom colour properly. This PR fixes that.

Closes #432.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 3.
2. Navigate to Customize > Colours, and switch to a custom primary colour (preferably one that will be obviously different than the default blue, like red).
3. Create a post and add at least two categories.
3. View on the front end; note the commas are blue:

![image](https://user-images.githubusercontent.com/177561/66177617-fffdc180-e616-11e9-90b1-8d5eaa3bddfb.png)

4. Apply the PR.
5. Confirm that the dividing commas are also using the primary colour:

![image](https://user-images.githubusercontent.com/177561/66177610-f4aa9600-e616-11e9-8a44-77abd9150987.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?