### PR TITLE
Update left/right alignment styles to include group

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -457,6 +457,10 @@ function newspack_filter_admin_body_class( $classes ) {
 		$classes .= ' style-pack-' . get_theme_mod( 'active_style_pack', 'default' );
 	}
 
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+		$classes .= ' no-sidebar';
+	}
+
 	if ( 'single-feature.php' === newspack_check_current_template() ) {
 		$classes .= ' newspack-single-column-template';
 	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -26,6 +26,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'newspack-front-page';
 	}
 
+	// Add a class to determine whether it has a sidebar.
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+		$classes[] = 'no-sidebar';
+	}
+
 	// Adds a class when in the Customizer.
 	if ( is_customize_preview() ) :
 		$classes[] = 'newspack-customizer';

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1130,18 +1130,15 @@
 
 .post-template-default.singular.no-sidebar,
 .page-template-default.singular.no-sidebar {
-	.entry .entry-content > * {
-		&.alignright,
-		&.wp-block-image .alignright {
-			@include media(mobile) {
-				/*rtl:ignore*/
-				margin-left: calc(2 * #{$size__spacing-unit});
-			}
+	.wp-block-group.alignright {
+		@include media(mobile) {
+			/*rtl:ignore*/
+			margin-left: calc(2 * #{$size__spacing-unit});
+		}
 
-			@include media( tablet ) {
-				/*rtl:ignore*/
-				margin-right: calc( -50% - #{ 1.5 * $size__spacing-unit } );
-			}
+		@include media( tablet ) {
+			/*rtl:ignore*/
+			margin-right: calc( -50% - #{ 1.5 * $size__spacing-unit } );
 		}
 	}
 }

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1130,11 +1130,8 @@
 
 .post-template-default.singular.no-sidebar,
 .page-template-default.singular.no-sidebar {
-	.wp-block-group.alignright {
-		@include media(mobile) {
-			/*rtl:ignore*/
-			margin-left: calc(2 * #{$size__spacing-unit});
-		}
+	.wp-block-group.alignright,
+	.wp-block-image figure.alignright {
 
 		@include media( tablet ) {
 			/*rtl:ignore*/

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1126,7 +1126,8 @@
 	}
 }
 
-.post-template-default.singular.no-sidebar {
+.post-template-default.singular.no-sidebar,
+.page-template-default.singular.no-sidebar {
 	.entry .entry-content > * {
 		&.alignright,
 		&.wp-block-image .alignright,

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -14,7 +14,7 @@
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
-		margin-top: 0;
+		margin-top: #{ 0.5 * $size__spacing-unit };
 		margin-left: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
@@ -26,7 +26,7 @@
 	&.alignright {
 		/*rtl:ignore*/
 		float: right;
-		margin-top: 0;
+		margin-top: #{ 0.5 * $size__spacing-unit };
 		margin-left: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
@@ -41,6 +41,18 @@
 		@include media(tablet) {
 			margin-left: 0;
 			margin-right: 0;
+		}
+	}
+
+	@include media( tablet ) {
+		&.wp-block-group.is-style-alignleft {
+			margin-top: #{ 0.5 * $size__spacing-unit };
+			margin-right: $size__spacing-unit;
+		}
+
+		&.wp-block-group.is-style-alignright {
+			margin-top: #{ 0.5 * $size__spacing-unit };
+			margin-left: $size__spacing-unit;
 		}
 	}
 }
@@ -800,6 +812,7 @@
 
 	//! Group
 	.wp-block-group {
+
 		.wp-block-group__inner-container > * {
 			margin: 32px 0;
 
@@ -997,7 +1010,8 @@
 		}
 
 		&.alignleft,
-		&.wp-block-image .alignleft {
+		&.wp-block-image .alignleft,
+		&.wp-block-group.is-style-alignleft {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-right: calc(2 * #{$size__spacing-unit});
@@ -1015,7 +1029,8 @@
 		}
 
 		&.alignright,
-		&.wp-block-image .alignright {
+		&.wp-block-image .alignright,
+		&.wp-block-group.is-style-alignright {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-left: calc(2 * #{$size__spacing-unit});
@@ -1107,6 +1122,24 @@
 		&.alignfull {
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;
+		}
+	}
+}
+
+.post-template-default.singular.no-sidebar {
+	.entry .entry-content > * {
+		&.alignright,
+		&.wp-block-image .alignright,
+		&.wp-block-group.is-style-alignright {
+			@include media(mobile) {
+				/*rtl:ignore*/
+				margin-left: calc(2 * #{$size__spacing-unit});
+			}
+
+			@include media( tablet ) {
+				/*rtl:ignore*/
+				margin-right: calc( -50% - #{ 1.5 * $size__spacing-unit } );
+			}
 		}
 	}
 }

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -14,7 +14,6 @@
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
-		margin-top: #{ 0.5 * $size__spacing-unit };
 		margin-left: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
@@ -26,12 +25,29 @@
 	&.alignright {
 		/*rtl:ignore*/
 		float: right;
-		margin-top: #{ 0.5 * $size__spacing-unit };
 		margin-left: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
 		max-width: 50%;
+	}
+
+	&.wp-block-image:not(:first-child) .alignleft,
+	&.alignleft:not(:first-child),
+	&.wp-block-image:not(:first-child) .alignright,
+	&.alignright:not(:first-child) {
+		margin-top: #{ 0.5 * $size__spacing-unit };
+	}
+
+	&.wp-block-group.alignleft,
+	&.wp-block-group.alignright {
+		max-width: 100%;
+		width: 100%;
+
+		@include media( mobile ) {
+			max-width: 360px;
+			width: 50%;
+		}
 	}
 
 	&.aligncenter {
@@ -41,18 +57,6 @@
 		@include media(tablet) {
 			margin-left: 0;
 			margin-right: 0;
-		}
-	}
-
-	@include media( tablet ) {
-		&.wp-block-group.is-style-alignleft {
-			margin-top: #{ 0.5 * $size__spacing-unit };
-			margin-right: $size__spacing-unit;
-		}
-
-		&.wp-block-group.is-style-alignright {
-			margin-top: #{ 0.5 * $size__spacing-unit };
-			margin-left: $size__spacing-unit;
 		}
 	}
 }
@@ -1010,8 +1014,7 @@
 		}
 
 		&.alignleft,
-		&.wp-block-image .alignleft,
-		&.wp-block-group.is-style-alignleft {
+		&.wp-block-image .alignleft {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-right: calc(2 * #{$size__spacing-unit});
@@ -1029,8 +1032,7 @@
 		}
 
 		&.alignright,
-		&.wp-block-image .alignright,
-		&.wp-block-group.is-style-alignright {
+		&.wp-block-image .alignright {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-left: calc(2 * #{$size__spacing-unit});
@@ -1130,8 +1132,7 @@
 .page-template-default.singular.no-sidebar {
 	.entry .entry-content > * {
 		&.alignright,
-		&.wp-block-image .alignright,
-		&.wp-block-group.is-style-alignright {
+		&.wp-block-image .alignright {
 			@include media(mobile) {
 				/*rtl:ignore*/
 				margin-left: calc(2 * #{$size__spacing-unit});

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -313,6 +313,7 @@ figcaption,
 .wp-block[data-type="core/image"][data-align="right"].wp-block .block-editor-block-list__block-edit {
 	max-width: 50%;
 
+
 	.wp-block-image {
 		table-layout: fixed;
 		max-width: 100%;
@@ -510,6 +511,16 @@ figcaption,
 	.wp-block-pullquote {
 		padding-left: $size__spacing-unit;
 		padding-right: $size__spacing-unit;
+	}
+}
+
+/** === Group === */
+
+.wp-block[data-type="core/group"][data-align="left"] > .block-editor-block-list__block-edit,
+.wp-block[data-type="core/group"][data-align="right"] > .block-editor-block-list__block-edit {
+	@include media( mobile ) {
+		max-width: 390px;
+		width: 50%;
 	}
 }
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -518,6 +518,10 @@ figcaption,
 
 .wp-block[data-type="core/group"][data-align="left"] > .block-editor-block-list__block-edit,
 .wp-block[data-type="core/group"][data-align="right"] > .block-editor-block-list__block-edit {
+	.block-editor-block-list__block-edit {
+		margin-left: inherit;
+		margin-right: inherit;
+	}
 	@include media( mobile ) {
 		max-width: 390px;
 		width: 50%;

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -28,7 +28,8 @@
 		max-width: 1286px;
 	}
 
-	.edit-post-visual-editor .block-editor-block-list__block {
+	.edit-post-visual-editor .block-editor-block-list__block,
+	.edit-post-visual-editor .block-editor-default-block-appender {
 		margin-left: 0;
 	}
 
@@ -108,7 +109,8 @@ body.newspack-single-column-template {
 		}
 	}
 
-	.wp-block[data-align="left"] {
+	.wp-block[data-align="left"],
+	.wp-block-group.is-style-alignleft {
 		@include media( desktop ) {
 			left: #{-2 * $size__spacing-unit };
 		}
@@ -121,7 +123,8 @@ body.newspack-single-column-template {
 		left: auto;
 	}
 
-	.wp-block[data-align="right"] {
+	.wp-block[data-align="right"],
+	.wp-block-group.is-style-alignright {
 		@include media( desktop ) {
 			right: #{-2 * $size__spacing-unit };
 		}
@@ -135,26 +138,27 @@ body.newspack-single-column-template {
 	}
 }
 
-/** === Single Posts === */
+/** === Single Posts & Pages === */
 
-body.post-type-post {
+.newspack-default-template:not(.newspack-static-front-page) {
+
 	.editor-post-title__block {
 		max-width: 1200px;
+	}
 
-		.editor-post-title__input {
-			font-size: $font__size-xl;
+	.editor-post-title__input {
+		font-size: $font__size-xl;
 
-			@include media( mobile ) {
-				font-size: $font__size-xxl;
-			}
+		@include media( mobile ) {
+			font-size: $font__size-xxl;
+		}
 
-			@include media( tablet ) {
-				font-size: $font__size-xxxl;
-			}
+		@include media( tablet ) {
+			font-size: $font__size-xxxl;
+		}
 
-			@include media(desktop) {
-				font-size: $font__size-xxxxl;
-			}
+		@include media(desktop) {
+			font-size: $font__size-xxxxl;
 		}
 	}
 

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -26,6 +26,22 @@
 		margin-left: auto;
 		margin-right: auto;
 		max-width: 1286px;
+		width: 100%;
+
+		& > .wp-block {
+			max-width: 70%;
+		}
+
+		.block-editor-block-list__layout {
+			& > .wp-block {
+				max-width: 100%;
+			}
+
+			.block-editor-block-list__block {
+				padding-left: 10px;
+				padding-right: 0;
+			}
+		}
 	}
 
 	.edit-post-visual-editor .block-editor-block-list__block,
@@ -34,7 +50,8 @@
 	}
 
 	&.no-sidebar {
-		.wp-block[data-align="right"][data-type="core/group"] {
+		.wp-block[data-align="right"][data-type="core/group"],
+		.wp-block[data-align="right"][data-type="core/image"] {
 			& > .block-editor-block-list__block-edit {
 
 				@include media( desktop ) {
@@ -48,7 +65,6 @@
 		}
 	}
 }
-
 
 
 /** === One Column Templates === */

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -34,8 +34,7 @@
 	}
 
 	&.no-sidebar {
-		.wp-block[data-align=right],
-		.wp-block[data-type="core/image"][data-align="right"].wp-block {
+		.wp-block[data-align="right"][data-type="core/group"] {
 			& > .block-editor-block-list__block-edit {
 
 				@include media( desktop ) {

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -28,18 +28,20 @@
 		max-width: 1286px;
 		width: 100%;
 
-		& > .wp-block {
-			max-width: 70%;
-		}
-
-		.block-editor-block-list__layout {
+		@include media( tablet ) {
 			& > .wp-block {
-				max-width: 100%;
+				max-width: 70%;
 			}
 
-			.block-editor-block-list__block {
-				padding-left: 10px;
-				padding-right: 0;
+			.block-editor-block-list__layout {
+				& > .wp-block {
+					max-width: 100%;
+				}
+
+				.block-editor-block-list__block {
+					padding-left: 10px;
+					padding-right: 0;
+				}
 			}
 		}
 	}

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -108,7 +108,9 @@ body.newspack-single-column-template {
 			padding: 0 $size__spacing-unit;
 		}
 	}
+}
 
+body.newspack-single-column-template {
 	.wp-block[data-align="left"],
 	.wp-block-group.is-style-alignleft {
 		@include media( desktop ) {

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -34,24 +34,17 @@
 	}
 
 	&.no-sidebar {
-		.wp-block[data-align=right] .block-editor-block-list__block-edit,
-		.wp-block[data-type="core/image"][data-align="right"].wp-block .block-editor-block-list__block-edit{
-			@include media( tablet ) {
-				max-width: 40%;
-			}
+		.wp-block[data-align=right],
+		.wp-block[data-type="core/image"][data-align="right"].wp-block {
+			& > .block-editor-block-list__block-edit {
 
-			@include media( desktop ) {
-				margin-right: -50%;
-			}
-		}
+				@include media( desktop ) {
+					margin-right: -55%;
+				}
 
-		.wp-block-group.is-style-alignright {
-			@include media( tablet ) {
-				max-width: 40%;
-			}
-
-			@include media( desktop ) {
-				margin-right: calc( -50% + 34px );
+				@include media( tablet ) {
+					max-width: 50%;
+				}
 			}
 		}
 	}
@@ -111,8 +104,7 @@ body.newspack-single-column-template {
 }
 
 body.newspack-single-column-template {
-	.wp-block[data-align="left"],
-	.wp-block-group.is-style-alignleft {
+	.wp-block[data-align="left"] {
 		@include media( desktop ) {
 			left: #{-2 * $size__spacing-unit };
 		}
@@ -125,8 +117,7 @@ body.newspack-single-column-template {
 		left: auto;
 	}
 
-	.wp-block[data-align="right"],
-	.wp-block-group.is-style-alignright {
+	.wp-block[data-align="right"] {
 		@include media( desktop ) {
 			right: #{-2 * $size__spacing-unit };
 		}

--- a/sass/style-editor-overrides.scss
+++ b/sass/style-editor-overrides.scss
@@ -19,6 +19,45 @@
 	}
 }
 
+/** === Default template + no sidebar === */
+
+.newspack-default-template:not(.newspack-static-front-page) {
+	.block-editor-block-list__layout {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1286px;
+	}
+
+	.edit-post-visual-editor .block-editor-block-list__block {
+		margin-left: 0;
+	}
+
+	&.no-sidebar {
+		.wp-block[data-align=right] .block-editor-block-list__block-edit,
+		.wp-block[data-type="core/image"][data-align="right"].wp-block .block-editor-block-list__block-edit{
+			@include media( tablet ) {
+				max-width: 40%;
+			}
+
+			@include media( desktop ) {
+				margin-right: -50%;
+			}
+		}
+
+		.wp-block-group.is-style-alignright {
+			@include media( tablet ) {
+				max-width: 40%;
+			}
+
+			@include media( desktop ) {
+				margin-right: calc( -50% + 34px );
+			}
+		}
+	}
+}
+
+
+
 /** === One Column Templates === */
 
 @include media(desktop) {
@@ -101,6 +140,7 @@ body.newspack-single-column-template {
 body.post-type-post {
 	.editor-post-title__block {
 		max-width: 1200px;
+
 		.editor-post-title__input {
 			font-size: $font__size-xl;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is ultimately meant to be tested with https://github.com/Automattic/newspack-blocks/pull/138. 

It updates the left and right alignment styles to include the group block; it also sets up the theme so if you don't add any right sidebars, blocks aligned to the right will sit in the 'sidebar' area.

The screenshots show off the updates; 

**Posts:**

Post, default:

![image](https://user-images.githubusercontent.com/177561/66261719-5c7fee80-e787-11e9-9fc0-79a0c15fbe50.png)

Post, one column template:

![image](https://user-images.githubusercontent.com/177561/66261715-50942c80-e787-11e9-83d7-b0b872503da1.png)

Post, wide template:

![image](https://user-images.githubusercontent.com/177561/66261716-5558e080-e787-11e9-9fc0-707759972375.png)

**Pages:**

Page, default template, no sidebar widgets:

![image](https://user-images.githubusercontent.com/177561/66261703-2d697d00-e787-11e9-8a20-b91ade6206be.png)

Page, one column template:

![image](https://user-images.githubusercontent.com/177561/66261706-38241200-e787-11e9-8c20-d345673b52c9.png)

Page, wide template:

![image](https://user-images.githubusercontent.com/177561/66261710-3f4b2000-e787-11e9-8544-9925405d5b43.png)

**Mobile:**

As you scale down the page, the group block should act like other blocks, and become part of the content: 

![image](https://user-images.githubusercontent.com/177561/66261724-77526300-e787-11e9-8575-62ff07875ce6.png)

For mobile-sized screens, the group block should become full-width:

![image](https://user-images.githubusercontent.com/177561/66261728-876a4280-e787-11e9-9f33-36121f3b4452.png)

**Editor**

This PR also makes the 'default' editor content appear offset (like it is on the front-end); the right-aligned elements aren't exactly 1:1 to the front-end -- the styles are difficult to work with -- but hopefully it's close enough to get the correct effect:

![image](https://user-images.githubusercontent.com/177561/66261739-a36de400-e787-11e9-95bb-a97b4e546e30.png)

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Widgets, and remove all sidebar widgets.
3. Set up three pages and three posts; assign each one a different template (default, one column, one column wide). In each post/page, include regular text, and blocks aligned left and right. If you have the Group Block style available, include one of each alignment for that block, too.
4. View each post/page on the front-end; confirm it matches the screenshots in appearance.
5. Adjust the screen-size for each post/page; confirm there isn't any weirdness.
6. View each post/page in the editor; confirm it matches the screenshots in appearance.
7. Navigate to Customize > Widgets, and re-add a sidebar widget.
8. View the post and page that use the default widget, and confirm that the right-aligned blocks appear 'within' the content, don't overlap with the sidebar. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
