### PR TITLE
Cover block: Tighten up spacing on cover blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -520,16 +520,16 @@
 	.wp-block-cover {
 		position: relative;
 		min-height: 430px;
-		padding: $size__spacing-unit;
+		padding: $size__spacing-unit #{ 1.5 * $size__spacing-unit };
+
+		.wp-block-cover__inner-container {
+			width: 100%;
+		}
 
 		h2 {
 			max-width: 100%;
 			padding-left: 0;
 			text-align: left;
-		}
-
-		@include media(tablet) {
-			padding: $size__spacing-unit 10%;
 		}
 
 		a,
@@ -562,8 +562,6 @@
 			}
 
 			.wp-block-cover__inner-container {
-				width: 100%;
-
 				[class*="wp-block-"]:first-child {
 					margin-top: 0;
 				}
@@ -997,7 +995,7 @@
 			.wp-block-cover-image-text,
 			.wp-block-cover-text,
 			h2 {
-				@include postContentMaxWidth();
+				width: 100%;
 			}
 
 			@include media(tablet) {

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -174,6 +174,10 @@ figcaption,
 
 .wp-block-cover {
 
+	.wp-block-cover__inner-container {
+		width: 100%;
+	}
+
 	.entry-meta,
 	.entry-meta a,
 	.entry-meta a:visited,
@@ -189,8 +193,8 @@ figcaption,
 	}
 
 	@include media(tablet) {
-		padding-left: 5%;
-		padding-right: 5%;
+		padding-left: $size__spacing-unit;
+		padding-right: $size__spacing-unit;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I know this is a block I keep tweaking, but the more I see it in use, the more it seems to have too much padding.

This PR knocks back the left and right padding a bit more, freeing up more space in the block for content.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/c9SkrcvzcLF) into a post, and select the one-column template.
2. View on the front end; note the space around the cover blocks.

![image](https://user-images.githubusercontent.com/177561/66276150-e772ee80-e844-11e9-9332-7f4837b1d74d.png)

3. Apply the PR and run `npm run build`
4. Confirm that there is less space, on the front-end and in the editor; as part of that, also confirm things don't seem too tight. 

![image](https://user-images.githubusercontent.com/177561/66276137-c5796c00-e844-11e9-9bc5-ed06bb221e55.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
