### PR TITLE
Fix issue with custom colour inheritance in editor.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -439,7 +439,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .article-section-title,
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
 			.editor-block-list__layout .editor-block-list__block .accent-header {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
@@ -469,7 +469,7 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
-			.editor-block-list__layout .editor-block-list__block .article-section-title {
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
@@ -485,7 +485,7 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-4' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .accent-header,
-			.editor-block-list__layout .editor-block-list__block .article-section-title {
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is intended to be tested with https://github.com/Automattic/newspack-blocks/pull/139, or after that PR is merged.

It helps make sure the theme's custom colours don't override the colour you've picked for the article block, when previewed in the editor.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Custom Colours, and switch to a custom colour.
2. Add three article blocks; leave one with the default colours, give one a colour from the colour palette, and the third a custom colour from the colour picker. 
3. Note the appearance of the section title in the editor for the default style pack, style 3 and style 4. They use the primary colour for the section header, but when you set a custom colour on a block, that colour should be used instead -- but it's not:

**Style default** 
![image](https://user-images.githubusercontent.com/177561/66276845-5fdcae00-e84b-11e9-9d82-d2d7dfdf3115.png)

**Style 3**
![image](https://user-images.githubusercontent.com/177561/66276911-51db5d00-e84c-11e9-985c-082a101d1a52.png)

**Style 4**
![image](https://user-images.githubusercontent.com/177561/66276991-155c3100-e84d-11e9-9eb7-36d79dd21487.png)

4. Apply the PR and run `npm run build`.
5. Cycle through each of the above style packs and confirm that the section headers are now using their custom colours:

**Style default**
![image](https://user-images.githubusercontent.com/177561/66277065-0924a380-e84e-11e9-9edd-b2a9d852f751.png)

**Style 3**
![image](https://user-images.githubusercontent.com/177561/66277061-f01bf280-e84d-11e9-9311-9d537c129817.png)

**Style 4**
![image](https://user-images.githubusercontent.com/177561/66277028-8e5b8880-e84d-11e9-9422-76f3ed536b22.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
