### PR TITLE
Remove 'entry-summary' classes from block styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,7 +1,6 @@
 /* !Block styles */
 
-.entry .entry-content > *,
-.entry .entry-summary > * {
+.entry .entry-content > * {
 	margin: 32px 0;
 	max-width: 100%;
 
@@ -91,8 +90,7 @@
  * - Prevents layout styles from cascading too deeply
  * - helps with plugin compatibility
  */
-.entry .entry-content,
-.entry .entry-summary {
+.entry .entry-content {
 
 	.entry-content,
 	.entry-summary,
@@ -926,8 +924,7 @@
 
 //! 'Feature' alignments
 .post-template-single-feature {
-	.entry .entry-content > *,
-	.entry .entry-summary > * {
+	.entry .entry-content > * {
 		&.alignwide {
 			@include media( tablet ) {
 				margin-left: calc(25% - 25vw);

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -93,7 +93,6 @@
 .entry .entry-content {
 
 	.entry-content,
-	.entry-summary,
 	.entry {
 		margin: inherit;
 		max-width: inherit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme doesn't use the class `.entry-summary`, so the block styles referencing it aren't needed. 

This PR trims over 1.5KB from the generated style.css.

### How to test the changes in this Pull Request:

There isn't really anything to visually test here since I removed styles that aren't actually used; the following should help rule out this change causing new issues:

1. Apply the PR and run `npm run build`
2. Make sure there aren't any errors generating the CSS.
3. Confirm that only `.entry-summary` selectors were removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
