### PR TITLE
Paragraph Block: Simplify styles

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -279,7 +279,7 @@ function newspack_custom_colors_css() {
 				color: ' . $primary_color_contrast . ';
 			}
 
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.has-drop-cap:not(:focus)::first-letter {
 				border-color: ' . $primary_color . ';
 			}
 		';
@@ -324,7 +324,7 @@ function newspack_custom_colors_css() {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter {
+			.has-drop-cap:not(:focus)::first-letter {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -110,7 +110,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-1' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.has-drop-cap:not(:focus)::first-letter,
 			.entry .entry-content .wp-block-pullquote,
 			.entry .entry-content .wp-block-pullquote cite {
 				font-family: $font_header;
@@ -120,7 +120,7 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$css_blocks .= "
 			blockquote,
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description {
 				font-family: $font_header;
 			}";
@@ -128,7 +128,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-3' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description {
 				font-family: $font_header;
 			}";
@@ -136,7 +136,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-4' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description,
 			.entry .entry-content blockquote, .entry .entry-content blockquote cite, .entry .entry-content .wp-block-pullquote cite {
 				font-family: $font_header;

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -146,7 +146,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-5' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .has-drop-cap:not(:focus)::first-letter,
+			.has-drop-cap:not(:focus)::first-letter,
 			.entry .entry-content .wp-block-pullquote {
 				font-family: $font_header;
 			}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -109,6 +109,14 @@
 	}
 }
 
+//! Paragraphs
+.has-drop-cap:not(:focus)::first-letter {
+	font-size: 4em;
+	line-height: 0.75;
+	margin: 0.125em #{ 0.75 * $size__spacing-unit } 0 0;
+	position: relative;
+}
+
 .entry .entry-content {
 
 	//! Paragraphs
@@ -310,16 +318,6 @@
 		font-family: $font__body;
 		font-size: $font__size_base;
 		line-height: 1.8;
-	}
-
-	//! Paragraphs
-	.has-drop-cap {
-		&:not(:focus)::first-letter {
-			font-size: 4em;
-			line-height: 0.75;
-			margin: 0.125em #{ 0.75 * $size__spacing-unit } 0 0;
-			position: relative;
-		}
 	}
 
 	//! Pullquote

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -97,12 +97,13 @@
 
 /* Blocks */
 
-.entry .entry-content {
-	.has-drop-cap:not(:focus)::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
+}
 
+.entry .entry-content {
 	.wp-block-pullquote {
 		background-color: $color__background-body;
 		border-width: 0;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -307,6 +307,15 @@ blockquote {
 	}
 }
 
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	border: 7px solid $color__primary;
+	font-family: $font__heading;
+	font-weight: 800;
+	font-size: $font__size-xxl;
+	padding: 0.4em;
+}
+
 .entry .entry-content {
 
 	.wp-block-newspack-blocks-homepage-articles {
@@ -322,14 +331,6 @@ blockquote {
 				font-size: #{ 0.6 * $font__size_base };
 			}
 		}
-	}
-
-	.has-drop-cap:not(:focus)::first-letter {
-		border: 7px solid $color__primary;
-		font-family: $font__heading;
-		font-weight: 800;
-		font-size: $font__size-xxl;
-		padding: 0.4em;
 	}
 
 	.wp-block-pullquote {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -102,11 +102,10 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
-.entry .entry-content {
-	.has-drop-cap:not(:focus)::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
 }
 
 // Posts & Pages

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -122,16 +122,17 @@ figcaption,
 	}
 }
 
-.entry .entry-content {
-	.has-drop-cap:not(:focus)::first-letter {
-		background-color: $color__primary;
-		color: #fff;
-		font-family: $font__heading;
-		font-weight: bold;
-		font-size: $font__size-xxl;
-		padding: 0.4em;
-	}
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	background-color: $color__primary;
+	color: #fff;
+	font-family: $font__heading;
+	font-weight: bold;
+	font-size: $font__size-xxl;
+	padding: 0.4em;
+}
 
+.entry .entry-content {
 	blockquote,
 	cite {
 		font-family: $font__heading;

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -245,13 +245,14 @@ textarea {
 	}
 }
 
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
+}
+
 /* Blocks */
 .entry .entry-content {
-	.has-drop-cap:not(:focus)::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
-
 	.wp-block-separator,
 	hr {
 		background: transparent !important;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR starts the process of simplifying block styles one by one -- this one specifically deals with removing the `.entry .entry-content` selector from the paragraph styles.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add a paragraph to the editor and turn on 'drop caps'; publish the post.
3. Cycle through the following combinations to make sure the styles display correctly on the front end:

* **Default style pack**

<img width="856" alt="image" src="https://user-images.githubusercontent.com/177561/66364648-52a0eb80-e93f-11e9-928f-c8042b90c5eb.png">

* **Default style pack + custom header and body font** (suggest using a serif font for the header, and sans-serif font for the body - the dropcap should use the body font)

<img width="798" alt="image" src="https://user-images.githubusercontent.com/177561/66364682-6e0bf680-e93f-11e9-832f-bda8bdce132d.png">

* **Style 1**

<img width="817" alt="image" src="https://user-images.githubusercontent.com/177561/66364707-85e37a80-e93f-11e9-952b-1e9a0d086113.png">

* **Style 1 + custom header and body font**  (suggest using a serif font for the header, and sans-serif font for the body -- the dropcap should use the header font)

<img width="827" alt="image" src="https://user-images.githubusercontent.com/177561/66364746-a0b5ef00-e93f-11e9-94ae-733373be9e99.png">

* **Style 2**

<img width="797" alt="image" src="https://user-images.githubusercontent.com/177561/66364794-bcb99080-e93f-11e9-9fc7-6c1abfe1fdc0.png">

* **Style 2 + custom header and body font + custom colour** (suggest using two different serif fonts. The dropcap should use the primary colour, and the dropcap should use the header font).

<img width="816" alt="image" src="https://user-images.githubusercontent.com/177561/66364837-df4ba980-e93f-11e9-8536-ac9d6e558425.png">

* **Style 3**

<img width="826" alt="image" src="https://user-images.githubusercontent.com/177561/66364864-f4c0d380-e93f-11e9-808c-8553c5c7b136.png">

* **Style 3 + custom header and body font** (use two serif fonts, or fonts noticeably different than the current sans-serif font. The dropcap should use your header font).

<img width="823" alt="image" src="https://user-images.githubusercontent.com/177561/66364920-233eae80-e940-11e9-9025-2744cfbd69ac.png">

* **Style 4**

<img width="828" alt="image" src="https://user-images.githubusercontent.com/177561/66364960-3baec900-e940-11e9-98d5-825b9e31fb04.png">

* **Style 4 + custom header and body font + custom colour.** (Use two different sans-serif fonts; the dropcap should use the primary colour and the header font):

<img width="843" alt="image" src="https://user-images.githubusercontent.com/177561/66364991-5bde8800-e940-11e9-8e10-dff9a82b7164.png">

**Style 5**

![image](https://user-images.githubusercontent.com/177561/66419669-55402700-e9b9-11e9-90be-8ec621e14c27.png)

**Style 5 + custom header and body font** (use two different sans-serif fonts; the dropcap should use your header font):

![image](https://user-images.githubusercontent.com/177561/66419722-6db04180-e9b9-11e9-985e-5734af504763.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
