### PR TITLE
Pullquote block: Simplify style selectors

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -248,7 +248,7 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.entry .entry-content .wp-block-pullquote blockquote p:first-of-type:before {
+			.wp-block-pullquote blockquote p:first-of-type:before {
 				color: ' . $primary_color . ';
 			}
 

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -322,7 +322,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-5' ) ) {
 			$css_blocks .= "
-			.entry .entry-content .wp-block-pullquote cite {
+			.wp-block-pullquote cite {
 				font-family: $font_body;
 			}";
 		}

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -119,8 +119,8 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'style-1' ) ) {
 			$css_blocks .= "
 			.has-drop-cap:not(:focus)::first-letter,
-			.entry .entry-content .wp-block-pullquote,
-			.entry .entry-content .wp-block-pullquote cite {
+			.wp-block-pullquote,
+			.wp-block-pullquote cite {
 				font-family: $font_header;
 			}";
 		}
@@ -147,7 +147,7 @@ function newspack_custom_typography_css() {
 			.site-description,
 			.has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description,
-			.entry .entry-content blockquote, .entry .entry-content blockquote cite, .entry .entry-content .wp-block-pullquote cite {
+			.entry .entry-content blockquote, .entry .entry-content blockquote cite, .wp-block-pullquote cite {
 				font-family: $font_header;
 			}
 			";
@@ -382,7 +382,7 @@ function newspack_custom_typography_css() {
 				.page-title,
 				#secondary .widget-title,
 				.author-bio .accent-header span,
-				.entry .entry-content .wp-block-pullquote cite,
+				.wp-block-pullquote cite,
 				#colophon .widget-title {
 					text-transform: uppercase;
 				}
@@ -407,7 +407,7 @@ function newspack_custom_typography_css() {
 				.entry-meta .byline a,
 				.tags-links a,
 				.post-edit-link,
-				.entry .entry-content .wp-block-pullquote cite,
+				.wp-block-pullquote cite,
 				.author-bio h2 span,
 				.site-footer .widget-title {
 					letter-spacing: 0.05em;
@@ -434,7 +434,7 @@ function newspack_custom_typography_css() {
 				.author-bio h2 span,
 				.entry-meta .byline a,
 				.entry-meta .entry-date,
-				.entry .entry-content .wp-block-pullquote cite,
+				.wp-block-pullquote cite,
 				.site-footer .widget-title,
 				.site-info {
 					text-transform: uppercase;

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -382,15 +382,13 @@ function newspack_custom_typography_css() {
 				.page-title,
 				#secondary .widget-title,
 				.author-bio .accent-header span,
-				.wp-block-pullquote cite,
 				#colophon .widget-title {
 					text-transform: uppercase;
 				}
 			';
 			$editor_css_blocks .= '
 				.editor-block-list__layout .editor-block-list__block .accent-header,
-				.editor-block-list__layout .editor-block-list__block .article-section-title,
-				.editor-block-list__layout .editor-block-list__block .wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation {
+				.editor-block-list__layout .editor-block-list__block .article-section-title {
 					text-transform: uppercase;
 				}
 			';
@@ -407,7 +405,6 @@ function newspack_custom_typography_css() {
 				.entry-meta .byline a,
 				.tags-links a,
 				.post-edit-link,
-				.wp-block-pullquote cite,
 				.author-bio h2 span,
 				.site-footer .widget-title {
 					letter-spacing: 0.05em;
@@ -418,8 +415,7 @@ function newspack_custom_typography_css() {
 				.editor-block-list__layout .editor-block-list__block .accent-header,
 				.editor-block-list__layout .editor-block-list__block .article-section-title,
 				.editor-block-list__layout .editor-block-list__block .entry-meta .byline a,
-				.editor-block-list__layout .editor-block-list__block .cat-links,
-				.editor-block-list__layout .editor-block-list__block .wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation {
+				.editor-block-list__layout .editor-block-list__block .cat-links {
 					letter-spacing: 0.05em;
 					text-transform: uppercase;
 				}
@@ -434,7 +430,6 @@ function newspack_custom_typography_css() {
 				.author-bio h2 span,
 				.entry-meta .byline a,
 				.entry-meta .entry-date,
-				.wp-block-pullquote cite,
 				.site-footer .widget-title,
 				.site-info {
 					text-transform: uppercase;
@@ -444,8 +439,7 @@ function newspack_custom_typography_css() {
 				.editor-block-list__layout .editor-block-list__block .accent-header,
 				.editor-block-list__layout .editor-block-list__block .article-section-title,
 				.editor-block-list__layout .editor-block-list__block .entry-meta .byline a,
-				.editor-block-list__layout .editor-block-list__block .entry-meta .entry-date,
-				.editor-block-list__layout .editor-block-list__block .wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation {
+				.editor-block-list__layout .editor-block-list__block .entry-meta .entry-date {
 					text-transform: uppercase;
 				}
 			';

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -160,6 +160,7 @@
 	}
 }
 
+
 //! Paragraphs
 .has-drop-cap:not(:focus)::first-letter {
 	font-size: 4em;
@@ -167,7 +168,6 @@
 	margin: 0.125em #{ 0.75 * $size__spacing-unit } 0 0;
 	position: relative;
 }
-
 
 //! Newspack Article Block
 .wpnbha {
@@ -279,6 +279,129 @@
 		min-height: 330px;
 		padding-left: $size__spacing-unit;
 		padding-right: $size__spacing-unit;
+	}
+}
+
+//! Pullquote
+.wp-block-pullquote {
+	border-color: transparent;
+	border-width: 4px 0 2px;
+	color: inherit;
+	padding: $size__spacing-unit 0;
+	text-align: left;
+
+	blockquote {
+		border: none;
+		margin: $size__spacing-unit 0 calc(1.25 * #{ $size__spacing-unit});
+		padding-left: 0;
+	}
+
+	p {
+		font-size: $font__size-md;
+		font-style: italic;
+		line-height: 1.3;
+		margin-bottom: 0.5em;
+		margin-top: 0.5em;
+
+
+		em {
+			font-style: normal;
+		}
+
+		@include media(tablet) {
+			font-size: $font__size-lg;
+		}
+	}
+
+	cite {
+		display: inline-block;
+		font-family: $font__heading;
+		line-height: 1.6;
+		text-transform: none;
+		font-size: $font__size-xs;
+
+		&:before {
+			content: "\2014";
+			margin-right: #{ 0.25 * $size__spacing-unit };
+		}
+	}
+
+	&.alignleft,
+	&.alignright {
+		padding: 0;
+		width: 100%;
+
+		@include media(mobile) {
+			border-bottom-width: 0;
+			width: 50%;
+		}
+
+		blockquote {
+			margin: $size__spacing-unit 0;
+			padding: 0;
+			text-align: left;
+			max-width: 100%;
+
+			p {
+				font-size: 1rem;
+
+				@include media(tablet) {
+					font-size: $font__size-md;
+				}
+
+				&:first-child {
+					margin-top: 0;
+				}
+			}
+		}
+	}
+
+	&.is-style-solid-color {
+		background-color: $color__primary;
+		padding-left: 0;
+		padding-right: 0;
+
+		@include media(tablet) {
+			padding-left: #{ 1.5 * $size__spacing-unit };
+			padding-right: #{ 1.5 * $size__spacing-unit };
+		}
+
+		a {
+			color: $color__background-body;
+		}
+
+		cite {
+			color: inherit;
+		}
+
+		blockquote {
+			max-width: 100%;
+			padding-left: 0;
+			margin-left: $size__spacing-unit;
+			margin-right: $size__spacing-unit;
+
+			&.has-text-color p,
+			&.has-text-color a,
+			&.has-primary-color,
+			&.has-primary-variation-color,
+			&.has-secondary-color,
+			&.has-secondary-variation-color,
+			&.has-white-color {
+				color: inherit;
+			}
+
+			@include media(tablet) {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+
+		&.alignright,
+		&.alignleft {
+			@include media(tablet) {
+				padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
+			}
+		}
 	}
 }
 
@@ -483,130 +606,6 @@
 		font-family: $font__body;
 		font-size: $font__size_base;
 		line-height: 1.8;
-	}
-
-	//! Pullquote
-	.wp-block-pullquote {
-		border-color: transparent;
-		border-width: 4px 0 2px;
-		color: inherit;
-		padding: $size__spacing-unit 0;
-		text-align: left;
-
-		blockquote {
-			border: none;
-			margin: $size__spacing-unit 0 calc(1.25 * #{ $size__spacing-unit});
-			padding-left: 0;
-		}
-
-		p {
-			font-size: $font__size-md;
-			font-style: italic;
-			line-height: 1.3;
-			margin-bottom: 0.5em;
-			margin-top: 0.5em;
-
-
-			em {
-				font-style: normal;
-			}
-
-			@include media(tablet) {
-				font-size: $font__size-lg;
-			}
-		}
-
-		cite {
-			display: inline-block;
-			font-family: $font__heading;
-			line-height: 1.6;
-			text-transform: none;
-			font-size: $font__size-xs;
-
-			&:before {
-				content: "\2014";
-				margin-right: #{ 0.25 * $size__spacing-unit };
-			}
-		}
-
-		&.alignleft,
-		&.alignright {
-			padding: 0;
-			width: 100%;
-
-			@include media(mobile) {
-				border-bottom-width: 0;
-				width: 50%;
-			}
-
-			blockquote {
-				margin: $size__spacing-unit 0;
-				padding: 0;
-				text-align: left;
-				max-width: 100%;
-
-				p {
-					font-size: 1rem;
-
-					@include media(tablet) {
-						font-size: $font__size-md;
-					}
-
-					&:first-child {
-						margin-top: 0;
-					}
-				}
-			}
-		}
-
-		&.is-style-solid-color {
-			background-color: $color__primary;
-			padding-left: 0;
-			padding-right: 0;
-
-			@include media(tablet) {
-				padding-left: #{ 1.5 * $size__spacing-unit };
-				padding-right: #{ 1.5 * $size__spacing-unit };
-			}
-
-			a {
-				color: $color__background-body;
-			}
-
-			cite {
-				color: inherit;
-			}
-
-			blockquote {
-				max-width: 100%;
-				padding-left: 0;
-				margin-left: $size__spacing-unit;
-				margin-right: $size__spacing-unit;
-
-				&.has-text-color p,
-				&.has-text-color a,
-				&.has-primary-color,
-				&.has-primary-variation-color,
-				&.has-secondary-color,
-				&.has-secondary-variation-color,
-				&.has-white-color {
-					color: inherit;
-				}
-
-				@include media(tablet) {
-					margin-left: 0;
-					margin-right: 0;
-				}
-			}
-
-			&.alignright,
-			&.alignleft {
-				@include media(tablet) {
-					padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
-				}
-			}
-
-		}
 	}
 
 	//! Blockquote

--- a/newspack-theme/sass/styles/style-1/style-1-editor.scss
+++ b/newspack-theme/sass/styles/style-1/style-1-editor.scss
@@ -132,6 +132,7 @@ Newspack Theme Editor Styles - Style Pack 1
 	.wp-block-pullquote__citation {
 		font-size: $font__size-sm;
 		font-weight: normal;
+		text-transform: uppercase;
 	}
 
 	&[data-align="left"] .wp-block-pullquote,

--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -106,7 +106,6 @@
 
 //! Pullquote
 .wp-block-pullquote {
-	background-color: $color__background-body;
 	border-width: 0;
 	border-color: transparent;
 	font-family: $font__heading;
@@ -151,7 +150,7 @@
 			display: inline-block;
 			font-size: calc( 1rem * 5 );
 			font-weight: normal;
-			left: calc( 50% - 0.25em );
+			left: calc( 50% - 0.3em );
 			line-height: 0.75;
 			position: absolute;
 			text-align: center;
@@ -228,15 +227,6 @@
 			blockquote:before {
 				left: 4em;
 			}
-		}
-	}
-}
-
-.entry .entry-content {
-	.wp-block-cover,
-	.wp-block-group {
-		.wp-block-pullquote {
-			background-color: transparent;
 		}
 	}
 }

--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -165,9 +165,18 @@
 	}
 
 	&.is-style-solid-color {
-		blockquote:before,
-		blockquote:after {
-			border-top-color: currentColor;
+
+		blockquote {
+			text-align: center;
+
+			&:before,
+			&:after {
+				border-top-color: currentColor;
+			}
+
+			cite {
+				text-transform: uppercase;
+			}
 		}
 
 		p:first-of-type:before {
@@ -192,6 +201,10 @@
 
 	&.alignleft,
 	&.alignright {
+		blockquote {
+			text-align: left;
+		}
+
 		&,
 		&.is-style-solid-color {
 			padding-top: #{ 3 * $size__spacing-unit };

--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -233,11 +233,6 @@
 }
 
 .entry .entry-content {
-	.has-drop-cap:not(:focus)::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
-
 	.wp-block-cover,
 	.wp-block-group {
 		.wp-block-pullquote {

--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -173,10 +173,6 @@
 			&:after {
 				border-top-color: currentColor;
 			}
-
-			cite {
-				text-transform: uppercase;
-			}
 		}
 
 		p:first-of-type:before {
@@ -187,15 +183,22 @@
 	cite {
 		font-size: $font__size-sm;
 		font-weight: normal;
+		text-transform: uppercase;
 	}
 
 	&.is-style-solid-color {
-		blockquote:before {
-			color: inherit;
-		}
+		blockquote{
+			&:before {
+				color: inherit;
+			}
 
-		blockquote:after {
-			border-top-color: currentColor;
+			&:after {
+				border-top-color: currentColor;
+			}
+
+			cite {
+				text-transform: uppercase;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -97,138 +97,145 @@
 
 /* Blocks */
 
+
 //! Paragraph
 .has-drop-cap:not(:focus)::first-letter {
 	font-family: $font__heading;
 	font-weight: bold;
 }
 
-.entry .entry-content {
-	.wp-block-pullquote {
-		background-color: $color__background-body;
-		border-width: 0;
-		border-color: transparent;
-		font-family: $font__heading;
-		font-weight: bold;
-		padding-top: #{ 4 * $size__spacing-unit };
-		position: relative;
+//! Pullquote
+.wp-block-pullquote {
+	background-color: $color__background-body;
+	border-width: 0;
+	border-color: transparent;
+	font-family: $font__heading;
+	font-weight: bold;
+	padding-top: #{ 4 * $size__spacing-unit };
+	position: relative;
+
+	p {
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
+	blockquote {
+		border-color: inherit;
+		text-align: center;
+
+		&:before,
+		&:after {
+			border-top: 2px solid;
+			border-color: inherit;
+			content: "";
+			display: block;
+			position: absolute;
+			opacity: 0.8;
+			top: #{ 2 * $size__spacing-unit };
+		}
+
+		&:before {
+			left: 15%;
+			right: calc( 50% + 2em);
+		}
+
+		&:after {
+			left: calc( 50% + 2em);
+			right: 15%;
+		}
+
+		p:first-of-type:before {
+			color: $color__primary;
+			content: "\201C";
+			display: inline-block;
+			font-size: calc( 1rem * 5 );
+			font-weight: normal;
+			left: calc( 50% - 0.25em );
+			line-height: 0.75;
+			position: absolute;
+			text-align: center;
+			top: #{ 1.5 * $size__spacing-unit };
+			width: 0.5em;
+			z-index: 1;
+
+			@include media( tablet ) {
+				font-size: calc( 1rem * 7 );
+			}
+		}
+	}
+
+	&.is-style-solid-color {
+		blockquote:before,
+		blockquote:after {
+			border-top-color: currentColor;
+		}
+
+		p:first-of-type:before {
+			color: inherit;
+		}
+	}
+
+	cite {
+		font-size: $font__size-sm;
+		font-weight: normal;
+	}
+
+	&.is-style-solid-color {
+		blockquote:before {
+			color: inherit;
+		}
+
+		blockquote:after {
+			border-top-color: currentColor;
+		}
+	}
+
+	&.alignleft,
+	&.alignright {
+		&,
+		&.is-style-solid-color {
+			padding-top: #{ 3 * $size__spacing-unit };
+		}
 
 		p {
-			@include media( tablet ) {
-				font-size: $font__size-xl;
+			font-size: $font__size-md;
+
+				&:first-of-type:before {
+				font-size: calc( 1rem * 5 );
+				left: 0;
+				text-align: left;
+				width: 0.5em;
 			}
 		}
 
 		blockquote {
-			border-color: inherit;
-			text-align: center;
-
-			&:before,
-			&:after {
-				border-top: 2px solid;
-				border-color: inherit;
-				content: "";
-				display: block;
-				position: absolute;
-				opacity: 0.8;
-				top: #{ 2 * $size__spacing-unit };
-			}
-
 			&:before {
-				left: 15%;
-				right: calc( 50% + 2em);
-			}
-
-			&:after {
-				left: calc( 50% + 2em);
+				left: 3em;
 				right: 15%;
 			}
 
-			p:first-of-type:before {
-				color: $color__primary;
-				content: "\201C";
-				display: inline-block;
-				font-size: calc( 1rem * 5 );
-				font-weight: normal;
-				left: calc( 50% - 0.25em );
-				line-height: 0.75;
-				position: absolute;
-				text-align: center;
-				top: #{ 1.5 * $size__spacing-unit };
-				width: 0.5em;
-				z-index: 1;
-
-				@include media( tablet ) {
-					font-size: calc( 1rem * 7 );
-				}
+			&:after {
+				display: none;
 			}
 		}
 
 		&.is-style-solid-color {
-			blockquote:before,
-			blockquote:after {
-				border-top-color: currentColor;
-			}
-
 			p:first-of-type:before {
-				color: inherit;
+				left: #{ 1.5 * $size__spacing-unit };
 			}
-		}
 
-		cite {
-			font-size: $font__size-sm;
-			font-weight: normal;
-		}
-
-		&.is-style-solid-color {
 			blockquote:before {
-				color: inherit;
-			}
-
-			blockquote:after {
-				border-top-color: currentColor;
+				left: 4em;
 			}
 		}
+	}
+}
 
-		&.alignleft,
-		&.alignright {
-			&,
-			&.is-style-solid-color {
-				padding-top: #{ 3 * $size__spacing-unit };
-			}
-
-			p {
-				font-size: $font__size-md;
-
-					&:first-of-type:before {
-					font-size: calc( 1rem * 5 );
-					left: 0;
-					text-align: left;
-					width: 0.5em;
-				}
-			}
-
-			blockquote {
-				&:before {
-					left: 3em;
-					right: 15%;
-				}
-
-				&:after {
-					display: none;
-				}
-			}
-
-			&.is-style-solid-color {
-				p:first-of-type:before {
-					left: #{ 1.5 * $size__spacing-unit };
-				}
-
-				blockquote:before {
-					left: 4em;
-				}
-			}
-		}
+.entry .entry-content {
+	.has-drop-cap:not(:focus)::first-letter {
+		font-family: $font__heading;
+		font-weight: bold;
 	}
 
 	.wp-block-cover,

--- a/newspack-theme/sass/styles/style-2/style-2-editor.scss
+++ b/newspack-theme/sass/styles/style-2/style-2-editor.scss
@@ -93,7 +93,9 @@ blockquote {
 
 	.wp-block-pullquote__citation {
 		font-weight: bold;
+		letter-spacing: 0.05em;
 		opacity: 0.9;
+		text-transform: uppercase;
 	}
 
 	&[data-align="left"] .wp-block-pullquote,

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -341,63 +341,13 @@ blockquote {
 			width: 75%;
 		}
 
-		&.is-solid-color:before {
+		&.is-style-solid-color:before {
 			display: none;
 		}
 	}
 }
 
 .entry .entry-content {
-
-	.wp-block-pullquote {
-		border-width: 16px 0 4px;
-
-		blockquote {
-			margin: #{ 2 * $size__spacing-unit } 0;
-
-			p {
-				font-size: $font__size-lg;
-				font-style: normal;
-
-				@include media( tablet ) {
-					font-size: $font__size-xl;
-				}
-			}
-		}
-
-		cite {
-			font-weight: bold;
-			letter-spacing: 0.05em;
-			opacity: 0.9;
-		}
-
-		&.alignleft,
-		&.alignright {
-			border-width: 0;
-			position: relative;
-			margin-top: #{ 1.5 * $size__spacing-unit };
-			margin-bottom: #{ 1.5 * $size__spacing-unit };
-
-			@include media( tablet ) {
-				p {
-					font-size: $font__size-lg;
-				}
-			}
-
-			&:before {
-				border-color: inherit;
-				border-width: 10px 0 0;
-				border-style: solid;
-				content: "";
-				display: block;
-				width: 75%;
-			}
-
-			&.is-solid-color:before {
-				display: none;
-			}
-		}
-	}
 
 	.wp-block-separator {
 		border-top: 2px solid $color__text-main;
@@ -409,6 +359,10 @@ blockquote {
 		&.is-style-dots::before {
 			color: $color__text-main;
 		}
+	}
+
+	.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
+		border-top: 5px solid $color__text-main;
 	}
 }
 

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -319,6 +319,10 @@ blockquote {
 		opacity: 0.9;
 	}
 
+	&.is-style-solid-color blockquote cite {
+		text-transform: uppercase;
+	}
+
 	&.alignleft,
 	&.alignright {
 		border-width: 0;

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -319,6 +319,7 @@ blockquote {
 		opacity: 0.9;
 	}
 
+	cite,
 	&.is-style-solid-color blockquote cite {
 		text-transform: uppercase;
 	}

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -279,6 +279,7 @@ blockquote {
 	font-weight: 800;
 }
 
+
 //! Newspack Article Block
 .wpnbha {
 	 article .entry-meta {
@@ -291,6 +292,57 @@ blockquote {
 	&.type-scale4 {
 		article .entry-meta {
 			font-size: #{ 0.6 * $font__size_base };
+		}
+	}
+}
+
+//! Pullquote
+.wp-block-pullquote {
+	border-width: 16px 0 4px;
+
+	blockquote {
+		margin: #{ 2 * $size__spacing-unit } 0;
+
+		p {
+			font-size: $font__size-lg;
+			font-style: normal;
+
+			@include media( tablet ) {
+				font-size: $font__size-xl;
+			}
+		}
+	}
+
+	cite {
+		font-weight: bold;
+		letter-spacing: 0.05em;
+		opacity: 0.9;
+	}
+
+	&.alignleft,
+	&.alignright {
+		border-width: 0;
+		position: relative;
+		margin-top: #{ 1.5 * $size__spacing-unit };
+		margin-bottom: #{ 1.5 * $size__spacing-unit };
+
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-lg;
+			}
+		}
+
+		&:before {
+			border-color: inherit;
+			border-width: 10px 0 0;
+			border-style: solid;
+			content: "";
+			display: block;
+			width: 75%;
+		}
+
+		&.is-solid-color:before {
+			display: none;
 		}
 	}
 }

--- a/newspack-theme/sass/styles/style-3/style-3-editor.scss
+++ b/newspack-theme/sass/styles/style-3/style-3-editor.scss
@@ -105,6 +105,7 @@ Newspack Theme Editor Styles - Style Pack 3
 	.wp-block-pullquote__citation {
 		font-weight: bold;
 		opacity: 0.6;
+		text-transform: uppercase;
 	}
 
 	&[data-align="left"],

--- a/newspack-theme/sass/styles/style-3/style-3.scss
+++ b/newspack-theme/sass/styles/style-3/style-3.scss
@@ -249,6 +249,10 @@ figcaption,
 		color: $color__text-light;
 	}
 
+	&.is-style-solid-color blockquote cite {
+		text-transform: uppercase;
+	}
+
 	&:not(.is-style-solid-color) {
 
 		blockquote {

--- a/newspack-theme/sass/styles/style-3/style-3.scss
+++ b/newspack-theme/sass/styles/style-3/style-3.scss
@@ -249,6 +249,7 @@ figcaption,
 		color: $color__text-light;
 	}
 
+	cite,
 	&.is-style-solid-color blockquote cite {
 		text-transform: uppercase;
 	}

--- a/newspack-theme/sass/styles/style-3/style-3.scss
+++ b/newspack-theme/sass/styles/style-3/style-3.scss
@@ -221,10 +221,126 @@ figcaption,
 	display: none;
 }
 
+
 //! Columns Block
 .wp-block-columns.is-style-borders .wp-block-column:after {
 	border-style: dotted;
 	border-color: $color__text-main;
+}
+
+//! Pullquote
+.wp-block-pullquote {
+	border-width: 0;
+	position: relative;
+
+	blockquote {
+		font-weight: bold;
+		p {
+			font-style: normal;
+			font-size: $font__size-lg;
+
+			@include media( tablet ) {
+				font-size: $font__size-xl;
+			}
+		}
+	}
+
+	cite {
+		color: $color__text-light;
+	}
+
+	&:not(.is-style-solid-color) {
+
+		blockquote {
+			padding-left: #{ 2 * $size__spacing-unit };
+		}
+
+		&:before {
+			border-top: 8px solid;
+			border-left: 8px solid;
+			border-color: inherit;
+			content: "";
+			display: block;
+			height: 40px;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 40px;
+		}
+	}
+
+	&.alignleft,
+	&.alignright {
+
+		@include media( tablet ) {
+			blockquote p {
+				font-size: $font__size-lg;
+			}
+		}
+
+		&:not(.is-style-solid-color) {
+			padding-top: $size__spacing-unit;
+
+			blockquote {
+				padding-left: 0;
+			}
+
+			&:before {
+				border-left: 0;
+			}
+		}
+	}
+
+	&.alignfull:not(.is-style-solid-color):before {
+		left: 8px;
+	}
+}
+
+//! Paragraph
+.has-drop-cap:not(:focus)::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
+}
+
+//! Newspack Article Block
+.wpnbha.is-style-borders article {
+	border-bottom-style: dotted;
+	border-bottom-color: $color__text-main;
+}
+
+.wpnbha.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
+	background-color: $color__background-body;
+	margin-top: -1.5em;
+	padding: 0.5em 0.25em 0 0;
+	position: relative;
+	width: 85%;
+	z-index: 1;
+}
+
+.wpnbha figcaption:after {
+	display: none;
+}
+
+.wpnbha .cat-links {
+	&:before {
+		display: none;
+	}
+
+	a,
+	a:visited,
+	a:hover {
+		color: $color__text-light;
+	}
+}
+
+.wp-block-cover,
+.wp-block-group {
+	.wpnbha.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
+		background-color: transparent;
+		margin-top: 0;
+		padding: 0;
+		width: auto;
+	}
 }
 
 .entry .entry-content {
@@ -239,73 +355,6 @@ figcaption,
 		text-align: left;
 	}
 
-	.wp-block-pullquote {
-		border-width: 0;
-		position: relative;
-
-		blockquote {
-			font-weight: bold;
-			p {
-				font-style: normal;
-				font-size: $font__size-lg;
-
-				@include media( tablet ) {
-					font-size: $font__size-xl;
-				}
-			}
-		}
-
-		cite {
-			color: $color__text-light;
-		}
-
-		&:not(.is-style-solid-color) {
-
-			blockquote {
-				padding-left: #{ 2 * $size__spacing-unit };
-			}
-
-			&:before {
-				border-top: 8px solid;
-				border-left: 8px solid;
-				border-color: inherit;
-				content: "";
-				display: block;
-				height: 40px;
-				left: 0;
-				position: absolute;
-				top: 0;
-				width: 40px;
-			}
-		}
-
-		&.alignleft,
-		&.alignright {
-
-			@include media( tablet ) {
-				blockquote p {
-					font-size: $font__size-lg;
-				}
-			}
-
-			&:not(.is-style-solid-color) {
-				padding-top: $size__spacing-unit;
-
-				blockquote {
-					padding-left: 0;
-				}
-
-				&:before {
-					border-left: 0;
-				}
-			}
-		}
-
-		&.alignfull:not(.is-style-solid-color):before {
-			left: 8px;
-		}
-	}
-
 	.wp-block-separator,
 	hr {
 		border-top: 1px dotted $color__text-main;
@@ -315,19 +364,6 @@ figcaption,
 	.jp-relatedposts-i2 {
 		border-top: 1px dotted $color__text-main;
 		border-bottom: 1px dotted $color__text-main;
-	}
-}
-
-//! Newspack
-.wpnbha .cat-links {
-	&:before {
-		display: none;
-	}
-
-	a,
-	a:visited,
-	a:hover {
-		color: $color__text-light;
 	}
 }
 

--- a/newspack-theme/sass/styles/style-4/style-4.scss
+++ b/newspack-theme/sass/styles/style-4/style-4.scss
@@ -131,6 +131,7 @@ figcaption,
 	}
 }
 
+
 //! Paragraph
 .has-drop-cap:not(:focus)::first-letter {
 	background-color: $color__primary;
@@ -139,6 +140,38 @@ figcaption,
 	font-weight: bold;
 	font-size: $font__size-xxl;
 	padding: 0.4em;
+}
+
+//! Pullquote
+
+.wp-block-pullquote {
+	border-width: 2px 0;
+
+	blockquote {
+		p {
+			font-size: $font__size-lg;
+
+			@include media( tablet ) {
+				font-size: $font__size-xl;
+			}
+		}
+	}
+
+	cite {
+		font-style: italic;
+	}
+
+	&.alignleft,
+	&.alignright {
+		margin-top: #{ 1.5 * $size__spacing-unit };
+		margin-bottom: #{ 1.5 * $size__spacing-unit };
+
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-lg;
+			}
+		}
+	}
 }
 
 .entry .entry-content {
@@ -151,36 +184,6 @@ figcaption,
 		em,
 		i {
 			font-style: normal;
-		}
-	}
-
-	.wp-block-pullquote {
-		border-width: 2px 0;
-
-		blockquote {
-			p {
-				font-size: $font__size-lg;
-
-				@include media( tablet ) {
-					font-size: $font__size-xl;
-				}
-			}
-		}
-
-		cite {
-			font-style: italic;
-		}
-
-		&.alignleft,
-		&.alignright {
-			margin-top: #{ 1.5 * $size__spacing-unit };
-			margin-bottom: #{ 1.5 * $size__spacing-unit };
-
-			@include media( tablet ) {
-				p {
-					font-size: $font__size-lg;
-				}
-			}
 		}
 	}
 }

--- a/newspack-theme/sass/styles/style-4/style-4.scss
+++ b/newspack-theme/sass/styles/style-4/style-4.scss
@@ -131,6 +131,17 @@ figcaption,
 	}
 }
 
+blockquote,
+cite {
+	font-family: $font__heading;
+	font-style: italic;
+	text-align: center;
+
+	em,
+	i {
+		font-style: normal;
+	}
+}
 
 //! Paragraph
 .has-drop-cap:not(:focus)::first-letter {

--- a/newspack-theme/sass/styles/style-4/style-4.scss
+++ b/newspack-theme/sass/styles/style-4/style-4.scss
@@ -173,29 +173,22 @@ cite {
 		font-style: italic;
 	}
 
+	&.is-style-solid-color blockquote {
+		text-align: center;
+	}
+
 	&.alignleft,
 	&.alignright {
 		margin-top: #{ 1.5 * $size__spacing-unit };
 		margin-bottom: #{ 1.5 * $size__spacing-unit };
+		blockquote {
+			text-align: left;
+		}
 
 		@include media( tablet ) {
 			p {
 				font-size: $font__size-lg;
 			}
-		}
-	}
-}
-
-.entry .entry-content {
-	blockquote,
-	cite {
-		font-family: $font__heading;
-		font-style: italic;
-		text-align: center;
-
-		em,
-		i {
-			font-style: normal;
 		}
 	}
 }

--- a/newspack-theme/sass/styles/style-4/style-4.scss
+++ b/newspack-theme/sass/styles/style-4/style-4.scss
@@ -168,6 +168,7 @@ cite {
 		}
 	}
 
+	&.is-style-solid-color blockquote cite,
 	cite {
 		font-style: italic;
 	}

--- a/newspack-theme/sass/styles/style-5/style-5-editor.scss
+++ b/newspack-theme/sass/styles/style-5/style-5-editor.scss
@@ -88,6 +88,19 @@
 		font-size: $font__size-base;
 		font-weight: normal;
 	}
+
+	&[data-align="left"],
+	&[data-align="right"] {
+		blockquote {
+			text-align: left;
+		}
+
+		@include media( tablet ) {
+			.wp-block-pullquote p {
+				font-size: $font__size-md;
+			}
+		}
+	}
 }
 
 /* Newspack Homepage Articles */

--- a/newspack-theme/sass/styles/style-5/style-5.scss
+++ b/newspack-theme/sass/styles/style-5/style-5.scss
@@ -308,6 +308,10 @@ textarea {
 
 	&.is-style-solid-color {
 		border: 0;
+
+		&:not(.alignleft):not(.alignright) blockquote {
+			text-align: center;
+		}
 	}
 
 	cite {

--- a/newspack-theme/sass/styles/style-5/style-5.scss
+++ b/newspack-theme/sass/styles/style-5/style-5.scss
@@ -284,6 +284,41 @@ textarea {
 	}
 }
 
+//! Pullquote
+.wp-block-pullquote {
+	background-color: transparent;
+	border: 0;
+	border-bottom: 2px solid;
+	border-top: 1px solid;
+	font-family: $font__heading;
+	font-style: normal;
+	font-weight: bold;
+
+	p {
+		font-style: inherit;
+
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
+	blockquote {
+		border-color: inherit;
+		text-align: center;
+	}
+
+	&.is-style-solid-color {
+		border: 0;
+	}
+
+	cite {
+		color: inherit;
+		font-family: $font__body;
+		font-size: $font__size-base;
+		font-weight: normal;
+	}
+}
+
 /* Blocks */
 .entry .entry-content {
 	.wp-block-separator,
@@ -295,40 +330,6 @@ textarea {
 
 		&.is-style-dots:before {
 			color: currentColor;
-		}
-	}
-
-	.wp-block-pullquote {
-		background-color: transparent;
-		border: 0;
-		border-bottom: 2px solid;
-		border-top: 1px solid;
-		font-family: $font__heading;
-		font-style: normal;
-		font-weight: bold;
-
-		p {
-			font-style: inherit;
-
-			@include media( tablet ) {
-				font-size: $font__size-xl;
-			}
-		}
-
-		blockquote {
-			border-color: inherit;
-			text-align: center;
-		}
-
-		&.is-style-solid-color {
-			border: 0;
-		}
-
-		cite {
-			color: inherit;
-			font-family: $font__body;
-			font-size: $font__size-base;
-			font-weight: normal;
 		}
 	}
 

--- a/newspack-theme/sass/styles/style-5/style-5.scss
+++ b/newspack-theme/sass/styles/style-5/style-5.scss
@@ -286,7 +286,6 @@ textarea {
 
 //! Pullquote
 .wp-block-pullquote {
-	background-color: transparent;
 	border: 0;
 	border-bottom: 2px solid;
 	border-top: 1px solid;
@@ -330,13 +329,6 @@ textarea {
 
 		&.is-style-dots:before {
 			color: currentColor;
-		}
-	}
-
-	.wp-block-cover,
-	.wp-block-group {
-		.wp-block-pullquote {
-			background-color: transparent;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR simplifies the selectors used to style the pullquote block, to remove the `.entry .entry-content` selectors.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Copy-paste [this content](https://cloudup.com/cZxGy5_XoTg) into the editor -- it includes multiple blocks with different settings. Note: you may have to 'recover' the blocks with the main colour setting after you exit the editor. There are also some display issues with Style 1 in the editor (missing quotes) that will be fixed in a separate PR. 
3. Cycle through different settings and style packs, and make sure the blocks carry the styles correctly:

* **Default Style**

<img width="860" alt="image" src="https://user-images.githubusercontent.com/177561/66366320-e2956400-e944-11e9-8fdc-1a1dacb15f06.png">

<img width="811" alt="image" src="https://user-images.githubusercontent.com/177561/66366326-e923db80-e944-11e9-8ffe-fa13fa3b4c48.png">

* **Default Style + custom fonts + custom colours**

<img width="828" alt="image" src="https://user-images.githubusercontent.com/177561/66366362-05c01380-e945-11e9-978d-a56d44e8114b.png">

<img width="809" alt="image" src="https://user-images.githubusercontent.com/177561/66366371-0bb5f480-e945-11e9-947f-ee2699176845.png">

* **Style 1**

<img width="802" alt="image" src="https://user-images.githubusercontent.com/177561/66366401-22f4e200-e945-11e9-851a-24f71dff4aa7.png">

<img width="816" alt="image" src="https://user-images.githubusercontent.com/177561/66366422-33a55800-e945-11e9-8bb2-91065df2375a.png">

<img width="815" alt="image" src="https://user-images.githubusercontent.com/177561/66366434-3a33cf80-e945-11e9-91b4-70219bc131d9.png">

* **Style 1 + custom fonts + custom colours**

<img width="808" alt="image" src="https://user-images.githubusercontent.com/177561/66366455-55064400-e945-11e9-9205-469f37ec0977.png">

<img width="839" alt="image" src="https://user-images.githubusercontent.com/177561/66366462-5c2d5200-e945-11e9-8c00-66731546fce9.png">

<img width="824" alt="image" src="https://user-images.githubusercontent.com/177561/66366467-60f20600-e945-11e9-8796-74f0f50a8718.png">

* **Style 2**

<img width="842" alt="image" src="https://user-images.githubusercontent.com/177561/66366495-7830f380-e945-11e9-80be-e6a126029bb5.png">

<img width="826" alt="image" src="https://user-images.githubusercontent.com/177561/66366498-7e26d480-e945-11e9-9205-e4913b902a4c.png">

<img width="823" alt="image" src="https://user-images.githubusercontent.com/177561/66366503-8252f200-e945-11e9-8294-7162ad1482a5.png">

* **Style 2 + custom fonts + custom colours**

<img width="823" alt="image" src="https://user-images.githubusercontent.com/177561/66366532-9c8cd000-e945-11e9-9826-d40dcf1984ea.png">

<img width="822" alt="image" src="https://user-images.githubusercontent.com/177561/66366540-a282b100-e945-11e9-9071-2fa327a7e5da.png">

<img width="817" alt="image" src="https://user-images.githubusercontent.com/177561/66366547-a9a9bf00-e945-11e9-9641-df4337e94f11.png">

* **Style 3**

<img width="824" alt="image" src="https://user-images.githubusercontent.com/177561/66366602-d2ca4f80-e945-11e9-92ba-10c2fab85e5a.png">

<img width="811" alt="image" src="https://user-images.githubusercontent.com/177561/66366606-d8279a00-e945-11e9-9370-2c6f648b8d06.png">

* **Style 3 + custom fonts + custom colours**

<img width="697" alt="image" src="https://user-images.githubusercontent.com/177561/66366641-f55c6880-e945-11e9-87c7-a59c3b55327e.png">

<img width="819" alt="image" src="https://user-images.githubusercontent.com/177561/66366649-fab9b300-e945-11e9-866a-d3fca29aca4b.png">

* **Style 4**

<img width="843" alt="image" src="https://user-images.githubusercontent.com/177561/66366667-11600a00-e946-11e9-9ab6-5986bd105e24.png">

<img width="824" alt="image" src="https://user-images.githubusercontent.com/177561/66366673-17ee8180-e946-11e9-8bfd-b73096fb75a3.png">

* **Style 4 + custom fonts + custom colours**

<img width="831" alt="image" src="https://user-images.githubusercontent.com/177561/66366697-2e94d880-e946-11e9-88f4-055b15e07d99.png">

<img width="818" alt="image" src="https://user-images.githubusercontent.com/177561/66366705-33f22300-e946-11e9-9073-8f2b176edf4e.png">

* **Style 5**

![image](https://user-images.githubusercontent.com/177561/68635341-16682a00-04ad-11ea-8a11-60373908c11e.png)

![image](https://user-images.githubusercontent.com/177561/68635349-1bc57480-04ad-11ea-93a3-fb862616f56a.png)

* **Style 5 + custom fonts + custom colours**

![image](https://user-images.githubusercontent.com/177561/68635390-37c91600-04ad-11ea-96d7-6c5a1878082c.png)

![image](https://user-images.githubusercontent.com/177561/68635401-40215100-04ad-11ea-916e-02a850c7fda5.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
