### PR TITLE
Style 5: Make sure the figcaption uses the body font

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -150,6 +150,7 @@ function newspack_custom_typography_css() {
 			.entry .entry-content .wp-block-pullquote {
 				font-family: $font_header;
 			}
+			figcaption,
 			.entry-meta,
 			.cat-links,
 			.entry-footer,

--- a/sass/styles/style-5/style-5-editor.scss
+++ b/sass/styles/style-5/style-5-editor.scss
@@ -133,6 +133,7 @@
 }
 
 /* Font Family */
+figcaption,
 .entry-meta,
 .cat-links,
 .entry-footer,

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -41,6 +41,7 @@ body {
 }
 
 /* Font Family */
+figcaption,
 .entry-meta,
 .cat-links,
 .entry-footer,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using the heading font for the caption, we use the body font

### How to test the changes in this Pull Request:

1. Add an image block and add a caption
2. Add the Homepage Articles block with posts using "Show Featured Image Caption"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
