### PR TITLE
Make sure 'highlight menu' inherits header font.

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -74,6 +74,9 @@ function newspack_custom_typography_css() {
 		/* _menu-top-navigation.scss */
 		.secondary-menu,
 
+		/* _menu-highlight-navigation.scss */
+		.highlight-menu-contain .wrapper,
+
 		/* _next_previous.scss */
 		.comment-navigation .nav-previous,
 		.comment-navigation .nav-next,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the 'highlight menu' inherits the site's custom typography.

### How to test the changes in this Pull Request:

1. Add a menu to the highlight location.
2. Navigate to Customize > Typography, and change the Header font.
3. Look at the highlight menu; it should still be using the style pack's header font.
4. Apply the PR.
5. Confirm that the menu is now updated to use the header font.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
