### PR TITLE
Columns Block: Fix selector for last child

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -718,7 +718,7 @@
 	//! Columns
 	.wp-block-columns {
 
-		.wp-block-column > * :last-child {
+		.wp-block-column > *:last-child {
 			margin-bottom: 0;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There's a typo in the styles that should be removing a bottom margin from the last element in a column block, so it removes the bottom margin from the last element in every child of the column block. This PR fixes that.

### How to test the changes in this Pull Request:

1. Set up some columns with content or copy [this test content](https://cloudup.com/c2QSiOQUBIP) into a post.
2. Apply the PR and run` npm run build`
3. Confirm that at the bottom of each column, there's not a ton of space.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
