### PR TITLE
Fixes issue with default colour used in highlight navigation

### DIFF
--- a/sass/navigation/_menu-highlight-navigation.scss
+++ b/sass/navigation/_menu-highlight-navigation.scss
@@ -28,7 +28,7 @@
 	}
 
 	.menu-label {
-		color: $color__background-body;
+		color: $color__primary;
 		font-weight: bold;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The 'Highlight' menu should use the primary colour at the start, but the default right now is set to white. 

This PR fixes that.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Colours, and set the site to use custom colours.
2. Navigate to Customize > Menus, and add a menu to the 'Highlight Menu' spot.
3. View on front-end; you should be able to see the menu title, but it's white:

![image](https://user-images.githubusercontent.com/177561/66423477-a7d11180-e9c0-11e9-83d2-1abf7ebb69a7.png)

4. Apply the PR and run `npm run build`
5. Confirm you can now see the menu label:

![image](https://user-images.githubusercontent.com/177561/66423562-ccc58480-e9c0-11e9-920b-d25e6ce8594a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
