### PR TITLE
Update styles for style 3 to work with the 'image behind the article' block style

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -36,7 +36,7 @@ Newspack Theme Editor Styles - Style Pack 3
 }
 
 .wp-block-newspack-blocks-homepage-articles {
-	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.75em;
 		padding: 0.5em 0.25em 0 0;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -185,7 +185,7 @@ figcaption,
 
 .entry .entry-content {
 	.wp-block-newspack-blocks-homepage-articles {
-		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
 			background-color: $color__background-body;
 			margin-top: -1.5em;
 			padding: 0.5em 0.25em 0 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is meant to be used with https://github.com/Automattic/newspack-blocks/pull/73.

It makes sure the white backgrounds in style 3 don't appear when you're using the 'Image behind' option for the article block.

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-blocks/pull/73
2. Navigate to Customize > Style Packs, and pick style 3.
3. Add an article block; make sure the articles in it have featured images, and pick the 'behind' option
4. Note that you have a weird white box hiding the title:

![image](https://user-images.githubusercontent.com/177561/66424879-4cece980-e9c3-11e9-94e4-4649f4eb4332.png)

5. Apply the PR and run `npm run build`
6. Confirm that the white box is now gone:

![image](https://user-images.githubusercontent.com/177561/66424265-2b3f3280-e9c2-11e9-8aa2-3351bac7b806.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
