### PR TITLE
Add object fit AMP fix to behind, beside image styles

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,18 +158,30 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			?>
 
 			<figure class="post-thumbnail">
-				<?php the_post_thumbnail( 'newspack-featured-image' ); ?>
+				<?php
+				$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+
+				// If using the behind or beside image styles, add the object-fit argument for AMP.
+				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) {
+					the_post_thumbnail(
+						'newspack-featured-image',
+						array(
+							'object-fit' => 'cover',
+						)
+					);
+				} else {
+					the_post_thumbnail( 'newspack-featured-image' );
+				}
+				?>
 			</figure><!-- .post-thumbnail -->
 
-			<?php
-		else :
-			?>
+		<?php else : ?>
 
-		<figure class="post-thumbnail">
-			<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-				<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
-			</a>
-		</figure>
+			<figure class="post-thumbnail">
+				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+					<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
+				</a>
+			</figure>
 
 			<?php
 		endif; // End is_singular().


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, when AMP is enabled, the 'behind' and 'beside' image styles didn't display correctly.

### How to test the changes in this Pull Request:

1. Set up a single post with a featured image, and set it to display behind the post title.
2. Enable AMP.
3. View the front-end of the post - note the black bars on the left and right: 

![image](https://user-images.githubusercontent.com/177561/66430918-e02c1c00-e9cf-11e9-8dae-018ea98478ba.png)

4. Edit the single post, and set the featured image to display beside the title. 
5. View the front-end of the post.

![image](https://user-images.githubusercontent.com/177561/66430606-4d8b7d00-e9cf-11e9-9e33-67a46fe8a0b8.png)

6. Apply the PR and run `npm run build`.
7. Confirm that the beside image setting looks good:

![image](https://user-images.githubusercontent.com/177561/66431106-3a2ce180-e9d0-11e9-8787-dd34009f0260.png)

8. Switch the post back to display the featured image behind the article title.
9. Confirm that it's also fixed on the front-end.

![image](https://user-images.githubusercontent.com/177561/66430958-f508af80-e9cf-11e9-9499-0edc6457b4ec.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
