### PR TITLE
Make styles to hide 'highlight menu' more specific

### DIFF
--- a/sass/navigation/_menu-highlight-navigation.scss
+++ b/sass/navigation/_menu-highlight-navigation.scss
@@ -40,7 +40,7 @@
 
 .single-featured-image-beside,
 .single-featured-image-behind {
-	.highlight-menu-contain {
+	.highlight-menu-contain.desktop-only {
 		display: none;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The 'Highlight' menu should be hidden on posts where you have the featured image displayed as behind or beside the article title, since it creates a lot of visual noise and pulls attention away from the article. 

An unrelated change, making some selectors more specific, caused this to no longer work. This PR makes the original behind/beside styles specific enough to work again.

### How to test the changes in this Pull Request:

1. Add a menu to the "Highlight menu" location.
2. Create a post; add a featured image and set it to display 'beside' or 'behind' the article title.
3. Save and publish; view on the front-end. Note you can see the menu:

![image](https://user-images.githubusercontent.com/177561/66432058-136faa80-e9d2-11e9-88a7-3076af745163.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the menu is now hidden.

![image](https://user-images.githubusercontent.com/177561/66432163-474ad000-e9d2-11e9-98b0-47f112045de3.png)

6. Confirm that the menu still displays on other posts and pages on the site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
