### PR TITLE
Style 3: Update styles to go with column block borders fix.

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -14,9 +14,23 @@ get_header();
 
 		<header class="page-header">
 			<?php
-				the_archive_title( '<h1 class="page-title">', '</h1>' );
-				the_archive_description( '<div class="taxonomy-description">', '</div>' );
+				if ( is_author() ) {
+					$author_id     = get_query_var( 'author' );
+					$author_avatar = get_avatar( $author_id, 120 );
+
+					if ( $author_avatar ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo $author_avatar;
+					}
+				}
 			?>
+			<span>
+				<?php
+					the_archive_title( '<h1 class="page-title">', '</h1>' );
+					the_archive_description( '<div class="taxonomy-description">', '</div>' );
+				?>
+			</span>
+
 		</header><!-- .page-header -->
 
 		<main id="main" class="site-main">

--- a/footer.php
+++ b/footer.php
@@ -21,7 +21,10 @@
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 
 		<div class="site-info">
-			<div class="wrapper">
+
+			<?php get_template_part( 'template-parts/footer/below-footer', 'widgets' ); ?>
+
+			<div class="wrapper site-info-contain">
 				<?php $blog_info = get_bloginfo( 'name' ); ?>
 				<?php if ( ! empty( $blog_info ) ) : ?>
 					<span class="copyright">&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>.</span>

--- a/functions.php
+++ b/functions.php
@@ -258,6 +258,18 @@ function newspack_widgets_init() {
 
 	register_sidebar(
 		array(
+			'name'          => __( 'Above Copyright', 'newspack' ),
+			'id'            => 'footer-2',
+			'description'   => __( 'Add widgets here to appear below the footer, above the copyright information.', 'newspack' ),
+			'before_widget' => '<section id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		)
+	);
+
+	register_sidebar(
+		array(
 			'name'          => __( 'Article above content', 'newspack' ),
 			'id'            => 'article-1',
 			'description'   => __( 'Add widgets here to appear above article content.', 'newspack' ),

--- a/functions.php
+++ b/functions.php
@@ -152,8 +152,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
-		$primary_color   = newspack_get_primary_color();
-		$secondary_color = newspack_get_secondary_color();
+		$primary_color           = newspack_get_primary_color();
+		$primary_color_variation = newspack_get_primary_color_variation();
+		$secondary_color         = newspack_get_secondary_color();
 
 		// Editor color palette.
 		add_theme_support(
@@ -170,7 +171,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 					'name'  => __( 'Primary Variation', 'newspack' ),
 					'slug'  => 'primary-variation',
 					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						newspack_adjust_brightness( $primary_color, -40 ) :
+						$primary_color_variation :
 						newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
 				),
 				array(

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -8,7 +8,8 @@
 /**
  * Define default color filters.
  */
-define( 'NEWSPACK_DEFAULT_PRIMARY', '#2A7DE1' ); // Hex
+define( 'NEWSPACK_DEFAULT_PRIMARY', '#3366ff' ); // Hex
+define( 'NEWSPACK_DEFAULT_PRIMARY_VARIATION', '#2240d5' ); // Hex
 define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
 /**
@@ -27,6 +28,24 @@ function newspack_get_primary_color() {
 	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
 	 */
 	return apply_filters( 'newspack_primary_color', NEWSPACK_DEFAULT_PRIMARY );
+}
+
+/**
+ * The default color used for the primary color variation throughout this theme
+ *
+ * @return string the default hexidecimal color.
+ */
+function newspack_get_primary_color_variation() {
+	/**
+	 * Default primary color variation.
+	 *
+	 * Sets the default primary color variation for the theme's custom colors.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
+	 */
+	return apply_filters( 'newspack_primary_color_variation', NEWSPACK_DEFAULT_PRIMARY_VARIATION );
 }
 
 /**
@@ -64,5 +83,3 @@ function newspack_has_custom_primary_color() {
 function newspack_has_custom_secondary_color() {
 	return newspack_get_secondary_color() !== NEWSPACK_DEFAULT_SECONDARY;
 }
-
-

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -340,7 +340,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4' ) ) {
+	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
 		$theme_css .= '
 			.header-solid-background .middle-header-contain {
 				background-color: ' . $primary_color . ';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -258,6 +258,25 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'author_bio_options',
 		)
 	);
+
+	// Add option to hide author email address.
+	$wp_customize->add_setting(
+		'show_author_email',
+		array(
+			'default'           => false,
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'show_author_email',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display Author Email', 'newspack' ),
+			'description' => esc_html__( 'Display Author email with bio on individual posts.', 'newspack' ),
+			'section'     => 'author_bio_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -104,6 +104,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-author-bio';
 	}
 
+	$display_author_email = get_theme_mod( 'show_author_email', false );
+	if ( false === $display_author_email ) {
+		$classes[] = 'hide-author-email';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -158,18 +158,30 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			?>
 
 			<figure class="post-thumbnail">
-				<?php the_post_thumbnail( 'newspack-featured-image' ); ?>
+				<?php
+				$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+
+				// If using the behind or beside image styles, add the object-fit argument for AMP.
+				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) {
+					the_post_thumbnail(
+						'newspack-featured-image',
+						array(
+							'object-fit' => 'cover',
+						)
+					);
+				} else {
+					the_post_thumbnail( 'newspack-featured-image' );
+				}
+				?>
 			</figure><!-- .post-thumbnail -->
 
-			<?php
-		else :
-			?>
+		<?php else : ?>
 
-		<figure class="post-thumbnail">
-			<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-				<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
-			</a>
-		</figure>
+			<figure class="post-thumbnail">
+				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+					<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
+				</a>
+			</figure>
 
 			<?php
 		endif; // End is_singular().

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -154,25 +154,34 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			return;
 		}
 
-		if ( is_singular() ) :
-			?>
+		if ( is_singular() ) : ?>
 
 			<figure class="post-thumbnail">
+
 				<?php
 				$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
 				// If using the behind or beside image styles, add the object-fit argument for AMP.
-				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) {
+				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) :
+
 					the_post_thumbnail(
 						'newspack-featured-image',
 						array(
 							'object-fit' => 'cover',
 						)
 					);
-				} else {
+
+				else :
 					the_post_thumbnail( 'newspack-featured-image' );
-				}
+					$caption = get_post( get_post_thumbnail_id() )->post_excerpt;
+					if ( $caption ) :
+					?>
+						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+					<?php
+					endif;
+				endif;
 				?>
+
 			</figure><!-- .post-thumbnail -->
 
 		<?php else : ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -47,19 +47,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 		printf(
 			/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
 			'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
-			wp_kses(
-				get_avatar( get_the_author_meta( 'ID' ) ),
-				array(
-					'img' => array(
-						'alt'    => array(),
-						'src'    => array(),
-						'srcset' => array(),
-						'class'  => array(),
-						'width'  => array(),
-						'height' => array(),
-					),
-				)
-			),
+			get_avatar( get_the_author_meta( 'ID' ) ),
 			esc_html__( 'by', 'newspack' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 			esc_html( get_the_author() )

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -116,18 +116,6 @@ function newspack_woo_account_registration_heading() {
 add_action( 'woocommerce_before_checkout_registration_form', 'newspack_woo_account_registration_heading' );
 
 /**
- * Remove sidebar on Checkout page to reduce distractions.
- */
-function newspack_woo_remove_checkout_sidebar( $is_active ) {
-	if ( is_page( wc_get_page_id( 'checkout' ) ) ) {
-		return false;
-	}
-
-	return $is_active;
-}
-add_filter( 'is_active_sidebar', 'newspack_woo_remove_checkout_sidebar' );
-
-/**
  * Remove default WooCommerce wrapper.
  */
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -58,7 +58,6 @@ function newspack_woo_custom_colors_css( $css, $primary_color ) {
 	}
 	$css      .= '
 		.onsale,
-		.woocommerce-info,
 		.woocommerce-store-notice {
 			background-color: ' . $primary_color . ';
 		}

--- a/js/src/customize-controls.js
+++ b/js/src/customize-controls.js
@@ -37,6 +37,24 @@
 				setting.bind( visibility );
 			});
 		});
+
+
+		// Only show the rest of the author controls when the bio is visible.
+		wp.customize( 'show_author_bio', function( setting ) {
+			console.log( setting );
+			wp.customize.control( 'show_author_email', function( control ) {
+				var visibility = function() {
+					if ( '1' === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+
+				visibility();
+				setting.bind( visibility );
+			});
+		});
 	});
 
 })( jQuery );

--- a/js/src/customize-preview.js
+++ b/js/src/customize-preview.js
@@ -39,4 +39,15 @@
 			}
 		});
 	});
+
+	// Hide Author email
+	wp.customize( 'show_author_email', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( 'body' ).addClass( 'hide-author-email' );
+			} else {
+				$( 'body' ).removeClass( 'hide-author-email' );
+			}
+		});
+	});
 })( jQuery );

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -711,7 +711,7 @@
 	//! Columns
 	.wp-block-columns {
 
-		.wp-block-column > * :last-child {
+		.wp-block-column > *:last-child {
 			margin-bottom: 0;
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -59,6 +59,29 @@
 				&.wp-block-cover {
 					width: auto;
 				}
+
+				&.wp-block-columns {
+					margin-left: calc(25% - 25vw - 16px);
+					margin-right: calc(25% - 25vw - 16px);
+					max-width: calc(100vw + 32px);
+					width: auto;
+
+					&.is-style-borders {
+						margin-left: calc(25% - 25vw - 24px);
+						margin-right: calc(25% - 25vw - 24px);
+						max-width: calc(100vw + 48px);
+					}
+				}
+			}
+
+			@include media(desktop) {
+				&.wp-block-columns {
+					&.is-style-borders {
+						margin-left: calc(25% - 25vw - 32px);
+						margin-right: calc(25% - 25vw - 32px);
+						max-width: calc(100vw + 64px);
+					}
+				}
 			}
 		}
 		.alignfull {
@@ -68,6 +91,37 @@
 
 			&.wp-block-cover {
 				width: 100vw;
+			}
+
+			&.wp-block-columns {
+				margin-left: 0;
+				margin-right: 0;
+				max-width: 100%;
+
+				@include media(mobile) {
+					margin-left: calc(50% - 50vw - 16px);
+					margin-right: calc(50% - 50vw - 16px);
+					max-width: calc(100vw + 32px);
+					width: calc(100vw + 32px);
+				}
+
+				@include media(tablet) {
+					&.is-style-borders {
+						margin-left: calc(50% - 50vw - 24px);
+						margin-right: calc(50% - 50vw - 24px);
+						max-width: calc(100vw + 48px);
+						width: calc(100vw + 48px);
+					}
+				}
+
+				@include media(desktop) {
+					&.is-style-borders {
+						margin-left: calc(50% - 50vw - 32px);
+						margin-right: calc(50% - 50vw - 32px);
+						max-width: calc(100vw + 64px);
+						width: calc(100vw + 64px);
+					}
+				}
 			}
 		}
 
@@ -715,44 +769,25 @@
 			margin-bottom: 0;
 		}
 
-		@include media(tablet) {
-			.wp-block-column {
-				margin-bottom: 0;
-			}
+		@include media( mobile ) {
+			margin-left: -16px;
+			max-width: calc(100% + 32px);
+		}
 
-			&[class*='has-'] > * {
-				margin-right: $size__spacing-unit;
-
-				&:last-child {
-					margin-right: 0;
-				}
+		@include media( tablet ) {
+			&.is-style-borders {
+				margin-left: -24px;
+				max-width: calc(100% + 48px);
 			}
 		}
 
-		&.is-style-borders {
-			.wp-block-column {
-
-				&:not(:last-child) > *:last-child {
-					margin-bottom: 32px;
-				}
-
-				@include media(tablet) {
-					flex-basis: calc(50% - 32px);
-
-					&:not(:first-child) {
-						margin-left: 64px;
-					}
-
-					&:after {
-						right: -32px;
-					}
-
-					&:not(:last-child) > *:last-child {
-						margin-bottom: 0;
-					}
-				}
+		@include media( desktop ) {
+			&.is-style-borders {
+				margin-left: -32px;
+				max-width: calc(100% + 64px);
 			}
 		}
+
 	}
 
 	//! Group

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -732,6 +732,10 @@
 		&.is-style-borders {
 			.wp-block-column {
 
+				&:not(:last-child) > *:last-child {
+					margin-bottom: 32px;
+				}
+
 				@include media(tablet) {
 					flex-basis: calc(50% - 32px);
 
@@ -741,6 +745,10 @@
 
 					&:after {
 						right: -32px;
+					}
+
+					&:not(:last-child) > *:last-child {
+						margin-bottom: 0;
 					}
 				}
 			}

--- a/sass/forms/_buttons.scss
+++ b/sass/forms/_buttons.scss
@@ -9,6 +9,7 @@ input[type="submit"] {
 	border: none;
 	border-radius: 5px;
 	box-sizing: border-box;
+	display: inline-block;
 	color: $color__background-body;
 	font-family: $font__heading;
 	font-size: $font__size-sm;

--- a/sass/navigation/_menu-highlight-navigation.scss
+++ b/sass/navigation/_menu-highlight-navigation.scss
@@ -40,7 +40,7 @@
 
 .single-featured-image-beside,
 .single-featured-image-behind {
-	.highlight-menu-contain {
+	.highlight-menu-contain.desktop-only {
 		display: none;
 	}
 }

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -7,7 +7,7 @@ $headings: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu
 $body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
 
 $body-color: #111;
-$highlights-color: #2A7DE1;
+$highlights-color: #36f;
 
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -113,8 +113,15 @@
 			font-size: inherit;
 
 			@include media( mobile ) {
-				margin-bottom: 0;
-				min-width: 25%;
+				margin: 0 $size__spacing-unit;
+
+				&:first-child {
+					margin-left: 0;
+				}
+
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 
@@ -134,13 +141,22 @@
 		}
 
 		@include media( mobile ) {
-			ul, li {
+			ul, li a {
 				display: inline;
 			}
 
-			ul li a {
+			li {
 				display: inline-block;
 				margin: 0 $size__spacing-unit 0 0;
+
+				ul {
+					display: inline-block;
+					margin-left: $size__spacing-unit;
+				}
+
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 

--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -25,7 +25,7 @@
 		}
 	}
 
-	.widget-area {
+	.footer-widgets {
 		padding: $size__spacing-unit 0 #{ 2 * $size__spacing-unit };
 
 		.wrapper {
@@ -34,7 +34,7 @@
 		}
 	}
 
-	.widget {
+	.footer-widgets .widget {
 		width: 100%;
 
 		@include media( mobile ) {
@@ -60,26 +60,28 @@
 
 .site-info {
 	color: $color__text-light;
+	padding-bottom: $size__spacing-unit;
 
 	.wrapper {
-		border-top: 1px solid $color__border;
 		display: block;
-		padding: $size__spacing-unit 0;
 
 		@include media( tablet ) {
-
 			display: flex;
-			justify-content: flex-start;
 
-			& > * {
-				margin-left: $size__spacing-unit;
-			}
+			&.site-info-contain {
+				justify-content: flex-start;
 
-			& > *:last-child {
-				margin-left: auto;
+				& > *:not(:first-child) {
+					margin-left: $size__spacing-unit;
+				}
+
+				& > *:last-child {
+					margin-left: auto;
+				}
 			}
 		}
 	}
+
 
 	a {
 		color: inherit;
@@ -93,5 +95,57 @@
 	a,
 	.copyright {
 		margin: #{ 0.25 * $size__spacing-unit } 0;
+	}
+
+	.site-info-contain:first-child {
+		border-top: 1px solid $color__border;
+		padding-top: $size__spacing-unit;
+	}
+
+	.widget-area {
+		.wrapper {
+			border-top: 1px solid $color__border;
+			justify-content: space-between;
+			padding: $size__spacing-unit 0 #{ 0.5 * $size__spacing-unit };
+		}
+
+		.widget {
+			font-size: inherit;
+
+			@include media( mobile ) {
+				margin-bottom: 0;
+				min-width: 25%;
+			}
+		}
+
+		.widget-title {
+			display: inline-block;
+			margin: 0 $size__spacing-unit 0 0;
+		}
+
+		ul, li {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		a {
+			margin: 0;
+		}
+
+		@include media( mobile ) {
+			ul, li {
+				display: inline;
+			}
+
+			ul li a {
+				display: inline-block;
+				margin: 0 $size__spacing-unit 0 0;
+			}
+		}
+
+		p {
+			margin: 0;
+		}
 	}
 }

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -78,6 +78,32 @@
 			}
 		}
 	}
+
+	&.author .page-header {
+		display: flex;
+		justify-content: space-between;
+
+		.avatar {
+			flex-shrink: 0;
+			height: 30px;
+			margin-right: $size__spacing-unit;
+			width: 30px;
+		}
+
+		@include media( mobile ) {
+			.avatar {
+				height: 80px;
+				width: 80px;
+			}
+		}
+
+		@include media( tablet ) {
+			.avatar {
+				height: 120px;
+				width: 120px;
+			}
+		}
+	}
 }
 
 .page-description {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -256,6 +256,24 @@ body.page {
 		}
 	}
 
+	.entry-meta {
+		margin-bottom: #{ 0.5 * $size__spacing-unit };
+
+		@include media( mobile ) {
+			margin-bottom: 0;
+		}
+	}
+
+	.avatar {
+		height: #{ 1.75 * $size__spacing-unit };
+		width: #{ 1.75 * $size__spacing-unit };
+
+		@include media( tablet) {
+			height: #{ 2.25 * $size__spacing-unit };
+			width: #{ 2.25 * $size__spacing-unit };
+		}
+	}
+
 	.main-content > .post-thumbnail:first-child {
 		margin-top: #{ 2 * $size__spacing-unit };
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -388,7 +388,8 @@ body.page {
 	}
 }
 
-.hide-author-bio .author-bio {
+.hide-author-bio .author-bio,
+.hide-author-email .author-bio .author-email {
 	display: none;
 }
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -154,6 +154,11 @@ body.page {
 			display: block;
 		}
 	}
+
+	figcaption {
+		max-width: 100%;
+		width: 100%;
+	}
 }
 
 .entry-content {
@@ -472,6 +477,13 @@ body.page {
 .featured-image-beside > .wrapper {
 	max-width: 100%;
 	width: 100%;
+}
+
+.featured-image-behind + figcaption,
+.featured-image-beside + figcaption {
+	margin: #{ 0.25 * $size__spacing-unit } auto 0;
+	width: 1200px;
+	max-width: 100%;
 }
 
 @include media( tablet ) {

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.10
+Version: 1.0.0-alpha.11
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.11
+Version: 1.0.0-alpha.12
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.9
+Version: 1.0.0-alpha.10
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.12
+Version: 1.0.0-alpha.13
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -254,7 +254,7 @@
 	}
 
 	.footer-branding .wrapper,
-	.widget-area:first-child {
+	.footer-widgets:first-child {
 		border-top: 3px solid currentColor;
 	}
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -481,8 +481,16 @@ blockquote {
 	.wrapper {
 		border: 0;
 	}
+}
 
+.site-footer .site-info {
 	a {
 		color: inherit;
+	}
+
+	a:hover,
+	a:visited {
+		color: inherit;
+		opacity: 0.7;
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -478,7 +478,8 @@ blockquote {
 	background-color: $color__text-main;
 	color: $color__background-body;
 
-	.wrapper {
+	.site-info-contain:first-child,
+	.widget-area .wrapper {
 		border: 0;
 	}
 }

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -36,7 +36,7 @@ Newspack Theme Editor Styles - Style Pack 3
 }
 
 .wp-block-newspack-blocks-homepage-articles {
-	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.75em;
 		padding: 0.5em 0.25em 0 0;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -298,27 +298,13 @@ figcaption,
 
 	.wp-block-columns.is-style-borders {
 		.wp-block-column {
-			border-bottom: 1px dotted $color__text-main;
-
-			&:last-child {
-				border-bottom: 0;
-			}
+			border-bottom-style: dotted;
+			border-bottom-color: $color__text-main;
 
 			@include media( mobile ) {
-				border-bottom: 0;
-
 				&:after {
-					border-right: 1px dotted transparent;
-				}
-
-				&:nth-child(odd):after {
-					border-color: $color__text-main;
-				}
-			}
-
-			@include media( tablet ) {
-				&:after {
-					border-color: $color__text-main;
+					border-right-style: dotted;
+					border-right-color: $color__text-main;
 				}
 			}
 		}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -375,7 +375,8 @@ figcaption,
 .site-info {
 	color: $color__background-body;
 
-	.wrapper {
+	.site-info-contain:first-child,
+	.widget-area .wrapper {
 		border: 0;
 	}
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -116,6 +116,12 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
+.post-thumbnail figcaption:after,
+.featured-image-behind + figcaption:after,
+.featured-image-beside + figcaption:after {
+	display: none;
+}
+
 .entry-meta,
 .entry .wp-block-newspack-blocks-homepage-articles article .entry-meta {
 	font-size: $font__size-xs;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -184,7 +184,7 @@ figcaption,
 
 .entry .entry-content {
 	.wp-block-newspack-blocks-homepage-articles {
-		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
 			background-color: $color__background-body;
 			margin-top: -1.5em;
 			padding: 0.5em 0.25em 0 0;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -297,16 +297,9 @@ figcaption,
 	}
 
 	.wp-block-columns.is-style-borders {
-		.wp-block-column {
-			border-bottom-style: dotted;
-			border-bottom-color: $color__text-main;
-
-			@include media( mobile ) {
-				&:after {
-					border-right-style: dotted;
-					border-right-color: $color__text-main;
-				}
-			}
+		.wp-block-column:after {
+			border-style: dotted;
+			border-color: $color__text-main;
 		}
 	}
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -415,7 +415,8 @@ figcaption,
 .site-info {
 	background-color: $color__background-dark;
 
-	.wrapper {
+	.site-info-contain:first-child,
+	.widget-area .wrapper {
 		border: 0;
 	}
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -366,6 +366,24 @@ figcaption,
 	.page-header {
 		text-align: center;
 	}
+
+	&.author .page-header {
+		display: block;
+
+		.avatar {
+			margin: 0 auto $size__spacing-unit;
+
+			@include media( mobile ) {
+				height: 60px;
+				width: 60px;
+			}
+
+			@include media( tablet ) {
+				height: 80px;
+				width: 80px;
+			}
+		}
+	}
 }
 
 

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -358,7 +358,7 @@ textarea {
 	}
 
 	.footer-branding .wrapper,
-	.widget-area:first-child {
+	.footer-widgets:first-child {
 		border-top: 3px solid currentColor;
 	}
 

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -30,6 +30,7 @@ body {
 
 .header-solid-background {
 	.bottom-header-contain,
+	.middle-header-contain,
 	.top-header-contain {
 		background-color: $color__text-main;
 	}
@@ -119,6 +120,24 @@ input[type="submit"] {
 		flex: 1 0 0.25rem;
 		height: 1px;
 		margin: 0 0 0 0.25rem;
+	}
+}
+
+/* Navigation */
+.mobile-sidebar {
+	background: $color__text-main;
+}
+
+.site-header {
+	.main-navigation {
+		.main-menu {
+			.sub-menu {
+				a:hover,
+				a:focus {
+					background: $color__text-main;
+				}
+			}
+		}
 	}
 }
 

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -29,7 +29,6 @@ body {
 }
 
 .header-solid-background {
-	.site-header,
 	.bottom-header-contain,
 	.top-header-contain {
 		background-color: $color__text-main;

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -130,7 +130,7 @@ body.header-default-background.header-default-height {
 /* Footer */
 
 .site-footer .footer-branding,
-.site-footer .widget-area:first-child {
+.site-footer .footer-widgets:first-child {
 	.wrapper {
 		border-top: 4px solid $color__border;
 	}

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -109,7 +109,11 @@ h4 {
 }
 
 .page-title {
-	font-size: $font__size_base;
+	font-size: $font__size_sm;
+
+	@include media( tablet ) {
+		font-size: $font__size_base;
+	}
 }
 
 .entry-meta,

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -1,7 +1,7 @@
 
 // Custom Colors - defaults
-$color__primary: #2A7DE1;
-$color__primary-variation: darken( $color__primary, 10% );
+$color__primary: #36f;
+$color__primary-variation: #2240d5;
 $color__secondary: #555;
 $color__secondary-variation: darken( $color__secondary, 10% );
 
@@ -32,7 +32,7 @@ $color__link-hover: $color__secondary-variation;
 
 // Borders
 $color__border: #ccc;
-$color__border-link: #2A7DE1;
+$color__border-link: #36f;
 $color__border-link-hover: $color__primary-variation;
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;

--- a/template-parts/footer/below-footer-widgets.php
+++ b/template-parts/footer/below-footer-widgets.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Displays the footer widget area
+ *
+ * @package Newspack
+ */
+
+if ( is_active_sidebar( 'footer-2' ) ) : ?>
+	<aside class="widget-area" role="complementary" aria-label="<?php esc_attr_e( 'Below Footer', 'newspack' ); ?>">
+		<div class="wrapper">
+			<?php dynamic_sidebar( 'footer-2' ); ?>
+		</div><!-- .wrapper -->
+	</aside><!-- .widget-area -->
+<?php endif; ?>

--- a/template-parts/footer/footer-widgets.php
+++ b/template-parts/footer/footer-widgets.php
@@ -7,7 +7,7 @@
 
 if ( is_active_sidebar( 'footer-1' ) ) : ?>
 
-	<aside class="widget-area" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
+	<aside class="widget-area footer-widgets" role="complementary" aria-label="<?php esc_attr_e( 'Footer', 'newspack' ); ?>">
 		<div class="wrapper">
 			<?php
 			if ( is_active_sidebar( 'footer-1' ) ) {

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -9,45 +9,25 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 <div class="author-bio">
 
 	<?php
-	if ( ! newspack_is_active_style_pack( 'style-4' ) ) :
+	if ( ! newspack_is_active_style_pack( 'style-4' ) ) {
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-		if ( $author_avatar ) :
-			echo wp_kses(
-				$author_avatar,
-				array(
-					'img' => array(
-						'src'    => array(),
-						'alt'    => array(),
-						'class'  => array(),
-						'width'  => array(),
-						'height' => array(),
-					),
-				)
-			);
-		endif;
-	endif;
+		if ( $author_avatar ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $author_avatar;
+		}
+	}
 	?>
 
 	<div class="author-bio-text">
 		<div class="author-bio-header">
 			<?php
-			if ( newspack_is_active_style_pack( 'style-4' ) ) :
+			if ( newspack_is_active_style_pack( 'style-4' ) ) {
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-				if ( $author_avatar ) :
-					echo wp_kses(
-						$author_avatar,
-						array(
-							'img' => array(
-								'src'    => array(),
-								'alt'    => array(),
-								'class'  => array(),
-								'width'  => array(),
-								'height' => array(),
-							),
-						)
-					);
-				endif;
-			endif;
+				if ( $author_avatar ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $author_avatar;
+				}
+			}
 			?>
 
 			<div>

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -56,7 +56,7 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 					<span><?php // TODO: Add Job title ?></span>
 				</h2>
 				<div class="author-meta">
-					<a href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
+					<a class="author-email" href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
 				</div>
 			</div>
 		</div><!-- .author-bio-header -->

--- a/template-parts/post/large-featured-image.php
+++ b/template-parts/post/large-featured-image.php
@@ -6,6 +6,7 @@
  */
 
 $featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+$caption                 = get_post( get_post_thumbnail_id() )->post_excerpt;
 
 if ( 'behind' === $featured_image_position ) :
 ?>
@@ -19,6 +20,10 @@ if ( 'behind' === $featured_image_position ) :
 		</div><!-- .wrapper -->
 	</div><!-- .featured-image-behind -->
 
+	<?php if ( $caption ) : ?>
+		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+	<?php endif; ?>
+
 <?php elseif ( 'beside' === $featured_image_position ) : ?>
 
 	<div class="featured-image-beside">
@@ -27,8 +32,13 @@ if ( 'behind' === $featured_image_position ) :
 				<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 			</header>
 		</div><!-- .wrapper -->
+
 		<?php newspack_post_thumbnail(); ?>
 	</div><!-- .featured-image-behind -->
+
+	<?php if ( $caption ) : ?>
+		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+	<?php endif; ?>
 
 <?php else : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is complementary to https://github.com/Automattic/newspack-blocks/pull/149; it's meant to make sure the style 3 column borders styles work with those changes, but it should work fine with the current column block styles by simplifying them and relying on inheritance a bit smarter than the original approach.

![image](https://user-images.githubusercontent.com/177561/66443848-97875980-e9f5-11e9-8501-eff43bc6268e.png)

### How to test the changes in this Pull Request:

1. Copy the test content from here: https://cloudup.com/csJfug8JLsO
2. Navigate to Customizer > Style Packs and pick Style 2.
3. Apply the PR and run `npm run build`.
4. Confirm that the borders displayed with the columns are all dotted. 
5. Apply https://github.com/Automattic/newspack-blocks/pull/149 to the newspack blocks, and run `npm run build:webpack` in that directory.
6. Confirm the borders are still displaying as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
