### PR TITLE
Update the Primary Color to use Newspack new blue: `#36f`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -152,8 +152,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
-		$primary_color   = newspack_get_primary_color();
-		$secondary_color = newspack_get_secondary_color();
+		$primary_color           = newspack_get_primary_color();
+		$primary_color_variation = newspack_get_primary_color_variation();
+		$secondary_color         = newspack_get_secondary_color();
 
 		// Editor color palette.
 		add_theme_support(
@@ -170,7 +171,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 					'name'  => __( 'Primary Variation', 'newspack' ),
 					'slug'  => 'primary-variation',
 					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						newspack_adjust_brightness( $primary_color, -40 ) :
+						$primary_color_variation :
 						newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
 				),
 				array(

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -9,6 +9,7 @@
  * Define default color filters.
  */
 define( 'NEWSPACK_DEFAULT_PRIMARY', '#3366ff' ); // Hex
+define( 'NEWSPACK_DEFAULT_PRIMARY_VARIATION', '#2240d5' ); // Hex
 define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
 /**
@@ -27,6 +28,24 @@ function newspack_get_primary_color() {
 	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
 	 */
 	return apply_filters( 'newspack_primary_color', NEWSPACK_DEFAULT_PRIMARY );
+}
+
+/**
+ * The default color used for the primary color variation throughout this theme
+ *
+ * @return string the default hexidecimal color.
+ */
+function newspack_get_primary_color_variation() {
+	/**
+	 * Default primary color variation.
+	 *
+	 * Sets the default primary color variation for the theme's custom colors.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $value Sets a hexidecimal color; uses theme default defined above.
+	 */
+	return apply_filters( 'newspack_primary_color_variation', NEWSPACK_DEFAULT_PRIMARY_VARIATION );
 }
 
 /**

--- a/inc/color-filters.php
+++ b/inc/color-filters.php
@@ -8,7 +8,7 @@
 /**
  * Define default color filters.
  */
-define( 'NEWSPACK_DEFAULT_PRIMARY', '#2A7DE1' ); // Hex
+define( 'NEWSPACK_DEFAULT_PRIMARY', '#3366ff' ); // Hex
 define( 'NEWSPACK_DEFAULT_SECONDARY', '#666666' ); // Hex
 
 /**
@@ -64,5 +64,3 @@ function newspack_has_custom_primary_color() {
 function newspack_has_custom_secondary_color() {
 	return newspack_get_secondary_color() !== NEWSPACK_DEFAULT_SECONDARY;
 }
-
-

--- a/sass/plugins/woocommerce.scss
+++ b/sass/plugins/woocommerce.scss
@@ -7,7 +7,7 @@ $headings: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu
 $body: "Baskerville Old Face", Garamond, "Times New Roman", serif;
 
 $body-color: #111;
-$highlights-color: #2A7DE1;
+$highlights-color: #36f;
 
 @import "sass/variables-site/variables-site";
 @import "sass/mixins/mixins-master";

--- a/sass/variables-site/_colors.scss
+++ b/sass/variables-site/_colors.scss
@@ -1,7 +1,7 @@
 
 // Custom Colors - defaults
-$color__primary: #2A7DE1;
-$color__primary-variation: darken( $color__primary, 10% );
+$color__primary: #36f;
+$color__primary-variation: #2240d5;
 $color__secondary: #555;
 $color__secondary-variation: darken( $color__secondary, 10% );
 
@@ -32,7 +32,7 @@ $color__link-hover: $color__secondary-variation;
 
 // Borders
 $color__border: #ccc;
-$color__border-link: #2A7DE1;
+$color__border-link: #36f;
 $color__border-link-hover: $color__primary-variation;
 $color__border-button: #ccc #ccc #bbb;
 $color__border-button-hover: #ccc #bbb #aaa;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Update the `$color__primary` variable
* Update the `$color__primary-variation` variable
* Update the `$color__border-link` variable
* Update the `$highlights-color` variable
* Update the color filters with the new `NEWSPACK_DEFAULT_PRIMARY`

### How to test the changes in this Pull Request:

1. Check out the branch and execute `npm run build`
2. Test the theme and see if any of the old blue is still appearing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
