### PR TITLE
Style 5: Update the navigation to make sure it's using a dark background colour

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -340,7 +340,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4' ) ) {
+	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
 		$theme_css .= '
 			.header-solid-background .middle-header-contain {
 				background-color: ' . $primary_color . ';

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -31,6 +31,7 @@ body {
 .header-solid-background {
 	.site-header,
 	.bottom-header-contain,
+	.middle-header-contain,
 	.top-header-contain {
 		background-color: $color__text-main;
 	}
@@ -120,6 +121,24 @@ input[type="submit"] {
 		flex: 1 0 0.25rem;
 		height: 1px;
 		margin: 0 0 0 0.25rem;
+	}
+}
+
+/* Navigation */
+.mobile-sidebar {
+	background: $color__text-main;
+}
+
+.site-header {
+	.main-navigation {
+		.main-menu {
+			.sub-menu {
+				a:hover,
+				a:focus {
+					background: $color__text-main;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Update the `mobile-sidebar`
* Update sub-menu links
* Add correct background colour to `.middle-header-contain`

### How to test the changes in this Pull Request:

1. Check out the branch and execute npm run build
2. Test the theme with style pack 5 and check the menu with and without custom colours

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
