### PR TITLE
Fix minor issue in style 5 header when highlight menu is assigned.

### DIFF
--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -29,7 +29,6 @@ body {
 }
 
 .header-solid-background {
-	.site-header,
 	.bottom-header-contain,
 	.top-header-contain {
 		background-color: $color__text-main;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed this while testing an unrelated change to Style 5 -- it was caused by some moving parts in the master branch while this style pack was under development, and was missed:

When you have a solid background header + have a 'Highlight Menu' assigned, the solid background incorrectly bleeds into the menu:

![image](https://user-images.githubusercontent.com/177561/66513960-12518280-ea91-11e9-9b43-d7d0057f52bc.png)

This PR fixes that by making the styles a bit more specific:

![image](https://user-images.githubusercontent.com/177561/66513914-fe0d8580-ea90-11e9-8b88-9a53ca09ff00.png)

### How to test the changes in this Pull Request:

1. Add a menu to the 'Highlight' menu spot. 
2. Set the header to be solid background.
3. Note the above issue.
4. Apply the PR and run `npm run build`
5. Confirm the issue is fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
