### PR TITLE
Add captions to featured images

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -154,25 +154,34 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			return;
 		}
 
-		if ( is_singular() ) :
-			?>
+		if ( is_singular() ) : ?>
 
 			<figure class="post-thumbnail">
+
 				<?php
 				$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
 				// If using the behind or beside image styles, add the object-fit argument for AMP.
-				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) {
+				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) :
+
 					the_post_thumbnail(
 						'newspack-featured-image',
 						array(
 							'object-fit' => 'cover',
 						)
 					);
-				} else {
+
+				else :
 					the_post_thumbnail( 'newspack-featured-image' );
-				}
+					$caption = get_post( get_post_thumbnail_id() )->post_excerpt;
+					if ( $caption ) :
+					?>
+						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+					<?php
+					endif;
+				endif;
 				?>
+
 			</figure><!-- .post-thumbnail -->
 
 		<?php else : ?>

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -154,6 +154,11 @@ body.page {
 			display: block;
 		}
 	}
+
+	figcaption {
+		max-width: 100%;
+		width: 100%;
+	}
 }
 
 .entry-content {
@@ -472,6 +477,13 @@ body.page {
 .featured-image-beside > .wrapper {
 	max-width: 100%;
 	width: 100%;
+}
+
+.featured-image-behind + figcaption,
+.featured-image-beside + figcaption {
+	margin: #{ 0.25 * $size__spacing-unit } auto 0;
+	width: 1200px;
+	max-width: 100%;
 }
 
 @include media( tablet ) {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -116,6 +116,12 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
+.post-thumbnail figcaption:after,
+.featured-image-behind + figcaption:after,
+.featured-image-beside + figcaption:after {
+	display: none;
+}
+
 .entry-meta,
 .entry .wp-block-newspack-blocks-homepage-articles article .entry-meta {
 	font-size: $font__size-xs;

--- a/template-parts/post/large-featured-image.php
+++ b/template-parts/post/large-featured-image.php
@@ -6,6 +6,7 @@
  */
 
 $featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+$caption                 = get_post( get_post_thumbnail_id() )->post_excerpt;
 
 if ( 'behind' === $featured_image_position ) :
 ?>
@@ -19,6 +20,10 @@ if ( 'behind' === $featured_image_position ) :
 		</div><!-- .wrapper -->
 	</div><!-- .featured-image-behind -->
 
+	<?php if ( $caption ) : ?>
+		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+	<?php endif; ?>
+
 <?php elseif ( 'beside' === $featured_image_position ) : ?>
 
 	<div class="featured-image-beside">
@@ -27,8 +32,13 @@ if ( 'behind' === $featured_image_position ) :
 				<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 			</header>
 		</div><!-- .wrapper -->
+
 		<?php newspack_post_thumbnail(); ?>
 	</div><!-- .featured-image-behind -->
+
+	<?php if ( $caption ) : ?>
+		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
+	<?php endif; ?>
 
 <?php else : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes any captions associated with featured images display on the front-end of the site on single posts and pages.

Closes #488.

### How to test the changes in this Pull Request:

1. Apply the PR and run`npm run build`
2. Run through the following variations of the featured images, and make sure the caption displays well:
* Featured image less than 1200px wide:

![image](https://user-images.githubusercontent.com/177561/66531978-97a15b00-eac2-11e9-805b-b6e07044ba1e.png)

* Featured image more than 1200px wide:

![image](https://user-images.githubusercontent.com/177561/66532014-b0aa0c00-eac2-11e9-8c77-fb1ba80fe08b.png)

* Featured image behind:

![image](https://user-images.githubusercontent.com/177561/66532036-cc151700-eac2-11e9-9f70-7f96322b7739.png)

* Featured image beside:

![image](https://user-images.githubusercontent.com/177561/66532053-e3ec9b00-eac2-11e9-996a-cc53f4bc2eae.png)

3. If you're not already on it, switch to Style 3, and make sure the little coloured block that normally appears on captions inline does not appear (it was a bit too much going on in that one spot).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
