### PR TITLE
Rework Columns Block by moving changes to Newspack Blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -59,6 +59,29 @@
 				&.wp-block-cover {
 					width: auto;
 				}
+
+				&.wp-block-columns {
+					margin-left: calc(25% - 25vw - 16px);
+					margin-right: calc(25% - 25vw - 16px);
+					max-width: calc(100vw + 32px);
+					width: auto;
+
+					&.is-style-borders {
+						margin-left: calc(25% - 25vw - 24px);
+						margin-right: calc(25% - 25vw - 24px);
+						max-width: calc(100vw + 48px);
+					}
+				}
+			}
+
+			@include media(desktop) {
+				&.wp-block-columns {
+					&.is-style-borders {
+						margin-left: calc(25% - 25vw - 32px);
+						margin-right: calc(25% - 25vw - 32px);
+						max-width: calc(100vw + 64px);
+					}
+				}
 			}
 		}
 		.alignfull {
@@ -68,6 +91,37 @@
 
 			&.wp-block-cover {
 				width: 100vw;
+			}
+
+			&.wp-block-columns {
+				margin-left: 0;
+				margin-right: 0;
+				max-width: 100%;
+
+				@include media(mobile) {
+					margin-left: calc(50% - 50vw - 16px);
+					margin-right: calc(50% - 50vw - 16px);
+					max-width: calc(100vw + 32px);
+					width: calc(100vw + 32px);
+				}
+
+				@include media(tablet) {
+					&.is-style-borders {
+						margin-left: calc(50% - 50vw - 24px);
+						margin-right: calc(50% - 50vw - 24px);
+						max-width: calc(100vw + 48px);
+						width: calc(100vw + 48px);
+					}
+				}
+
+				@include media(desktop) {
+					&.is-style-borders {
+						margin-left: calc(50% - 50vw - 32px);
+						margin-right: calc(50% - 50vw - 32px);
+						max-width: calc(100vw + 64px);
+						width: calc(100vw + 64px);
+					}
+				}
 			}
 		}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -715,36 +715,25 @@
 			margin-bottom: 0;
 		}
 
-		@include media(tablet) {
-			.wp-block-column {
-				margin-bottom: 0;
-			}
+		@include media( mobile ) {
+			margin-left: -16px;
+			max-width: calc(100% + 32px);
+		}
 
-			&[class*='has-'] > * {
-				margin-right: $size__spacing-unit;
-
-				&:last-child {
-					margin-right: 0;
-				}
+		@include media( tablet ) {
+			&.is-style-borders {
+				margin-left: -24px;
+				max-width: calc(100% + 48px);
 			}
 		}
 
-		&.is-style-borders {
-			.wp-block-column {
-
-				@include media(tablet) {
-					flex-basis: calc(50% - 32px);
-
-					&:not(:first-child) {
-						margin-left: 64px;
-					}
-
-					&:after {
-						right: -32px;
-					}
-				}
+		@include media( desktop ) {
+			&.is-style-borders {
+				margin-left: -32px;
+				max-width: calc(100% + 64px);
 			}
 		}
+
 	}
 
 	//! Group


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
_This is an experiement_

The theme now relies on the Newspack Blocks own CSS. We just overwrite the margin-left and the max-width.

See: https://github.com/Automattic/newspack-blocks/pull/158

### How to test the changes in this Pull Request:

1. Check out this branch and compile the CSS
2. You will also need to [update the blocks](https://github.com/Automattic/newspack-blocks/pull/158)
3. Add different sizes of columns, does it work as expected?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
