### PR TITLE
Make sure WooCommerce notice doesn't inherit primary colour.

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -58,7 +58,6 @@ function newspack_woo_custom_colors_css( $css, $primary_color ) {
 	}
 	$css      .= '
 		.onsale,
-		.woocommerce-info,
 		.woocommerce-store-notice {
 			background-color: ' . $primary_color . ';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, any WooCommerce errors inherit the primary colour as a background, which looks a bit odd in some cases, and can make the message impossible to read.

This PR removes that style.

Closes #491.

### How to test the changes in this Pull Request:

1. Set your site to use a custom primary colour under Customizer > Colours; preferrably something dark.
2. Add something to the cart (the Donate block is a good way to do this) and navigate to the checkout page on your site (www.site.com/checkout/ if you have the default settings).
3. If you don't have any payment options set up, you should see an error like this at the bottom:

![image](https://user-images.githubusercontent.com/177561/66611788-739e5200-eb74-11e9-8936-d84e1cad8559.png)

Or it may not be faded out:

![image](https://user-images.githubusercontent.com/177561/66611804-7c8f2380-eb74-11e9-8863-7e3fa912da5c.png)

4. Apply the PR.
5. Confirm that the background is now gone:

![image](https://user-images.githubusercontent.com/177561/66611759-62eddc00-eb74-11e9-8cc1-3eeca4e7aa77.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
