### PR TITLE
Fix styles for article block categories

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -282,6 +282,15 @@ function newspack_custom_colors_css() {
 			.has-drop-cap:not(:focus)::first-letter {
 				border-color: ' . $primary_color . ';
 			}
+
+			.entry-content .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
+				background-color: ' . $secondary_color . ';
+			}
+			.entry-content .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a,
+			.entry-content .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:visited,
+			.entry-content .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:hover {
+				color: ' . $secondary_color_contrast . ';
+			}
 		';
 	}
 
@@ -472,6 +481,15 @@ function newspack_custom_colors_css() {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				border-color: ' . $primary_color . ';
+			}
+
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
+				background-color: ' . $secondary_color . ';
+			}
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a,
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:visited,
+			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:hover {
+				color: ' . $secondary_color_contrast . ';
 			}
 		';
 	}

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -25,6 +25,7 @@ function newspack_custom_typography_css() {
 		.comments-title,
 		.comment-author .fn,
 		.discussion-meta-info,
+		.cat-links,
 		.entry-meta,
 		.entry-footer,
 		.main-navigation,
@@ -186,6 +187,7 @@ function newspack_custom_typography_css() {
 		.editor-block-list__layout .editor-block-list__block h6,
 		.editor-block-list__layout .editor-block-list__block figcaption,
 		.editor-block-list__layout .editor-block-list__block .gallery-caption,
+		.editor-block-list__layout .editor-block-list__block .cat-links,
 
 		/* Post Title */
 		.editor-styles-wrapper .editor-post-title .editor-post-title__block .editor-post-title__input,
@@ -339,7 +341,14 @@ function newspack_custom_typography_css() {
 		$css_blocks .= '
 			.tags-links span:first-child,
 			.page-title,
+			.cat-links,
 			.highlight-menu .menu-label {
+				text-transform: uppercase;
+			}
+		';
+
+		$editor_css_blocks .= '
+			.cat-links {
 				text-transform: uppercase;
 			}
 		';
@@ -347,8 +356,7 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'default', 'style-4', 'style-5' ) ) {
 			$css_blocks        .= '
 				.accent-header,
-				.article-section-title,
-				.cat-links a {
+				.article-section-title {
 					text-transform: uppercase;
 				}
 			';
@@ -364,7 +372,6 @@ function newspack_custom_typography_css() {
 			$css_blocks        .= '
 				.accent-header:not(.widget-title),
 				.article-section-title,
-				.cat-links,
 				.page-title,
 				#secondary .widget-title,
 				.author-bio .accent-header span,
@@ -389,7 +396,6 @@ function newspack_custom_typography_css() {
 				.mobile-menu-toggle,
 				.accent-header,
 				.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-				.cat-links,
 				.entry-meta .byline a,
 				.tags-links a,
 				.post-edit-link,
@@ -415,7 +421,6 @@ function newspack_custom_typography_css() {
 			$css_blocks        .= '
 				.accent-header,
 				.site-content .wp-block-newspack-blocks-homepage-articles .article-section-title,
-				.cat-links,
 				.archive .page-title,
 				.author-bio h2 span,
 				.entry-meta .byline a,

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -138,6 +138,10 @@ figcaption,
 	}
 }
 
+.cat-links {
+	font-family: $font__heading;
+}
+
 /** === Default Appender === */
 
 .editor-default-block-appender .editor-default-block-appender__content {

--- a/sass/styles/style-1/style-1.scss
+++ b/sass/styles/style-1/style-1.scss
@@ -239,6 +239,11 @@
 	}
 }
 
+//! Newspack
+.wp-block-newspack-blocks-homepage-articles .cat-links:before {
+	display: none;
+}
+
 // Archive
 
 .archive .page-title {

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -130,3 +130,8 @@ blockquote {
 .wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 	border-top: 5px solid $color__text-main;
 }
+
+//! Newspack
+.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
+	background-color: $color__secondary;
+}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -388,6 +388,12 @@ blockquote {
 	}
 }
 
+//! Newspack
+
+.entry-content .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
+	background-color: $color__secondary;
+}
+
 // Author Bio
 
 .author-bio {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -331,6 +331,11 @@ figcaption,
 	}
 }
 
+//! Newspack
+.wp-block-newspack-blocks-homepage-articles .cat-links:before {
+	display: none;
+}
+
 // Archives
 
 .archive .page-title {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -230,6 +230,12 @@ figcaption,
 	}
 }
 
+//! Newspack
+.wp-block-newspack-blocks-homepage-articles .cat-links {
+	text-align: left;
+}
+
+
 @include media( tablet ) {
 	.header-solid-background .featured-image-beside {
 		background-color: $color__background-pre;

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -319,6 +319,11 @@ textarea {
 	}
 }
 
+//! Newspack
+.wp-block-newspack-blocks-homepage-articles .cat-links:after {
+	display: none;
+}
+
 /* Archive */
 .archive .page-title {
 	color: $color__text-light;

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -2,7 +2,7 @@
 
 .accent-header,
 .article-section-title {
-	border-bottom: 4px solid #ccc;
+	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
 	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
@@ -51,6 +51,19 @@ body.header-default-background.header-default-height {
 		&:hover {
 			background-color: $color__primary-variation;
 			color: #fff;
+		}
+	}
+}
+
+.wp-block-newspack-blocks-homepage-articles .cat-links {
+	a {
+		margin: 0;
+		padding: 0;
+		&,
+		&:visited,
+		&:hover {
+			background-color: transparent;
+			color: inherit;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The newly added categories in the article block use the same class (`.cat-links`) as most themes; this helps them inherit styles. This PR updates the style packs to make sure these in-block categories don't inherit specific styles that they shouldn't.

It also consolidates the `cat-links` selectors when used for the custom typography all-caps settings. 

Closes #478.

### How to test the changes in this Pull Request:

1. Add an article block to the homepage, and turn on "Show Categories" in the settings. Make sure you have a mix of both articles with and without images.
2. Apply the PR and run `npm run build`.
3. Cycle through each of the style packs, and view the blocks on both the front-end and in the editor:

**Default styles**

Before:

![image](https://user-images.githubusercontent.com/177561/66671878-d8f45080-ec11-11e9-9715-8b9450ae8ee5.png)

After:

![image](https://user-images.githubusercontent.com/177561/66671829-c24df980-ec11-11e9-8b17-6f87f7602437.png)

**Style 1**

Before:

![image](https://user-images.githubusercontent.com/177561/66671962-0640fe80-ec12-11e9-8d3d-ecf4173eb578.png)

After:

![image](https://user-images.githubusercontent.com/177561/66672028-2f618f00-ec12-11e9-9cc1-54f307df2086.png)

**Style 2**

Before:

![image](https://user-images.githubusercontent.com/177561/66673782-2e326100-ec16-11e9-9f2c-a4e6c69bb07a.png)

After:

![image](https://user-images.githubusercontent.com/177561/66672051-3c7e7e00-ec12-11e9-836c-e6872397eeef.png)

(This style pack uses the secondary colour for the category background when overlaid on images)

![image](https://user-images.githubusercontent.com/177561/66672076-53bd6b80-ec12-11e9-88d6-e4a50c9c1742.png)

**Style 3**

Before:

![image](https://user-images.githubusercontent.com/177561/66673807-40140400-ec16-11e9-8946-d6755fc57a96.png)

After:

![image](https://user-images.githubusercontent.com/177561/66673956-997c3300-ec16-11e9-8ae7-7f866e158dd1.png)

**Style 4**

Before:

![image](https://user-images.githubusercontent.com/177561/66674457-c11fcb00-ec17-11e9-9daa-99c350e591ee.png)

After:

![image](https://user-images.githubusercontent.com/177561/66674005-b57fd480-ec16-11e9-9681-95bcf1bbde9d.png)


**Style 5**

Before:

![image](https://user-images.githubusercontent.com/177561/66674555-093eed80-ec18-11e9-8758-04526dd2150b.png)

After:

![image](https://user-images.githubusercontent.com/177561/66674512-ead8f200-ec17-11e9-8a77-fab50545d759.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
