### PR TITLE
Add option to hide author email from bios

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -258,6 +258,25 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'author_bio_options',
 		)
 	);
+
+	// Add option to hide author email address.
+	$wp_customize->add_setting(
+		'show_author_email',
+		array(
+			'default'           => false,
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'show_author_email',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display Author Email', 'newspack' ),
+			'description' => esc_html__( 'Display Author email with bio on individual posts.', 'newspack' ),
+			'section'     => 'author_bio_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -104,6 +104,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-author-bio';
 	}
 
+	$display_author_email = get_theme_mod( 'show_author_email', false );
+	if ( false === $display_author_email ) {
+		$classes[] = 'hide-author-email';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/js/src/customize-controls.js
+++ b/js/src/customize-controls.js
@@ -37,6 +37,24 @@
 				setting.bind( visibility );
 			});
 		});
+
+
+		// Only show the rest of the author controls when the bio is visible.
+		wp.customize( 'show_author_bio', function( setting ) {
+			console.log( setting );
+			wp.customize.control( 'show_author_email', function( control ) {
+				var visibility = function() {
+					if ( '1' === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+
+				visibility();
+				setting.bind( visibility );
+			});
+		});
 	});
 
 })( jQuery );

--- a/js/src/customize-preview.js
+++ b/js/src/customize-preview.js
@@ -39,4 +39,15 @@
 			}
 		});
 	});
+
+	// Hide Author email
+	wp.customize( 'show_author_email', function( value ) {
+		value.bind( function( to ) {
+			if ( false === to ) {
+				$( 'body' ).addClass( 'hide-author-email' );
+			} else {
+				$( 'body' ).removeClass( 'hide-author-email' );
+			}
+		});
+	});
 })( jQuery );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -370,7 +370,8 @@ body.page {
 	}
 }
 
-.hide-author-bio .author-bio {
+.hide-author-bio .author-bio,
+.hide-author-email .author-bio .author-email {
 	display: none;
 }
 

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -56,7 +56,7 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 					<span><?php // TODO: Add Job title ?></span>
 				</h2>
 				<div class="author-meta">
-					<a href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
+					<a class="author-email" href="<?php echo 'mailto:' . esc_attr( get_the_author_meta( 'user_email' ) ); ?>"><?php the_author_meta( 'user_email' ); ?></a>
 				</div>
 			</div>
 		</div><!-- .author-bio-header -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to hide the author email from the bio that appears at the bottom of each post.

The toggle is labelled "Display Author Email"; I've opted to set it to false as a default, so it will hide the email from existing sites. 

Closes #433.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to a post that displays an author bio; confirm that the email is hidden:

![image](https://user-images.githubusercontent.com/177561/66706557-1972cd80-ece9-11e9-841e-a47c6d1616b9.png)

3. Navigate to Customizer > Author Bio Settings; toggle on 'Display Author Email' and confirm it works in the Customizer Preview, and on the front end.
4. Navigate back to Customizer > Author Bio Settings, and toggle off 'Display Author Bio'; confirm that the email setting disappears (since the whole containing element is hidden, we can't show/hide the email individually).

![image](https://user-images.githubusercontent.com/177561/66706574-4921d580-ece9-11e9-9d07-dddde24e70fb.png)

![image](https://user-images.githubusercontent.com/177561/66706579-4e7f2000-ece9-11e9-828c-076fbc90ef2d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?