### PR TITLE
Style 2: Make sure site info links don't disappear on hover

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -481,8 +481,16 @@ blockquote {
 	.wrapper {
 		border: 0;
 	}
+}
 
+.site-footer .site-info {
 	a {
 		color: inherit;
+	}
+
+	a:hover,
+	a:visited {
+		color: inherit;
+		opacity: 0.8;
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -491,6 +491,6 @@ blockquote {
 	a:hover,
 	a:visited {
 		color: inherit;
-		opacity: 0.8;
+		opacity: 0.7;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, with Style 2, if you have a dark primary colour set, the links in the footer's "site info" section all but disappear on hover. 

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and switch to Style 2.
2. Navigate to Customize > Colours, and switch to custom colours, and set the primary colour to a dark colour:
3. On the front end, try hovering over links in the site info section of the footer (the very bottom section that has a black background). You can barely see the dark blue I picked against the black background:

![image](https://user-images.githubusercontent.com/177561/66706678-af5b2800-ecea-11e9-9b7c-4a6852db03ec.png)

4. Apply the PR and run `npm run build`.
5. Repeat step 3; confirm that the links go from white to a light grey:

![image](https://user-images.githubusercontent.com/177561/66706667-78851200-ecea-11e9-8858-887436031080.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
