### PR TITLE
Add author avatar to the archive page

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -14,9 +14,33 @@ get_header();
 
 		<header class="page-header">
 			<?php
-				the_archive_title( '<h1 class="page-title">', '</h1>' );
-				the_archive_description( '<div class="taxonomy-description">', '</div>' );
+				if ( is_author() ) {
+					$author_id     = get_query_var( 'author' );
+					$author_avatar = get_avatar( $author_id, 120 );
+
+					if ( $author_avatar ) {
+						echo wp_kses(
+							$author_avatar,
+							array(
+								'img' => array(
+									'src'    => array(),
+									'alt'    => array(),
+									'class'  => array(),
+									'width'  => array(),
+									'height' => array(),
+								),
+							)
+						);
+					}
+				}
 			?>
+			<span>
+				<?php
+					the_archive_title( '<h1 class="page-title">', '</h1>' );
+					the_archive_description( '<div class="taxonomy-description">', '</div>' );
+				?>
+			</span>
+
 		</header><!-- .page-header -->
 
 		<main id="main" class="site-main">

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -78,6 +78,30 @@
 			}
 		}
 	}
+
+	&.author .page-header {
+		display: flex;
+
+		.avatar {
+			height: 30px;
+			margin-right: $size__spacing-unit;
+			width: 30px;
+		}
+
+		@include media( mobile ) {
+			.avatar {
+				height: 80px;
+				width: 80px;
+			}
+		}
+
+		@include media( tablet ) {
+			.avatar {
+				height: 120px;
+				width: 120px;
+			}
+		}
+	}
 }
 
 .page-description {

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -109,7 +109,11 @@ h4 {
 }
 
 .page-title {
-	font-size: $font__size_base;
+	font-size: $font__size_sm;
+
+	@include media( tablet ) {
+		font-size: $font__size_base;
+	}
 }
 
 .entry-meta,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the author avatar, if present, to the author archive page.

See #350.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm the author avatar now appears on the author archive pages, next to the information about them:

![image](https://user-images.githubusercontent.com/177561/66722022-bc951700-edbd-11e9-82af-68d7947178d0.png)

![image](https://user-images.githubusercontent.com/177561/66722026-cb7bc980-edbd-11e9-9fb2-881d0ae38ecf.png)

![image](https://user-images.githubusercontent.com/177561/66722027-d5053180-edbd-11e9-90fb-a94434d16016.png)

3. Check the appearance on different screensizes.
4. Navigate to Settings > Discussion, and hide avatars; confirm this removes them from the author archive page, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
