### PR TITLE
Fix avatar duplication

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -47,19 +47,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 		printf(
 			/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
 			'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
-			wp_kses(
-				get_avatar( get_the_author_meta( 'ID' ) ),
-				array(
-					'img' => array(
-						'alt'    => array(),
-						'src'    => array(),
-						'srcset' => array(),
-						'class'  => array(),
-						'width'  => array(),
-						'height' => array(),
-					),
-				)
-			),
+			get_avatar( get_the_author_meta( 'ID' ) ),
 			esc_html__( 'by', 'newspack' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 			esc_html( get_the_author() )

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -9,45 +9,23 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 <div class="author-bio">
 
 	<?php
-	if ( ! newspack_is_active_style_pack( 'style-4' ) ) :
+	if ( ! newspack_is_active_style_pack( 'style-4' ) ) {
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-		if ( $author_avatar ) :
-			echo wp_kses(
-				$author_avatar,
-				array(
-					'img' => array(
-						'src'    => array(),
-						'alt'    => array(),
-						'class'  => array(),
-						'width'  => array(),
-						'height' => array(),
-					),
-				)
-			);
-		endif;
-	endif;
+		if ( $author_avatar ) {
+			echo get_avatar( get_the_author_meta( 'ID' ), 80 );
+		}
+	}
 	?>
 
 	<div class="author-bio-text">
 		<div class="author-bio-header">
 			<?php
-			if ( newspack_is_active_style_pack( 'style-4' ) ) :
+			if ( newspack_is_active_style_pack( 'style-4' ) ) {
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-				if ( $author_avatar ) :
-					echo wp_kses(
-						$author_avatar,
-						array(
-							'img' => array(
-								'src'    => array(),
-								'alt'    => array(),
-								'class'  => array(),
-								'width'  => array(),
-								'height' => array(),
-							),
-						)
-					);
-				endif;
-			endif;
+				if ( $author_avatar ) {
+					echo get_avatar( get_the_author_meta( 'ID' ), 80 );
+				}
+			}
 			?>
 
 			<div>

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -12,7 +12,8 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 	if ( ! newspack_is_active_style_pack( 'style-4' ) ) {
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 		if ( $author_avatar ) {
-			echo get_avatar( get_the_author_meta( 'ID' ), 80 );
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $author_avatar;
 		}
 	}
 	?>
@@ -23,7 +24,8 @@ if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
 			if ( newspack_is_active_style_pack( 'style-4' ) ) {
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 				if ( $author_avatar ) {
-					echo get_avatar( get_the_author_meta( 'ID' ), 80 );
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $author_avatar;
 				}
 			}
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue reported in the review of #506:

The theme's using a `wp_kses()` function unnecessarily with the avatars, causing them to be duplicated when using Jetpack's lazy loading.

`get_avatar()` doesn't actually need this sanitization.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Check a single post; confirm the author avatar is displaying as expected in the byline at the top.
3. Check the author bio at the bottom of the post; confirm the author avatar is displaying as expected.
4. Navigate to Customize > Style Packs and switch to Style 4 (or if you're already on style 4, switch away from it). 
5. Re-confirm that the author bio is displaying as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
