### PR TITLE
Correct initial check for author bio

### DIFF
--- a/js/src/customize-controls.js
+++ b/js/src/customize-controls.js
@@ -41,16 +41,14 @@
 
 		// Only show the rest of the author controls when the bio is visible.
 		wp.customize( 'show_author_bio', function( setting ) {
-			console.log( setting );
 			wp.customize.control( 'show_author_email', function( control ) {
 				var visibility = function() {
-					if ( '1' === setting.get() ) {
+					if ( true === setting.get() ) {
 						control.container.slideDown( 180 );
 					} else {
 						control.container.slideUp( 180 );
 					}
 				};
-
 				visibility();
 				setting.bind( visibility );
 			});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For some reason, when I try to use the author email toggle added in #501, on a fresh site, it is not visible (I experienced this on a couple of our staging sites, and a fresh local site).

I tried switching the value being checked from `1` to `true` and it seems to have fixed it on my fresh local site. I would be interested to know if it continues to work for everyone else on a fresh site -- I suspect I somehow messed up my main testing site by adding the toggle and saving the value before I added the JS to show/hide it, but I might be missing something.

(This also removes an unneeded `console.log` -- whoops!)

### How to test the changes in this Pull Request:

1. Apply the PR, ideally on a site that didn't have #501 applied to it.
2. Navigate to Customize > Author Bio Settings, and confirm you see a checkbox to display the author email.
3. Confirm when you uncheck "Display Author Bio", the email checkbox disappears, but it comes back when "Display Author Bio" is re-checked.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
