### PR TITLE
Styles: Make Style 5 observe the custom colours

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -340,6 +340,21 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+	if ( newspack_is_active_style_pack( 'style-5' ) ) {
+		$theme_css .= '
+			.cat-links a,
+			.cat-links a:visited,
+			body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a {
+				background-color: ' . $primary_color . ';
+				color: ' . $primary_color_contrast . ';
+			}
+			.cat-links a:hover {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
+				color: ' . $primary_color_contrast . ';
+			}
+		';
+	}
+
 	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
 		$theme_css .= '
 			.header-solid-background .middle-header-contain {

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -352,6 +352,10 @@ function newspack_custom_colors_css() {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 				color: ' . $primary_color_contrast . ';
 			}
+			.accent-header, .article-section-title,
+			.entry .entry-footer a:hover {
+				color: ' . newspack_color_with_contrast( $primary_color ) . ';
+			}
 		';
 	}
 


### PR DESCRIPTION
On article pages when using Style 5, the category links above the title and other areas do not use the custom colours as selected in the customiser. Instead they use the default Newspack colours.

This change ensures they use the customiser colours, just like other style packs.
