### PR TITLE
Don't remove checkout sidebars

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -116,18 +116,6 @@ function newspack_woo_account_registration_heading() {
 add_action( 'woocommerce_before_checkout_registration_form', 'newspack_woo_account_registration_heading' );
 
 /**
- * Remove sidebar on Checkout page to reduce distractions.
- */
-function newspack_woo_remove_checkout_sidebar( $is_active ) {
-	if ( is_page( wc_get_page_id( 'checkout' ) ) ) {
-		return false;
-	}
-
-	return $is_active;
-}
-add_filter( 'is_active_sidebar', 'newspack_woo_remove_checkout_sidebar' );
-
-/**
  * Remove default WooCommerce wrapper.
  */
 remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Looks like the sidebars were getting intentionally removed on the Checkout page (a holdover from 2019 theme probably). This PR removes that tweak so the sidebars display normally on the Checkout page.

### How to test the changes in this Pull Request:

1. Visit Checkout page. Observe sidebar and footer sidebar are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
