### PR TITLE
Fix up some of the styles in the new footer widget area

### DIFF
--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -113,8 +113,15 @@
 			font-size: inherit;
 
 			@include media( mobile ) {
-				margin-bottom: 0;
-				min-width: 25%;
+				margin: 0 $size__spacing-unit;
+
+				&:first-child {
+					margin-left: 0;
+				}
+
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 
@@ -134,13 +141,22 @@
 		}
 
 		@include media( mobile ) {
-			ul, li {
+			ul, li a {
 				display: inline;
 			}
 
-			ul li a {
+			li {
 				display: inline-block;
 				margin: 0 $size__spacing-unit 0 0;
+
+				ul {
+					display: inline-block;
+					margin-left: $size__spacing-unit;
+				}
+
+				&:last-child {
+					margin-right: 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I added a new footer widget area in #499, intended primarily for simple menus, disclaimer text, or 'sponsor' logos. 

I noticed on implementation that it had some display issues: 

1. If you had a menu or category widget as the second & last widget, there was a small space between it and the right edge (due to a right margin on each list item):



2. If you put a short/smaller widget in the second/last widget area, the `min-width` was obvious -- it wouldn't go all the way to the end.

Removing the min-width does mean that it will be important to make sure the widget content is relatively even, but I think this is easier to control on the WordPress UI level; we can also make further adjustments as needed.

Closes # .

### How to test the changes in this Pull Request:

1. Navigate to Customize > Widgets > Above Copyright, and add a Text widget with a short string of text.
2. Under it, add a Navigation Menu widget, and assign a short, but multi-level, menu to the Navigation Menu widget. 
3. View on the front-end; note that there's a slight space between the last menu item in the widget, and the end of the availalbe space:

![image](https://user-images.githubusercontent.com/177561/66858547-5c79ae80-ef3e-11e9-8571-45e6ece108e9.png)

4. Navigate back to Customize > Widgets Above Copyright, and switch the widget locations.
5. View on the front-end; note that the shorter widget has a minimum width, so it doesn't reach the right side:

![image](https://user-images.githubusercontent.com/177561/66858495-410ea380-ef3e-11e9-9344-6b8a40c7fa1e.png)

6. Apply the PR and run `npm run build`
7. Confirm the short widget sits all the way to the right.

![image](https://user-images.githubusercontent.com/177561/66858698-a8c4ee80-ef3e-11e9-8437-1eac28b0f9c4.png)


8. Switch the widget locations again, confirm that the menu goes all the way to the right.

![image](https://user-images.githubusercontent.com/177561/66858640-8df27a00-ef3e-11e9-890b-01e3fcfff045.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
