### PR TITLE
"Above Copyright" footer widget spacing fix

### DIFF
--- a/sass/site/footer/_site-footer.scss
+++ b/sass/site/footer/_site-footer.scss
@@ -113,11 +113,7 @@
 			font-size: inherit;
 
 			@include media( mobile ) {
-				margin: 0 $size__spacing-unit;
-
-				&:first-child {
-					margin-left: 0;
-				}
+				margin: 0 $size__spacing-unit 0 0;
 
 				&:last-child {
 					margin-right: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR changes the spacing for the 'above copyright' widgets, to prevent some odd spacing when they wrap on tablet-sized screens.

**Before:**

![image](https://user-images.githubusercontent.com/177561/67115064-2df41180-f192-11e9-87ac-ad77e26a4cfb.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/67115026-19b01480-f192-11e9-8c19-097af0bbdc43.png)

Closes #518


### How to test the changes in this Pull Request:

1. Add two widgets to the "Above Copyright" widget space.
2. Shrink the browser window on the front-end, until the widgets wrap to two lines; note the space before the second one.
3. Apply the PR and run `npm run build`
4. Confirm that the space is now gone. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
