### PR TITLE
Style 3: Fix article border styles

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -48,6 +48,11 @@ Newspack Theme Editor Styles - Style Pack 3
 	figcaption:after {
 		display: none;
 	}
+
+	&.is-style-borders article {
+		border-bottom-style: dotted;
+		border-bottom-color: $color__text-main;
+	}
 }
 
 .wp-block-cover,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -202,6 +202,11 @@ figcaption,
 		figcaption:after {
 			display: none;
 		}
+
+		&.is-style-borders article {
+			border-bottom-style: dotted;
+			border-bottom-color: $color__text-main;
+		}
 	}
 
 	.wp-block-cover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the article block borders use the correct border style when you're using 'Style 3'.

### How to test the changes in this Pull Request:

1. Add an article block, and apply the 'border' style.
2. Navigate to Customize > Style Packs and switch to Style 3.
3. View the article block on the front end and in the editor; unlike other border styles in this style pack, they are solid and light grey:

![image](https://user-images.githubusercontent.com/177561/67248736-44ac9980-f41a-11e9-8424-41f8a24be66a.png)

4. Apply the PR and run `npm run build`.
5. View the block again in the editor and on the front-end, and confirm the borders are now dotted:

![image](https://user-images.githubusercontent.com/177561/67246491-6f472400-f413-11e9-922d-a69a77a77267.png)

Related to https://github.com/Automattic/newspack-blocks/pull/175;.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
