### PR TITLE
Update check for image size to add body class

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -82,7 +82,7 @@ function newspack_body_classes( $classes ) {
 
 	// Adds a class if singular post has a large featured image
 	$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-	if ( is_single() && has_post_thumbnail() && 1200 < (int) $thumbnail_info['width'] ) {
+	if ( is_single() && has_post_thumbnail() && 1200 <= (int) $thumbnail_info['width'] ) {
 		$classes[] = 'has-large-featured-image';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There's a check in the theme that adds a class to the body, `.has-large-featured-image`, if the featured image is more than 1200px.

It's used to add a top border when the image is not; however, the check is `1200 < width` (greater than), but it should be `1200 <= width` (great than or equal to 1200px). Otherwise, if you upload an image that's exactly 1200px wide, it will show both the large image, and an unnecessary border above it.

### How to test the changes in this Pull Request:

1. Set up a post and add a featured image that's exactly 1200px wide; view on the front-end: 

![image](https://user-images.githubusercontent.com/177561/67250801-ae7c7180-f421-11e9-8a07-d669a7696742.png)

2. Set up a second post and add a featured image that's less than 1200px; view on front-end:

![image](https://user-images.githubusercontent.com/177561/67250792-a58ba000-f421-11e9-9a0f-3f0354848552.png)

3. Note that both have a border underneath the `.entry-header` (if using Style 3, it's easier to see the border). 

4. Apply the PR and run `npm run build`.
5. Confirm that the first post no longer has the border, but the second one still does:

![image](https://user-images.githubusercontent.com/177561/67250845-dff53d00-f421-11e9-9e32-7658461e7642.png)

![image](https://user-images.githubusercontent.com/177561/67250792-a58ba000-f421-11e9-9a0f-3f0354848552.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
