### PR TITLE
Style 3: Fix Article Block image overlap

### DIFF
--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -189,24 +189,23 @@ figcaption,
 }
 
 .entry .entry-content {
-	.wp-block-newspack-blocks-homepage-articles {
-		.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
-			background-color: $color__background-body;
-			margin-top: -1.5em;
-			padding: 0.5em 0.25em 0 0;
-			position: relative;
-			width: 85%;
-			z-index: 1;
-		}
 
-		figcaption:after {
-			display: none;
-		}
+	.wp-block-newspack-blocks-homepage-articles.is-style-borders article {
+		border-bottom-style: dotted;
+		border-bottom-color: $color__text-main;
+	}
 
-		&.is-style-borders article {
-			border-bottom-style: dotted;
-			border-bottom-color: $color__text-main;
-		}
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+		background-color: $color__background-body;
+		margin-top: -1.5em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
+	}
+
+	.wp-block-newspack-blocks-homepage-articles figcaption:after {
+		display: none;
 	}
 
 	.wp-block-cover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Style 3, the post titles should overlap the image slightly in some cases, but this isn't happening right now.

It looks like a change to the caption styles may have broken this; this PR fixes it again.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and switch to Style 3.
2. Add an article block to the editor; make sure at least one article has an image. 
3. Leave the image aligned to the top, and make sure captions are turned off.
4. View on front-end; note that the title isn't overlapped on the front-end, even though it should be:

![image](https://user-images.githubusercontent.com/177561/67257237-d24eb000-f43f-11e9-82d4-95012a3a0925.png)


5. Apply the PR and run `npm run build`
6. Confirm that the title now overlaps the image:

![image](https://user-images.githubusercontent.com/177561/67257169-99aed680-f43f-11e9-9ba9-bae0fe21b050.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
