### PR TITLE
PWA: Add 'offline.php' template

### DIFF
--- a/header.php
+++ b/header.php
@@ -172,7 +172,7 @@
 
 					<?php
 					// If logo is not centered.
-					if ( false === $header_center_logo ) {
+					if ( false === $header_center_logo && has_nav_menu( 'primary-menu' ) ) {
 						get_template_part( 'template-parts/header/header', 'search' );
 					}
 					?>

--- a/offline.php
+++ b/offline.php
@@ -9,13 +9,16 @@ get_header();
 ?>
 	<section id="primary" class="content-area">
 		<header class="entry-header">
-			<h1 class="entry-title"><?php esc_html_e( 'Error', 'newspack' ); ?></h1>
+			<h1 class="entry-title"><?php esc_html_e( 'Oops! It looks like you&rsquo;re offline.', 'newspack' ); ?></h1>
 		</header><!-- .entry-header -->
 		<main id="main" class="site-main">
-			<?php wp_service_worker_error_message_placeholder(); ?>
+			<?php
+			if ( function_exists( 'wp_service_worker_error_message_placeholder' ) ) {
+				wp_service_worker_error_message_placeholder();
+			}
+			?>
 		</main><!-- .site-main -->
 	</section><!-- .content-area -->
-
 <?php
 get_footer();
 

--- a/offline.php
+++ b/offline.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * The main template file
+ *
+ * This is the most generic template file in a WordPress theme
+ * and one of the two required files for a theme (the other being style.css).
+ * It is used to display a page when nothing more specific matches a query.
+ * E.g., it puts together the home page when no home.php file exists.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package Newspack
+ */
+
+get_header();
+?>
+	<section id="primary" class="content-area">
+		<main id="main" class="site-main">
+			<?php wp_service_worker_error_message_placeholder(); ?>
+		</main><!-- .site-main -->
+	</section><!-- .content-area -->
+
+<?php
+get_footer();
+
+

--- a/offline.php
+++ b/offline.php
@@ -9,7 +9,7 @@ get_header();
 ?>
 	<section id="primary" class="content-area">
 		<header class="entry-header">
-			<h1 class="entry-title"><?php esc_html_e( 'Oops! It looks like you&rsquo;re offline.', 'newspack' ); ?></h1>
+			<h1 class="entry-title"><?php esc_html_e( 'Offline', 'newspack' ); ?></h1>
 		</header><!-- .entry-header -->
 		<main id="main" class="site-main">
 			<?php

--- a/offline.php
+++ b/offline.php
@@ -5,6 +5,16 @@
  * @package Newspack
  */
 
+// Prevent showing nav menus.
+add_filter( 'has_nav_menu', '__return_false' );
+
+// Prevent showing widgets.
+add_filter( 'is_active_sidebar', '__return_false' );
+
+// Disable WordAds in the header.
+// See: https://wordads.co/2018/02/07/how-to-control-jetpack-ad-placements-using-hooks/
+add_filter( 'wordads_header_disable', '__return_true' );
+
 get_header();
 ?>
 	<section id="primary" class="content-area">

--- a/offline.php
+++ b/offline.php
@@ -1,13 +1,6 @@
 <?php
 /**
- * The main template file
- *
- * This is the most generic template file in a WordPress theme
- * and one of the two required files for a theme (the other being style.css).
- * It is used to display a page when nothing more specific matches a query.
- * E.g., it puts together the home page when no home.php file exists.
- *
- * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ * The PWA Offline template file
  *
  * @package Newspack
  */
@@ -15,6 +8,9 @@
 get_header();
 ?>
 	<section id="primary" class="content-area">
+		<header class="entry-header">
+			<h1 class="entry-title"><?php esc_html_e( 'Error', 'newspack' ); ?></h1>
+		</header><!-- .entry-header -->
 		<main id="main" class="site-main">
 			<?php wp_service_worker_error_message_placeholder(); ?>
 		</main><!-- .site-main -->

--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -20,6 +20,7 @@
 }
 
 .site-content {
+	min-height: 30vh;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a first pass at adding a customized PWA error template to the theme.

It should use the theme's branding, and display a PWA error message, like:

![IMG_9259](https://user-images.githubusercontent.com/177561/67259205-725d0700-f449-11e9-9001-762f35025c22.PNG)

On top of the actual code, I'd be interested to hear feedback about what elements actually make sense to have in this template. Right now, for example, it loads the menu, footer widgets, and ads. Would it be better to strip that kind of stuff out? 

Once the template itself looks okay, we can look at jazzing it up a bit (like maybe adding headlines for the five most recently published articles?).

@westonruter I would especially appreciate your expertise on that part! 

Closes #357.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Make sure the PWA plugin is installed and enabled.
3. Test the presence of the PWA error message in one of two ways:

a) You can add `?wp_error_template=offline` to the URL, to see the template and page title (but not actual error message).

**OR** 

a) On a mobile device, view the site and add it to the Home Screen. 
b) Switch the phone to airplane mode.
c) Try loading the site from the link on the homepage; the initial page you saved should still work, but if you click another link that hasn't been saved, you should see the error message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
