### PR TITLE
Style 3: Fix 'image behind' styles with block

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -35,8 +35,7 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles {
-	&.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
+.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.75em;
 		padding: 0.5em 0.25em 0 0;
@@ -45,14 +44,13 @@ Newspack Theme Editor Styles - Style Pack 3
 		z-index: 1;
 	}
 
-	figcaption:after {
-		display: none;
-	}
+.wp-block-newspack-blocks-homepage-articles figcaption:after {
+	display: none;
+}
 
-	&.is-style-borders article {
-		border-bottom-style: dotted;
-		border-bottom-color: $color__text-main;
-	}
+.wp-block-newspack-blocks-homepage-articles.is-style-borders article {
+	border-bottom-style: dotted;
+	border-bottom-color: $color__text-main;
 }
 
 .wp-block-cover,

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -35,7 +35,7 @@ Newspack Theme Editor Styles - Style Pack 3
 	}
 }
 
-.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
+.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.75em;
 		padding: 0.5em 0.25em 0 0;
@@ -55,7 +55,7 @@ Newspack Theme Editor Styles - Style Pack 3
 
 .wp-block-cover,
 .wp-block-group {
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
+	.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: transparent;
 		margin-top: 0;
 		padding: 0;

--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -36,7 +36,7 @@ Newspack Theme Editor Styles - Style Pack 3
 }
 
 .wp-block-newspack-blocks-homepage-articles {
-	&.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption):not(.image-alignbehind) .post-has-image .entry-title {
+	&.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.75em;
 		padding: 0.5em 0.25em 0 0;
@@ -57,7 +57,7 @@ Newspack Theme Editor Styles - Style Pack 3
 
 .wp-block-cover,
 .wp-block-group {
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: transparent;
 		margin-top: 0;
 		padding: 0;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -196,7 +196,7 @@ figcaption,
 		border-bottom-color: $color__text-main;
 	}
 
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
+	.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.5em;
 		padding: 0.5em 0.25em 0 0;
@@ -211,7 +211,7 @@ figcaption,
 
 	.wp-block-cover,
 	.wp-block-group {
-		.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
+		.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption):not(.show-category) .post-has-image .entry-title {
 			background-color: transparent;
 			margin-top: 0;
 			padding: 0;

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -196,7 +196,7 @@ figcaption,
 		border-bottom-color: $color__text-main;
 	}
 
-	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.show-caption) .post-has-image .entry-title {
+	.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
 		background-color: $color__background-body;
 		margin-top: -1.5em;
 		padding: 0.5em 0.25em 0 0;
@@ -211,7 +211,7 @@ figcaption,
 
 	.wp-block-cover,
 	.wp-block-group {
-		.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright) .post-has-image .entry-title {
+		.wp-block-newspack-blocks-homepage-articles.show-image:not(.image-alignleft):not(.image-alignright):not(.image-alignbehind):not(.show-caption):not(.show-category) .post-has-image .entry-title {
 			background-color: transparent;
 			margin-top: 0;
 			padding: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue with the image 'behind' article block style, and style 3's title overlapping style.

It also simplifies the styles a bit, and fixes an issue I introduced rebasing the styles when the `.show-category` class should have been added.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and switch to style 3. 
2. Add four article blocks to a page; make sure each block has an article with at least one image. 3. Apply these settings, one to each block.
-- Make one have the image behind
-- Make one show the image caption
-- Set one to show the article categories
-- Leave one as is. 
4. View on the front-end and in the editor; confirm there are no issues with the title overlapping the image when it shouldn't and covering the category/caption, or making the title unreadable when the image is set as the background.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
