### PR TITLE
Add 'display=swap' to style pack Google Font query strings

### DIFF
--- a/inc/style-packs.php
+++ b/inc/style-packs.php
@@ -35,16 +35,16 @@ new Newspack_Style_Packs_Core(
 		// Style fonts
 		'fonts'              => array(
 			'style-1' => array(
-				'Fira Sans Condensed' => 'https://fonts.googleapis.com/css?family=Fira+Sans+Condensed:400,400i,600,600i',
+				'Fira Sans Condensed' => 'https://fonts.googleapis.com/css?family=Fira+Sans+Condensed:400,400i,600,600i&display=swap',
 			),
 			'style-2' => array(
-				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:500,700,800',
+				'Montserrat' => 'https://fonts.googleapis.com/css?family=Montserrat:500,700,800&display=swap',
 			),
 			'style-3' => array(
 				'Barlow' => 'https://fonts.googleapis.com/css?family=Barlow:400,400i,700,700i&display=swap',
 			),
 			'style-4' => array(
-				'IBM Plex Serif' => 'https://fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700,700i',
+				'IBM Plex Serif' => 'https://fonts.googleapis.com/css?family=IBM+Plex+Serif:400,400i,700,700i&display=swap',
 			),
 			'style-5' => array(
 				'Old Standard TT' => 'https://fonts.googleapis.com/css?family=Old+Standard+TT:400,400i,700&display=swap',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `&display=swap` to the Google font URLs, where it's missing.

### How to test the changes in this Pull Request:

1. Apply PR and run `npm run build`
2. Confirm that all Google Font URLs being enqueued for the style packs now include &display=swap` at the end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
