### PR TITLE
Offline template: Remove Newspack ads

### DIFF
--- a/offline.php
+++ b/offline.php
@@ -15,6 +15,11 @@ add_filter( 'is_active_sidebar', '__return_false' );
 // See: https://wordads.co/2018/02/07/how-to-control-jetpack-ad-placements-using-hooks/
 add_filter( 'wordads_header_disable', '__return_true' );
 
+// Remove everything from the theme's do_action locations above and below the header, and footer.
+remove_all_actions( 'before_header' );
+remove_all_actions( 'after_header' );
+remove_all_actions( 'before_footer' );
+
 get_header();
 ?>
 	<section id="primary" class="content-area">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes Newspack ads (and anything else that may have been hooked into the theme's `before_header`, `after_header` and `before_footer` locations) for the PWA offline template.

### How to test the changes in this Pull Request:

1. Test the PR on a test site that has ads enabled through Google's ad manager.
2. View the PWA template (either by testing the site on a mobile device, or by appending the `/?wp_error_template=offline` query string to the URL). 
3. Confirm that you're seeing the theme's design, a title that says Offline, and your Newspack ads.
4. Apply the PR.
5. Confirm the ads are now gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
