### PR TITLE
Remove underline styles from links when inside of headings

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -198,6 +198,22 @@ body.page {
 		}
 	}
 
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		a {
+			color: $color__text-main;
+			text-decoration: none;
+
+			&:visited {
+				color: $color__text-main;
+			}
+		}
+	}
+
 	// Overwrite iframe embeds that have inline styles.
 	> iframe[style] {
 		margin: 32px 0 !important;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -91,6 +91,22 @@ a {
 	}
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	a {
+		color: $color__text-main;
+		text-decoration: none;
+
+		&:visited {
+			color: $color__text-main;
+		}
+	}
+}
+
 table td,
 table th {
 	font-family: $font__body;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the text underline from links when they appear in h1-h6, as well as removes the light grey colour.

**Before:**

![image](https://user-images.githubusercontent.com/177561/67693049-4d432980-f95e-11e9-8287-197abe9b13be.png)


**After:**

![image](https://user-images.githubusercontent.com/177561/67692871-0b19e800-f95e-11e9-8563-f53b1abff2ce.png)


### How to test the changes in this Pull Request:

1. Set up a series of headings with links inside of them, or copy-paste [this test content](https://cloudup.com/cmPGl1qWJBY) into the editor. Note the text decoration on the links.
2. Apply the PR and run `npm run build`
3. Confirm that the underline is gone on the front-end and in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
