### PR TITLE
Remove 'clear both' from headings

### DIFF
--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -40,7 +40,6 @@ h3,
 h4,
 h5,
 h6 {
-	clear: both;
 	margin: $size__spacing-unit 0;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the `clear: both` style from the `h1` thru `h6` tags, so they can be floated beside images.

### How to test the changes in this Pull Request:

1. In the editor, add an image and a heading right after it; float the image, and note that the heading sits beside it in the editor.
2. Publish the page and view on the front-end; now it does not:

![image](https://user-images.githubusercontent.com/177561/67694340-6b118e00-f960-11e9-9f5d-20b8862b3894.png)

3. Apply the PR and run `npm run build`
4. Confirm that the header sits next to the image now:

![image](https://user-images.githubusercontent.com/177561/67694252-4b7a6580-f960-11e9-82ca-f27ab14d9fdd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
