### PR TITLE
Make sure author archive pages aren't spread out

### DIFF
--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -81,7 +81,7 @@
 
 	&.author .page-header {
 		display: flex;
-		justify-content: space-between;
+		justify-content: flex-start;
 
 		.avatar {
 			flex-shrink: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where, if an author does not have any description text, the image and name are spread out on the author archive page.

Closes #527 .

### How to test the changes in this Pull Request:

1. Visit an author archive page for an author that does not have a description; note that the author name is to the far right:

![image](https://user-images.githubusercontent.com/177561/67699907-2a1e7700-f96a-11e9-9f1f-1093221fe8d7.png)

2. Apply the PR and run `npm run build`
3. Confirm the author name is now next to the author image:

![image](https://user-images.githubusercontent.com/177561/67699862-18d56a80-f96a-11e9-8715-5332847934c8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
