### PR TITLE
Fix issue with missing image causing display problems.

### DIFF
--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -74,6 +74,10 @@
 		&:not(paged) article.has-post-thumbnail:first-of-type {
 			display: block;
 
+			.post-thumbnail {
+				max-width: 100%;
+			}
+
 			.entry-header {
 				margin: $size__spacing-unit 0 0;
 			}

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -44,8 +44,9 @@
 			display: flex;
 
 			.post-thumbnail {
+				flex-basis: 25%;
+				flex-grow: 0;
 				margin: 0 1em 0 0;
-				flex-basis: 25%
 			}
 
 			.entry-container {

--- a/sass/site/primary/_archives.scss
+++ b/sass/site/primary/_archives.scss
@@ -45,7 +45,7 @@
 
 			.post-thumbnail {
 				flex-basis: 25%;
-				flex-grow: 0;
+				max-width: 25%;
 				margin: 0 1em 0 0;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue on the archive page, where the layout 'falls apart' when images are missing.

Closes #532.

### How to test the changes in this Pull Request:

1. Go to a category archive where all articles have a thumbnail
2. Choose one of the articles and deliberately delete the thumbnail file from the uploads directory (NOT from the media library); make sure this thumbnail has 'alt' text first, the longer, the better.
3. Refresh the page
4. The content flow should break at the point where the thumbnail is missing:

![image](https://user-images.githubusercontent.com/177561/67721221-3ec33500-f993-11e9-8bec-06e6d40b3871.png)

5. Apply the PR and run `npm run build`
6. Confirm that the archive page is no longer messed up:

![image](https://user-images.githubusercontent.com/177561/67721364-8fd32900-f993-11e9-89fa-2f1b4928a1a9.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
