### PR TITLE
Only display primary category on singles if set

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -77,8 +77,25 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 	 * Prints HTML with the current post's categories.
 	 */
 	function newspack_categories() {
-		/* translators: used between list items; followed by a space. */
-		$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '&nbsp;</span>' );
+		$categories_list = '';
+
+		// Only display Yoast primary category if set.
+		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+			$category_id = $primary_term->get_primary_term();
+			if ( $category_id ) {
+				$category = get_term( $category_id );
+				if ( $category ) {
+					$categories_list = '<a href="' . esc_url( get_category_link( $category->term_id ) ) . '" rel="category tag">' . $category->name . '</a>';
+				}
+			}
+		}
+
+		if ( ! $categories_list ) {
+			/* translators: used between list items; followed by a space. */
+			$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '&nbsp;</span>' );
+		}
+
 		if ( $categories_list ) {
 			printf(
 				/* translators: 1: posted in label, only visible to screen readers. 2: list of categories. */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #537 

This PR makes it so that only the primary category is displayed on single posts when possible. If people complain and want the old behavior, we should add this feature as a customizer setting or something so that everybody is happy.

### How to test the changes in this Pull Request:

1. Set multiple categories on a post and select a primary category. Before applying the PR you should see something like this:
<img width="868" alt="Screen Shot 2019-10-29 at 10 17 36 AM" src="https://user-images.githubusercontent.com/7317227/67792242-0d4f7580-fa36-11e9-9fa1-61e260257187.png">

2. After applying the PR you should just see the primary category:
<img width="428" alt="Screen Shot 2019-10-29 at 10 17 49 AM" src="https://user-images.githubusercontent.com/7317227/67792250-10e2fc80-fa36-11e9-89fc-3968deb5ed63.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
