### PR TITLE
Add check for menus before outputting mobile menu toggle

### DIFF
--- a/header.php
+++ b/header.php
@@ -146,11 +146,12 @@
 					?>
 				</div><!-- .nav-wrapper -->
 
-
-				<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
-					<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-					<?php esc_html_e( 'Menu', 'newspack' ); ?>
-				</button>
+				<?php if ( newspack_has_menus() ) : ?>
+					<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<?php esc_html_e( 'Menu', 'newspack' ); ?>
+					</button>
+				<?php endif; ?>
 
 			</div><!-- .wrapper -->
 		</div><!-- .middle-header-contain -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -243,6 +243,15 @@ if ( ! function_exists( 'newspack_the_posts_navigation' ) ) :
 endif;
 
 /**
+ * Check if any header menus are applied; used to show menu toggle on smaller screens.
+ */
+function newspack_has_menus() {
+	if ( has_nav_menu( 'primary-menu' ) || has_nav_menu( 'secondary-menu' ) || has_nav_menu( 'tertiary-menu' ) ) {
+		return true;
+	}
+}
+
+/**
  * Displays primary menu; created a function to reduce duplication.
  */
 function newspack_primary_menu() {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -248,6 +248,8 @@ endif;
 function newspack_has_menus() {
 	if ( has_nav_menu( 'primary-menu' ) || has_nav_menu( 'secondary-menu' ) || has_nav_menu( 'tertiary-menu' ) ) {
 		return true;
+	} else {
+		return false;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR checks for a primary, secondary or tertiary menu before outputting a 'Menu' toggle on mobile screens.

It's largely to make sure an empty menu space isn't added to the PWA offline.php template, but it also makes sense in the odd case where a site might not have a menu to open.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Test the offline.php template, and make sure the 'Menu' toggle can't be seen on smaller screens (one way to test is to add `?wp_error_template=offline` to the end of your site URL).
3. Make sure the menu toggle still appears on other pages on smaller screens.
4. Empty the primary, secondary and tertiary menu spaces and confirm the menu toggle no longer appears on any page. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
