### PR TITLE
Style 2: Update dropcap style

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -280,7 +280,7 @@ function newspack_custom_colors_css() {
 			}
 
 			.has-drop-cap:not(:focus)::first-letter {
-				border-color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $secondary_color ) . ';
 			}
 		';
 	}
@@ -471,7 +471,7 @@ function newspack_custom_colors_css() {
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$editor_css .= '
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
-				border-color: ' . $primary_color . ';
+				color: ' . newspack_color_with_contrast( $secondary_color ) . ';
 			}
 
 			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -63,11 +63,9 @@ blockquote {
 
 .wp-block-paragraph {
 	&.has-drop-cap:not(:focus)::first-letter {
-		border: 7px solid $color__primary;
+		color: $color__secondary;
 		font-family: $font__heading;
 		font-weight: 800;
-		font-size: $font__size-xxl;
-		padding: 0.4em;
 	}
 }
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -309,11 +309,9 @@ blockquote {
 
 //! Paragraph
 .has-drop-cap:not(:focus)::first-letter {
-	border: 7px solid $color__primary;
+	color: $color__secondary;
 	font-family: $font__heading;
 	font-weight: 800;
-	font-size: $font__size-xxl;
-	padding: 0.4em;
 }
 
 .entry .entry-content {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We had a request to simplify the Style 2 dropcap, removing the border, and making it use the secondary colour instead.

Since the style pack is only used on one live site, and it's not using dropcaps, this seems like a safe time to make this change.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 2.
2. In a post or page, add a paragraph block, and switch on the dropcap -- it should look something like this, with smaller text and a border using the primary colour:

![image](https://user-images.githubusercontent.com/177561/67815208-8b764100-fa63-11e9-8e2f-39e84af59b1a.png)

3. Apply the PR and run` npm run build`.
4. View the dropcap in the editor and on the front-end -- it should now be borderless, larger, and using your secondary colour:

![image](https://user-images.githubusercontent.com/177561/67815136-4d791d00-fa63-11e9-8ee1-9a89161cd23b.png)

5. If your test site isn't already using custom colours, switch to custom colours and change the secondary colour. Note: because the dropcap is text against a white background, it uses the 'contrast' functionality, which swaps out too-light colours with a mid-grey. As an aside, this is _very_ aggressive right now and it'd be nice to allow a bit more range of colours, but for now it's something to keep in mind; if you pick a lighter colour, it could appear not to work. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
