### PR TITLE
Remove left padding from first menu item in some cases

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -147,7 +147,7 @@
 					color: inherit;
 				}
 
-				&:first-child a {
+				&:first-child > a {
 					padding-left: 0;
 				}
 

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -47,7 +47,6 @@
 	.main-menu {
 		overflow: visible;
 		width: 100%;
-
 		> li {
 			> a {
 				color: inherit;
@@ -146,6 +145,10 @@
 
 				> a {
 					color: inherit;
+				}
+
+				&:first-child a {
+					padding-left: 0;
 				}
 
 				> .sub-menu {

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -29,6 +29,10 @@ nav.secondary-menu {
 			margin-right: #{ $size__spacing-unit }
 		}
 
+		li:first-child a {
+			padding-left: 0;
+		}
+
 		a {
 			font-size: $font__size-xs;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

All of the menu links have some left and right padding, but in some cases (left aligned, regular header), this mix of padded items (primary and secondary navigation) and non-padded items (Site title, 'highlight' navigation) can appear mis-matched (the primary and highlight menus being the worst):

![image](https://user-images.githubusercontent.com/177561/67816335-e65d6780-fa66-11e9-8f3b-086fb6a509c0.png)

This PR removes the padding from the top level first link in the primary and secondary menus, so all of these elements appear to line up:

![image](https://user-images.githubusercontent.com/177561/67816300-c9c12f80-fa66-11e9-9ad6-e2dbef46f287.png)

Closes #509

### How to test the changes in this Pull Request:

1. Set up a header similar to the above:
* Customizer > Header Settings: uncheck simplify header, and uncheck centre logo.
* Customizer > Menus: add a menu to the primary, secondary and highlight locations. For testing purposes, add a dropdown menu to the first item in the primary menu, to spook out any issues.
2. View on the front-end; note the slight 'jig-jagginess' on the left side. 
3. Apply the PR and run `npm run build`
4. Confirm that the left edge of the header appears "lined up"
5. Confirm that the left padding seems 'normal' in the dropdown (same as before), and when you view the menu on mobile-sized screens (all of the links appear evenly lined up still). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
