### PR TITLE
Make the content area narrower, more consistent in Style 2

### DIFF
--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -109,21 +109,6 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-.newspack-front-page:not(.page-template-single-feature) #primary {
-	padding: 0;
-
-	.site-main > article > .entry-content > *:first-child {
-
-		@include media(tablet) {
-			padding: $size__spacing-unit #{ 3 * $size__spacing-unit } 0;
-		}
-
-		@include media(desktop) {
-			padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
-		}
-	}
-}
-
 .single-featured-image-behind {
 	#primary {
 		padding-top: 0;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -100,11 +100,12 @@ body:not(.header-solid-background) .site-header {
 
 	@include media(tablet) {
 		border-top: 4px solid $color__primary-variation;
-		padding: #{ 3 * $size__spacing-unit } #{ 3 * $size__spacing-unit } 0;
+		padding: #{ 3 * $size__spacing-unit } #{ 2 * $size__spacing-unit } 0;
 	}
 
 	@include media(desktop) {
-		padding: #{ 3.5 * $size__spacing-unit } #{ 4.5 * $size__spacing-unit } 0;
+		padding-left: #{ 3 * $size__spacing-unit };
+		padding-right: #{ 3 * $size__spacing-unit };
 	}
 }
 
@@ -119,23 +120,6 @@ body:not(.header-solid-background) .site-header {
 
 		@include media(desktop) {
 			padding: $size__spacing-unit #{ 4.5 * $size__spacing-unit } 0;
-		}
-	}
-}
-
-.single-post #primary {
-	padding-left: 0;
-	padding-right: 0;
-
-	.site-main > .entry-header {
-		@include media(tablet) {
-			padding-left: #{ 3 * $size__spacing-unit };
-			padding-right: #{ 3 * $size__spacing-unit };
-		}
-
-		@include media(desktop) {
-			padding-left: #{ 4.5 * $size__spacing-unit };
-			padding-right: #{ 4.5 * $size__spacing-unit };
 		}
 	}
 }

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -381,10 +381,6 @@ blockquote {
 	.page-header {
 		border-bottom: 2px solid $color__text-main;
 		padding-bottom: #{ 2 * $size__spacing-unit };
-
-		@include media( tablet ) {
-			padding-bottom: #{ 4 * $size__spacing-unit };
-		}
 	}
 
 	.page-title {

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -109,6 +109,12 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
+.newspack-front-page:not(.page-template-single-feature) #primary {
+	@include media(tablet) {
+		padding-top: $size__spacing-unit;
+	}
+}
+
 .single-featured-image-behind {
 	#primary {
 		padding-top: 0;

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -143,23 +143,6 @@ body:not(.header-solid-background) .site-header {
 	}
 }
 
-.archive #primary {
-	padding-left: 0;
-	padding-right: 0;
-
-	& > .page-header {
-		@include media(tablet) {
-			padding-left: #{ 3 * $size__spacing-unit };
-			padding-right: #{ 3 * $size__spacing-unit };
-		}
-
-		@include media(desktop) {
-			padding-left: #{ 4.5 * $size__spacing-unit };
-			padding-right: #{ 4.5 * $size__spacing-unit };
-		}
-	}
-}
-
 // HTML Elements
 
 h1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In certain circumstances, the way the widths are set up in Style 2 can look... odd. Originally post titles, or the first block on the homepage, would be narrower than the rest of the content. This PR makes them all the same size, by making the content area a bit narrower. 

Closes #536.

### How to test the changes in this Pull Request:

Testing this PR requires cycling through a number of areas and settings on the site -- unfortunately! -- to make sure it hasn't introduced any issues. It may be easiest to switch between the master and PR branches, to compare each case one by one:

1. Navigate to Customize > Style Packs, and switch to Style 2.
2. View the homepage:

**Before:** the first child (usually a block) is narrower than the rest:

![image](https://user-images.githubusercontent.com/177561/68153024-a6303600-fef9-11e9-8b5e-4a054232bc8a.png)

**After:** all of the content is the same width:

![image](https://user-images.githubusercontent.com/177561/68152994-9284cf80-fef9-11e9-8d87-cd72b190a4ae.png)

3. Single post - no featured image

**Before:** the title is narrower than the content:

![image](https://user-images.githubusercontent.com/177561/68153649-b98fd100-fefa-11e9-8da6-d3dc3ade73a9.png)

**After:** the title and content are the same width: 

![image](https://user-images.githubusercontent.com/177561/68153776-fcea3f80-fefa-11e9-88fa-93889c98f6c1.png)

a. Single post - with featured image

**Before:** Title is narrower and featured image, content are wider:

![image](https://user-images.githubusercontent.com/177561/68154692-ec3ac900-fefc-11e9-953b-0218ba6b474a.png)

**After:** Title, featured image and content are all the same width:

![image](https://user-images.githubusercontent.com/177561/68154630-c4e3fc00-fefc-11e9-9885-cf7152d27047.png)

b. Single post - featured image, displaying behind

The before and after should be the same here -- the content area is a bit narrower, like on other pages, but the important bit to check is that no issues are introduced to the featured image area:

![image](https://user-images.githubusercontent.com/177561/68154160-bea15000-fefb-11e9-8acf-7af7a5734446.png)

c. Single post - featured image, image beside

The before and after should be the same here -- the content area is a little narrower, but the important bit to check is that no issues are introduced in the featured image area:

![image](https://user-images.githubusercontent.com/177561/68153838-260ad000-fefb-11e9-8df8-57d9157c7556.png)

e. Single post - one column template

**Before:** Border below title spans 1200px; content is about 780px:

![image](https://user-images.githubusercontent.com/177561/68154744-11c7d280-fefd-11e9-90bc-b132287b3aed.png)

**After:**  Border below title spans width of title; content is about 700px:

![image](https://user-images.githubusercontent.com/177561/68154780-21471b80-fefd-11e9-9744-0dc5634db26f.png)

f. Single post - one column wide template

**Before:** title and content are different widths:

![image](https://user-images.githubusercontent.com/177561/68155282-3ff9e200-fefe-11e9-8cd0-245e71a1055a.png)

**After:** title and content are the same width: 

![image](https://user-images.githubusercontent.com/177561/68155252-2f496c00-fefe-11e9-87e8-987004270f25.png)

4. Single page - no featured image

**Before:** content and title are same space

![image](https://user-images.githubusercontent.com/177561/68155685-037ab600-feff-11e9-9839-c0cfb627529d.png)

**After**: content and title are still the same width, but a bit wider:

![image](https://user-images.githubusercontent.com/177561/68155622-e7771480-fefe-11e9-8067-d8b3ac9f65a6.png)

a. Single page - featured image

**Before:** content and title are same space (vertical spacing issue is fixed in #549)

![image](https://user-images.githubusercontent.com/177561/68155328-599b2980-fefe-11e9-9657-6b12e57579a4.png)

**After**: content and title are still the same width, but a bit wider:

![image](https://user-images.githubusercontent.com/177561/68155463-99621100-fefe-11e9-825f-6ff660d89afa.png)

b. Single page - one column template

**Before: ** narrower title, content: 

![image](https://user-images.githubusercontent.com/177561/68156243-5012c100-ff00-11e9-9b42-65d97752fd89.png)

**After:** narrower title, content, but both are overall a bit wider:

![image](https://user-images.githubusercontent.com/177561/68156309-6a4c9f00-ff00-11e9-98be-0de111114f43.png)

c. Single page - one column wide template

**Before: content and title are the same width:**

![image](https://user-images.githubusercontent.com/177561/68156706-2a39ec00-ff01-11e9-840f-a077fa86bc0c.png)

**After: content and title are still the same width; the content is a bit narrower:**

![image](https://user-images.githubusercontent.com/177561/68156614-0c6c8700-ff01-11e9-8f19-e59546402aee.png)

5. Archive page

**Before:** Header is narrower than the rest of the page:

![image](https://user-images.githubusercontent.com/177561/68156758-4178d980-ff01-11e9-8930-0e03fc3c64f2.png)

**After:** Header and content is the same width; the latter is narrower:

![image](https://user-images.githubusercontent.com/177561/68156808-59505d80-ff01-11e9-8b78-b767bcce92ec.png)

6. Search Results page

**Before:** The search field and content are the same width:

![image](https://user-images.githubusercontent.com/177561/68156907-80a72a80-ff01-11e9-830d-3b0107da01e9.png)

**After:** All is still the same width, but wider: 

![image](https://user-images.githubusercontent.com/177561/68156841-68371000-ff01-11e9-9e80-8806bf28195e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
