### PR TITLE
Style 2: Remove missed background colour from block category links.

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -473,15 +473,6 @@ function newspack_custom_colors_css() {
 			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				border-color: ' . $primary_color . ';
 			}
-
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
-				background-color: ' . $secondary_color . ';
-			}
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a,
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:visited,
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links a:hover {
-				color: ' . $secondary_color_contrast . ';
-			}
 		';
 	}
 

--- a/sass/styles/style-2/style-2-editor.scss
+++ b/sass/styles/style-2/style-2-editor.scss
@@ -130,8 +130,3 @@ blockquote {
 .wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
 	border-top: 5px solid $color__text-main;
 }
-
-//! Newspack
-.wp-block-newspack-blocks-homepage-articles.image-aligntop .post-has-image .cat-links {
-	background-color: $color__secondary;
-}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes some cruft from Style 2 that was still adding a background to the category in the article block, when paired with an image.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and pick Style 2.
2. In the editor, add an article block; make sure at least one article has an image.
3. Turn on 'Show Categories'
4. Note the background:

![image](https://user-images.githubusercontent.com/177561/67902508-9514ad00-fb26-11e9-8b33-35518f208eb4.png)

5. Apply the PR and run `npm run build`
6. Refresh the editor; confirm the background is gone:

![image](https://user-images.githubusercontent.com/177561/67902301-1a4b9200-fb26-11e9-9e90-b1d3d4bf221b.png)

7. Navigate to Customizer > Colours; if using the default colour, switch to custom, and vis versa.
8. Confirm that the issue is still fixed in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
