### PR TITLE
Add space between page title and featured image

### DIFF
--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -304,10 +304,8 @@ body.page {
 }
 
 
-.page:not( .home ) {
-	.entry-header {
-		padding: 0 0 $size__spacing-unit;
-	}
+.page:not(.home) article.page > .post-thumbnail {
+	margin-top: #{ 1.5 * $size__spacing-unit };
 }
 
 .page.home .entry .entry-content {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -303,6 +303,13 @@ body.page {
 	}
 }
 
+
+.page:not( .home ) {
+	.entry-header {
+		padding: 0 0 $size__spacing-unit;
+	}
+}
+
 .page.home .entry .entry-content {
 	max-width: 100%;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On pages, if you add a featured image, there's very little space between it and the page title.

This PR adds a top margin to the featured image. 

### How to test the changes in this Pull Request:

1. Set up a page and add a featured image.
2. View on the front end; note the spacing between the title and image:

![image](https://user-images.githubusercontent.com/177561/68147402-d0302b00-feee-11e9-9151-6a90483a23ed.png)

3. Apply the PR and run `npm run build`
4. Confirm that there's a more reasonable amount of space:

![image](https://user-images.githubusercontent.com/177561/68147340-b0990280-feee-11e9-86e5-629e28064422.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
