### PR TITLE
Fix 'wide' and 'full' width blocks on pages

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -961,7 +961,8 @@
 }
 
 //! 'Feature' alignments
-.post-template-single-feature {
+.post-template-single-feature,
+.page-template-single-feature {
 	.entry .entry-content > * {
 		&.alignwide {
 			@include media( tablet ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed by chance that if you use the 'One Column' template on a page, it doesn't respect wide or full alignment on blocks.

This PR fixes that.

### How to test the changes in this Pull Request:

1. Create a page; set it to use the One Column template.
2. Add two group blocks; set one to wide and one to full.
3. View on the front-end; though they preview correctly in the editor, they should be the same width as the rest of the content on the front-end:

![image](https://user-images.githubusercontent.com/177561/68150218-1c319e80-fef4-11e9-9f79-1a6949cca686.png)

4. Apply the PR and run `npm run build`
5. Confirm that the blocks are now the right width:

![image](https://user-images.githubusercontent.com/177561/68150104-e4c2f200-fef3-11e9-8e3e-cbf23407c2bf.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
