### PR TITLE
Tighten up horizontal spacing in primary menu

### DIFF
--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -141,7 +141,7 @@
 				color: #555;
 				display: inline-block;
 				line-height: 1.25;
-				margin-right: #{0.75 * $size__spacing-unit};
+				margin-right: #{ 0.25 * $size__spacing-unit };
 
 				> a {
 					color: inherit;
@@ -149,6 +149,12 @@
 
 				&:first-child > a {
 					padding-left: 0;
+				}
+
+				@include media( tablet ) {
+					&.menu-item-has-children > a {
+						padding-right: 0;
+					}
 				}
 
 				> .sub-menu {
@@ -263,14 +269,7 @@
 
 .header-simplified {
 	.site-header .main-navigation .main-menu > li {
-		margin-right: #{ 0.25 * $size__spacing-unit };
 		padding: #{ 0.25 * $size__spacing-unit } 0;
-
-		@include media( tablet ) {
-			&.menu-item-has-children > a {
-				padding-right: 0;
-			}
-		}
 
 		> .sub-menu {
 			padding-top: 20px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tightens up the space between menu items in the primary menu, when you're not using the 'short' header option.

This spacing was originally only applied to the 'short' header, but now it's applied in all cases, to create a little more wiggle room for more links. 

Closes #548

### How to test the changes in this Pull Request:

1. Navigate to Customize > Menus, and assign a menu to the Primary Menu location (if not already)
2. Navigate to Customize > Header Settings, and uncheck 'Short Header' (if it's not already)
3. View on the front-end; note the spacing between links:

![image](https://user-images.githubusercontent.com/177561/68161233-4726ed00-ff0a-11e9-8a58-740905e3df39.png)

4. Apply the PR and run `npm run build`
5. Confirm that the links have less space between them, but also that there's 'enough' space -- they shouldn't feel too squished (if they do, I can adjust!):

![image](https://user-images.githubusercontent.com/177561/68161187-29598800-ff0a-11e9-9878-2dcb10e888ba.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
