### PR TITLE
Style 3: Fix visited category link style in search

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -289,6 +289,7 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.cat-links,
 			.cat-links a,
+			.cat-links a:visited,
 			.article-section-title,
 			.entry .entry-footer,
 			.accent-header {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When using Style 3 and custom colours, visited category links still use the default primary blue colour in search results. This PR fixes that.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to Style 3.
2. Navigate to Customize > Colours, and change to custom colours.
3. Run a search; click one of the categories and click back, so it's visited. Note that it's now bright blue:

![image](https://user-images.githubusercontent.com/177561/68161761-6c682b00-ff0b-11e9-9bed-3cdc1c5c74a7.png)

4. Apply the PR.
5. Confirm that the links are now using the correct custom colour:

![image](https://user-images.githubusercontent.com/177561/68161815-84d84580-ff0b-11e9-915c-6f7e7be0d6fe.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
