### PR TITLE
Make top and bottom spacing more consistent in columns, group blocks

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -765,6 +765,10 @@
 	//! Columns
 	.wp-block-columns {
 
+		.wp-block-column > *:first-child {
+			margin-top: 0;
+		}
+
 		.wp-block-column > *:last-child {
 			margin-bottom: 0;
 		}
@@ -792,6 +796,10 @@
 
 	//! Group
 	.wp-block-group {
+		.wp-block-group__inner-container > *:first-child {
+			margin-top: 0;
+		}
+
 		.wp-block-group__inner-container > *:last-child {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the last item in the Group or Column block doesn't have a bottom margin, but the first item has a top margin, leading to some wacky uneven spacing:

This PR makes that spacing more consistent, and also gets it to line up with what's actually previewed in the editor.

Closes #544 

### How to test the changes in this Pull Request:

1. Copy-paste this test content into a post or page: https://cloudup.com/cdL1O8B9N2o
2. Publish and view on the front-end; note the uneven vertical spacing, especially noticeable when the paragraph block is involved:

![image](https://user-images.githubusercontent.com/177561/68166848-852b0d80-ff18-11e9-96c0-5cdfa7f55e74.png)

3. Apply the PR and run `npm run build`
4. Confirm that the spacing is more consistent on the front-end:

![image](https://user-images.githubusercontent.com/177561/68166907-af7ccb00-ff18-11e9-807f-31225a58055d.png)

5. Confirm that this spacing roughly matches what you see in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
