### PR TITLE
Add wp-components as dependency of extend-featured-image-editor.js

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -349,7 +349,7 @@ add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
  * Enqueue Block Styles Javascript
  */
 function newspack_extend_featured_image_script() {
-	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks' ), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks', 'wp-components' ), wp_get_theme()->get( 'Version' ) );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_extend_featured_image_script' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #556 

I'm unsure exactly what configuration or race condition caused the original issue, but the root cause was that the `extend-featured-image-editor.js` script was getting loaded before `wp-components` were ready. This PR adds `wp-components` as a dependency of the script. I believe it should have been a dependency anyways, since `RadioControl` is in `wp-components`.

### How to test the changes in this Pull Request:

See #556 for testing instructions. If you can't reproduce the issue, this should at least not cause any new issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
