### PR TITLE
Add Small image option

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -80,12 +80,6 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-featured-image';
 	}
 
-	// Adds a class if singular post has a large featured image
-	$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-	if ( is_single() && has_post_thumbnail() && 1200 <= (int) $thumbnail_info['width'] ) {
-		$classes[] = 'has-large-featured-image';
-	}
-
 	// Adds a class to single artcles, if they're using a special featured image style.
 	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 	if ( is_single() ) {
@@ -96,6 +90,12 @@ function newspack_body_classes( $classes ) {
 		} else {
 			$classes[] = 'single-featured-image-default';
 		}
+	}
+
+	// Adds a class if singular post has a large featured image
+	$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+	if ( is_single() && has_post_thumbnail() && 1200 <= (int) $thumbnail_info['width'] && 'small' !== $current_featured_image_style ) {
+		$classes[] = 'has-large-featured-image';
 	}
 
 	// Adds a class if the author bio is hidden.

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -17,6 +17,7 @@ class RadioCustom extends Component {
 				selected={ meta.newspack_featured_image_position }
 				options={ [
 					{ label: __( 'Default' ), value: '' },
+					{ label: __( 'Small' ), value: 'small' },
 					{ label: __( 'Behind article title' ), value: 'behind' },
 					{ label: __( 'Beside article title' ), value: 'beside' },
 				] }

--- a/single-feature.php
+++ b/single-feature.php
@@ -12,6 +12,7 @@
 
 get_header();
 $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
 
 
@@ -26,7 +27,7 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -43,7 +44,7 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single-wide.php
+++ b/single-wide.php
@@ -12,6 +12,7 @@
 
 get_header();
 $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
 
 	<section id="primary" class="content-area">
@@ -24,7 +25,7 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -41,7 +42,7 @@ $thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single.php
+++ b/single.php
@@ -7,6 +7,7 @@
  * @package Newspack
  */
 
+$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 get_header();
 ?>
 
@@ -22,7 +23,7 @@ get_header();
 				$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -39,7 +40,7 @@ get_header();
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] ) {
+					if ( has_post_thumbnail() && ( 1200 > $thumbnail_info['width'] || 'small' === $image_position ) ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single.php
+++ b/single.php
@@ -7,8 +7,9 @@
  * @package Newspack
  */
 
-$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 get_header();
+$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
 
 	<section id="primary" class="content-area">
@@ -18,9 +19,6 @@ get_header();
 			/* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
-
-				// Get the post thumbnail.
-				$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 
 				// Template part for large featured images.
 				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a new 'Small' option to the featured image style settings. When active, the image will be rendered within the post content (like small images are), instead of above the post content.

### How to test the changes in this Pull Request:

1. Set the 'Small' image option on a post with the default template. On the frontend it should be rendered at the top of the post content.
2. The existing image options and template options should still work nicely, as well as the 'Small' image setting with the one-column templates.

**Default:**

<img width="1279" alt="Screen Shot 2019-11-06 at 10 59 29 AM" src="https://user-images.githubusercontent.com/7317227/68328992-351d8980-0085-11ea-98d6-ef602c7d40b1.png">

**Small:**

<img width="1267" alt="Screen Shot 2019-11-06 at 10 59 43 AM" src="https://user-images.githubusercontent.com/7317227/68329000-38b11080-0085-11ea-938f-50451cb3ddbc.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
