### PR TITLE
Add support for Co-Authors Plus plugin

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -15,8 +15,13 @@ get_header();
 		<header class="page-header">
 			<?php
 				if ( is_author() ) {
-					$author_id     = get_query_var( 'author' );
-					$author_avatar = get_avatar( $author_id, 120 );
+
+					if ( function_exists( 'coauthors_posts_links' ) ) {
+						$author_avatar = coauthors_get_avatar( get_queried_object(), 120 );
+					} else {
+						$author_id     = get_query_var( 'author' );
+						$author_avatar = get_avatar( $author_id, 120 );
+					}
 
 					if ( $author_avatar ) {
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -44,14 +44,60 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 	 * Prints HTML with meta information about theme author.
 	 */
 	function newspack_posted_by() {
-		printf(
-			/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
-			'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
-			get_avatar( get_the_author_meta( 'ID' ) ),
-			esc_html__( 'by', 'newspack' ),
-			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-			esc_html( get_the_author() )
+
+		if ( function_exists( 'coauthors_posts_links' ) ) :
+
+			$authors      = get_coauthors();
+			$author_count = count( $authors );
+			$i            = 1;
+
+			foreach ( $authors as $author ) {
+				echo '<span class="author-avatar">' . wp_kses_post( coauthors_get_avatar( $author ) ) . '</span>';
+			}
+			?>
+
+
+			printf( __( '<span class="%1$s">Posted on</span> %2$s <span class="meta-sep">by</span> %3$s', 'twentyten' ), 'meta-prep meta-prep-author',
+			sprintf( '<a href="%1$s" title="%2$s" rel="bookmark"><span class="entry-date">%3$s</span></a>',
+				get_permalink(),
+				esc_attr( get_the_time() ),
+				get_the_date()
+			),
+			coauthors_posts_links( null, null, null, null, false )
 		);
+
+			<span class="byline">
+				<span><?php echo esc_html__( 'by', 'newspack' ); ?></span>
+				<?php foreach ( $authors as $author ) { ?>
+					<span class="author vcard">
+						<a class="url fn n" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>">
+							<?php the_coauthor_meta( 'display_name', $author->ID ); ?>
+						</a>
+					</span>
+
+					<?php
+						if ( ( $author_count - 1 ) === $i ) :
+							echo ' and ';
+						elseif ( $author_count > $i ) :
+							echo ', ';
+						endif;
+						$i++;
+					?>
+				<?php } ?>
+			</span><!-- .byline -->
+		<?php
+		else :
+
+			printf(
+				/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
+				'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
+				get_avatar( get_the_author_meta( 'ID' ) ),
+				esc_html__( 'by', 'newspack' ),
+				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
+				esc_html( get_the_author() )
+			);
+
+		endif;
 	}
 endif;
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -56,38 +56,34 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 			}
 			?>
 
-
-			printf( __( '<span class="%1$s">Posted on</span> %2$s <span class="meta-sep">by</span> %3$s', 'twentyten' ), 'meta-prep meta-prep-author',
-			sprintf( '<a href="%1$s" title="%2$s" rel="bookmark"><span class="entry-date">%3$s</span></a>',
-				get_permalink(),
-				esc_attr( get_the_time() ),
-				get_the_date()
-			),
-			coauthors_posts_links( null, null, null, null, false )
-		);
-
 			<span class="byline">
 				<span><?php echo esc_html__( 'by', 'newspack' ); ?></span>
-				<?php foreach ( $authors as $author ) { ?>
-					<span class="author vcard">
-						<a class="url fn n" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>">
-							<?php the_coauthor_meta( 'display_name', $author->ID ); ?>
-						</a>
-					</span>
+				<?php
+				foreach ( $authors as $author ) {
 
-					<?php
-						if ( ( $author_count - 1 ) === $i ) :
-							echo ' and ';
-						elseif ( $author_count > $i ) :
-							echo ', ';
-						endif;
-						$i++;
-					?>
-				<?php } ?>
+					$i++;
+					if ( $author_count === $i ) :
+						/* translators: separates last two author names; needs a space on either side. */
+						$sep = esc_html__( ' and ', 'newspack' );
+					elseif ( $author_count > $i ) :
+						/* translators: separates all but the last two author names; needs a space at the end. */
+						$sep = esc_html__( ', ', 'newspack' );
+					else :
+						$sep = '';
+					endif;
+
+					printf(
+						/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
+						'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>%3$s ',
+						esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+						esc_html( $author->display_name ),
+						esc_html( $sep )
+					);
+				}
+				?>
 			</span><!-- .byline -->
 		<?php
 		else :
-
 			printf(
 				/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
 				'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -5,7 +5,70 @@
  * @package Newspack
  */
 
-if ( (bool) get_the_author_meta( 'description' ) && is_single() ) : ?>
+
+if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
+
+	$authors      = get_coauthors();
+	$author_count = count( $authors );
+	$i            = 1;
+
+	foreach ( $authors as $author ) {
+
+		if ( '' !== $author->description ) { ?>
+
+			<div class="author-bio">
+				<?php
+				if ( ! newspack_is_active_style_pack( 'style-4' ) ) {
+					$author_avatar = coauthors_get_avatar( $author, 80 );
+					if ( $author_avatar ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo $author_avatar;
+					}
+				}
+				?>
+
+				<div class="author-bio-text">
+					<div class="author-bio-header">
+						<?php
+						if ( newspack_is_active_style_pack( 'style-4' ) ) {
+							$author_avatar = coauthors_get_avatar( $author, 80 );
+							if ( $author_avatar ) {
+								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								echo $author_avatar;
+							}
+						}
+						?>
+
+						<div>
+							<h2 class="accent-header">
+								<?php echo esc_html( esc_html( $author->display_name ) ); ?>
+								<span><?php // TODO: Add Job title ?></span>
+							</h2>
+							<div class="author-meta">
+								<a class="author-email" href="<?php echo 'mailto:' . esc_attr( $author->user_email ); ?>"><?php echo esc_html( $author->user_email ); ?></a>
+							</div>
+						</div>
+					</div><!-- .author-bio-header -->
+
+					<p>
+						<?php echo wp_kses_post( $author->description ); ?>
+					</p><!-- .author-description -->
+					<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+						<?php
+							/* translators: %s is the current author's name. */
+							printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+						?>
+					</a>
+				</div><!-- .author-bio-text -->
+
+			</div><!-- .author-bio -->
+		<?php
+		}
+	}
+
+elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
+?>
+
 <div class="author-bio">
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds Co-Author Plus support to the theme.

Closes #553.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. If you don't have it already, install and activate the [Co-Author Plus](https://en-ca.wordpress.org/plugins/co-authors-plus/) plugin.
3. Add at least one 'Guest' author.
3. On a post, add two more authors -- an existing one with a real WordPress account, and your guest author. Make sure at least two of them have author descriptions (this is required to test the author bio). 
4. View the post on the front end; confirm that all the authors are displaying at the top, and that the information (display name, avatar, and link to their archive) is correct:

![image](https://user-images.githubusercontent.com/177561/68348555-0b795800-00af-11ea-882b-f852ce5c2076.png)

5. Scroll to the bottom of the post; confirm that all authors that have descriptions (guest or otherwise) are displaying on the bottom and that display name, avatar, description, and links to archive pages are correct:

![image](https://user-images.githubusercontent.com/177561/68348564-116f3900-00af-11ea-8de7-1990b7d27b48.png)

6. View the archive page for your guest author. Confirm that the name, description, and avatar are correct:

![image](https://user-images.githubusercontent.com/177561/68348573-192edd80-00af-11ea-85ad-017550bbd950.png)

7. Make sure the regular author archives are also still displaying correctly:

![image](https://user-images.githubusercontent.com/177561/68348595-2cda4400-00af-11ea-861e-02db6c507dcb.png)

8. View your post on a regular archive page (like the category archive) and confirm all of your authors are displayed:

![image](https://user-images.githubusercontent.com/177561/68348679-6f9c1c00-00af-11ea-952b-81b2a18c1475.png)

9. Search for your post and confirm all of the authors display with it in the search results:

![image](https://user-images.githubusercontent.com/177561/68348692-817dbf00-00af-11ea-8f48-6a4fb8c7d512.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
