### PR TITLE
Simplify main menu classes

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -55,7 +55,7 @@ function newspack_custom_colors_css() {
 
 		/* Set primary color that contrasts against white */
 		.entry .entry-content .more-link:hover,
-		.main-navigation .main-menu > li > a + svg,
+		.nav1 .main-menu > li > a + svg,
 		.search-form button:active, .search-form button:hover, .search-form button:focus,
 		.entry-footer a,
 		.comment .comment-metadata > a:hover,
@@ -78,12 +78,12 @@ function newspack_custom_colors_css() {
 		.mobile-sidebar button:hover,
 		.mobile-sidebar a,
 		.mobile-sidebar a:visited,
-		.mobile-sidebar .main-navigation .sub-menu > li > a,
-		.mobile-sidebar .main-navigation ul.main-menu > li > a,
-		.site-header .main-navigation .sub-menu a:hover,
-		.site-header .main-navigation .sub-menu a:focus,
-		.site-header .main-navigation .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
-		.site-header .main-navigation .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
+		.mobile-sidebar .nav1 .sub-menu > li > a,
+		.mobile-sidebar .nav1 ul.main-menu > li > a,
+		.site-header .nav1 .sub-menu a:hover,
+		.site-header .nav1 .sub-menu a:focus,
+		.site-header .nav1 .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
+		.site-header .nav1 .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
 		.highlight-menu .menu-label,
 		body.header-default-background.header-default-height .site-header .tertiary-menu .menu-highlight a,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
@@ -105,7 +105,7 @@ function newspack_custom_colors_css() {
 			border-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.mobile-sidebar nav.main-navigation + nav.secondary-menu {
+		.mobile-sidebar nav.nav1 + nav.secondary-menu {
 			border-color: ' . $primary_color_contrast . ';
 		}
 
@@ -151,14 +151,14 @@ function newspack_custom_colors_css() {
 
 		/* Set primary variation background color */
 
-		.site-header .main-navigation .sub-menu > li > a:hover,
-		.site-header .main-navigation .sub-menu > li > a:focus,
-		.site-header .main-navigation .sub-menu > li > a:hover:after,
-		.site-header .main-navigation .sub-menu > li > a:focus:after,
-		.site-header .main-navigation .sub-menu > li > .menu-item-link-return:hover,
-		.site-header .main-navigation .sub-menu > li > .menu-item-link-return:focus,
-		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):hover,
-		.site-header .main-navigation .sub-menu > li > a:not(.submenu-expand):focus,
+		.site-header .nav1 .sub-menu > li > a:hover,
+		.site-header .nav1 .sub-menu > li > a:focus,
+		.site-header .nav1 .sub-menu > li > a:hover:after,
+		.site-header .nav1 .sub-menu > li > a:focus:after,
+		.site-header .nav1 .sub-menu > li > .menu-item-link-return:hover,
+		.site-header .nav1 .sub-menu > li > .menu-item-link-return:focus,
+		.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):hover,
+		.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):focus,
 		.entry .entry-content .has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
@@ -309,8 +309,8 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:hover,
-			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:focus {
+			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -334,8 +334,8 @@ function newspack_custom_colors_css() {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:hover,
-			.header-solid-background.header-simplified .site-header .main-navigation .main-menu .sub-menu a:focus {
+			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -356,12 +356,12 @@ function newspack_custom_colors_css() {
 			.header-solid-background .site-title a:link,
 			.header-solid-background .site-title a:visited,
 			.header-solid-background .site-description,
-			.header-solid-background.header-simplified .main-navigation .main-menu > li,
-			.header-solid-background.header-simplified .main-navigation ul.main-menu > li > a,
-			.header-solid-background.header-simplified .main-navigation ul.main-menu > li > a:hover,
+			.header-solid-background.header-simplified .nav1 .main-menu > li,
+			.header-solid-background.header-simplified .nav1 ul.main-menu > li > a,
+			.header-solid-background.header-simplified .nav1 ul.main-menu > li > a:hover,
 			.header-solid-background .top-header-contain,
 			.header-solid-background .middle-header-contain,
-			.main-navigation .sub-menu a {
+			.nav1 .sub-menu a {
 				color: ' . $primary_color_contrast . ';
 			}
 		';

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -303,7 +303,7 @@ function newspack_primary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation nav1" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -28,7 +28,7 @@ function newspack_custom_typography_css() {
 		.cat-links,
 		.entry-meta,
 		.entry-footer,
-		.main-navigation,
+		.nav1,
 		.no-comments,
 		.not-found .page-title,
 		.error-404 .page-title,
@@ -67,7 +67,7 @@ function newspack_custom_typography_css() {
 		.site-main #infinite-handle span button:focus,
 
 		/* _menu-main-navigation.scss */
-		.main-navigation button,
+		.nav1 button,
 
 		/* _menu-tertiary-navigation.scss */
 		.tertiary-menu,
@@ -158,7 +158,7 @@ function newspack_custom_typography_css() {
 			.entry-meta,
 			.cat-links,
 			.entry-footer,
-			.main-navigation,
+			.nav1,
 			.secondary-menu,
 			.tertiary-menu,
 			.site-description,
@@ -391,7 +391,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$css_blocks        .= '
-				.main-navigation ul li,
+				.nav1 ul li,
 				.tertiary-menu,
 				.mobile-menu-toggle,
 				.accent-header,

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -1,6 +1,6 @@
 /** === Main menu === */
 
-.main-navigation {
+.nav1 {
 	/* Un-style buttons */
 	button {
 		display: inline-block;
@@ -131,7 +131,7 @@
 /* Desktop-specific styles */
 
 .site-header {
-	.main-navigation {
+	.nav1 {
 		font-size: $font__size-xs;
 
 		.main-menu {
@@ -263,12 +263,12 @@
 	}
 }
 
-.header-default-height .site-header .main-navigation .main-menu > li {
+.header-default-height .site-header .nav1 .main-menu > li {
 	padding: calc( #{$size__spacing-unit} * 0.5 ) 0;
 }
 
 .header-simplified {
-	.site-header .main-navigation .main-menu > li {
+	.site-header .nav1 .main-menu > li {
 		padding: #{ 0.25 * $size__spacing-unit } 0;
 
 		> .sub-menu {

--- a/sass/navigation/_menu-mobile-navigation.scss
+++ b/sass/navigation/_menu-mobile-navigation.scss
@@ -63,7 +63,7 @@
 
 	a,
 	a:visited,
-	.main-navigation .sub-menu > li > a {
+	.nav1 .sub-menu > li > a {
 		color: #fff;
 	}
 
@@ -79,18 +79,18 @@
 	}
 
 	nav.secondary-menu a,
-	.main-navigation .main-menu > li > a {
+	.nav1 .main-menu > li > a {
 		padding-left: 0;
 		padding-right: 0;
 	}
 
-	nav.main-navigation + nav.secondary-menu {
+	nav.nav1 + nav.secondary-menu {
 		border-top: 1px solid #fff;
 		padding-top: #{ 0.75 * $size__spacing-unit };
 	}
 
-	.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg,
-	.main-navigation .sub-menu > li.menu-item-has-children .submenu-expand,
+	.nav1 .main-menu > li.menu-item-has-children .submenu-expand svg,
+	.nav1 .sub-menu > li.menu-item-has-children .submenu-expand,
 	.submenu-expand {
 		display: none;
 	}

--- a/sass/print.scss
+++ b/sass/print.scss
@@ -119,8 +119,8 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	}
 
 	/* Visibility */
-	.main-navigation,
-	.site-title + .main-navigation,
+	.nav1,
+	.site-title + .nav1,
 	.social-navigation,
 	.site-branding-container:before,
 	.entry .entry-title:before,

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -239,8 +239,8 @@
 	.site-title a:visited,
 	.site-description,
 	.middle-header-contain,
-	.main-navigation .main-menu > li,
-	.main-navigation .main-menu > li > a {
+	.nav1 .main-menu > li,
+	.nav1 .main-menu > li > a {
 		color: #fff;
 	}
 
@@ -265,8 +265,8 @@
 			border: 0;
 		}
 
-		.main-navigation .main-menu > li,
-		.main-navigation .main-menu > li > a,
+		.nav1 .main-menu > li,
+		.nav1 .main-menu > li > a,
 		#search-toggle {
 			color: #fff;
 		}
@@ -295,7 +295,7 @@
 			margin-right: $size__spacing-unit;
 		}
 
-		&.hide-site-tagline .main-navigation {
+		&.hide-site-tagline .nav1 {
 			flex-grow: 2;
 		}
 	}

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -85,8 +85,8 @@ body:not(.header-solid-background) .site-header {
 .header-solid-background .bottom-header-contain {
 	background-color: transparent;
 
-	.main-navigation .main-menu > li,
-	.main-navigation .main-menu > li > a,
+	.nav1 .main-menu > li,
+	.nav1 .main-menu > li > a,
 	#search-toggle {
 		color: inherit;
 	}

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -25,7 +25,7 @@ Newspack Theme Styles - Style Pack 3
 }
 
 .header-solid-background.header-simplified {
-	.site-header .main-navigation .main-menu .sub-menu {
+	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -25,7 +25,7 @@ Newspack Theme Styles - Style Pack 4
 }
 
 .header-solid-background.header-simplified {
-	.site-header .main-navigation .main-menu .sub-menu {
+	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
 

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -45,7 +45,7 @@ figcaption,
 .entry-meta,
 .cat-links,
 .entry-footer,
-.main-navigation,
+.nav1, // main-navigation
 .secondary-menu,
 .tertiary-menu,
 .site-description,
@@ -129,7 +129,7 @@ input[type="submit"] {
 }
 
 .site-header {
-	.main-navigation {
+	.nav1 {
 		.main-menu {
 			.sub-menu {
 				a:hover,

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -7,7 +7,7 @@
 .cat-links,
 .entry-footer,
 .author-bio .author-link,
-.main-navigation,
+.nav1,
 .secondary-menu,
 .tertiary-menu,
 .no-comments,
@@ -52,7 +52,7 @@ h6 {
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.main-navigation {
+.nav1 {
 	line-height: $font__line-height-heading;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the `main-navigation` class with a shorter `nav1`, in an attempt to shrink the CSS.

For me, it reduces the generated style.css by about 0.7kb, plus more for the colour and typography CSS.

Unfortunately, this is one of those changes that should be tested with the different style packs and header settings; I will do the same for the secondary and tertiary menus, so it might make sense to test them all together and cycle between the different PRs. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Cycle through the different style packs; ensure the main navigation looks right on mobile and desktop.

Default:

![image](https://user-images.githubusercontent.com/177561/68550155-3ddbcb80-03b5-11ea-9f4e-51d87d4e7d1e.png)

![image](https://user-images.githubusercontent.com/177561/68550161-459b7000-03b5-11ea-892f-6afa3fd4c25b.png)

Style 1:
![image](https://user-images.githubusercontent.com/177561/68550169-577d1300-03b5-11ea-8489-14ecc11343f6.png)

![image](https://user-images.githubusercontent.com/177561/68550174-5e0b8a80-03b5-11ea-8888-9711f1b0c87e.png)

Style 2:

![image](https://user-images.githubusercontent.com/177561/68550191-767ba500-03b5-11ea-8b30-531a0daad4e3.png)

![image](https://user-images.githubusercontent.com/177561/68550188-6a8fe300-03b5-11ea-97e9-921f6986fda6.png)

Style 3:

![image](https://user-images.githubusercontent.com/177561/68550192-81ced080-03b5-11ea-8045-23917eb1d56f.png)

![image](https://user-images.githubusercontent.com/177561/68550196-8abfa200-03b5-11ea-96b7-14fc623e8d88.png)

Style 4:

![image](https://user-images.githubusercontent.com/177561/68550207-9c08ae80-03b5-11ea-8d77-df897fbaba21.png)


![image](https://user-images.githubusercontent.com/177561/68550203-9317dd00-03b5-11ea-94a4-c91252aa37c0.png)

Style 5:

![image](https://user-images.githubusercontent.com/177561/68550216-aaef6100-03b5-11ea-93c8-7a10a0d74d79.png)

![image](https://user-images.githubusercontent.com/177561/68550221-b17dd880-03b5-11ea-9453-76c8a20d5995.png)


3. Cycle through the different header settings (simplified; solid background; centred logo); confirm the main navigation looks right on mobile on desktop.

Simplified:

![image](https://user-images.githubusercontent.com/177561/68550251-fd308200-03b5-11ea-8dcc-3adc6f3da0a8.png)

Solid bg:

![image](https://user-images.githubusercontent.com/177561/68550255-10435200-03b6-11ea-9219-f4af957a2e40.png)

Centred logo:

![image](https://user-images.githubusercontent.com/177561/68550265-31a43e00-03b6-11ea-8b21-a7e374ce9330.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
