### PR TITLE
Replace 'secondary-menu' class with the shorter 'nav2' class

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -105,7 +105,7 @@ function newspack_custom_colors_css() {
 			border-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.mobile-sidebar nav.nav1 + nav.secondary-menu {
+		.mobile-sidebar .nav1 + nav.secondary-menu {
 			border-color: ' . $primary_color_contrast . ';
 		}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -326,7 +326,7 @@ function newspack_secondary_menu() {
 		return;
 	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu nav2" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
 		<?php
 		wp_nav_menu(
 			array(

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -159,7 +159,7 @@ function newspack_custom_typography_css() {
 			.cat-links,
 			.entry-footer,
 			.nav1,
-			.secondary-menu,
+			.nav2,
 			.tertiary-menu,
 			.site-description,
 			.site-info,

--- a/sass/navigation/_menu-secondary-navigation.scss
+++ b/sass/navigation/_menu-secondary-navigation.scss
@@ -1,4 +1,4 @@
-nav.secondary-menu {
+.nav2 {
 
 	ul, li {
 		list-style: none;
@@ -18,7 +18,7 @@ nav.secondary-menu {
 
 /* Desktop-specific styles */
 .site-header {
-	nav.secondary-menu {
+	.nav2 {
 		ul, li {
 			align-items: center;
 			display: flex;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the longer 'secondary-menu' class with a shorter 'nav2' class.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Cycle through the style packs and confirm that the secondary menu displays correctly on desktop and mobile-sized headers:

Default:

![image](https://user-images.githubusercontent.com/177561/68550867-e9881a00-03bb-11ea-938f-38217b5d1efb.png)

![image](https://user-images.githubusercontent.com/177561/68550873-f0af2800-03bb-11ea-9b24-21248b391aef.png)

Style 1:

![image](https://user-images.githubusercontent.com/177561/68550883-03296180-03bc-11ea-81b8-32b30e9a8c6c.png)

![image](https://user-images.githubusercontent.com/177561/68550880-fc9aea00-03bb-11ea-962d-66046d9b0a81.png)

Style 2:

![image](https://user-images.githubusercontent.com/177561/68550895-1b997c00-03bc-11ea-932b-189cfd633134.png)

![image](https://user-images.githubusercontent.com/177561/68550896-2227f380-03bc-11ea-81fd-2062553ca552.png)

Style 3:

![image](https://user-images.githubusercontent.com/177561/68550905-34099680-03bc-11ea-898c-f3c1f335cbc7.png)

![image](https://user-images.githubusercontent.com/177561/68550907-3b30a480-03bc-11ea-935c-6bc6f3250e7c.png)

Style 4:

![image](https://user-images.githubusercontent.com/177561/68550912-4a175700-03bc-11ea-86bf-041e07fc524c.png)

![image](https://user-images.githubusercontent.com/177561/68550915-50a5ce80-03bc-11ea-89f7-6ba6f9056283.png)

Style 5:

![image](https://user-images.githubusercontent.com/177561/68550931-69ae7f80-03bc-11ea-90c4-c888890924ac.png)

![image](https://user-images.githubusercontent.com/177561/68550936-703cf700-03bc-11ea-9d01-66527c421b09.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
