### PR TITLE
Style 1: Fix Pullquote Block preview in editor

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -463,7 +463,7 @@ function newspack_custom_colors_css() {
 			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
 				background-color: ' . $primary_color . ';
 			}
-			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) .block-library-pullquote__content:before {
+			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) blockquote > .editor-rich-text__editable:first-child:before {
 				color: ' . $primary_color . ';
 			}
 		';

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -242,7 +242,7 @@ function newspack_custom_typography_css() {
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .block-library-pullquote__content::before
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text__editable:first-child::before
 
 			{
 				font-family: $font_header;

--- a/sass/styles/style-1/style-1-editor.scss
+++ b/sass/styles/style-1/style-1-editor.scss
@@ -92,29 +92,28 @@ Newspack Theme Editor Styles - Style Pack 1
 		}
 	}
 
-	.block-library-pullquote__content {
-		&:before {
-			color: $color__primary;
-			content: "\201C";
-			display: inline-block;
-			font-family: $font__heading;
-			font-size: calc( 1rem * 5 );
-			font-weight: normal;
-			left: calc( 50% - 0.25em );
-			line-height: 0.75;
-			position: absolute;
-			text-align: center;
-			top: #{ -3.5 * $size__spacing-unit };
-			width: 0.5em;
-			z-index: 1;
+	blockquote > .editor-rich-text__editable:first-child:before {
+		color: $color__primary;
+		content: "\201C";
+		display: inline-block;
+		font-family: $font__heading;
+		font-size: calc( 1rem * 6 );
+		font-style: italic;
+		font-weight: normal;
+		left: calc( 50% - 0.3em );
+		line-height: 0.75;
+		position: absolute;
+		text-align: center;
+		top: 0.2em;
+		width: 0.5em;
+		z-index: 1;
 
-			@include media( tablet ) {
-				font-size: calc( 1rem * 7 );
-			}
+		@include media( tablet ) {
+			font-size: calc( 1rem * 8 );
 		}
 	}
 
-	.wp-block-pullquote.is-style-solid-color .block-library-pullquote__content:before {
+	.wp-block-pullquote.is-style-solid-color blockquote > .editor-rich-text__editable:first-child:before {
 		color: inherit;
 	}
 
@@ -144,7 +143,7 @@ Newspack Theme Editor Styles - Style Pack 1
 			text-align: left;
 
 			&:before {
-				left: 2em;
+				left: 3em;
 				right: 0;
 			}
 
@@ -153,22 +152,24 @@ Newspack Theme Editor Styles - Style Pack 1
 			}
 		}
 
-		.block-library-pullquote__content {
-			&:before {
-				font-size: calc( 1rem * 5 );
-				left: 0;
-				text-align: left;
-				top: #{ -2.5 * $size__spacing-unit };
-				width: 0.5em;
-			}
+		blockquote > .editor-rich-text__editable:first-child:before {
+			font-size: calc( 1rem * 6 );
+			left: 0;
+			text-align: left;
+			top: 0.3em;
+			width: 0.5em;
 		}
 
 		&.is-style-solid-color blockquote {
 			padding-top: #{ 0.25 * $size__spacing-unit };
 
 			&:before {
-				left: #{ 4 * $size__spacing-unit };
+				left: #{ 5 * $size__spacing-unit };
 				right: #{ 2 * $size__spacing-unit };
+			}
+
+			& > .editor-rich-text__editable:first-child:before {
+				left: #{ 1.5 * $size__spacing-unit };
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Something structural appears to have changed in the Pullquote block, so the quote style is no longer previewing correctly in the editor.

This PR changes the selector and hopefully takes care of that. 

### How to test the changes in this Pull Request:

1. Copy-paste [this content](https://cloudup.com/cZxGy5_XoTg) into the editor -- it includes multiple blocks with different settings. Note: you may have to 'recover' the blocks with the main colour setting after you exit the editor. 
2. View in the editor; note the lack of quotation marks:

![image](https://user-images.githubusercontent.com/177561/68635893-c5593580-04ae-11ea-8674-f26988fbbb88.png)

![image](https://user-images.githubusercontent.com/177561/68635912-cd18da00-04ae-11ea-9c92-f57b61f883c2.png)

3. Apply the PR and run `npm run build`
4. View the post in the editor again and confirm that the quotation is there:

![image](https://user-images.githubusercontent.com/177561/68635649-19174f00-04ae-11ea-903b-228d88f88078.png)

![image](https://user-images.githubusercontent.com/177561/68635665-1ddc0300-04ae-11ea-9b89-8ee3c796df23.png)

![image](https://user-images.githubusercontent.com/177561/68635672-22a0b700-04ae-11ea-9661-f3a11a3b9887.png)

![image](https://user-images.githubusercontent.com/177561/68635677-27656b00-04ae-11ea-9f07-cbbf9f7ca440.png)

5. Try changing the custom fonts and colours; confirm that the quotation mark is picking both up:

![image](https://user-images.githubusercontent.com/177561/68635729-4b28b100-04ae-11ea-9147-7c52b7dbd6b4.png)

![image](https://user-images.githubusercontent.com/177561/68635744-5845a000-04ae-11ea-8a9a-ae419aa3fb37.png)

![image](https://user-images.githubusercontent.com/177561/68635754-60054480-04ae-11ea-85b6-62c8ed48b0ef.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
