### PR TITLE
Cover Block: Simplify front-end styles

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -168,6 +168,14 @@
 	position: relative;
 }
 
+
+//! Newspack Article Block
+.wpnbha {
+	figcaption {
+		max-width: 100%;
+	}
+}
+
 //! Columns
 .wp-block-columns {
 
@@ -203,11 +211,61 @@
 	}
 }
 
+//! Cover Image
+.wp-block-cover-image,
+.wp-block-cover {
+	position: relative;
+	min-height: 430px;
+	padding: $size__spacing-unit #{ 1.5 * $size__spacing-unit };
 
-//! Newspack Article Block
-.wpnbha {
-	figcaption {
+	.wp-block-cover__inner-container {
+		width: 100%;
+	}
+
+	h2 {
 		max-width: 100%;
+		padding-left: 0;
+		text-align: left;
+	}
+
+	a,
+	a:hover,
+	a:visited,
+	.entry-meta,
+	.entry-meta a,
+	.entry-meta a:visited,
+	article .entry-meta a,
+	article .entry-meta a:visited {
+		color: #fff;
+	}
+
+	&.alignleft,
+	&.alignright {
+		min-height: 250px;
+		max-width: 100%;
+
+		@include media(mobile) {
+			width: 50%;
+		}
+
+		@include media(tablet) {
+			padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
+		}
+
+		blockquote,
+		.wp-block-pullquote:not(.is-style-solid-color) blockquote {
+			padding-left: 0;
+		}
+
+		.wp-block-cover__inner-container {
+			[class*="wp-block-"]:first-child {
+				margin-top: 0;
+			}
+
+			[class*="wp-block-"]:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 }
 
@@ -608,64 +666,6 @@
 
 		figcaption {
 			text-align: left;
-		}
-	}
-
-	//! Cover Image
-	.wp-block-cover-image,
-	.wp-block-cover {
-		position: relative;
-		min-height: 430px;
-		padding: $size__spacing-unit #{ 1.5 * $size__spacing-unit };
-
-		.wp-block-cover__inner-container {
-			width: 100%;
-		}
-
-		h2 {
-			max-width: 100%;
-			padding-left: 0;
-			text-align: left;
-		}
-
-		a,
-		a:hover,
-		a:visited,
-		.entry-meta,
-		.entry-meta a,
-		.entry-meta a:visited,
-		article .entry-meta a,
-		article .entry-meta a:visited {
-			color: #fff;
-		}
-
-		&.alignleft,
-		&.alignright {
-			min-height: 250px;
-			max-width: 100%;
-
-			@include media(mobile) {
-				width: 50%;
-			}
-
-			@include media(tablet) {
-				padding: $size__spacing-unit calc(2 * #{$size__spacing-unit});
-			}
-
-			blockquote,
-			.wp-block-pullquote:not(.is-style-solid-color) blockquote {
-				padding-left: 0;
-			}
-
-			.wp-block-cover__inner-container {
-				[class*="wp-block-"]:first-child {
-					margin-top: 0;
-				}
-
-				[class*="wp-block-"]:last-child {
-					margin-bottom: 0;
-				}
-			}
 		}
 	}
 

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1045,7 +1045,6 @@
 	.wp-block-cover,
 	.wp-block-cover-image {
 		&.alignfull {
-
 			.wp-block-cover-image-text,
 			.wp-block-cover-text,
 			h2 {
@@ -1055,8 +1054,7 @@
 			@include media(tablet) {
 
 				.wp-block-cover-image-text,
-				.wp-block-cover-text,
-				h2 {
+				.wp-block-cover-text {
 					padding: 0;
 				}
 			}

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -269,6 +269,15 @@
 	}
 }
 
+.wp-block-columns {
+	.wp-block-cover,
+	.wp-block-cover-image {
+		min-height: 330px;
+		padding-left: $size__spacing-unit;
+		padding-right: $size__spacing-unit;
+	}
+}
+
 .entry .entry-content {
 
 	//! Paragraphs
@@ -666,19 +675,6 @@
 
 		figcaption {
 			text-align: left;
-		}
-	}
-
-	.wp-block-columns {
-		.wp-block-cover,
-		.wp-block-cover-image {
-			height: auto;
-			min-height: 330px;
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
-			.wp-block-cover__inner-container {
-				width: 100%;
-			}
 		}
 	}
 

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -209,7 +209,6 @@ figcaption,
 	h2 {
 		max-width: 100%;
 		padding-left: 0;
-		text-align: left;
 	}
 
 	@include media(tablet) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the `.entry .entry-content` selector from the Cover block styles.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cNe7Yz8Srp9) into the editor, and publish the post.
2. View the different cover blocks on the front-end and note their appearance.
3. Apply the PR and run `npm run build`.
4. View the cover blocks on the front-end again and confirm no issues were introduced. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
