### PR TITLE
Column block: Simplify selectors

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -168,6 +168,42 @@
 	position: relative;
 }
 
+//! Columns
+.wp-block-columns {
+
+	.wp-block-column > * {
+		margin: 32px 0;
+
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	@include media( mobile ) {
+		margin-left: -16px;
+		max-width: calc(100% + 32px);
+	}
+
+	@include media( tablet ) {
+		&.is-style-borders {
+			margin-left: -24px;
+			max-width: calc(100% + 48px);
+		}
+	}
+
+	@include media( desktop ) {
+		&.is-style-borders {
+			margin-left: -32px;
+			max-width: calc(100% + 64px);
+		}
+	}
+
+}
+
 .entry .entry-content {
 
 	//! Paragraphs
@@ -760,42 +796,6 @@
 			white-space: pre-wrap;
     	                word-break: break-word;
 		}
-	}
-
-	//! Columns
-	.wp-block-columns {
-
-		.wp-block-column > * {
-			margin: 32px 0;
-
-			&:first-child {
-				margin-top: 0;
-			}
-
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
-
-		@include media( mobile ) {
-			margin-left: -16px;
-			max-width: calc(100% + 32px);
-		}
-
-		@include media( tablet ) {
-			&.is-style-borders {
-				margin-left: -24px;
-				max-width: calc(100% + 48px);
-			}
-		}
-
-		@include media( desktop ) {
-			&.is-style-borders {
-				margin-left: -32px;
-				max-width: calc(100% + 64px);
-			}
-		}
-
 	}
 
 	//! Group

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -189,6 +189,12 @@ figcaption,
 	display: none;
 }
 
+//! Columns Block
+.wp-block-columns.is-style-borders .wp-block-column:after {
+	border-style: dotted;
+	border-color: $color__text-main;
+}
+
 .entry .entry-content {
 
 	.wp-block-newspack-blocks-homepage-articles.is-style-borders article {
@@ -299,13 +305,6 @@ figcaption,
 	.wp-block-separator,
 	hr {
 		border-top: 1px dotted $color__text-main;
-	}
-
-	.wp-block-columns.is-style-borders {
-		.wp-block-column:after {
-			border-style: dotted;
-			border-color: $color__text-main;
-		}
 	}
 
 	// Jetpack Blocks

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -270,6 +270,17 @@ textarea {
 	font-weight: bold;
 }
 
+//! Columns Block
+.wp-block-columns.is-style-borders {
+	.wp-block-column {
+		border-color: currentColor;
+
+		&:after {
+			border-color: currentColor;
+		}
+	}
+}
+
 /* Blocks */
 .entry .entry-content {
 	.wp-block-separator,
@@ -322,18 +333,6 @@ textarea {
 	.wp-block-group {
 		.wp-block-pullquote {
 			background-color: transparent;
-		}
-	}
-
-	.wp-block-columns {
-		&.is-style-borders {
-			.wp-block-column {
-				border-color: currentColor;
-
-				&:after {
-					border-color: currentColor;
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR simplifies the selectors used to style the column block, by removing the `.entry .entry-content` part of the selector.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/c5qzWkUfLt4) into the editor and publish the page. It included the column block with and without borders.
2. Apply the PR and run `npm run build`
3. Confirm the columns display correctly on the front-end.
4. Switch the style to Style 3; confirm the borders on the block with the border styles have a dotted line (instead of the light grey border)
4. Switch the style to Style 5; confirm the borders on the block with the border styles are black (instead of the light grey border)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
