### PR TITLE
Styles 4, 5: Fix accent header border alignment in editor

### DIFF
--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -21,6 +21,7 @@ Newspack Theme Editor Styles - Style Pack 4
 
 .article-section-title {
 	margin-bottom: #{ 1.5 * $size__spacing-unit };
+	position: relative;
 	overflow: hidden;
 
 	&:before,

--- a/sass/styles/style-5/style-5-editor.scss
+++ b/sass/styles/style-5/style-5-editor.scss
@@ -89,6 +89,8 @@
 	font-family: $font__body;
 	font-size: $font__size-base;
 	margin-bottom: $size__spacing-unit;
+	overflow: hidden;
+	position: relative;
 
 	&:after {
 		background-color: currentColor;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an alignment issue of the decorative borders with the article block section header in styles 4 and 5. 

Closes #575.

**Before:**

![image](https://user-images.githubusercontent.com/177561/69099140-e40b7f00-0a0e-11ea-9734-65c6411e2ae9.png)

![image](https://user-images.githubusercontent.com/177561/69099228-1d43ef00-0a0f-11ea-8983-fdac8a6dd6ee.png)

**After:**

![image](https://user-images.githubusercontent.com/177561/69099344-65631180-0a0f-11ea-9c06-b5e2f790e806.png)

![image](https://user-images.githubusercontent.com/177561/69099303-4795ac80-0a0f-11ea-911d-bce721588757.png)

### How to test the changes in this Pull Request:

1. Set up an article block in the editor and add a section header.
2. Navigate to Customizer > Style Packs, switch to style 4.
3. View that block in the editor; note the position of the light-grey border (should be, vertically, about halfway down the block).
4. Navigate to Customizer > Style Packs, switch to style 5.
5. View that block in the editor; note the position of the black border (should be, vertically, about halfway down the block).
6. Apply the PR and run `npm run build`.
7. Repeat steps 2-3 and 4-5 -- confirm that the border sits in the middle of the section header.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
