### PR TITLE
Article Block: Add full styles to make sure the block isn't cut off

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1099,11 +1099,18 @@
 			}
 		}
 	}
+}
 
+.newspack-front-page,
+.post-template-single-wide,
+.page-template-single-wide,
+.post-template-single-feature,
+.page-template-single-feature {
 	//! Add padding to some fullalign blocks to prevent text cut-offs.
 	.wp-block-pullquote,
 	.wp-block-columns,
-	.wp-block-table {
+	.wp-block-table,
+	.wpnbha {
 		&.alignfull {
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR needs to be tested with https://github.com/Automattic/newspack-blocks/pull/221.

It makes sure that when you align the Article block 'full', it doesn't get cut off on the edges.

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-blocks/pull/221 if it hasn't been merged already, and run `npm run build:webpack`
2. Add two article blocks to the static front page; align one wide and one full (might as well test both with the different templates).
3. Note that the 'full' block gets cut off on the left and right: 

![image](https://user-images.githubusercontent.com/177561/69257237-99554880-0b6f-11ea-85bb-a6685c2ebb44.png)

4. Apply this theme PR and run `npm run build`
5. Confirm that the 'cut off' issue is now fixed:

![image](https://user-images.githubusercontent.com/177561/69257289-b4c05380-0b6f-11ea-8919-5c79a29bb07c.png)

6. Repeat step 2 on a single post or page; change the page to use the one column template.
7. Confirm the blocks are displaying as expected on the front-end, and the full block isn't getting cut off.
8. Repeat step 2 on a single post or page; change the page to use the one column wide template.
9. Confirm the blocks are displaying as expected on the front-end, and the full block isn't getting cut off. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
