### PR TITLE
Replace header solid background and header default backgrounds with simpler classes

### DIFF
--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -36,7 +36,7 @@ function newspack_custom_colors_css() {
 		/* Set primary background color */
 
 		.mobile-sidebar,
-		body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a,
+		body.h-db.header-default-height .site-header .nav3 .menu-highlight a,
 		.entry .entry-content .has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
@@ -48,7 +48,7 @@ function newspack_custom_colors_css() {
 		}
 
 		@media only screen and (min-width: 782px) {
-			.hd-bg .featured-image-beside {
+			.h-db .featured-image-beside {
 				background-color: ' . $primary_color . ';
 			}
 		}
@@ -85,13 +85,13 @@ function newspack_custom_colors_css() {
 		.site-header .nav1 .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
 		.site-header .nav1 .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
 		.highlight-menu .menu-label,
-		body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a,
+		body.h-db.header-default-height .site-header .nav3 .menu-highlight a,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
 		}
 
 		@media only screen and (min-width: 782px) {
-			.hd-bg .featured-image-beside .entry-header {
+			.h-db .featured-image-beside .entry-header {
 				color: ' . $primary_color_contrast . ';
 			}
 		}
@@ -208,7 +208,7 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.cat-links a,
 			.cat-links a:visited,
-			body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a {
+			body.h-db.header-default-height .site-header .nav3 .menu-highlight a {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}
@@ -248,7 +248,7 @@ function newspack_custom_colors_css() {
 			}
 
 			@media only screen and (min-width: 782px) {
-				.hd-bg .featured-image-beside .cat-links:before {
+				.h-db .featured-image-beside .cat-links:before {
 					background-color: ' . $primary_color_contrast . ';
 				}
 			}
@@ -257,20 +257,20 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
-			.hs-bg .site-header {
+			.h-sb .site-header {
 				background-color: ' . $primary_color . ';
 			}
 
 			.site-header,
-			.hd-bg .site-header,
-			.header-simplified.hd-bg .site-header,
+			.h-db .site-header,
+			.header-simplified.h-db .site-header,
 			.site-content #primary,
 			#page .site-header {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}
 
-			.hs-bg .site-header .highlight-menu .menu-label,
-			.hs-bg .site-header .highlight-menu a {
+			.h-sb .site-header .highlight-menu .menu-label,
+			.h-sb .site-header .highlight-menu a {
 				color: ' . $primary_color_contrast . ';
 			}
 
@@ -309,8 +309,8 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
-			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
+			.h-sb.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.h-sb.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -334,8 +334,8 @@ function newspack_custom_colors_css() {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
-			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
+			.h-sb.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.h-sb.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -343,24 +343,24 @@ function newspack_custom_colors_css() {
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
 		$theme_css .= '
-			.hs-bg .middle-header-contain {
+			.h-sb .middle-header-contain {
 				background-color: ' . $primary_color . ';
 			}
-			.hs-bg .top-header-contain {
+			.h-sb .top-header-contain {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -10 ) . ';
 				border-bottom-color: ' . newspack_adjust_brightness( $primary_color, -15 ) . ';
 			}
 
-			.hs-bg .site-header,
-			.hs-bg .site-title,
-			.hs-bg .site-title a:link,
-			.hs-bg .site-title a:visited,
-			.hs-bg .site-description,
-			.hs-bg.header-simplified .nav1 .main-menu > li,
-			.hs-bg.header-simplified .nav1 ul.main-menu > li > a,
-			.hs-bg.header-simplified .nav1 ul.main-menu > li > a:hover,
-			.hs-bg .top-header-contain,
-			.hs-bg .middle-header-contain,
+			.h-sb .site-header,
+			.h-sb .site-title,
+			.h-sb .site-title a:link,
+			.h-sb .site-title a:visited,
+			.h-sb .site-description,
+			.h-sb.header-simplified .nav1 .main-menu > li,
+			.h-sb.header-simplified .nav1 ul.main-menu > li > a,
+			.h-sb.header-simplified .nav1 ul.main-menu > li > a:hover,
+			.h-sb .top-header-contain,
+			.h-sb .middle-header-contain,
 			.nav1 .sub-menu a {
 				color: ' . $primary_color_contrast . ';
 			}

--- a/inc/color-patterns.php
+++ b/inc/color-patterns.php
@@ -36,7 +36,7 @@ function newspack_custom_colors_css() {
 		/* Set primary background color */
 
 		.mobile-sidebar,
-		body.header-default-background.header-default-height .site-header .nav3 .menu-highlight a,
+		body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a,
 		.entry .entry-content .has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
@@ -48,7 +48,7 @@ function newspack_custom_colors_css() {
 		}
 
 		@media only screen and (min-width: 782px) {
-			.header-default-background .featured-image-beside {
+			.hd-bg .featured-image-beside {
 				background-color: ' . $primary_color . ';
 			}
 		}
@@ -85,13 +85,13 @@ function newspack_custom_colors_css() {
 		.site-header .nav1 .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
 		.site-header .nav1 .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
 		.highlight-menu .menu-label,
-		body.header-default-background.header-default-height .site-header .nav3 .menu-highlight a,
+		body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
 		}
 
 		@media only screen and (min-width: 782px) {
-			.header-default-background .featured-image-beside .entry-header {
+			.hd-bg .featured-image-beside .entry-header {
 				color: ' . $primary_color_contrast . ';
 			}
 		}
@@ -208,7 +208,7 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.cat-links a,
 			.cat-links a:visited,
-			body.header-default-background.header-default-height .site-header .nav3 .menu-highlight a {
+			body.hd-bg.header-default-height .site-header .nav3 .menu-highlight a {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}
@@ -248,7 +248,7 @@ function newspack_custom_colors_css() {
 			}
 
 			@media only screen and (min-width: 782px) {
-				.header-default-background .featured-image-beside .cat-links:before {
+				.hd-bg .featured-image-beside .cat-links:before {
 					background-color: ' . $primary_color_contrast . ';
 				}
 			}
@@ -257,20 +257,20 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
-			.header-solid-background .site-header {
+			.hs-bg .site-header {
 				background-color: ' . $primary_color . ';
 			}
 
 			.site-header,
-			.header-default-background .site-header,
-			.header-simplified.header-default-background .site-header,
+			.hd-bg .site-header,
+			.header-simplified.hd-bg .site-header,
 			.site-content #primary,
 			#page .site-header {
 				border-color: ' . newspack_adjust_brightness( $primary_color, -40 ) . ';
 			}
 
-			.header-solid-background .site-header .highlight-menu .menu-label,
-			.header-solid-background .site-header .highlight-menu a {
+			.hs-bg .site-header .highlight-menu .menu-label,
+			.hs-bg .site-header .highlight-menu a {
 				color: ' . $primary_color_contrast . ';
 			}
 
@@ -309,8 +309,8 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
-			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
+			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -334,8 +334,8 @@ function newspack_custom_colors_css() {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
-			.header-solid-background.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
+			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:hover,
+			.hs-bg.header-simplified .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
 			}
 		';
@@ -343,24 +343,24 @@ function newspack_custom_colors_css() {
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
 		$theme_css .= '
-			.header-solid-background .middle-header-contain {
+			.hs-bg .middle-header-contain {
 				background-color: ' . $primary_color . ';
 			}
-			.header-solid-background .top-header-contain {
+			.hs-bg .top-header-contain {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -10 ) . ';
 				border-bottom-color: ' . newspack_adjust_brightness( $primary_color, -15 ) . ';
 			}
 
-			.header-solid-background .site-header,
-			.header-solid-background .site-title,
-			.header-solid-background .site-title a:link,
-			.header-solid-background .site-title a:visited,
-			.header-solid-background .site-description,
-			.header-solid-background.header-simplified .nav1 .main-menu > li,
-			.header-solid-background.header-simplified .nav1 ul.main-menu > li > a,
-			.header-solid-background.header-simplified .nav1 ul.main-menu > li > a:hover,
-			.header-solid-background .top-header-contain,
-			.header-solid-background .middle-header-contain,
+			.hs-bg .site-header,
+			.hs-bg .site-title,
+			.hs-bg .site-title a:link,
+			.hs-bg .site-title a:visited,
+			.hs-bg .site-description,
+			.hs-bg.header-simplified .nav1 .main-menu > li,
+			.hs-bg.header-simplified .nav1 ul.main-menu > li > a,
+			.hs-bg.header-simplified .nav1 ul.main-menu > li > a:hover,
+			.hs-bg .top-header-contain,
+			.hs-bg .middle-header-contain,
 			.nav1 .sub-menu a {
 				color: ' . $primary_color_contrast . ';
 			}

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -46,9 +46,9 @@ function newspack_body_classes( $classes ) {
 	// Adds classes to reflect the header layout
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {
-		$classes[] = 'header-solid-background';
+		$classes[] = 'hs-bg';
 	} else {
-		$classes[] = 'header-default-background';
+		$classes[] = 'hd-bg';
 	}
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -46,9 +46,9 @@ function newspack_body_classes( $classes ) {
 	// Adds classes to reflect the header layout
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {
-		$classes[] = 'h-sb'; // hs-bg
+		$classes[] = 'h-sb'; // header - solid background.
 	} else {
-		$classes[] = 'h-db'; // hd-bg
+		$classes[] = 'h-db'; // header - default background.
 	}
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -46,9 +46,9 @@ function newspack_body_classes( $classes ) {
 	// Adds classes to reflect the header layout
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {
-		$classes[] = 'hs-bg';
+		$classes[] = 'h-sb'; // hs-bg
 	} else {
-		$classes[] = 'hd-bg';
+		$classes[] = 'h-db'; // hd-bg
 	}
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -31,8 +31,8 @@
 	}
 }
 
-
-body.hd-bg.header-default-height .site-header {
+// Header - default background
+body.h-db.header-default-height .site-header {
 	.nav3 {
 		.menu-highlight a {
 			background-color: $color__primary;

--- a/sass/navigation/_menu-tertiary-navigation.scss
+++ b/sass/navigation/_menu-tertiary-navigation.scss
@@ -32,7 +32,7 @@
 }
 
 
-body.header-default-background.header-default-height .site-header {
+body.hd-bg.header-default-height .site-header {
 	.nav3 {
 		.menu-highlight a {
 			background-color: $color__primary;

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -156,7 +156,7 @@
 
  // Default Header
 
-.header-default-background {
+.hd-bg {
 	.middle-header-contain {
 		border-bottom: 1px solid $color__border;
 
@@ -229,7 +229,7 @@
 
 // Solid Background
 
-.header-solid-background {
+.hs-bg {
 	.site-header {
 		padding-bottom: 0;
 	}
@@ -300,7 +300,7 @@
 		}
 	}
 
-	&.header-default-background .middle-header-contain {
+	&.hd-bg .middle-header-contain {
 		border-bottom: 1px solid $color__border;
 	}
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -156,7 +156,7 @@
 
  // Default Header
 
-.hd-bg {
+.h-db {
 	.middle-header-contain {
 		border-bottom: 1px solid $color__border;
 
@@ -229,7 +229,7 @@
 
 // Solid Background
 
-.hs-bg {
+.h-sb {
 	.site-header {
 		padding-bottom: 0;
 	}
@@ -300,7 +300,8 @@
 		}
 	}
 
-	&.hd-bg .middle-header-contain {
+	// Default background color.
+	&.h-db .middle-header-contain {
 		border-bottom: 1px solid $color__border;
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -531,11 +531,11 @@ body.page {
 		margin-top: 0;
 	}
 
-	.header-default-background .featured-image-beside {
+	.hd-bg .featured-image-beside {
 		background-color: $color__primary;
 	}
 
-	.header-solid-background .featured-image-beside {
+	.hs-bg .featured-image-beside {
 		background-color: #333;
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -531,11 +531,13 @@ body.page {
 		margin-top: 0;
 	}
 
-	.hd-bg .featured-image-beside {
+	// Header - default background
+	.h-db .featured-image-beside {
 		background-color: $color__primary;
 	}
 
-	.hs-bg .featured-image-beside {
+	// Header - solid background
+	.h-sb .featured-image-beside {
 		background-color: #333;
 	}
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -8,13 +8,13 @@ Newspack Theme Styles - Style Pack 2
 @import "../../style-base.scss";
 
 // Header Overlap
-
-.hs-bg .site-header {
+// Header - Solid background
+.h-sb .site-header {
 	background-color: $color__primary;
 }
 
 .site-header,
-.hs-bg .site-header {
+.h-sb .site-header {
 	@include media(tablet) {
 		padding-bottom: #{ 4 * $size__spacing-unit };
 	}
@@ -61,13 +61,14 @@ Newspack Theme Styles - Style Pack 2
 // Header
 
 .site-header,
-.hd-bg .middle-header-contain,
-.header-simplified.hd-bg .site-header,
-body:not(.hs-bg) .site-header {
+.h-db .middle-header-contain, // default background
+.header-simplified.h-db .site-header,
+body:not(.h-sb) .site-header {
 	background-color: #efefef;
 }
 
-.header-simplified.hd-bg .middle-header-contain {
+// default background
+.header-simplified.h-db .middle-header-contain {
 	border-bottom: 0;
 }
 
@@ -82,7 +83,8 @@ body:not(.hs-bg) .site-header {
 	border: 0;
 }
 
-.hs-bg .bottom-header-contain {
+// Header - solid background
+.h-sb .bottom-header-contain {
 	background-color: transparent;
 
 	.nav1 .main-menu > li,

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -9,12 +9,12 @@ Newspack Theme Styles - Style Pack 2
 
 // Header Overlap
 
-.header-solid-background .site-header {
+.hs-bg .site-header {
 	background-color: $color__primary;
 }
 
 .site-header,
-.header-solid-background .site-header {
+.hs-bg .site-header {
 	@include media(tablet) {
 		padding-bottom: #{ 4 * $size__spacing-unit };
 	}
@@ -61,13 +61,13 @@ Newspack Theme Styles - Style Pack 2
 // Header
 
 .site-header,
-.header-default-background .middle-header-contain,
-.header-simplified.header-default-background .site-header,
-body:not(.header-solid-background) .site-header {
+.hd-bg .middle-header-contain,
+.header-simplified.hd-bg .site-header,
+body:not(.hs-bg) .site-header {
 	background-color: #efefef;
 }
 
-.header-simplified.header-default-background .middle-header-contain {
+.header-simplified.hd-bg .middle-header-contain {
 	border-bottom: 0;
 }
 
@@ -82,7 +82,7 @@ body:not(.header-solid-background) .site-header {
 	border: 0;
 }
 
-.header-solid-background .bottom-header-contain {
+.hs-bg .bottom-header-contain {
 	background-color: transparent;
 
 	.nav1 .main-menu > li,

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -9,7 +9,7 @@ Newspack Theme Styles - Style Pack 3
 
 // Header
 
-.header-solid-background {
+.hs-bg {
 	.top-header-contain,
 	.middle-header-contain {
 		background-color: $color__background-dark;
@@ -24,7 +24,7 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
-.header-solid-background.header-simplified {
+.hs-bg.header-simplified {
 	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
@@ -188,7 +188,7 @@ Newspack Theme Styles - Style Pack 3
 }
 
 @include media( tablet ) {
-	.header-solid-background .featured-image-beside {
+	.hs-bg .featured-image-beside {
 		background-color: $color__primary;
 
 		.cat-links:before {

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -9,7 +9,8 @@ Newspack Theme Styles - Style Pack 3
 
 // Header
 
-.hs-bg {
+// Solid Background
+.h-sb {
 	.top-header-contain,
 	.middle-header-contain {
 		background-color: $color__background-dark;
@@ -24,7 +25,7 @@ Newspack Theme Styles - Style Pack 3
 	}
 }
 
-.hs-bg.header-simplified {
+.h-sb.header-simplified {
 	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
@@ -188,7 +189,8 @@ Newspack Theme Styles - Style Pack 3
 }
 
 @include media( tablet ) {
-	.hs-bg .featured-image-beside {
+	// Header - Solid background
+	.h-sb .featured-image-beside {
 		background-color: $color__primary;
 
 		.cat-links:before {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -9,7 +9,7 @@ Newspack Theme Styles - Style Pack 4
 
 // Header
 
-.header-solid-background {
+.hs-bg {
 	.top-header-contain,
 	.middle-header-contain {
 		background-color: $color__background-dark;
@@ -24,7 +24,7 @@ Newspack Theme Styles - Style Pack 4
 	}
 }
 
-.header-solid-background.header-simplified {
+.hs-bg.header-simplified {
 	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
@@ -237,7 +237,7 @@ figcaption,
 
 
 @include media( tablet ) {
-	.header-solid-background .featured-image-beside {
+	.hs-bg .featured-image-beside {
 		background-color: $color__background-pre;
 
 		.entry-header {

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -8,8 +8,8 @@ Newspack Theme Styles - Style Pack 4
 @import "../../style-base.scss";
 
 // Header
-
-.hs-bg {
+// Solid Background
+.h-sb {
 	.top-header-contain,
 	.middle-header-contain {
 		background-color: $color__background-dark;
@@ -24,7 +24,7 @@ Newspack Theme Styles - Style Pack 4
 	}
 }
 
-.hs-bg.header-simplified {
+.h-sb.header-simplified {
 	.site-header .nav1 .main-menu .sub-menu {
 		a {
 			background-color: $color__text-main;
@@ -237,7 +237,7 @@ figcaption,
 
 
 @include media( tablet ) {
-	.hs-bg .featured-image-beside {
+	.h-sb .featured-image-beside {
 		background-color: $color__background-pre;
 
 		.entry-header {

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -28,7 +28,8 @@ body {
 	}
 }
 
-.hs-bg {
+// Header - solid bg
+.h-sb {
 	.bottom-header-contain,
 	.middle-header-contain,
 	.top-header-contain {
@@ -177,8 +178,9 @@ input[type="submit"] {
 	}
 }
 
-.hd-bg,
-.hs-bg {
+// Default and solid header backgrounds
+.h-db,
+.h-sb {
 	.featured-image-beside {
 		@include media( tablet ) {
 			background-color: currentColor;
@@ -186,7 +188,8 @@ input[type="submit"] {
 	}
 }
 
-.hs-bg {
+// Solid header background
+.h-sb {
 	.featured-image-beside {
 		@include media( tablet ) {
 			border-top: 1px solid $color__background-body;

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -28,7 +28,7 @@ body {
 	}
 }
 
-.header-solid-background {
+.hs-bg {
 	.bottom-header-contain,
 	.middle-header-contain,
 	.top-header-contain {
@@ -177,8 +177,8 @@ input[type="submit"] {
 	}
 }
 
-.header-default-background,
-.header-solid-background {
+.hd-bg,
+.hs-bg {
 	.featured-image-beside {
 		@include media( tablet ) {
 			background-color: currentColor;
@@ -186,7 +186,7 @@ input[type="submit"] {
 	}
 }
 
-.header-solid-background {
+.hs-bg {
 	.featured-image-beside {
 		@include media( tablet ) {
 			border-top: 1px solid $color__background-body;

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -10,8 +10,8 @@
 }
 
 /* Navigation */
-
-body.hd-bg.header-default-height {
+// Header default background
+body.h-db.header-default-height {
 	.site-header {
 		.nav3 {
 			a {

--- a/sass/styles/style-default/style-default.scss
+++ b/sass/styles/style-default/style-default.scss
@@ -11,7 +11,7 @@
 
 /* Navigation */
 
-body.header-default-background.header-default-height {
+body.hd-bg.header-default-height {
 	.site-header {
 		.nav3 {
 			a {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the longer `.header-default-background` and `.header-solid-background` classes with ones that are shorter and simpler (`.h-db` and `.h-sb`). 

It removes about 1.2kb from the style.css, plus more from the styles generated by the custom colours.

### How to test the changes in this Pull Request:

Unfortunately, this is one of those PRs that needs a fair bit of testing to make sure it doesn't cause issues with the different style packs/settings.

1. Apply the PR and run `npm run build`
2. Set up a header with all the menus (including the 'highlights' menu -- if the title is missing with some of the configurations below, it should be fixed with #477)
3. Loop through the following header + style pack combinations:

**Default style pack** - default header (shows the highlight menu issue):

![image](https://user-images.githubusercontent.com/177561/69269055-15a65680-0b85-11ea-897e-804233ab7627.png)

**Default style pack** - solid header bg, default colour:

![image](https://user-images.githubusercontent.com/177561/69269098-2d7dda80-0b85-11ea-9a71-71b5bc3324c9.png)

**Default style pack** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269152-46868b80-0b85-11ea-9899-994cbe8f0fb7.png)

**Default style pack** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69269252-77ff5700-0b85-11ea-9879-2e1341534ab1.png)

**Default style pack** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269220-69b13b00-0b85-11ea-8ae9-089fa305e674.png)

----

**Style 1** - default header:

![image](https://user-images.githubusercontent.com/177561/69269389-c3b20080-0b85-11ea-834d-175f1b8c898a.png)

**Style 1** - solid header bg, default colour:

![image](https://user-images.githubusercontent.com/177561/69269414-d2001c80-0b85-11ea-9bb4-744bf50968ee.png)

**Style 1** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269439-e04e3880-0b85-11ea-9917-6ab361c167ea.png)

**Style 1** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69269556-22777a00-0b86-11ea-9414-2795793d135e.png)

**Style 1** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269491-f9ef8000-0b85-11ea-8e50-4fe8f89fa74b.png)

----

**Style 2** - default header:

![image](https://user-images.githubusercontent.com/177561/69269647-581c6300-0b86-11ea-9154-e253b8ed5250.png)

**Style 2** - solid header bg, default colour (created a bug for the highlight issue here: #582)

![image](https://user-images.githubusercontent.com/177561/69269705-74b89b00-0b86-11ea-88e3-af2ae37d25f4.png)

**Style 2** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269824-ac274780-0b86-11ea-90b3-4410e33a4897.png)

**Style 2** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69269939-e0026d00-0b86-11ea-910c-27afeb9a89f6.png)

**Style 2** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69269893-d0832400-0b86-11ea-8ef1-84d521698afe.png)

----

**Note:** for the rest of the styles packs, the dark headers are intentional:

**Style 3** - default header:

![image](https://user-images.githubusercontent.com/177561/69270021-07f1d080-0b87-11ea-8dbb-62b5e5fe2c4c.png)

**Style 3** - solid header bg, default colour:

![image](https://user-images.githubusercontent.com/177561/69270052-15a75600-0b87-11ea-8e1e-1c7e3cbda6d5.png)

**Style 3** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69270095-29eb5300-0b87-11ea-972d-682a6afa91a3.png)

**Style 3** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69270150-48e9e500-0b87-11ea-8075-b0601e9f9788.png)

**Style 3** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69270122-3a033280-0b87-11ea-9e84-460b032e44b7.png)

----

**Style 4** - default header:

![image](https://user-images.githubusercontent.com/177561/69270360-a120e700-0b87-11ea-92bc-07f2405d2eeb.png)

**Style 4** - solid header bg, default colour:

![image](https://user-images.githubusercontent.com/177561/69270429-c3b30000-0b87-11ea-9737-c6fe215251ce.png)

**Style 4** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69270524-e9d8a000-0b87-11ea-8c64-971339ca2fce.png)

**Style 4** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69270600-17bde480-0b88-11ea-9d49-97899aa3df7a.png)

**Style 4** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69270566-083e9b80-0b88-11ea-9c0a-9e27ba457328.png)

----

**Style 5** - default header:

![image](https://user-images.githubusercontent.com/177561/69270774-7e430280-0b88-11ea-8e0f-2c5af4912390.png)

**Style 5** - solid header bg, default colour:

![image](https://user-images.githubusercontent.com/177561/69270863-afbbce00-0b88-11ea-9baa-a92811854526.png)

**Style 5** - solid header bg + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69270892-bea28080-0b88-11ea-8cf6-4dc4416a19cb.png)

**Style 5** - solid header bg + short header + default colour:

![image](https://user-images.githubusercontent.com/177561/69271160-31136080-0b89-11ea-9626-da9e787c15d3.png)

**Style 5** - solid header bg + short header + lighter custom colour:

![image](https://user-images.githubusercontent.com/177561/69271077-104b0b00-0b89-11ea-9051-79f02d2e6d01.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
