### PR TITLE
Column block: Make sure it fills all available space

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,7 +1,7 @@
 /* !Block styles */
 
 .entry .entry-content > * {
-	margin: 32px auto;
+	margin: 32px 0;
 	max-width: 100%;
 
 	&:last-child {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,8 +1,13 @@
 /* !Block styles */
 
 .entry .entry-content > * {
-	margin: 32px 0;
+	margin-bottom: 32px;
+	margin-top: 32px;
 	max-width: 100%;
+
+	&.wp-block-columns {
+		max-width: calc( 100% + 32px );
+	}
 
 	&:last-child {
 		margin-bottom: 0;

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -1,8 +1,7 @@
 /* !Block styles */
 
 .entry .entry-content > * {
-	margin-bottom: 32px;
-	margin-top: 32px;
+	margin: 32px auto;
 	max-width: 100%;
 
 	&:last-child {

--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -5,10 +5,6 @@
 	margin-top: 32px;
 	max-width: 100%;
 
-	&.wp-block-columns {
-		max-width: calc( 100% + 32px );
-	}
-
 	&:last-child {
 		margin-bottom: 0;
 	}
@@ -188,7 +184,10 @@
 			margin-bottom: 0;
 		}
 	}
+}
 
+// Temporarily make some column styles more specific
+.entry .entry-content > .wp-block-columns {
 	@include media( mobile ) {
 		margin-left: -16px;
 		max-width: calc(100% + 32px);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

My work to simplify the Columns block styles introduced an issue where the block didn't fill the available space.

I've fixed this by making some of the styles more specific again; once all of the block styles have been untangled, this should be able to at least be partially undone again.

Closes #583.

### How to test the changes in this Pull Request:

1. Add two column blocks to a post or page -- one width borders and one without (you can also copy-paste [this test content](https://cloudup.com/cRqTOiOYfYL) )
2. View on front-end; notice the difference between the block width and the header width:

![image](https://user-images.githubusercontent.com/177561/69277400-15ae5280-0b95-11ea-801b-01eec6dab7c0.png)

3. Apply the PR and run `npm run build`
4. Confirm the columns block is the correct width now:

![image](https://user-images.githubusercontent.com/177561/69277626-6faf1800-0b95-11ea-8361-45765f659bb5.png)

5. Shrink down the browser window and confirm it remains consistent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
