### PR TITLE
Simplifies CSS selectors for the center align header options

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -53,9 +53,9 @@ function newspack_body_classes( $classes ) {
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );
 	if ( true === $header_center_logo ) {
-		$classes[] = 'header-center-logo';
+		$classes[] = 'h-cl';
 	} else {
-		$classes[] = 'header-left-logo';
+		$classes[] = 'h-ll';
 	}
 
 	$header_simplified = get_theme_mod( 'header_simplified', false );

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -53,9 +53,9 @@ function newspack_body_classes( $classes ) {
 
 	$header_center_logo = get_theme_mod( 'header_center_logo', false );
 	if ( true === $header_center_logo ) {
-		$classes[] = 'h-cl';
+		$classes[] = 'h-cl'; // Header - center-align logo.
 	} else {
-		$classes[] = 'h-ll';
+		$classes[] = 'h-ll'; // Header - left-align logo.
 	}
 
 	$header_simplified = get_theme_mod( 'header_simplified', false );

--- a/sass/navigation/_menu-highlight-navigation.scss
+++ b/sass/navigation/_menu-highlight-navigation.scss
@@ -33,7 +33,8 @@
 	}
 }
 
-.header-center-logo .site-header .highlight-menu-contain .wrapper {
+// Header Center Logo
+.h-cl .site-header .highlight-menu-contain .wrapper {
 	justify-content: center;
 	text-align: center;
 }

--- a/sass/navigation/_menu-main-navigation.scss
+++ b/sass/navigation/_menu-main-navigation.scss
@@ -254,7 +254,8 @@
 	}
 }
 
-.header-center-logo.header-default-height .site-header #site-navigation {
+// Header Center Logo
+.h-cl.header-default-height .site-header #site-navigation {
 	flex-basis: 100%;
 	text-align: center;
 

--- a/sass/site/header/_site-header.scss
+++ b/sass/site/header/_site-header.scss
@@ -167,9 +167,7 @@
 }
 
 // Centred Logo
-
-.header-center-logo {
-
+.h-cl {
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
 			justify-content: center;
@@ -290,7 +288,8 @@
 		margin: 0;
 	}
 
-	&.header-left-logo {
+	// Left-aligned logo
+	&.h-ll {
 		.site-branding {
 			margin-right: $size__spacing-unit;
 		}
@@ -313,7 +312,8 @@
 		margin-left: #{ 0.75 * $size__spacing-unit };
 	}
 
-	&.header-left-logo {
+	// Left-aligned logo
+	&.h-ll {
 		&.hide-site-tagline .nav-wrapper {
 			margin-left: auto;
 
@@ -342,7 +342,8 @@
 	justify-content: flex-end;
 }
 
-.header-center-logo.header-simplified .nav-wrapper:first-of-type {
+// Left-aligned logo
+.h-cl.header-simplified .nav-wrapper:first-of-type {
 	justify-content: flex-start;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR simplifies the classes used for the left-aligned and centred logo classes.

It doesn't have nearly the impact of the other header PRs for reducing CSS size, but it does make sure all three settings output similar classes.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Set up a header with a logo, tagline, and all menu locations populated.
3. Cycle through the following settings to make sure no issues have been introduced (thankfully there are no stylepack-specific styles in this case!):

Default logo alignment:

![image](https://user-images.githubusercontent.com/177561/69451613-a9f2f380-0d14-11ea-952a-57cb4cbee1ac.png)

Centred logo alignment:

![image](https://user-images.githubusercontent.com/177561/69451554-87f97100-0d14-11ea-867f-ad0aadbee459.png)

^ Shrink down the browser window and confirm the logo goes to the left and menu toggle goes to the right:

![image](https://user-images.githubusercontent.com/177561/69451941-6a78d700-0d15-11ea-94e5-6e9eb68647e4.png)

Default logo alignment + short header:

![image](https://user-images.githubusercontent.com/177561/69451790-1110a800-0d15-11ea-9255-d09f282936c2.png)

Centred logo + short header:

![image](https://user-images.githubusercontent.com/177561/69451843-31d8fd80-0d15-11ea-9653-23daa332ddf1.png)

^ Shrink down the browser window and confirm the logo goes to the left and menu toggle to the right: 

![image](https://user-images.githubusercontent.com/177561/69451881-474e2780-0d15-11ea-9eca-6cfda6423e1d.png)



### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
