### PR TITLE
Style 4: Hide author avatar when featured image is behind title

### DIFF
--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -111,13 +111,21 @@ figcaption,
 	font-weight: bold;
 }
 
-.single-featured-image-behind {
+.single-post {
 	.featured-image-behind {
 		.entry-subhead {
 			border: 0;
 			display: block;
 			padding: 0;
 			text-align: center;
+
+			.author-avatar {
+				display: none;
+			}
+		}
+
+		.entry-meta {
+			margin-bottom: $size__spacing-unit;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Typically when you pick the 'behind the title' position for the featured image on single posts, the author avatar is hidden. For Style 4, this wasn't the case; the spacing in the title area was also a bit odd.

This PR tidies that up, and gets the posts looking more consistent with the other style packs.

Closes #497.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Style Packs and pick Style 4.
2. Create a post; add a featured image and pick the 'Behind article title' placement.
3. View on front end; note the vertical spacing and avatar placement:

![image](https://user-images.githubusercontent.com/177561/69469020-84311300-0d43-11ea-954c-58ef509ef875.png)

4. Apply the PR and run `npm run build`
5. Confirm that the post header now has better spacing, and the author avatar is hidden, like with other style packs:

![image](https://user-images.githubusercontent.com/177561/69469009-6fed1600-0d43-11ea-941a-ae6ab4487508.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
