### PR TITLE
Use get_the_excerpt to get image caption/excerpt

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -231,7 +231,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 				else :
 					the_post_thumbnail( 'newspack-featured-image' );
-					$caption = get_post( get_post_thumbnail_id() )->post_excerpt;
+					$caption = get_the_excerpt( get_post_thumbnail_id() );
 					if ( $caption ) :
 					?>
 						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>


### PR DESCRIPTION
This PR changes the way we're getting the image caption in the theme. If we use `get_the_excerpt` we have access to the `get_the_excerpt` filter, which will let us modify the image caption if needed.

This change is required for https://github.com/Automattic/newspack-image-credits to work properly on featured images.

To test:
- Observe captions for the featured image work the same as before. Nothing should have changed on the frontend.
- You can add something like this if you want to verify we can now change the captions for the featured image:

```
add_filter( 'get_the_excerpt', function( $excerpt ) { return 'REPLACED THE CAPTION'; } );
```