### PR TITLE
Style 4: Fix custom typography issues

### DIFF
--- a/inc/typography.php
+++ b/inc/typography.php
@@ -140,6 +140,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-4' ) ) {
 			$css_blocks .= "
+			.site-description,
 			.has-drop-cap:not(:focus)::first-letter,
 			.taxonomy-description,
 			.entry .entry-content blockquote, .entry .entry-content blockquote cite, .entry .entry-content .wp-block-pullquote cite {

--- a/inc/typography.php
+++ b/inc/typography.php
@@ -278,7 +278,8 @@ function newspack_custom_typography_css() {
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
 			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
+			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+			.editor-block-list__layout .editor-block-list__block .entry-meta {
 				font-family: $font_header;
 			}";
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

While working on something unrelated, I noticed two spots in Style 4 where the custom fonts are not applied.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Typography and set a noticeably different font as the Header font (something sans-serif works well, since the header is otherwise serif).
2. View the front-end; note the site description is still using the style pack's default header font, IBM Plex Serif:

![image](https://user-images.githubusercontent.com/177561/69590286-d2dce800-0fa3-11ea-9648-6a039ef0043b.png)

3. In the editor, add a homepage block; note that the 'post meta' (author name and date) also use the default header font, IBM Plex Serif, rather than your custom font:

![image](https://user-images.githubusercontent.com/177561/69590353-0ae42b00-0fa4-11ea-81e2-90775e7acd66.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the tagline is now using your custom header font:

![image](https://user-images.githubusercontent.com/177561/69590257-bf318180-0fa3-11ea-9bbb-bf36df34a785.png)

6. View the editor and confirm the article block post meta uses the custom header font:

![image](https://user-images.githubusercontent.com/177561/69590324-f1db7a00-0fa3-11ea-82f2-b560bd93f684.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
