### PR TITLE
Make sure single post styles are also applied to CPTs

### DIFF
--- a/sass/layout/_layout.scss
+++ b/sass/layout/_layout.scss
@@ -69,7 +69,7 @@
 .blog #main,
 .search #main,
 .page .main-content,
-.single-post .main-content,
+.single .main-content,
 .newspack-front-page.page-template-single-feature .site-main {
 	@include media(tablet) {
 		width: 65%;
@@ -80,7 +80,7 @@
 .blog #secondary,
 .search #secondary,
 .page #secondary,
-.single-post #secondary {
+.single #secondary {
 	@include media(tablet) {
 		width: calc( 35% - #{ 2 * $size__spacing-unit } );
 	}

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -246,7 +246,7 @@ body.page {
 
 /* Single Post */
 
-.single-post {
+.single {
 	.entry-header {
 		padding: 0 0 $size__spacing-unit;
 	}

--- a/sass/site/secondary/_widgets.scss
+++ b/sass/site/secondary/_widgets.scss
@@ -137,7 +137,7 @@
 	}
 }
 
-.single-post #secondary {
+.single #secondary {
 	padding-top: calc( #{$size__spacing-unit} * 1.5 );
 }
 

--- a/sass/styles/style-2/style-2.scss
+++ b/sass/styles/style-2/style-2.scss
@@ -217,7 +217,7 @@ h4,
 	}
 }
 
-.single-post {
+.single {
 	.entry-header {
 		padding-bottom: #{ 2 * $size__spacing-unit };
 

--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -159,8 +159,8 @@ Newspack Theme Styles - Style Pack 3
 	font-size: $font__size-xs;
 }
 
-.single-post:not(.has-featured-image) .entry-header,
-.single-post:not(.has-large-featured-image) .entry-header {
+.single:not(.has-featured-image) .entry-header,
+.single:not(.has-large-featured-image) .entry-header {
 	border-bottom: 1px dotted $color__text-main;
 }
 

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -112,7 +112,7 @@ figcaption,
 	font-weight: bold;
 }
 
-.single-post {
+.single {
 	.featured-image-behind {
 		.entry-subhead {
 			border: 0;
@@ -185,7 +185,7 @@ figcaption,
 	}
 }
 
-.single-post {
+.single {
 	.cat-links {
 		text-align: center;
 	}
@@ -258,7 +258,7 @@ figcaption,
 		}
 	}
 
-	.single-post .featured-image-beside .entry-subhead {
+	.single .featured-image-beside .entry-subhead {
 		border: 0;
 		margin-bottom: 0;
 		padding: 0;

--- a/sass/styles/style-5/style-5.scss
+++ b/sass/styles/style-5/style-5.scss
@@ -157,7 +157,7 @@ input[type="submit"] {
 	}
 }
 
-.single-post:not(.has-large-featured-image) {
+.single:not(.has-large-featured-image) {
 	.entry-header {
 		border-bottom-color: currentColor;
 		border-bottom-width: 2px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR swaps the `.single-post` body class for `.single`.

`.single-post` is only applied to posts, where is `.single` is applied to any single post type, besides posts and attachments. Right now, CPTs have some singular styles applied, but not all -- this change makes sure they also have the single post styles applied, so they look less broken. 

Closes #591.

### How to test the changes in this Pull Request:

1. Add and publish a custom post type. (A quick way to do this is to navigate to WP Admin > Jetpack > Modules [bottom of the page], and activate "Custom content types", then navigate to Jetpack > Settings > Writing, and enable Testimonials or Portfolio, one of the two custom post types bundled with Jetpack). 
2. View the CPT on the front end; note that the title spacing is a bit weird, and the content displays at full width, pushing the sidebar underneath it:

![image](https://user-images.githubusercontent.com/177561/69833522-3015ab00-11e9-11ea-8c4a-618dd7383e26.png)

![image](https://user-images.githubusercontent.com/177561/69833524-3441c880-11e9-11ea-9bb1-4e4e9408d04a.png)

3. Apply the PR and run `npm run build`.
4. Confirm the CPT looks more like a post:

![image](https://user-images.githubusercontent.com/177561/69833552-65ba9400-11e9-11ea-8412-525e655f0df6.png)

5. View a regular post and confirm it looks as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
