### PR TITLE
Add body class when site has no sidebar widgets assigned

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -457,6 +457,10 @@ function newspack_filter_admin_body_class( $classes ) {
 		$classes .= ' style-pack-' . get_theme_mod( 'active_style_pack', 'default' );
 	}
 
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+		$classes .= ' no-sidebar';
+	}
+
 	if ( 'single-feature.php' === newspack_check_current_template() ) {
 		$classes .= ' newspack-single-column-template';
 	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -98,6 +98,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-large-featured-image';
 	}
 
+	// Add a class to determine whether it has a sidebar.
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
+		$classes[] = 'no-sidebar';
+	}
+
 	// Adds a class if the author bio is hidden.
 	$display_author_bio = get_theme_mod( 'show_author_bio', true );
 	if ( false === $display_author_bio ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a body class to the front end and editor when there's no sidebar widgets applied.

This functionality has been moved over from #465, to be used with custom CSS.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Remove all sidebar widgets.
3. Inspect the front end, and confirm that the class `no-sidebar` has been added to the body.
4. Inspect the editor, and confirm that the class `no-sidebar` has been added to the body.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
