### PR TITLE
Modify how we check for captions on featured images

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,9 +1,12 @@
+
+
 <?php
 /**
  * Custom template tags for this theme
  *
  * @package Newspack
  */
+
 
 if ( ! function_exists( 'newspack_posted_on' ) ) :
 	/**
@@ -231,8 +234,12 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 				else :
 					the_post_thumbnail( 'newspack-featured-image' );
+
 					$caption = get_the_excerpt( get_post_thumbnail_id() );
-					if ( $caption ) :
+					// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
+					$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
+
+					if ( $caption_exists ) :
 					?>
 						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
 					<?php

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,12 +1,9 @@
-
-
 <?php
 /**
  * Custom template tags for this theme
  *
  * @package Newspack
  */
-
 
 if ( ! function_exists( 'newspack_posted_on' ) ) :
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed a weird issue on a test site where ads are enabled: if a featured image doesn't have a caption, it displays the text 'Advertisements'.

I believe it's because the filter run on `the_excerpt` to insert ads, though I'm not entirely sure why it's behaving as it is.

I added a fix that checks if `get_post( get_post_thumbnail_id() )->post_excerpt;` (which is unfiltered) returns anything before echoing ` $caption = get_the_excerpt( get_post_thumbnail_id() );` (filtered, to add the credit). But there might be a better way to approach this. 

### How to test the changes in this Pull Request:

1. Start on a test site with ads enabled.
2. Navigate to Jetpack > Settings > Traffic and enable ads:

![image](https://user-images.githubusercontent.com/177561/70003033-bf3aff80-1516-11ea-9c6e-19314c4daa92.png)

3. View a single post; add a featured image that doesn't have a caption or a credit. 
4. View on front-end; note that the image has the caption 'Advertisements':

![image](https://user-images.githubusercontent.com/177561/70003087-f1e4f800-1516-11ea-984b-68459084c79e.png)

5. Apply the PR.
6. Confirm that the 'Advertisements' no longer appears.
7. Try adding a caption to the image, and confirm it still appears. 
8. Install and activate https://github.com/Automattic/newspack-image-credits (if you haven't already).
9. Add a credit to the featured image, and confirm it still displays. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
