### PR TITLE
Add option to hide featured images on individual posts

### DIFF
--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -75,13 +75,15 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
+	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
+
+
 	// Adds class if singular post or page has a featured image.
-	if ( is_singular() && has_post_thumbnail() ) {
+	if ( is_singular() && has_post_thumbnail() && 'hidden' !== $current_featured_image_style ) {
 		$classes[] = 'has-featured-image';
 	}
 
 	// Adds a class to single artcles, if they're using a special featured image style.
-	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 	if ( is_single() ) {
 		if ( 'behind' === $current_featured_image_style ) {
 			$classes[] = 'single-featured-image-behind';

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -20,6 +20,7 @@ class RadioCustom extends Component {
 					{ label: __( 'Small' ), value: 'small' },
 					{ label: __( 'Behind article title' ), value: 'behind' },
 					{ label: __( 'Beside article title' ), value: 'beside' },
+					{ label: __( 'Hidden' ), value: 'hidden' },
 				] }
 				onChange={ value => {
 					this.setState( { value } );

--- a/single-feature.php
+++ b/single-feature.php
@@ -27,7 +27,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -44,7 +44,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) {
+					if ( ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) && 'hidden' !== $image_position ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single-wide.php
+++ b/single-wide.php
@@ -25,7 +25,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -42,7 +42,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) {
+					if ( ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) && 'hidden' !== $image_position ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single.php
+++ b/single.php
@@ -21,7 +21,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position ) :
+				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -38,7 +38,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( has_post_thumbnail() && ( 1200 > $thumbnail_info['width'] || 'small' === $image_position ) ) {
+					if ( ( has_post_thumbnail() && ( 1200 > $thumbnail_info['width'] || 'small' === $image_position ) ) && 'hidden' !== $image_position ) {
 						newspack_post_thumbnail();
 					}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'position' option to hide the Featured Image on individual posts. 

Closes #604 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Create a post; add a featured image, and set it to 'Hidden'; leave it on the default template.
3. Confirm that the image is hidden on the front-end, and that the border that divides the title and content is present:

![image](https://user-images.githubusercontent.com/177561/70074655-f9a4ab00-15af-11ea-8caf-873dd6a819f7.png)

4. Switch to the One Column template; confirm it's the same.
5. Switch to the One Column Wide template; confirm it's the same.
6. Try a few of the different featured image setting with these two templates -- 'Small', 'Behind' and 'Default', to make sure no display issues are introduced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
