### PR TITLE
Add 'default' option for featured image position

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -295,6 +295,40 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'author_bio_options',
 		)
 	);
+
+	/**
+	 * Featured Image settings
+	 */
+	$wp_customize->add_section(
+		'featured_image_options',
+		array(
+			'title' => esc_html__( 'Featured Image Settings', 'newspack' ),
+		)
+	);
+
+	// Add option to hide the whole author bio.
+	$wp_customize->add_setting(
+		'featured_image_default',
+		array(
+			'default'           => 'large',
+			'sanitize_callback' => 'newspack_sanitize_feature_image_position',
+		)
+	);
+	$wp_customize->add_control(
+		'featured_image_default',
+		array(
+			'type'    => 'radio',
+			'label'   => __( 'Featured Image Default Position', 'newspack' ),
+			'choices' => array(
+				'large'  => esc_html__( 'Large', 'newspack' ),
+				'small'  => esc_html__( 'Small', 'newspack' ),
+				'behind' => esc_html__( 'Behind article title', 'newspack' ),
+				'beside' => esc_html__( 'Beside article title', 'newspack' ),
+				'hidden' => esc_html__( 'Hidden', 'newspack' ),
+			),
+			'section' => 'featured_image_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 
@@ -497,6 +531,29 @@ function newspack_sanitize_color_option( $choice ) {
 	}
 
 	return 'default';
+}
+
+/**
+ * Sanitize custom color choice.
+ *
+ * @param string $choice Whether image filter is active.
+ *
+ * @return string
+ */
+function newspack_sanitize_feature_image_position( $choice ) {
+	$valid = array(
+		'large',
+		'small',
+		'behind',
+		'beside',
+		'hidden',
+	);
+
+	if ( in_array( $choice, $valid, true ) ) {
+		return $choice;
+	}
+
+	return 'large';
 }
 
 /**

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -53,7 +53,6 @@ function newspack_jetpack_setup() {
 			),
 			'featured-images' => array(
 				'archive' => true,
-				'post'    => true,
 				'page'    => true,
 			),
 		)

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -12,6 +12,11 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 	 * @return string
 	 */
 	function newspack_featured_image_position() {
+		// If we're not on a single page, or if there's no thumbnail, return.
+		if ( ! is_single() || ! has_post_thumbnail() ) {
+			return;
+		}
+
 		// Get thumbnail
 		$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
 		$img_width      = $thumbnail_info['width'];
@@ -24,10 +29,6 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 
 		// Set a position value to return.
 		$position = '';
-
-		if ( ! has_post_thumbnail() ) {
-			return;
-		}
 
 		// First, check for a per-post image setting.
 		if ( '' !== $image_pos ) {
@@ -116,11 +117,8 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
-	$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-
-
 	// Adds class if singular post or page has a featured image.
-	if ( is_singular() && has_post_thumbnail() && 'hidden' !== $current_featured_image_style ) {
+	if ( is_singular() && has_post_thumbnail() && 'hidden' !== newspack_featured_image_position() ) {
 		$classes[] = 'has-featured-image';
 	}
 

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -14,7 +14,7 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 	function newspack_featured_image_position() {
 		// If we're not on a single page, or if there's no thumbnail, return.
 		if ( ! is_single() || ! has_post_thumbnail() ) {
-			return;
+			return '';
 		}
 
 		// Get thumbnail

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -217,10 +217,9 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			<figure class="post-thumbnail">
 
 				<?php
-				$current_featured_image_style = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
 				// If using the behind or beside image styles, add the object-fit argument for AMP.
-				if ( 'behind' === $current_featured_image_style || 'beside' === $current_featured_image_style ) :
+				if ( in_array( newspack_featured_image_position(), array( 'behind', 'beside' ) ) ) :
 
 					the_post_thumbnail(
 						'newspack-featured-image',

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -16,6 +16,7 @@ class RadioCustom extends Component {
 				label={ __( 'Featured Image Position' ) }
 				selected={ meta.newspack_featured_image_position }
 				options={ [
+					{ label: __( 'Default (set in Customizer)' ), value: '' },
 					{ label: __( 'Large' ), value: 'large' },
 					{ label: __( 'Small' ), value: 'small' },
 					{ label: __( 'Behind article title' ), value: 'behind' },

--- a/js/src/extend-featured-image-editor.js
+++ b/js/src/extend-featured-image-editor.js
@@ -16,7 +16,7 @@ class RadioCustom extends Component {
 				label={ __( 'Featured Image Position' ) }
 				selected={ meta.newspack_featured_image_position }
 				options={ [
-					{ label: __( 'Default' ), value: '' },
+					{ label: __( 'Large' ), value: 'large' },
 					{ label: __( 'Small' ), value: 'small' },
 					{ label: __( 'Behind article title' ), value: 'behind' },
 					{ label: __( 'Beside article title' ), value: 'beside' },

--- a/single-feature.php
+++ b/single-feature.php
@@ -11,11 +11,7 @@
  */
 
 get_header();
-$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
-
-
 
 	<section id="primary" class="content-area">
 		<main id="main" class="site-main">

--- a/single-feature.php
+++ b/single-feature.php
@@ -27,7 +27,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -44,7 +44,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) && 'hidden' !== $image_position ) {
+					if ( 'small' === newspack_featured_image_position() ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single-wide.php
+++ b/single-wide.php
@@ -11,8 +11,6 @@
  */
 
 get_header();
-$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
 
 	<section id="primary" class="content-area">
@@ -25,7 +23,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 				the_post();
 
 				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -42,7 +40,7 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( ( has_post_thumbnail() && 1200 > $thumbnail_info['width'] || 'small' === $image_position ) && 'hidden' !== $image_position ) {
+					if ( 'small' === newspack_featured_image_position() ) {
 						newspack_post_thumbnail();
 					}
 

--- a/single.php
+++ b/single.php
@@ -18,7 +18,7 @@ get_header();
 			while ( have_posts() ) :
 				the_post();
 
-				// Template part for large featured images (standard, behind and small).
+				// Template part for large featured images.
 				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :

--- a/single.php
+++ b/single.php
@@ -8,8 +8,6 @@
  */
 
 get_header();
-$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-$image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 ?>
 
 	<section id="primary" class="content-area">
@@ -20,14 +18,15 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 			while ( have_posts() ) :
 				the_post();
 
-				// Template part for large featured images.
-				if ( has_post_thumbnail() && 1200 <= $thumbnail_info['width'] && 'small' !== $image_position && 'hidden' !== $image_position ) :
+				// Template part for large featured images (standard, behind and small).
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
 					<header class="entry-header">
 						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
 					</header>
+
 				<?php endif; ?>
 
 				<div class="main-content">
@@ -38,9 +37,9 @@ $image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( ( has_post_thumbnail() && ( 1200 > $thumbnail_info['width'] || 'small' === $image_position ) ) && 'hidden' !== $image_position ) {
+					if ( 'small' === newspack_featured_image_position() ) :
 						newspack_post_thumbnail();
-					}
+					endif;
 
 					get_template_part( 'template-parts/content/content', 'single' );
 

--- a/template-parts/post/large-featured-image.php
+++ b/template-parts/post/large-featured-image.php
@@ -5,10 +5,9 @@
  * @package Newspack
  */
 
-$featured_image_position = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 $caption                 = get_post( get_post_thumbnail_id() )->post_excerpt;
 
-if ( 'behind' === $featured_image_position ) :
+if ( 'behind' === newspack_featured_image_position() ) :
 ?>
 
 	<div class="featured-image-behind">
@@ -24,7 +23,7 @@ if ( 'behind' === $featured_image_position ) :
 		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
 	<?php endif; ?>
 
-<?php elseif ( 'beside' === $featured_image_position ) : ?>
+<?php elseif ( 'beside' === newspack_featured_image_position() ) : ?>
 
 	<div class="featured-image-beside">
 		<div class="wrapper">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'default' option for the featured image placement in the Customizer, under Featured Image Settings.

Unfortunately, it's not possible to set a default for post meta, but I think that that would muddy things when switching between options (was this post set to 'small' by someone editing the page, or was that the default setting and it should be changed when the default is switched?). So this might for best. 

It does make for some disconnect, though -- if this otherwise seems like a good approach, we could probably pass the current default to the API and have it appear on a per-post basis next to the 'Default' label -- eg. `Default (set to "Large" in the Customizer)`. If not, I'm definitely open to trying different approaches! 

As part of this update, I also created a function that sets all the 'featured image position' logic in one spot -- hopefully that helps make the code a little easier to follow!

Lastly, I removed the option under 'Content Options' to hide featured images on single posts, since this will overlap that behaviour. 

Closes #609.

### How to test the changes in this Pull Request:

1. Set up a couple posts using the featured image position options like 'Small', 'Beside' and 'Hidden', and one with just the default setting (this is to help test that existing options stick after this change is applied). 
2. Apply the PR and run `npm run build`
3. Check your posts; confirm that they still have their featured images set.
4. Navigate to Customizer > Featured Image Settings, and confirm the default is currently set to 'Large'.
5. Pick another default. 
6. Cycle through your example posts again, and confirm that all but the 'default' one are the same -- the one using the 'default' image option should now be using whatever was set in the Customizer. 
7. Edit the post you created that uses the default image setting; confirm that it's still set to 'Default', but a new 'Large' option also displays:

![image](https://user-images.githubusercontent.com/177561/70100935-3ab8b180-15e8-11ea-8eba-93a20080601e.png)

8. Try switching it to 'Large' and confirm it displays with the original default display, overriding whatever you have set in the Customizer. 

A couple more notes:

1. If you use an image less than 1200px wide but pick "Large" or have "Large" as the default, it will still fall back to the 'Small' image display on the individual post where the image is too small (where it displays in the content area, with a max-width the same as the content area).
2. When using the 'wide' template, the 'small' image option doesn't really read as small -- since it just matches the content area, it can display up to 1200px wide. This is the same as it would've behaved prior to this PR, but I noticed it in my testing. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
<!-- Mark completed items with an [x] -->
