### PR TITLE
Make sure article blocks are using the correct border style for Style 3.

### DIFF
--- a/sass/styles/style-3/style-3.scss
+++ b/sass/styles/style-3/style-3.scss
@@ -112,7 +112,7 @@ Newspack Theme Styles - Style Pack 3
 }
 
 //! Newspack Article Block
-.wpnbha.is-style-borders article {
+.entry .wpnbha.is-style-borders article {
 	border-bottom-style: dotted;
 	border-bottom-color: $color__text-main;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the selector a bit more specific in Style 3, so the style pack's article border styles override the border styles set by the Newspack Blocks plugin.

Closes #612.

### How to test the changes in this Pull Request:

1. Navigate to the Customizer > Style Packs, and switch to style 3.
2. Add an article block to a page, and set it to use the Border block style; save and publish.
3. View on front-end; note the borders are light grey:

![image](https://user-images.githubusercontent.com/177561/70160461-629f2800-166f-11ea-9486-66d4c9133abd.png)

4. Apply the PR and run `npm run build`
5. Confirm that the borders are now darker and dotted:

![image](https://user-images.githubusercontent.com/177561/70160223-01775480-166f-11ea-868d-d6fc7b0fe27a.png)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
