### PR TITLE
Author Bio: Add control to truncate author bio text

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -584,6 +584,25 @@ function newspack_sanitize_svgs() {
 }
 
 /**
+ * Truncates text to a specific character length, without breaking a character.
+ */
+function newspack_truncate_text( $content, $length, $after = '...' ) {
+	// If content is already shorter than the truncate length, return it.
+	if ( strlen( $content ) <= $length ) {
+		return $content;
+	}
+
+	// Find the first space after the desired length:
+	$breakpoint = strpos( $content, ' ', $length );
+
+	// Make sure $breakpoint isn't returning false, and is less than length of content:
+	if ( false !== $breakpoint && $breakpoint < strlen( $content ) - 1 ) {
+		$content = substr( $content, 0, $breakpoint ) . $after;
+	}
+	return $content;
+}
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -290,8 +290,8 @@ function newspack_customize_register( $wp_customize ) {
 		'author_bio_length',
 		array(
 			'type'        => 'number',
-			'label'       => esc_html__( 'Author Bio Length (Characters)', 'newspack' ),
-			'description' => esc_html__( 'Truncates the author bio to the nearest word to the characters specified; links to rest of bio on author archive page.', 'newspack' ),
+			'label'       => esc_html__( 'Author Bio Length (in characters)', 'newspack' ),
+			'description' => esc_html__( 'Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page.', 'newspack' ),
 			'section'     => 'author_bio_options',
 		)
 	);

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -277,6 +277,24 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'author_bio_options',
 		)
 	);
+
+	// Add option to hide the whole author bio.
+	$wp_customize->add_setting(
+		'author_bio_length',
+		array(
+			'default'           => 200,
+			'sanitize_callback' => 'absint',
+		)
+	);
+	$wp_customize->add_control(
+		'author_bio_length',
+		array(
+			'type'        => 'number',
+			'label'       => esc_html__( 'Author Bio Length (Characters)', 'newspack' ),
+			'description' => esc_html__( 'Truncates the author bio to the nearest word to the characters specified; links to rest of bio on author archive page.', 'newspack' ),
+			'section'     => 'author_bio_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -55,14 +55,14 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 					</div><!-- .author-bio-header -->
 
 					<p>
-						<?php echo wp_kses_post( $author->description ); ?>
-					</p><!-- .author-description -->
-					<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+						<?php echo esc_html( newspack_truncate_text( $author->description, 200 ) ); ?>
+						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 						<?php
 							/* translators: %s is the current author's name. */
 							printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
 						?>
-					</a>
+						</a>
+					</p><!-- .author-description -->
 				</div><!-- .author-bio-text -->
 
 			</div><!-- .author-bio -->
@@ -109,14 +109,14 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		</div><!-- .author-bio-header -->
 
 		<p>
-			<?php the_author_meta( 'description' ); ?>
+			<?php echo esc_html( newspack_truncate_text( get_the_author_meta( 'description' ), 200 ) ); ?>
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+				<?php
+					/* translators: %s is the current author's name. */
+					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
+				?>
+			</a>
 		</p><!-- .author-description -->
-		<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-			<?php
-				/* translators: %s is the current author's name. */
-				printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
-			?>
-		</a>
 	</div><!-- .author-bio-text -->
 </div><!-- .author-bio -->
 <?php endif; ?>

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -5,6 +5,7 @@
  * @package Newspack
  */
 
+$author_bio_length = get_theme_mod( 'author_bio_length', 200 );
 
 if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 
@@ -55,7 +56,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 					</div><!-- .author-bio-header -->
 
 					<p>
-						<?php echo esc_html( newspack_truncate_text( $author->description, 200 ) ); ?>
+						<?php echo esc_html( newspack_truncate_text( $author->description, $author_bio_length ) ); ?>
 						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 						<?php
 							/* translators: %s is the current author's name. */
@@ -109,7 +110,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		</div><!-- .author-bio-header -->
 
 		<p>
-			<?php echo esc_html( newspack_truncate_text( get_the_author_meta( 'description' ), 200 ) ); ?>
+			<?php echo esc_html( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR truncates the author bio text as it appears on single posts (keeping the full text for the author archives).

It also adds a control to the Customizer to change how long the text should be; it currently defaults to 200 characters.

Closes #607.

### How to test the changes in this Pull Request:

1. If you haven't already, install the Co-Authors Plus plugin. 
2. Create two new guest authors -- one with a very short bio (4-5 words), and one with a very long one.
3. Create two new users, one with a very short bio (4-5 words), and one with a very long one.
4. Create a post with all four authors assigned (for easier testing!), and view on the front end:

![image](https://user-images.githubusercontent.com/177561/70165350-9ed68680-1677-11ea-9740-d1a776798e44.png)

5. Apply the PR.
6. View the post again; confirm that the longer bios are now truncated (but don't break a word), and the shorter ones still display in full with no '...' at the end:

![image](https://user-images.githubusercontent.com/177561/70165404-b6157400-1677-11ea-8166-905a2b7a1ae1.png)

7. Navigate to Customizer > Author Bio Settings.
8. Confirm there is a control for Author Bio length with a default value of 200 (I went with 200 over 150, because the former seemed a bit too short):

![image](https://user-images.githubusercontent.com/177561/70165631-186e7480-1678-11ea-8791-6f104564bddf.png)

9. Try changing it to a noticeably different length (like 20, or 400).
10. View your post again and confirm that the author bio lengths reflect your update:

![image](https://user-images.githubusercontent.com/177561/70165541-f1b03e00-1677-11ea-9cdf-ac8a1bb5601e.png)

11. Deactivate the Co-Author Plus plugin.
12. Create two posts and assign one to your user with the long bio, and another to the user with the short bio.
13. Confirm that both bios still appear to be respecting the truncate length. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
