### PR TITLE
Switch sanitization method for avatars to prevent lazy loading duplication

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -38,7 +38,7 @@ get_header();
 					}
 
 					if ( $author_avatar ) {
-						echo wp_kses_post( $author_avatar );
+						echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
 					}
 				}
 			?>

--- a/functions.php
+++ b/functions.php
@@ -608,15 +608,15 @@ function newspack_truncate_text( $content, $length, $after = '...' ) {
 function newspack_sanitize_avatars() {
 	$avatar_args = array(
 		'img' => array(
-			'class'            => true,
-			'src'              => true,
-			'alt'              => true,
-			'width'            => true,
-			'height'           => true,
-			'data-lazy-src'    => true,
-			'data-lazy-srcset' => true,
-			'data-lazy-sizes'  => true,
+			'class'  => true,
+			'src'    => true,
+			'alt'    => true,
+			'width'  => true,
+			'height' => true,
+			'data-*' => true,
+			'srcset' => true,
 		),
+		'noscript' => array(),
 	);
 
 	return $avatar_args;

--- a/functions.php
+++ b/functions.php
@@ -602,6 +602,26 @@ function newspack_truncate_text( $content, $length, $after = '...' ) {
 	return $content;
 }
 
+ /**
+ * Returns an array of 'acceptable' avatar tags, to use with wp_kses().
+ */
+function newspack_sanitize_avatars() {
+	$avatar_args = array(
+		'img' => array(
+			'class'            => true,
+			'src'              => true,
+			'alt'              => true,
+			'width'            => true,
+			'height'           => true,
+			'data-lazy-src'    => true,
+			'data-lazy-srcset' => true,
+			'data-lazy-sizes'  => true,
+		),
+	);
+
+	return $avatar_args;
+}
+
 /**
  * SVG Icons class.
  */

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 					$author_avatar = coauthors_get_avatar( $author, 80 );
 				}
 
-				echo '<span class="author-avatar">' . wp_kses_post( $author_avatar ) . '</span>';
+				echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 			}
 			?>
 

--- a/template-parts/post/author-bio.php
+++ b/template-parts/post/author-bio.php
@@ -32,7 +32,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 			<div class="author-bio">
 				<?php
 				if ( ! newspack_is_active_style_pack( 'style-4' ) && $author_avatar ) {
-					echo wp_kses_post( $author_avatar );
+					echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
 				}
 				?>
 
@@ -40,7 +40,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 					<div class="author-bio-header">
 						<?php
 						if ( newspack_is_active_style_pack( 'style-4' ) && $author_avatar ) {
-							echo wp_kses_post( $author_avatar );
+							echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
 						}
 						?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally, we were using `wp_kses_post()` to sanitize avatar output, but it was stripping attributes that Jetpack's lazy loading images were adding. This was causing duplicate avatars on sites when lazy loading images were on, but AMP was off.

This PR updates the sanitation used so those attributes are included.

Closes #617 .

### How to test the changes in this Pull Request:

1. Start on a test site where you can enable Lazy Loading images; enable them, and turn off AMP.
2. Navigate to Customizer > Style Packs, and switch to any but style pack #4.
3. Enable Co-Authors Plus plugin (if you don't, you'll only see this issue on the archive page).
4. Find an author with an author avatar, and view one of their posts; note the duplication on the top and bottom: 

![image](https://user-images.githubusercontent.com/177561/70174309-7d7e9600-1689-11ea-85e5-e709fa754420.png)

![image](https://user-images.githubusercontent.com/177561/70174318-82434a00-1689-11ea-8b52-d627bbaad172.png)

5. Navigate to the author archive and note the double image:

![image](https://user-images.githubusercontent.com/177561/70174371-9e46eb80-1689-11ea-96ac-0189ce11d0d6.png)

6. Apply the PR.
7. View the post and archive again and confirm that only a single image appears. 

![image](https://user-images.githubusercontent.com/177561/70174414-b6b70600-1689-11ea-9793-63733fb21068.png)

![image](https://user-images.githubusercontent.com/177561/70174422-bcace700-1689-11ea-9c6c-31108d7d9dd1.png)

![image](https://user-images.githubusercontent.com/177561/70174431-c20a3180-1689-11ea-8ca5-cd4b7821e5c6.png)

8. Switch to style pack 4 (which has a slightly different markup for the author bio) and confirm it still looks okay:

9. Try turning off the Co-Authors Plus plugin and confirm that the issue is still fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
