### PR TITLE
Remove link from dates when displayed on single posts

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -23,19 +23,34 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 			esc_html( get_the_modified_date() )
 		);
 
-		printf(
-			'<span class="posted-on"><a href="%1$s" rel="bookmark">%2$s</a></span>',
-			esc_url( get_permalink() ),
-			wp_kses(
-				$time_string,
-				array(
-					'time' => array(
-						'class'    => array(),
-						'datetime' => array(),
-					),
+		if ( is_single() ) {
+			printf(
+			'<span class="posted-on">%1$s</span>',
+				wp_kses(
+					$time_string,
+					array(
+						'time' => array(
+							'class'    => array(),
+							'datetime' => array(),
+						),
+					)
 				)
-			)
-		);
+			);
+		} else {
+			printf(
+			'<span class="posted-on"><a href="%1$s" rel="bookmark">%2$s</a></span>',
+				esc_url( get_permalink() ),
+				wp_kses(
+					$time_string,
+					array(
+						'time' => array(
+							'class'    => array(),
+							'datetime' => array(),
+						),
+					)
+				)
+			);
+		}
 	}
 endif;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, dates are single posts are linked to the current page. 

Dates often have links as a fallback, so if a post doesn't have a title when it appears in the search/archive, you can still get to it. But it really doesn't make sense to have the link on a page, linking to the page you're already on. This PR fixes that.

Closes #627.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Check a single post and confirm the date isn't linked.
3. Check the search results and archive and confirm the date is still linked.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
