### PR TITLE
Fixes border styles for style 3 and 5 for the column block

### DIFF
--- a/sass/styles/style-3/style-3-editor.scss
+++ b/sass/styles/style-3/style-3-editor.scss
@@ -176,7 +176,7 @@ hr {
 }
 
 .wp-block-columns.is-style-borders {
-	[data-type="core/column"] {
+	& > .editor-inner-blocks > .editor-block-list__layout > [data-type="core/column"] {
 		border-bottom: 1px dotted $color__text-main;
 
 		&:last-child {

--- a/sass/styles/style-5/style-5-editor.scss
+++ b/sass/styles/style-5/style-5-editor.scss
@@ -13,11 +13,17 @@
 /* Columns */
 .wp-block-columns {
 	&.is-style-borders {
-		[data-type="core/column"] {
+		& > .editor-inner-blocks > .editor-block-list__layout > [data-type="core/column"] {
 			border-color: currentColor;
 
 			&:after {
 				border-color: currentColor;
+			}
+
+			@include media( mobile ) {
+				&:nth-child(odd):after {
+					border-color: currentColor;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Needs to be tested with https://github.com/Automattic/newspack-blocks/pull/290.

This PR makes sure the style 3 and 5 border styles are still respected when paired with the more specific border styles in the PR above.

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-blocks/pull/290.
2. Follow the same steps in that PR, for setting up the two column blocks to test.
3. Apply this PR and run `npm run build`.
4. Navigate to Customize > Style Packs and pick Style 3.
5. View on the front-end and in the editor, and confirm that the dotted border style is used, and the borders are applied right (not on the nested column block):

![image](https://user-images.githubusercontent.com/177561/70758962-7a268280-1cf9-11ea-86f8-f672455085e1.png)

6. Make the browser window narrow and confirm that the borders only appear under columns that should have them, and that they use the right style:

![image](https://user-images.githubusercontent.com/177561/70758985-94f8f700-1cf9-11ea-992b-902fc6100157.png)

7. Navigate to Customize > Style Packs, and switch to Style 5.
8. View on the front-end and in the editor, and confirm the darker border is used, and the borders are applied right (not on the nested column block):

![image](https://user-images.githubusercontent.com/177561/70759281-be665280-1cfa-11ea-8b8f-07f382f1ef41.png)

9. Make the browser window narrow and confirm that the borders only appear under columns that should have them, and that they use the right style:

![image](https://user-images.githubusercontent.com/177561/70759312-d3db7c80-1cfa-11ea-973d-c7be1ffc23ef.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
