### PR TITLE
Add Post Subtitle (aka Dek) feature

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -346,32 +346,18 @@ function newspack_scripts() {
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
 
 /**
- * Enqueue Block Styles Javascript
+ * Enqueue scripts for:
+ * - Featured Image position option
+ * - Article Subtitle
  */
-function newspack_extend_featured_image_script() {
+function newspack_enqueue_scripts() {
 	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks', 'wp-components' ), wp_get_theme()->get( 'Version' ) );
-}
-add_action( 'enqueue_block_editor_assets', 'newspack_extend_featured_image_script' );
 
-/**
- * Post Subtitle feature
- * - enqueue JS script
- * - register post meta field
- */
-function newspack_post_subtitle_script() {
-	wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), '1.0', true );
+	if ( 'post' === get_current_screen()->post_type ) {
+		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+	}
 }
-add_action( 'enqueue_block_editor_assets', 'newspack_post_subtitle_script' );
-
-function register_post_subtitle_meta_field() {
-	register_post_meta( 'post', 'newspack_post_subtitle', array(
-		'show_in_rest' => true,
-		'single' => true,
-		'type' => 'string',
-	) );
-}
-add_action( 'init', 'register_post_subtitle_meta_field' );
-
+add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
 
 /**
  * Fix skip link focus in IE11.
@@ -515,12 +501,24 @@ function newspack_front_page_template( $template ) {
 add_filter( 'frontpage_template', 'newspack_front_page_template' );
 
 /**
- * Register Featured Image position option.
+ * Register meta fields:
+ * - Featured Image position option
+ * - Article Subtitle
  */
 function newspack_register_meta() {
 	register_meta(
 		'post',
 		'newspack_featured_image_position',
+		array(
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		)
+	);
+
+	register_post_meta(
+		'post',
+		'newspack_post_subtitle',
 		array(
 			'show_in_rest' => true,
 			'single'       => true,

--- a/functions.php
+++ b/functions.php
@@ -354,6 +354,26 @@ function newspack_extend_featured_image_script() {
 add_action( 'enqueue_block_editor_assets', 'newspack_extend_featured_image_script' );
 
 /**
+ * Post Subtitle feature
+ * - enqueue JS script
+ * - register post meta field
+ */
+function newspack_post_subtitle_script() {
+	wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), '1.0', true );
+}
+add_action( 'enqueue_block_editor_assets', 'newspack_post_subtitle_script' );
+
+function register_post_subtitle_meta_field() {
+	register_post_meta( 'post', 'newspack_post_subtitle', array(
+		'show_in_rest' => true,
+		'single' => true,
+		'type' => 'string',
+	) );
+}
+add_action( 'init', 'register_post_subtitle_meta_field' );
+
+
+/**
  * Fix skip link focus in IE11.
  *
  * This does not enqueue the script because it is tiny and because it is only for IE11,

--- a/js/src/post-subtitle/SubtitleEditor.js
+++ b/js/src/post-subtitle/SubtitleEditor.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { connectWithSelect, META_FIELD_NAME } from './utils';
+
+const decorate = compose(
+	connectWithSelect,
+	withDispatch( dispatch => ( {
+		saveSubtitle: subtitle => {
+			dispatch( 'core/editor' ).editPost( {
+				meta: {
+					[ META_FIELD_NAME ]: subtitle,
+				},
+			} );
+		},
+	} ) )
+);
+
+const SubtitleEditor = ( { subtitle, saveSubtitle } ) => {
+	const [ value, setValue ] = useState( subtitle );
+
+	useEffect(() => {
+		saveSubtitle( value );
+	}, [ value ]);
+
+	const onChange = ( { target } ) => {
+		setValue( target.value );
+	};
+
+	return (
+		<textarea
+			value={ value }
+			onChange={ onChange }
+			style={ { marginTop: '10px', width: '100%' } }
+		/>
+	);
+};
+
+export default decorate( SubtitleEditor );

--- a/js/src/post-subtitle/SubtitleEditor.js
+++ b/js/src/post-subtitle/SubtitleEditor.js
@@ -4,6 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
+import { TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -30,12 +31,12 @@ const SubtitleEditor = ( { subtitle, saveSubtitle } ) => {
 		saveSubtitle( value );
 	}, [ value ]);
 
-	const onChange = ( { target } ) => {
-		setValue( target.value );
+	const onChange = value => {
+		setValue( value );
 	};
 
 	return (
-		<textarea
+		<TextareaControl
 			value={ value }
 			onChange={ onChange }
 			style={ { marginTop: '10px', width: '100%' } }

--- a/js/src/post-subtitle/index.js
+++ b/js/src/post-subtitle/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SubtitleEditor from './SubtitleEditor';
+import { appendSubtitleToTitleDOMElement, connectWithSelect } from './utils';
+
+/**
+ * Component to be used as a panel in the Document tab of the Editor.
+ *
+ * https://developer.wordpress.org/block-editor/developers/slotfills/plugin-document-setting-panel/
+ */
+const NewspackSubtitlePanel = ( { subtitle } ) => {
+	// Update the DOM when subtitle value changes
+	useEffect(() => {
+		appendSubtitleToTitleDOMElement( subtitle );
+	}, [ subtitle ]);
+
+	return (
+		<PluginDocumentSettingPanel
+			name='newspack-subtitle'
+			title={__('Article Subtitle')}
+			className='newspack-subtitle'
+		>
+			{ __( 'Set a Subtitle for the Article' ) }
+			<SubtitleEditor />
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'plugin-document-setting-panel-newspack-subtitle', {
+	render: connectWithSelect( NewspackSubtitlePanel ),
+	icon: null,
+} );

--- a/js/src/post-subtitle/index.js
+++ b/js/src/post-subtitle/index.js
@@ -27,9 +27,9 @@ const NewspackSubtitlePanel = ( { subtitle } ) => {
 
 	return (
 		<PluginDocumentSettingPanel
-			name='newspack-subtitle'
-			title={__('Article Subtitle')}
-			className='newspack-subtitle'
+			name="newspack-subtitle"
+			title={ __( 'Article Subtitle' ) }
+			className="newspack-subtitle"
 		>
 			{ __( 'Set a Subtitle for the Article' ) }
 			<SubtitleEditor />

--- a/js/src/post-subtitle/utils.js
+++ b/js/src/post-subtitle/utils.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+const SUBTITLE_ID = 'newspack-post-subtitle-element';
+export const META_FIELD_NAME = 'newspack_post_subtitle';
+
+/**
+ * Appends subtitle to DOM, below the Title in the Editor.
+ * @param  {string} subtitle Subtitle text
+ */
+export const appendSubtitleToTitleDOMElement = subtitle => {
+	const titleEl = document.querySelector( '.editor-post-title__block > div' );
+	if ( titleEl && typeof subtitle === 'string' ) {
+		let subtitleEl = document.getElementById( SUBTITLE_ID );
+		if ( ! subtitleEl ) {
+			subtitleEl = document.createElement( 'div' );
+			subtitleEl.id = SUBTITLE_ID;
+			titleEl.appendChild( subtitleEl );
+		}
+		subtitleEl.innerText = subtitle;
+	}
+};
+
+export const connectWithSelect = withSelect( select => ( {
+	subtitle: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ META_FIELD_NAME ],
+} ) );

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -43,8 +43,11 @@
 }
 
 .newspack-post-subtitle {
-	margin-bottom: 2.3em;
+	margin-bottom: 1.3em;
 	font-style: italic;
+	@include media(mobile) {
+		margin-bottom: 2.3em;
+	}
 }
 
 body.page {

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -42,6 +42,11 @@
 	}
 }
 
+.newspack-post-subtitle {
+	margin-bottom: 2.3em;
+	font-style: italic;
+}
+
 body.page {
 	.entry-title {
 		font-size: $font__size-xl;
@@ -258,6 +263,10 @@ body.page {
 	.entry-title {
 		font-size: $font__size-xl;
 		margin: 0 0 0.5em;
+
+		&--with-subtitle {
+			margin-bottom: #{ 0.3 * $size__spacing-unit };
+		}
 
 		@include media( mobile ) {
 			font-size: $font__size-xxl;

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -747,3 +747,10 @@ ul.wp-block-archives,
 		}
 	}
 }
+
+/** === Post Subtitle === */
+
+#newspack-post-subtitle-element {
+	padding-left: 14px;
+	font-style: italic;
+}

--- a/sass/styles/style-4/style-4-editor.scss
+++ b/sass/styles/style-4/style-4-editor.scss
@@ -133,3 +133,7 @@ cite {
 		display: none;
 	}
 }
+
+#newspack-post-subtitle-element {
+	text-align: center;
+}

--- a/sass/styles/style-4/style-4.scss
+++ b/sass/styles/style-4/style-4.scss
@@ -190,16 +190,28 @@ figcaption,
 		text-align: center;
 	}
 
-	.entry-header .entry-title {
-		margin-bottom: #{ 1.5 * $size__spacing-unit };
-		margin-top: $size__spacing-unit;
-		text-align: center;
+	.entry-header {
+		.entry-title,
+		.newspack-post-subtitle {
+			text-align: center;
+		}
+		.entry-title {
+			margin-bottom: #{ 1.5 * $size__spacing-unit };
+			margin-top: $size__spacing-unit;
 
-		@include media( tablet ) {
-			margin-bottom: #{ 3 * $size__spacing-unit };
-			margin-left: auto;
-			margin-right: auto;
-			width: 85%;
+			@include media( tablet ) {
+				margin-bottom: #{ 3 * $size__spacing-unit };
+				margin-left: auto;
+				margin-right: auto;
+				width: 85%;
+			}
+
+			&--with-subtitle {
+				margin-bottom: #{ 0.7 * $size__spacing-unit };
+			}
+		}
+		.newspack-post-subtitle {
+			margin-bottom: #{ 3.3 * $size__spacing-unit };
 		}
 	}
 

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -15,14 +15,16 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 	endif;
 	?>
 	<?php
-		$subtitle = get_post_meta($post->ID, 'newspack_post_subtitle', true);
+		$subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
 	?>
-	<h1 class="entry-title <?php echo $subtitle ? 'entry-title--with-subtitle' : '' ?>">
+	<h1 class="entry-title <?php echo $subtitle ? 'entry-title--with-subtitle' : ''; ?>">
 		<?php echo wp_kses_post( get_the_title() ); ?>
 	</h1>
-	<div class="newspack-post-subtitle">
-		<?php echo $subtitle ?>
-	</div>
+	<?php if ( $subtitle ) : ?>
+		<div class="newspack-post-subtitle">
+			<?php echo esc_html( $subtitle ); ?>
+		</div>
+	<?php endif; ?>
 <?php else : ?>
 	<h2 class="entry-title">
 		<a href="<?php the_permalink(); ?>" rel="bookmark">

--- a/template-parts/header/entry-header.php
+++ b/template-parts/header/entry-header.php
@@ -14,9 +14,15 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 		newspack_categories();
 	endif;
 	?>
-	<h1 class="entry-title">
+	<?php
+		$subtitle = get_post_meta($post->ID, 'newspack_post_subtitle', true);
+	?>
+	<h1 class="entry-title <?php echo $subtitle ? 'entry-title--with-subtitle' : '' ?>">
 		<?php echo wp_kses_post( get_the_title() ); ?>
 	</h1>
+	<div class="newspack-post-subtitle">
+		<?php echo $subtitle ?>
+	</div>
 <?php else : ?>
 	<h2 class="entry-title">
 		<a href="<?php the_permalink(); ?>" rel="bookmark">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const getBaseWebpackConfig = require("@automattic/calypso-build/webpack.config.j
 const path = require("path");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
+// Add all js/src/*.js scripts
 const entry = fs
 	.readdirSync(path.join(__dirname, "js", "src"))
 	.filter(script => "js" === script.split(".").pop())
@@ -22,6 +23,13 @@ const entry = fs
 			[split.join(".")]: path.join(__dirname, "js", "src", item)
 		};
 	}, {});
+
+// Add all js/src/*/index.js scripts
+fs.readdirSync( path.join( __dirname, "js", "src" ) )
+	.filter( script => fs.existsSync( path.join( __dirname, "js", "src", script, "index.js" ) ) )
+	.forEach( function( script ) {
+		entry[ script ] = path.join( __dirname, "js", "src", script, "index.js" );
+	} );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },


### PR DESCRIPTION
This enables adding a subtitle to a post. Here's how it looks like in the editor:

![image](https://user-images.githubusercontent.com/7383192/71017806-7b8bec80-20f7-11ea-9e71-328bc227762e.png)

And that's how it looks like in the wild:

![image](https://user-images.githubusercontent.com/7383192/71017846-93637080-20f7-11ea-82b1-5616a8699fd2.png)

And with all styles:

![image](https://cdn-std.droplr.net/files/acc_887633/Cd8mGn)

Closes #98 .

### How to test the changes in this Pull Request:

1. Visit post editor
2. Open "Article Subtitle" panel in the sidebar ("Document" pane"
3. Edit the subtitle - it should appear in under the title in the editor
4. Save the post
5. The subtitle should appear below title

## To-do's

* [ ] **security** - user input should be sanitised
* [ ] **design** - this was not consulted yet with any designer 😱 cc @thomasguillot 
* [ ] translations?

