### PR TITLE
Add a theme support declaration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -221,6 +221,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				'google_fonts_caching' => true,
 			],
 		] );
+
+		// Add custom theme support - post subtitle
+		add_theme_support( 'post-subtitle' );
 	}
 endif;
 add_action( 'after_setup_theme', 'newspack_setup' );


### PR DESCRIPTION
Adds a theme support declaration, so that plugins can check if theme supports `'post-subtitle'` feature.

Follow up from #635, where it was suggested but I wrongly suspected it would take more work. 