### PR TITLE
Fix issue with search focus and AMP

### DIFF
--- a/template-parts/header/header-search.php
+++ b/template-parts/header/header-search.php
@@ -7,7 +7,7 @@
 ?>
 
 <div class="header-search-contain">
-	<button id="search-toggle" on="tap:AMP.setState( { searchVisible: !searchVisible } ), search-form-1.focus" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
+	<button id="search-toggle" on="tap:AMP.setState( { searchVisible: !searchVisible } ), search-form-2.focus" aria-controls="search-menu" [aria-expanded]="searchVisible ? 'true' : 'false'" aria-expanded="false">
 		<span class="screen-reader-text" [text]="searchVisible ? '<?php esc_html_e( 'Close Search', 'newspack' ); ?>' : '<?php esc_html_e( 'Open Search', 'newspack' ); ?>'">
 			<?php esc_html_e( 'Open Search', 'newspack' ); ?>
 		</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue when, if you navigate the page via keyboard and open the search box, the search input was no longer getting focus when you had AMP enabled.

I think this issue was introduced when the sidebar code was moved, making this search the second one in the code order.

### How to test the changes in this Pull Request:

1. With AMP enabled, navigate through the page using the keyboard and hitting 'tab'.
2. When you get to the Search icon, hit 'Return' to open.
3. Note that the keyboard focus remains on the search toggle button:

![image](https://user-images.githubusercontent.com/177561/71387100-f006d580-25a6-11ea-95bf-26d2cf0419aa.png)

4. Apply the PR. 
5. Tab through the page again and hit 'Return' to open the search; confirm that the focus is now in the text input:

![image](https://user-images.githubusercontent.com/177561/71387123-1a589300-25a7-11ea-8297-dd572b5c6695.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
