### PR TITLE
Style 2: Correct separator styles

### DIFF
--- a/newspack-theme/sass/styles/style-2/style-2-editor.scss
+++ b/newspack-theme/sass/styles/style-2/style-2-editor.scss
@@ -125,6 +125,16 @@ blockquote {
 	}
 }
 
-.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
-	border-top: 5px solid $color__text-main;
+.wp-block-separator{
+	&:not(.is-style-dots) {
+		border-top: 2px solid $color__text-main;
+	}
+
+	&:not(.is-style-dots):not(.is-style-wide) {
+		border-top: 5px solid $color__text-main;
+	}
+
+	&.is-style-dots::before {
+		color: $color__text-main;
+	}
 }

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -347,8 +347,16 @@ blockquote {
 		}
 	}
 
-	.wp-block-separator:not(.is-style-dots):not(.is-style-wide) {
-		border-top: 5px solid $color__text-main;
+	.wp-block-separator {
+		border-top: 2px solid $color__text-main;
+
+		&:not(.is-style-dots):not(.is-style-wide) {
+			border-top: 5px solid $color__text-main;
+		}
+
+		&.is-style-dots::before {
+			color: $color__text-main;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Style 2 originally had a bold default separator block style, and two others (wide and dotted) that didn't really match.

This PR makes them more consistent.

Closes #647.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Style Packs and switch to Style 2.
2. On a post or page, add three separator blocks; leave the first one as the default style, set the second to the 'wide' style and the third to the 'dotted' style. Note their appearance on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/71692783-b466cb00-2d5f-11ea-9abe-f7fbd46aa902.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the 'wide' style is now thicker/darker, and that the dotted style is darker, on both the front end and in the editor:

![image](https://user-images.githubusercontent.com/177561/71692741-a153fb00-2d5f-11ea-89dc-0bc2742ab05f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
