### PR TITLE
Default style: Minor spacing adjustment to accent headers

### DIFF
--- a/newspack-theme/sass/styles/style-default/style-default-editor.scss
+++ b/newspack-theme/sass/styles/style-default/style-default-editor.scss
@@ -3,6 +3,6 @@
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
-	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
-	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
+	margin: 0 0 #{$size__spacing-unit * 0.75};
+	padding: 0 0 #{$size__spacing-unit * 0.33};
 }

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -1,12 +1,12 @@
 /* Headers */
 
 .accent-header,
-.article-section-title {
+.entry-content .wpnbha .article-section-title {
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
-	margin: 0 0 calc( #{$size__spacing-unit} / 2 );
-	padding: 0 0 calc( #{$size__spacing-unit} / 2 );
+	margin: 0 0 #{$size__spacing-unit * 0.75};
+	padding: 0 0 #{$size__spacing-unit * 0.33};
 }
 
 /* Navigation */

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -1,10 +1,14 @@
 /* Headers */
 
 .accent-header,
-.entry-content .wpnbha .article-section-title {
+.article-section-title {
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
+}
+
+.accent-header,
+.entry-content .wpnbha .article-section-title {
 	margin: 0 0 #{$size__spacing-unit * 0.75};
 	padding: 0 0 #{$size__spacing-unit * 0.33};
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is really minor, but the spacing around the homepage posts section headers with the default style was a bit weird -- the border sat perfectly between the text and the articles underneath.

This PR moves the border a hair closer to the text.

Closes #648

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to the default style.
2. Add an article block to the editor, and add a section title.
3. Note the vertical spacing in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/71695251-6608fa80-2d66-11ea-881d-f691995d71d0.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the border is now visually closer to the header text:

![image](https://user-images.githubusercontent.com/177561/71695233-58ec0b80-2d66-11ea-90a9-5ca16cc43ee4.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
