### PR TITLE
Style 1, 3: Remove styles that hide :before on headers

### DIFF
--- a/sass/blocks/_blocks.scss
+++ b/sass/blocks/_blocks.scss
@@ -730,16 +730,6 @@
 				padding-left: $font__size-sm;
 			}
 		}
-
-		/* Remove duplicate rule-line when a separator
-		 * is followed by an H1, or H2 */
-		& + h1,
-		& + h2 {
-
-			&:before {
-				display: none;
-			}
-		}
 	}
 
 	//! Twitter Embed

--- a/sass/style-editor-base.scss
+++ b/sass/style-editor-base.scss
@@ -592,13 +592,6 @@ figcaption,
 	}
 }
 
-/* Remove duplicate rule-line when a separator
- * is followed by an H1, or H2 */
-.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h1:before,
-.wp-block[data-type="core/separator"] + .wp-block[data-type="core/heading"] h2:before {
-	display: none;
-}
-
 /** === Latest Posts, Archives, Categories === */
 
 ul.wp-block-archives,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There was some left-over styles from Twenty Nineteen that were causing issues with styles 1 and 3: 

If you had a separator block, then an h1 or h2 with the class 'accent-header', the little detail before the text -- beside in style 1 and above in style 3 -- were hidden. The old style was included in Twenty Nineteen because the separator block and the accent on that theme's `h1` and `h2` looked the same, but that's not the case for the Newspack theme, so this PR removes those styles.

Closes #649.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs and switch to style 1.
2. On a post or page, add a separator block and two header blocks, set to `h2`. Add the class `.accent-header` to both of the headers using the Advanced panel.
3. View in the editor and on the front end; note that the first header does not have the square:

![image](https://user-images.githubusercontent.com/177561/71697458-e2064100-2d6c-11ea-96f5-337ea1a7b756.png)

4. Navigate to Customize > Style Packs and switch to style 3.
5. View your headers; note that the first one doesn't have the floating rectangle above it:

![image](https://user-images.githubusercontent.com/177561/71697505-095d0e00-2d6d-11ea-96c5-fae41654df6f.png)

6. Apply the PR and run `npm run build`.
7. Confirm that the first header has the style element when using both style 1 and 3:

![image](https://user-images.githubusercontent.com/177561/71697394-bd11ce00-2d6c-11ea-80b2-bca3399ad56c.png)

![image](https://user-images.githubusercontent.com/177561/71697377-b2573900-2d6c-11ea-8449-cf20fd9dec0b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
