### PR TITLE
Make sure correct fonts are used for archive subheaders, menu toggle.

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -350,6 +350,7 @@ function newspack_custom_typography_css() {
 		$css_blocks .= '
 			.tags-links span:first-child,
 			.cat-links,
+			.page-title,
 			.highlight-menu .menu-label {
 				text-transform: uppercase;
 			}

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -40,6 +40,7 @@ function newspack_custom_typography_css() {
 		.site-info,
 		#cancel-comment-reply-link,
 		.entry .entry-content .jp-relatedposts-i2 a,
+		.page-title,
 		h1,
 		h2,
 		h3,
@@ -68,6 +69,7 @@ function newspack_custom_typography_css() {
 
 		/* _menu-main-navigation.scss */
 		.nav1 button,
+		.mobile-menu-toggle,
 
 		/* _menu-tertiary-navigation.scss */
 		.nav3,
@@ -129,7 +131,8 @@ function newspack_custom_typography_css() {
 			$css_blocks .= "
 			blockquote,
 			.has-drop-cap:not(:focus)::first-letter,
-			.taxonomy-description {
+			.taxonomy-description
+			{
 				font-family: $font_header;
 			}";
 		}
@@ -137,7 +140,8 @@ function newspack_custom_typography_css() {
 		if ( newspack_is_active_style_pack( 'style-3' ) ) {
 			$css_blocks .= "
 			.has-drop-cap:not(:focus)::first-letter,
-			.taxonomy-description {
+			.taxonomy-description,
+			.page-title {
 				font-family: $font_header;
 			}";
 		}
@@ -313,8 +317,7 @@ function newspack_custom_typography_css() {
 		textarea,
 
 		/* _blocks.scss */
-		.entry .entry-content .wp-block-verse,
-		.page-title
+		.entry .entry-content .wp-block-verse
 		{
 			font-family: $font_body;
 		}
@@ -346,7 +349,6 @@ function newspack_custom_typography_css() {
 	if ( true === get_theme_mod( 'accent_allcaps', true ) ) {
 		$css_blocks .= '
 			.tags-links span:first-child,
-			.page-title,
 			.cat-links,
 			.highlight-menu .menu-label {
 				text-transform: uppercase;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple small issues with custom fonts being applied incorrectly.

Right now, the body font is applied to both the menu toggle, and the 'subhead' section of the archives (the bit that says 'Category', 'Author', etc). Both should use the header font, for all style packs.

Closes #654, #655.

### How to test the changes in this Pull Request:

1. Navigate to the Customizer, and set a really obvious header/body font -- I used Chalkboard and Impact, respectively, since they're very different than anything used in any style pack.
2. View an archive page; confirm the 'subheader' is using your body font (in my case, Impact), instead of your header font (in my case, Chalkboard):

![image](https://user-images.githubusercontent.com/177561/71698557-cac95280-2d70-11ea-83e5-6cafb8792f98.png)

3. Decrease the size of the browser window until the menu toggle appears. Look at it, and open the menu; confirm both the 'Menu' and 'Close' buttons use your body font, instead of the header font:

![image](https://user-images.githubusercontent.com/177561/71698586-e7658a80-2d70-11ea-83b2-cffc29bb5c40.png)

4. Apply the PR.
5. Confirm both the archive subtitle and the menu toggle now use your custom header font:

![image](https://user-images.githubusercontent.com/177561/71698644-18de5600-2d71-11ea-93bf-bf2cd9ce0cf0.png)

![image](https://user-images.githubusercontent.com/177561/71698688-44f9d700-2d71-11ea-8266-d8f7e3750090.png)

6. Try cycling through a few of the style packs, and confirm that the fonts are still applied the same way. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
