### PR TITLE
Links: Fix issues with links not inheriting the correct colours

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -196,7 +196,7 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary variation color */
 
-		.entry .entry-content a:hover,
+		.entry-content a:hover,
 		.widget a:hover,
 		.author-bio .author-link:hover,
 		.entry .entry-content .has-secondary-variation-color,
@@ -446,6 +446,8 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */
+		.editor-block-list__layout .editor-block-list__block .has-text-color a,
+		.editor-block-list__layout .editor-block-list__block .has-text-color a:hover,
 		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-cover a,
 		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -232,14 +232,11 @@
 		text-align: left;
 	}
 
-	a,
-	a:hover,
-	a:visited,
-	.entry-meta,
-	.entry-meta a,
-	.entry-meta a:visited,
+	article .entry-meta,
 	article .entry-meta a,
-	article .entry-meta a:visited {
+	article .entry-meta a:visited,
+	article .cat-links a,
+	article .cat-links a:visited {
 		color: #fff;
 	}
 
@@ -273,12 +270,24 @@
 	}
 }
 
+.entry-content .wp-block-cover {
+	a,
+	a:hover,
+	a:visited {
+		color: inherit;
+	}
+}
+
 .wp-block-columns {
 	.wp-block-cover,
 	.wp-block-cover-image {
-		min-height: 330px;
-		padding-left: $size__spacing-unit;
-		padding-right: $size__spacing-unit;
+		a,
+		a:visited,
+		a:hover {
+			min-height: 330px;
+			padding-left: $size__spacing-unit;
+			padding-right: $size__spacing-unit;
+		}
 	}
 }
 
@@ -972,9 +981,9 @@
 	}
 }
 
-.has-text-color a,
-.has-text-color a:hover,
-.has-text-color a:visited {
+.entry-content .has-text-color a,
+.entry-content .has-text-color a:hover,
+.entry-content .has-text-color a:visited {
 	color: inherit;
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -281,13 +281,9 @@
 .wp-block-columns {
 	.wp-block-cover,
 	.wp-block-cover-image {
-		a,
-		a:visited,
-		a:hover {
-			min-height: 330px;
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
-		}
+		min-height: 330px;
+		padding-left: $size__spacing-unit;
+		padding-right: $size__spacing-unit;
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -972,6 +972,12 @@
 	}
 }
 
+.has-text-color a,
+.has-text-color a:hover,
+.has-text-color a:visited {
+	color: inherit;
+}
+
 //! 'Feature' alignments
 .post-template-single-feature,
 .page-template-single-feature {

--- a/newspack-theme/sass/elements/_elements.scss
+++ b/newspack-theme/sass/elements/_elements.scss
@@ -12,28 +12,6 @@ body {
 	background-color: $color__background-body;
 }
 
-a {
-	@include link-transition;
-	color: $color__link;
-}
-
-a:visited {
-	color: $color__link;
-}
-
-a:hover,
-a:active {
-	color: $color__link-hover;
-	outline: 0;
-	text-decoration: none;
-}
-
-a:focus {
-	outline: thin;
-	outline-style: dotted;
-	text-decoration: underline;
-}
-
 h1,
 h2,
 h3,

--- a/newspack-theme/sass/navigation/_links.scss
+++ b/newspack-theme/sass/navigation/_links.scss
@@ -4,7 +4,7 @@ a {
 	color: $color__text-light;
 
 	&:visited {
-		color: $color__text-light;
+		color: inherit;
 	}
 
 	&:hover,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -198,6 +198,8 @@ figcaption,
 		width: 100%;
 	}
 
+	a,
+	a:visited,
 	.entry-meta,
 	.entry-meta a,
 	.entry-meta a:visited,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Links -- primarily visited links -- aren't inheriting the text colour when they're in a block with a custom text colour (like a paragraph), or in a cover block (when the rest of the text is automatically changed to white). This PR helps them inherit the correct colours more consistently.

Closes #651 .

### How to test the changes in this Pull Request:

1. Copy-paste this text into the editor: https://cloudup.com/c0_FcwPD5eB
2. Click on the links to make sure they show as visited (all are pointing to Google, so clicking on one should take care of all of them). 
3. Note the colours of the links on the front-end and in the editor:

Front end: 

![image](https://user-images.githubusercontent.com/177561/71699238-74a9de80-2d73-11ea-984b-437a8b8fa108.png)

Editor: 

![image](https://user-images.githubusercontent.com/177561/71699257-87bcae80-2d73-11ea-88f0-995c4943a401.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the links are now displaying the correct colours on the front end and in the editor:

Front-end:

![image](https://user-images.githubusercontent.com/177561/71699225-652a9580-2d73-11ea-8550-4cf93c01839b.png)

Editor:

![image](https://user-images.githubusercontent.com/177561/71699341-d9fdcf80-2d73-11ea-9b29-6e9040028bcd.png)

6. Try switching to a custom colour (or if already using a custom colour, to the default), and confirm the links still match the colour of the text, unless it's unaltered. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
