### PR TITLE
Update function that checks if style pack is assigned

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -440,7 +440,13 @@ function newspack_is_static_front_page() {
  */
 function newspack_is_active_style_pack() {
 	$args              = func_get_args();
-	$active_style_pack = get_theme_mod( 'active_style_pack', 'default' );
+	$active_style_pack = '';
+
+	// Only assign an active style pack if not using a child theme.
+	if ( ! is_child_theme() ) {
+		$active_style_pack = get_theme_mod( 'active_style_pack', 'default' );
+	}
+
 	return in_array( $active_style_pack, $args );
 }
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -353,7 +353,7 @@ function newspack_custom_colors_css() {
 		';
 	}
 
-	if ( true === get_theme_mod( 'header_solid_background', false ) && ! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5' ) ) {
+	if ( true === get_theme_mod( 'header_solid_background', false ) && newspack_is_active_style_pack( 'default', 'style-1', 'style-2' ) ) {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .middle-header-contain {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`newspack_is_active_style_pack()` checked for the current style pack, and is used primarily in the colour and typography checks. 

This PR updates it to return empty if a child theme is currently assigned, and also updates a `! newspack_is_active_style_pack()` check in the colour code to flip it (rather than `! newspack_is_active_style_pack( 'style-3', 'style-4', 'style-5')`, it switch its to ` newspack_is_active_style_pack( 'default', 'style-1', 'style-2')`

Moved over from #594.

### How to test the changes in this Pull Request:

The testing steps focus on making sure no functionality is lost; the `is_child_theme()` part can be tested easier once we have the first child theme in place. 

1. Apply the PR.
2. Navigate to Customize > Header Settings, and select the 'solid background' option.
3. Navigate to Customize > Colours, and switch away from the primary colours.
4. Navigate to Customize > Style Packs, and rotate through the style packs (note: they will preview incorrectly, so you'll need to save an publish each style pack, and view outside of the Customizer, to confirm that this is actually working). Styles default, 1 and 2 should use the current primary colour as the header background; 3 and 4 should use dark grey, and 5 should use black.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
