### PR TITLE
Move `newspack_color_with_contrast()` function

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -21,17 +21,6 @@ function newspack_custom_colors_css() {
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
-	/**
-	 * Checks if color has sufficient contrast against white; if no, replaces it.
-	 */
-	function newspack_color_with_contrast( $color ) {
-		$contrast = newspack_get_color_contrast( $color );
-		if ( '#000' === $contrast ) {
-			return '#5a5a5a';
-		}
-		return $color;
-	}
-
 	$theme_css = '
 		/* Set primary background color */
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -429,3 +429,14 @@ function newspack_get_color_contrast( $hex ) {
 		return '#fff';
 	}
 }
+
+/**
+ * Checks if color has sufficient contrast against white; if no, replaces it.
+ */
+function newspack_color_with_contrast( $color ) {
+	$contrast = newspack_get_color_contrast( $color );
+	if ( '#000' === $contrast ) {
+		return '#5a5a5a';
+	}
+	return $color;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves the function `newspack_color_with_contrast()` outside of the color-patterns.php and into the template-functions.php, with the other colour function (`newspack_get_color_contrast()`), so it can be used easier from the child theme.

Moved over from #594.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customize > Style Packs, and switch to style 2.
3. Navigate to Customize > Colours and switch the primary colour to a lighter colour.
4. View a single post -- confirm that the text for the category is grey (sufficient contrast against white), instead of your lighter colour:

![image](https://user-images.githubusercontent.com/177561/71852268-2fe0b900-308d-11ea-8a4d-a00906bee59d.png)

Compared to the text colour in style 2, when using a darker colour:

![image](https://user-images.githubusercontent.com/177561/71852320-4a1a9700-308d-11ea-825c-1692fe05c426.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
