### PR TITLE
Fix styling: footer credits for style 1

### DIFF
--- a/newspack-theme/sass/styles/style-1/style-1.scss
+++ b/newspack-theme/sass/styles/style-1/style-1.scss
@@ -275,11 +275,13 @@
 		color: $color__text-main;
 		font-size: $font__size_base;
 	}
+}
 
-	.widget,
-	.site-info {
-		font-family: $font__heading;
-	}
+#colophon .widget,
+// If custom font is set, `#colophon .site-info` selector would override it
+// (See issue #663)
+.site-info {
+	font-family: $font__heading;
 }
 
 /* Pop-up */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes footer credit displaying in wrong font.

Closes #663 

### How to test the changes in this Pull Request:

1. Set style 1 in theme customiser
1. Set a custom font
1. Footer credit should use the custom font

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
