### PR TITLE
Style: make button block inherit custom font

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -59,7 +59,7 @@ function newspack_custom_typography_css() {
 		input[type=\"submit\"],
 
 		/* _blocks.scss */
-		.wp-block-button,
+		.entry .entry-content .wp-block-button .wp-block-button__link,
 
 		/* _captions.scss */
 		.wp-caption-text,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -58,6 +58,9 @@ function newspack_custom_typography_css() {
 		input[type=\"reset\"],
 		input[type=\"submit\"],
 
+		/* _blocks.scss */
+		.wp-block-button,
+
 		/* _captions.scss */
 		.wp-caption-text,
 		.gallery-caption,


### PR DESCRIPTION
Issue #664

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Styling: make button block inherit custom font

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #664

### How to test the changes in this Pull Request:

1. Set custom font in customiser
2. Create a button block
3. The button should display text using the custom font

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
