### PR TITLE
Beside image style: Make sure colours are inherited correctly

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -309,8 +309,13 @@ function newspack_custom_colors_css() {
 				background-color: ' . $primary_color . ';
 			}
 
-			.h-sb .featured-image-beside a {
+			.featured-image-beside a,
+			.featured-image-beside .cat-links a {
 				color: ' . $primary_color_contrast . ';
+			}
+
+			.featured-image-beside .cat-links:before {
+				background-color: ' . $primary_color_contrast . ';
 			}
 
 			/* Header solid background; short height */

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -304,18 +304,25 @@ function newspack_custom_colors_css() {
 			.cat-links:before,
 			.archive .page-title:before,
 			figcaption:after,
-			.wp-caption-text:after,
-			.h-sb .featured-image-beside {
+			.wp-caption-text:after {
 				background-color: ' . $primary_color . ';
 			}
 
-			.featured-image-beside a,
-			.featured-image-beside .cat-links a {
-				color: ' . $primary_color_contrast . ';
-			}
+			@media only screen and (min-width: 782px) {
+				.h-sb .featured-image-beside {
+					background-color: ' . $primary_color . ';
+				}
 
-			.featured-image-beside .cat-links:before {
-				background-color: ' . $primary_color_contrast . ';
+				.h-sb .featured-image-beside,
+				.h-sb .featured-image-beside a,
+				.featured-image-beside a,
+				.featured-image-beside a:visited {
+					color: ' . $primary_color_contrast . ';
+				}
+
+				.featured-image-beside .cat-links:before {
+					background-color: ' . $primary_color_contrast . ';
+				}
 			}
 
 			/* Header solid background; short height */
@@ -331,9 +338,14 @@ function newspack_custom_colors_css() {
 			.accent-header,
 			.article-section-title,
 			.cat-links,
-			.entry .entry-footer,
-			.h-sb .featured-image-beside .cat-links {
+			.entry .entry-footer {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
+			}
+
+			@media only screen and (min-width: 782px) {
+				.h-sb .featured-image-beside .cat-links {
+					color: ' . newspack_color_with_contrast( $primary_color ) . ';
+				}
 			}
 
 			.has-drop-cap:not(:focus)::first-letter {

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -304,8 +304,13 @@ function newspack_custom_colors_css() {
 			.cat-links:before,
 			.archive .page-title:before,
 			figcaption:after,
-			.wp-caption-text:after {
+			.wp-caption-text:after,
+			.h-sb .featured-image-beside {
 				background-color: ' . $primary_color . ';
+			}
+
+			.h-sb .featured-image-beside a {
+				color: ' . $primary_color_contrast . ';
 			}
 
 			/* Header solid background; short height */
@@ -321,7 +326,8 @@ function newspack_custom_colors_css() {
 			.accent-header,
 			.article-section-title,
 			.cat-links,
-			.entry .entry-footer {
+			.entry .entry-footer,
+			.h-sb .featured-image-beside .cat-links {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -316,7 +316,8 @@ function newspack_custom_colors_css() {
 				.h-sb .featured-image-beside,
 				.h-sb .featured-image-beside a,
 				.featured-image-beside a,
-				.featured-image-beside a:visited {
+				.featured-image-beside a:visited,
+				.featured-image-beside .cat-links a {
 					color: ' . $primary_color_contrast . ';
 				}
 
@@ -361,6 +362,16 @@ function newspack_custom_colors_css() {
 			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
 			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
+			}
+		';
+	}
+
+	if ( newspack_is_active_style_pack( 'style-5' ) ) {
+		$theme_css .= '
+			@media only screen and (min-width: 782px) {
+				.h-db .featured-image-beside .entry-header {
+					color: #fff;
+				}
 			}
 		';
 	}

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -554,6 +554,7 @@ body.page {
 	}
 
 	.featured-image-beside {
+		color: #fff;
 		display: flex;
 		margin: 0 calc(50% - 50vw);
 		min-height: calc( 100vh - 220px );
@@ -597,7 +598,6 @@ body.page {
 		}
 
 		.entry-header {
-			color: #fff;
 			margin-left: auto;
 			max-width: 600px;
 			padding-left: 0;
@@ -641,7 +641,7 @@ body.page {
 			font-size: $font__size-xxl;
 		}
 	}
-} 
+}
 
 .entry-content #jp-relatedposts {
 	h3.jp-relatedposts-headline {
@@ -656,7 +656,7 @@ body.page {
 		opacity: 1.0;
 
 		.jp-relatedposts-post-img {
-			margin-bottom: #{ 0.5 * $size__spacing-unit };	
+			margin-bottom: #{ 0.5 * $size__spacing-unit };
 		}
 
 		.jp-relatedposts-post-title {
@@ -665,7 +665,7 @@ body.page {
 			a {
 				color: $color__text-main;
 				font-family: $font__heading;
-				font-size: $font__size-base;	
+				font-size: $font__size-base;
 				font-weight: bold;
 			}
 		}

--- a/newspack-theme/sass/styles/style-3/style-3.scss
+++ b/newspack-theme/sass/styles/style-3/style-3.scss
@@ -199,10 +199,6 @@ Newspack Theme Styles - Style Pack 3
 	// Header - Solid background
 	.h-sb .featured-image-beside {
 		background-color: $color__primary;
-
-		.cat-links:before {
-			background-color: $color__background-body;
-		}
 	}
 }
 

--- a/newspack-theme/sass/styles/style-3/style-3.scss
+++ b/newspack-theme/sass/styles/style-3/style-3.scss
@@ -143,8 +143,14 @@ Newspack Theme Styles - Style Pack 3
 // Posts & Pages
 
 @include media( tablet ) {
-	.featured-image-beside .cat-links:before {
-		background-color: $color__background-body;
+	.featured-image-beside {
+		.cat-links a {
+			color: $color__background-body;
+		}
+
+		.cat-links:before {
+			background-color: $color__background-body;
+		}
 	}
 }
 

--- a/newspack-theme/sass/styles/style-5/style-5.scss
+++ b/newspack-theme/sass/styles/style-5/style-5.scss
@@ -179,11 +179,11 @@ input[type="submit"] {
 }
 
 // Default and solid header backgrounds
-.h-db,
-.h-sb {
+.h-db.single-featured-image-beside,
+.h-sb.single-featured-image-beside  {
 	.featured-image-beside {
 		@include media( tablet ) {
-			background-color: currentColor;
+			background-color: $color__text-main;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some issues with custom colours and the 'beside' featured image style.

Closes #674.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a post; add a featured image and select the 'Beside post title' option.
3. Navigate to Customize > Colours, and set a custom colour.
4. Cycle through each style pack, with and without the solid header option selected. Make sure the custom colour is always used (either in the header or behind the title), and that the title, category and post meta are always legible. 

**Default:**

![image](https://user-images.githubusercontent.com/177561/71919638-fe71f700-3139-11ea-9965-28a2dd774e70.png)

![image](https://user-images.githubusercontent.com/177561/71919650-0762c880-313a-11ea-91f7-910a6a1d1239.png)

**Style 1:**

![image](https://user-images.githubusercontent.com/177561/71919698-23ff0080-313a-11ea-98d8-ba933a92e038.png)

![image](https://user-images.githubusercontent.com/177561/71919717-2eb99580-313a-11ea-89ff-f3d2100b948b.png)

**Style 2:**

![image](https://user-images.githubusercontent.com/177561/71919737-3d07b180-313a-11ea-82e1-a0e6602b25a8.png)

![image](https://user-images.githubusercontent.com/177561/71919758-47c24680-313a-11ea-8bb8-0af1cd9b3928.png)

**Style 3:**

![image](https://user-images.githubusercontent.com/177561/71920964-c324f780-313c-11ea-912e-4a0223b41d6c.png)

![image](https://user-images.githubusercontent.com/177561/71921447-c1a7ff00-313d-11ea-9093-97f38eabbbba.png)

**Style 4:**

![image](https://user-images.githubusercontent.com/177561/71921689-2d8a6780-313e-11ea-9838-bd9264577923.png)

![image](https://user-images.githubusercontent.com/177561/71921710-3844fc80-313e-11ea-85be-1d59b2653c4d.png)

**Style 5:**

![image](https://user-images.githubusercontent.com/177561/71922222-67a83900-313f-11ea-8f82-a4f60586cd19.png)

![image](https://user-images.githubusercontent.com/177561/71922269-7f7fbd00-313f-11ea-9ec6-d761324c6f48.png)

5. To rule out all possible issues, try the same with the default colour, and a second custom colour (light if the first one you tested was dark, and dark if the first one you tested was light).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

