### PR TITLE
Improve styles of Latest Comments block

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -90,13 +90,13 @@ function newspack_custom_typography_css() {
 		/* _comments.scss */
 		.comment-list .pingback .comment-body,
 		.comment-list .trackback .comment-body,
-
 		.comment-list .pingback .comment-body .comment-edit-link,
 		.comment-list .trackback .comment-body .comment-edit-link,
-
-
 		.comment-form label,
 		.comment-form .comment-notes,
+
+		/* _blocks.scss */
+		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 
 		/* _widgets.scss */
 		.widget_archive ul li,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -412,6 +412,31 @@
 	}
 }
 
+//! Latest Comments
+.wp-block-latest-comments {
+	padding-left: 0;
+
+	.wp-block-latest-comments__comment-meta {
+		font-family: $font__heading;
+		font-weight: bold;
+
+		.wp-block-latest-comments__comment-date {
+			color: $color__text-light;
+			font-weight: normal;
+			margin: #{ 0.25 * $size__spacing-unit } 0;
+		}
+	}
+
+	.wp-block-latest-comments__comment {
+		line-height: $font__line-height-body;
+	}
+
+	.wp-block-latest-comments__comment-excerpt p {
+		font-size: 1.1em;
+		line-height: $font__line-height-body;
+	}
+}
+
 .entry .entry-content {
 
 	//! Paragraphs
@@ -819,41 +844,6 @@
 			&:last-child {
 				margin-bottom: 0;
 			}
-		}
-	}
-
-
-	//! Latest Comments
-	.wp-block-latest-comments {
-
-		.wp-block-latest-comments__comment-meta {
-			font-family: $font__heading;
-			font-weight: bold;
-
-			.wp-block-latest-comments__comment-date {
-				font-weight: normal;
-			}
-		}
-
-		.wp-block-latest-comments__comment,
-		.wp-block-latest-comments__comment-date,
-		.wp-block-latest-comments__comment-excerpt p {
-			font-size: inherit;
-		}
-
-		&.has-avatars {
-
-		}
-
-		&.has-dates {
-
-			.wp-block-latest-comments__comment-date {
-				font-size: $font__size-xs;
-			}
-		}
-
-		&.has-excerpts {
-
 		}
 	}
 

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -668,24 +668,28 @@ ul.wp-block-archives,
 /** === Latest Comments === */
 
 .wp-block-latest-comments {
+	margin-left: 0;
+	padding-left: 0;
 
 	.wp-block-latest-comments__comment-meta {
 		font-family: $font__heading;
 		font-weight: bold;
 
 		.wp-block-latest-comments__comment-date {
+			color: $color__text-light;
 			font-weight: normal;
 		}
 	}
 
-	.wp-block-latest-comments__comment,
-	.wp-block-latest-comments__comment-date,
-	.wp-block-latest-comments__comment-excerpt p {
-		font-size: inherit;
+	.wp-block-latest-comments__comment {
+		line-height: $font__line-height-body;
+		margin-bottom: $size__spacing-unit;
 	}
 
-	.wp-block-latest-comments__comment-date {
-		font-size: $font__size-xs;
+	.wp-block-latest-comments__comment-excerpt p {
+		font-size: 1.1em;
+		line-height: $font__line-height-body;
+		margin: 0;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the styles of the Latest Comments block, to remove some unnecessary spacing, and improve the font sizing.

Closes #643.

### How to test the changes in this Pull Request:

1. Copy-paste [this test content](https://cloudup.com/cXa0udfjT6K) into the editor.
2. View in the editor and on the front-end; note the spacing and font-sizing:

**Front-end:**

![image](https://user-images.githubusercontent.com/177561/72027049-76234d00-3232-11ea-83b3-1ea7e74ea073.png)

**Editor:**

![image](https://user-images.githubusercontent.com/177561/72027074-89361d00-3232-11ea-8f4e-ad8bdc0114c3.png)

3. Apply the PR and run `npm run build`.
4. View the block on the front-end and in the editor; confirm that the spacing/sizing is improved, and fairly consistent between the front-end and in the editor:

**Front-end:** 

![image](https://user-images.githubusercontent.com/177561/72027019-60158c80-3232-11ea-87ef-ba8e2718a088.png)

**Editor:** 

![image](https://user-images.githubusercontent.com/177561/72027025-66a40400-3232-11ea-813b-55e4f8f4eeee.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
