### PR TITLE
Organic Profile Block: Overwrite some of the default styles to make the block more generic to Newspack

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -855,7 +855,7 @@
 		}
 	}
 
-	// Jetpack Blocks
+	//! Jetpack Blocks
 	.jp-relatedposts-i2 {
 		border-top: 1px solid $color__border;
 		border-bottom: 1px solid $color__border;
@@ -870,6 +870,32 @@
 		.jp-related-posts-i2__post-date,
 		.jp-related-posts-i2__post-context {
 			font-size: $font__size-xs;
+		}
+	}
+
+	//! Organic Profile Block
+	.wp-block-organic-profile-block {
+		box-shadow: none;
+
+		.organic-profile-image {
+			margin-right: 32px;
+		}
+
+		.organic-profile-content {
+			padding: 0;
+		}
+
+		.organic-profile-social {
+			.social-link {
+				border: 0;
+				display: inline-block;
+				font-size: 16px;
+				height: 32px;
+				line-height: 32px;
+				padding: 0;
+				text-align: center;
+				width: 32px;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -878,7 +878,15 @@
 		box-shadow: none;
 
 		.organic-profile-image {
+			align-items: flex-start;
+			background: none !important;
 			margin-right: 32px;
+
+			img {
+				display: block;
+				margin: 0;
+				opacity: 1;
+			}
 		}
 
 		.organic-profile-content {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -873,40 +873,6 @@
 		}
 	}
 
-	//! Organic Profile Block
-	.wp-block-organic-profile-block {
-		box-shadow: none;
-
-		.organic-profile-image {
-			align-items: flex-start;
-			background: none !important;
-			margin-right: 32px;
-
-			img {
-				display: block;
-				margin: 0;
-				opacity: 1;
-			}
-		}
-
-		.organic-profile-content {
-			padding: 0;
-		}
-
-		.organic-profile-social {
-			.social-link {
-				border: 0;
-				display: inline-block;
-				font-size: 16px;
-				height: 32px;
-				line-height: 32px;
-				padding: 0;
-				text-align: center;
-				width: 32px;
-			}
-		}
-	}
-
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;
@@ -1152,6 +1118,63 @@
 		&.alignfull {
 			padding-left: $size__spacing-unit;
 			padding-right: $size__spacing-unit;
+		}
+	}
+}
+
+//! Organic Profile Block
+.wp-block-organic-profile-block {
+	box-shadow: none;
+
+	.organic-profile-image {
+		align-items: center;
+		background: none !important;
+		margin-bottom: 16px;
+
+		@media only screen and (min-width: 768px) {
+			margin-bottom: 0;
+			margin-right: 32px;
+		}
+
+		&[class*="amp-wp-"] figure {
+			display: flex;
+			height: 100%;
+		}
+
+		img {
+			display: block;
+			height: auto;
+			margin: 0;
+			opacity: 1;
+			width: 100%;
+		}
+	}
+
+	.organic-profile-content {
+		padding: 0;
+
+		h5 {
+			color: $color__text-light;
+		}
+	}
+
+	.organic-profile-social {
+		.social-link {
+			border: 0;
+			color: $color__text-light;
+			display: inline-block;
+			font-size: 16px;
+			height: 32px;
+			line-height: 32px;
+			padding: 0;
+			text-align: center;
+			width: 32px;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
 		}
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -715,9 +715,18 @@ ul.wp-block-archives,
 	box-shadow: none;
 
 	.organic-profile-image {
-		align-items: flex-start;
+		align-items: center;
 		background: none !important;
-		margin-right: 32px;
+		margin-bottom: 16px;
+
+		@media only screen and (min-width: 768px) {
+			margin-bottom: 0;
+			margin-right: 32px;
+		}
+
+		&.image-active {
+			max-width: 100%;
+		}
 
 		button.image-button {
 			border-radius: 0;
@@ -733,18 +742,32 @@ ul.wp-block-archives,
 
 	.organic-profile-content {
 		padding: 0;
+		width: 100%;
+
+		h5 {
+			color: $color__text-light;
+		}
 	}
 
 	.organic-profile-social {
 		.social-link {
 			border: 0;
+			color: $color__text-light;
+			cursor: default;
 			display: inline-block;
 			font-size: 16px;
 			height: 32px;
 			line-height: 32px;
 			padding: 0;
+			pointer-events: none;
 			text-align: center;
 			width: 32px;
+
+			&:active,
+			&:focus,
+			&:hover {
+				color: inherit;
+			}
 		}
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -715,7 +715,20 @@ ul.wp-block-archives,
 	box-shadow: none;
 
 	.organic-profile-image {
+		align-items: flex-start;
+		background: none !important;
 		margin-right: 32px;
+
+		button.image-button {
+			border-radius: 0;
+			height: auto;
+
+			img {
+				display: block;
+				margin: 0;
+				opacity: 1;
+			}
+		}
 	}
 
 	.organic-profile-content {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -710,6 +710,32 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Organic Profile Block === */
+.wp-block-organic-profile-block {
+	box-shadow: none;
+
+	.organic-profile-image {
+		margin-right: 32px;
+	}
+
+	.organic-profile-content {
+		padding: 0;
+	}
+
+	.organic-profile-social {
+		.social-link {
+			border: 0;
+			display: inline-block;
+			font-size: 16px;
+			height: 32px;
+			line-height: 32px;
+			padding: 0;
+			text-align: center;
+			width: 32px;
+		}
+	}
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR remove some of the custom styles and makes the block a bit more generic:

* Adjusted the margin/padding
* Removed the box-shadow
* Social Icons to follow a 8px grid
* The image was being displayed via a background-image with a `background-size: cover` property on larger screens. I switched this to using `<img />` all the time.

See #683 and https://github.com/Automattic/newspack-plugin/pull/374

### How to test the changes in this Pull Request:

1. Add the Organic Profile Block to your site.
2. Create a page/post with that block.
3. Check the front-end and back-end

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
