### PR TITLE
Update editor classes to match what's currently in Gutenberg

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -380,75 +380,75 @@ function newspack_custom_colors_css() {
 		 * - buttons
 		 */
 
-		.entry-meta .byline a {
+		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
 			color: ' . newspack_color_with_contrast( $primary_color ) . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
-		.editor-styles-wrapper .editor-block-list__layout .wp-block-freeform blockquote {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
+		.editor-styles-wrapper .block-editor-block-list__layout .wp-block-freeform blockquote {
 			border-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . $primary_color . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . $primary_color_contrast . ';
 		}
 
 		/* Secondary color */
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__button,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			background-color: ' . $secondary_color . '; /* base: #0073a8; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__button,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			color: ' . $secondary_color_contrast . '; /* base: #0073a8; */
 		}
 
 		/* Hover colors */
-		.editor-block-list__layout .editor-block-list__block a:hover,
-		.editor-block-list__layout .editor-block-list__block a:active,
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
+		.block-editor-block-list__layout .block-editor-block-list__block a:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block a:active,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
 			color: ' . newspack_adjust_brightness( $secondary_color, -40 ) . '; /* base: #005177; */
 		}
 
-		.editor-block-list__layout .editor-block-list__block a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
-		.editor-block-list__layout .editor-block-list__block .wp-block-file .wp-block-file__textlink {
+		.block-editor-block-list__layout .block-editor-block-list__block a,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink {
 			color: ' . newspack_color_with_contrast( $secondary_color ) . ';
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */
-		.editor-block-list__layout .editor-block-list__block .has-text-color a,
-		.editor-block-list__layout .editor-block-list__block .has-text-color a:hover,
-		.editor-block-list__layout .editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-cover a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a,
-		.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover,
-		.editor-block-list__layout .editor-block-list__block .wp-block-cover .article-section-title {
+		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a,
+		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color a,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover a,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover .article-section-title {
 			color: inherit;
 		}
 		';
 
 	if ( newspack_is_active_style_pack( 'default', 'style-3', 'style-4' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .entry-meta .byline a {
+			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
@@ -456,8 +456,8 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
-			.editor-block-list__layout .editor-block-list__block .accent-header {
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
@@ -465,8 +465,8 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-1' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .accent-header:not(.widget-title):before,
-			.editor-block-list__layout .editor-block-list__block .article-section-title:before {
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header:not(.widget-title):before,
+			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before {
 				background-color: ' . $primary_color . ';
 			}
 			.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) blockquote > .editor-rich-text__editable:first-child:before {
@@ -477,7 +477,7 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				color: ' . newspack_color_with_contrast( $secondary_color ) . ';
 			}
 		';
@@ -485,15 +485,15 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-3' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .accent-header,
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 
-			.editor-block-list__layout .editor-block-list__block .accent-header:before,
-			.editor-block-list__layout .editor-block-list__block .article-section-title:before,
-			.editor-block-list__layout .editor-block-list__block figcaption:after,
-			.editor-block-list__layout .editor-block-list__block .wp-caption-text:after {
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header:before,
+			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before,
+			.block-editor-block-list__layout .block-editor-block-list__block figcaption:after,
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-caption-text:after {
 				background-color: ' . $primary_color . ';
 			}
 		';
@@ -501,14 +501,14 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-4' ) ) {
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .accent-header,
-			.editor-block-list__layout .editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 				color: ' . newspack_color_with_contrast( $primary_color ) . ';
 			}
 		';
 
 		$editor_css .= '
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -191,57 +191,57 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= "
-		.editor-block-list__layout .editor-block-list__block h1,
-		.editor-block-list__layout .editor-block-list__block h2,
-		.editor-block-list__layout .editor-block-list__block h3,
-		.editor-block-list__layout .editor-block-list__block h4,
-		.editor-block-list__layout .editor-block-list__block h5,
-		.editor-block-list__layout .editor-block-list__block h6,
-		.editor-block-list__layout .editor-block-list__block figcaption,
-		.editor-block-list__layout .editor-block-list__block .gallery-caption,
-		.editor-block-list__layout .editor-block-list__block .cat-links,
+		.block-editor-block-list__layout .block-editor-block-list__block h1,
+		.block-editor-block-list__layout .block-editor-block-list__block h2,
+		.block-editor-block-list__layout .block-editor-block-list__block h3,
+		.block-editor-block-list__layout .block-editor-block-list__block h4,
+		.block-editor-block-list__layout .block-editor-block-list__block h5,
+		.block-editor-block-list__layout .block-editor-block-list__block h6,
+		.block-editor-block-list__layout .block-editor-block-list__block figcaption,
+		.block-editor-block-list__layout .block-editor-block-list__block .gallery-caption,
+		.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
 
 		/* Post Title */
 		.editor-styles-wrapper .editor-post-title .editor-post-title__block .editor-post-title__input,
 
 		/* Table Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block-table,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table,
 
 		/* Cover Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block-cover h2,
-		.editor-block-list__layout .editor-block-list__block .wp-block-cover .wp-block-cover-text,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover h2,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover .wp-block-cover-text,
 
 		/* Button Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block-button .wp-block-button__link,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button .wp-block-button__link,
 
 		/* Blockquote Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block-quote cite,
-		.editor-block-list__layout .editor-block-list__block .wp-block-quote footer,
-		.editor-block-list__layout .editor-block-list__block .wp-block-quote .wp-block-quote__citation,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote cite,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote footer,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote .wp-block-quote__citation,
 
 		/* Pullquote Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='left'] .wp-block-pullquote__citation,
-		.editor-block-list__layout .editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='right'] .wp-block-pullquote__citation,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='left'] .wp-block-pullquote__citation,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block[data-type='core/pullquote'][data-align='right'] .wp-block-pullquote__citation,
 
 		/* File Block */
-		.editor-block-list__layout .editor-block-list__block .wp-block-file,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file,
 
 		/* Widget blocks */
-		.editor-block-list__layout .editor-block-list__block ul.wp-block-archives li,
-		.editor-block-list__layout .editor-block-list__block .wp-block-categories li,
-		.editor-block-list__layout .editor-block-list__block .wp-block-latest-posts li,
+		.block-editor-block-list__layout .block-editor-block-list__block ul.wp-block-archives li,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-categories li,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-posts li,
 
 		/* Latest Comments blocks */
-		.editor-block-list__layout .editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 
 		/* Jetpack blocks */
-		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 a,
-		.editor-block-list__layout .editor-block-list__block .jp-relatedposts-i2 strong,
+		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 a,
+		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 strong,
 
 		/* Classic Editor */
-		.editor-block-list__layout .editor-block-list__block .wp-caption dd,
-		.editor-block-list__layout .editor-block-list__block .wp-block-freeform blockquote cite
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-caption dd,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-freeform blockquote cite
 
 		{
 			font-family: $font_header;
@@ -250,11 +250,11 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-1' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text__editable:first-child::before
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] p,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text__editable:first-child::before
 
 			{
 				font-family: $font_header;
@@ -264,8 +264,8 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-2' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block blockquote,
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+			.block-editor-block-list__layout .block-editor-block-list__block blockquote,
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 
 			{
 				font-family: $font_header;
@@ -276,7 +276,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-3' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter
 
 			{
 				font-family: $font_header;
@@ -286,24 +286,24 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-4' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
-			.editor-block-list__layout .editor-block-list__block .entry-meta {
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty='true']::before,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] p,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation,
+			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta {
 				font-family: $font_header;
 			}";
 		}
 
 		if ( newspack_is_active_style_pack( 'style-5' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] p {
+			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] blockquote > .editor-rich-text p,
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] p {
 				font-family: $font_header;
 			}
-			.editor-block-list__layout .editor-block-list__block .article-section-title,
-			.editor-block-list__layout .editor-block-list__block .accent-header {
+			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
+			.block-editor-block-list__layout .block-editor-block-list__block .accent-header {
 				font-family: inherit;
 			}";
 		}
@@ -334,7 +334,7 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block,
+			.block-editor-block-list__layout .block-editor-block-list__block,
 			.editor-default-block-appender .editor-default-block-appender__content
 			{
 				font-family: $font_body;
@@ -343,7 +343,7 @@ function newspack_custom_typography_css() {
 
 		if ( newspack_is_active_style_pack( 'style-5' ) ) {
 			$editor_css_blocks .= "
-			.editor-block-list__layout .editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type='core/pullquote'] .wp-block-pullquote__citation {
 				font-family: $font_body;
 			}";
 		}
@@ -360,8 +360,8 @@ function newspack_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
-			.cat-links {
-			.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+			.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
+			.block-editor-block-list__layout .block-editor-block-list__block #jp-relatedposts h3.jp-relatedposts-headline {
 				text-transform: uppercase;
 			}
 		';
@@ -374,8 +374,8 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.accent-header,
-				.article-section-title {
+				.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+				.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 					text-transform: uppercase;
 				}
 			';
@@ -393,8 +393,8 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.editor-block-list__layout .editor-block-list__block .accent-header,
-				.editor-block-list__layout .editor-block-list__block .article-section-title {
+				.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+				.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 					text-transform: uppercase;
 				}
 			';
@@ -418,10 +418,10 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.editor-block-list__layout .editor-block-list__block .accent-header,
-				.editor-block-list__layout .editor-block-list__block .article-section-title,
-				.editor-block-list__layout .editor-block-list__block .entry-meta .byline a,
-				.editor-block-list__layout .editor-block-list__block .cat-links {
+				.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+				.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
+				.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
+				.block-editor-block-list__layout .block-editor-block-list__block .cat-links {
 					letter-spacing: 0.05em;
 					text-transform: uppercase;
 				}
@@ -442,10 +442,10 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.editor-block-list__layout .editor-block-list__block .accent-header,
-				.editor-block-list__layout .editor-block-list__block .article-section-title,
-				.editor-block-list__layout .editor-block-list__block .entry-meta .byline a,
-				.editor-block-list__layout .editor-block-list__block .entry-meta .entry-date {
+				.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+				.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
+				.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
+				.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .entry-date {
 					text-transform: uppercase;
 				}
 			';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As of Gutenberg 7.2, the legacy classes `.editor-block-list__layout` and `.editor-block-list__block` [were removed from the editor](https://github.com/WordPress/gutenberg/pull/19050).

These are currently used in the editor for the custom colours and typography; this PR updates them to their replacement classes `.block-editor-block-list__layout` and `.block-editor-block-list__block`

### How to test the changes in this Pull Request:

1. Verify that you're running Gutenberg 7.2.
2. Under the Customizer, apply custom colours and fonts.
3. View a few posts/pages in the editor; note that the colours/fonts are not being applied.
4. Apply the PR.
5. Confirm that your custom colours/fonts are now being applied. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
