### PR TITLE
Group Block: Sit right under header on home page

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -976,6 +976,13 @@
 	}
 }
 
+.newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child {
+	margin-top: 0;
+	@include media( tablet ) {
+		margin-top: calc( #{ -0.5 * $size__spacing-unit } - 1px ); // minus 1px to offset bottom border on header
+	}
+}
+
 .entry-content .has-text-color a,
 .entry-content .has-text-color a:hover,
 .entry-content .has-text-color a:visited {

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -21,7 +21,6 @@
 
 .site-content {
 	min-height: 30vh;
-	overflow: hidden;
 }
 
 .site-content {

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -126,7 +126,7 @@ body:not(.h-sb) .site-header { // Not Header solid background
 	margin-top: #{ -1 * $size__spacing-unit };
 
 	@include media( tablet ) {
-		margin-top: calc( #{ -1 * $size__spacing-unit } - 4px );
+		margin-top: calc( #{ -1 * $size__spacing-unit } - 4px );  // minus 4px to offset bottom border on header
 	}
 }
 

--- a/newspack-theme/sass/styles/style-2/style-2.scss
+++ b/newspack-theme/sass/styles/style-2/style-2.scss
@@ -122,6 +122,14 @@ body:not(.h-sb) .site-header { // Not Header solid background
 	}
 }
 
+.newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child {
+	margin-top: #{ -1 * $size__spacing-unit };
+
+	@include media( tablet ) {
+		margin-top: calc( #{ -1 * $size__spacing-unit } - 4px );
+	}
+}
+
 .single-featured-image-behind {
 	#primary {
 		padding-top: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes it so on the static front page, if you hide the page title, if you add a full-width group block as the first thing on the page, it will sit right below the header. This is to help recreate similar layouts to some of our cohort's live sites. 

When using Style 2, this group block will cover the 'overlap' style, similar to how the 'behind'/'beside' featured image styles are handled. I'm open to approaching this in another way, if anyone thinks this could be handled better!

Lastly, this PR also removes the `overflow: hidden` from the `.site-content` class, to allow the group block to be bumped up. This style was in place to make sure that full-width blocks didn't cause side scrolling. It's also on the `#page` element, though, and having it there alone prevents this issue, so it isn't needed on `.site-content`. 

Closes #688.

### How to test the changes in this Pull Request:

1. On your test site, if it's not already set up this way, set a static page as the homepage and hide the title using the controls under Customizer > Homepage Settings.
2. Edit the homepage, and add a Group block as the first thing. Make it full-width, and give it a background colour so it's easier to see.
3. Save and publish; view on the front page -- note the gap:

![image](https://user-images.githubusercontent.com/177561/72196893-693c6000-33d0-11ea-882b-0dd8a88799bd.png)

4. Apply the PR and run `npm run build`
5. View the homepage again; confirm the group block sits immediately under the header, with no gap; resize the window and confirm it stays that way:

![image](https://user-images.githubusercontent.com/177561/72196911-a9034780-33d0-11ea-8d9b-cf5e69e6f8a3.png)

![image](https://user-images.githubusercontent.com/177561/72196917-af91bf00-33d0-11ea-831e-6011e21ce9b7.png)

6. Navigate to Customizer > Header Settings, and test group styles with the short header setting:

![image](https://user-images.githubusercontent.com/177561/72196948-e667d500-33d0-11ea-9d38-bf943a533e01.png)

7. Navigate to Customizer > Style Packs, and switch to Style 2.
8. Confirm that on desktop-sized screens, the group block covers the 'overlap' style, including the wide border at the top of the content. On mobile-sized screens, the group block should sit immediately below the 2px border:

![image](https://user-images.githubusercontent.com/177561/72196958-fbdcff00-33d0-11ea-83cc-2df20409d654.png)

![image](https://user-images.githubusercontent.com/177561/72196963-026b7680-33d1-11ea-907f-c24c4d771ec3.png)

9. Edit the homepage again; test a narrower group block at the top, and confirm the gap returns:

![image](https://user-images.githubusercontent.com/177561/72197019-963d4280-33d1-11ea-8993-cf35bc89845e.png)

10. Try other blocks at the top of the homepage, and confirm they sit the standard distance from the header:

![image](https://user-images.githubusercontent.com/177561/72197035-c5ec4a80-33d1-11ea-91fe-91704ae6537e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
