### PR TITLE
Bump version number

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.25
+Version: 1.0.0-alpha.26
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-theme/sass/style.scss
+++ b/newspack-theme/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.25
+Version: 1.0.0-alpha.26
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the version number of the Newspack Theme and Newspack Sacha child theme for release.

### How to test the changes in this Pull Request:

1. Apply PR.
2. Confirm version numbers for both themes have been bumped to `1.0.0-alpha.26`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
