### PR TITLE
Default Style: Make 'Tertiary menu' styles more consistent across header settings

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -199,10 +199,17 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '
+			.nav3 a {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -20 ) . ';
+				color: ' . $primary_color_contrast . ';
+			}
+			.h-sb .site-header .nav3 .menu-highlight a {
+				background-color: ' . $secondary_color . ';
+				color: ' . $secondary_color_contrast . ';
+			}
 			.cat-links a,
 			.cat-links a:visited,
-			/* Header default background; default height */
-			body.h-db.h-dh .site-header .nav3 .menu-highlight a {
+			.site-header .nav3 .menu-highlight a {
 				background-color: ' . $primary_color . ';
 				color: ' . $primary_color_contrast . ';
 			}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -199,7 +199,13 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '
-			.h-sb .nav3 a {
+			.mobile-sidebar .nav3 a {
+				background: transparent;
+			}
+			.mobile-sidebar .nav3 .menu-highlight a {
+				background: ' . newspack_adjust_brightness( $primary_color, -20 ) . ';
+			}
+			.h-sb .site-header .nav3 a {
 				background-color: ' . newspack_adjust_brightness( $primary_color, -17 ) . ';
 				color: ' . $primary_color_contrast . ';
 			}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -199,8 +199,8 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '
-			.nav3 a {
-				background-color: ' . newspack_adjust_brightness( $primary_color, -20 ) . ';
+			.h-sb .nav3 a {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -17 ) . ';
 				color: ' . $primary_color_contrast . ';
 			}
 			.h-sb .site-header .nav3 .menu-highlight a {

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -24,25 +24,36 @@
 		font-size: $font__size-sm;
 		font-weight: 700;
 		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+	}
 
+	.menu-highlight a {
+		background-color: $color__primary;
+		border: 0;
+		color: #fff;
+	}
+}
+
+.h-sb .nav3 {
+	a {
+		background-color: darken($color__primary, 10%);
+		color: #fff;
+	}
+
+	.menu-highlight a {
+		background-color: $color__secondary;
+	}
+}
+
+.nav3,
+.h-sb .nav3 {
+	li a,
+	li.menu-highlight a {
 		&:hover,
 		&:focus {
 			background-color: $color__text-main;
 			color: #fff;
 			opacity: 1.0;
 		}
-	}
-
-	.menu-highlight a {
-		border: 0;
-	}
-}
-
-body.h-sb .nav3 .menu-highlight a {
-	&:hover,
-	&:focus {
-		background-color: $color__text-main;
-		color: #fff;
 	}
 }
 

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -15,29 +15,37 @@
 
 /* Navigation */
 
-// Header default background; header default height
-body.h-db.h-dh {
-	.site-header {
-		.nav3 {
-			a {
-				background-color: lighten($color__text-light, 45%);
-				color: $color__text-main;
-				@include button-transition;
-				border-radius: 5px;
-				font-size: $font__size-sm;
-				font-weight: 700;
-				padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+.nav3 {
+	a {
+		background-color: lighten($color__text-light, 45%);
+		color: $color__text-main;
+		@include button-transition;
+		border-radius: 5px;
+		font-size: $font__size-sm;
+		font-weight: 700;
+		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
 
-				&:hover,
-				&:focus {
-					background-color: $color__text-main;
-					color: #fff;
-					opacity: 1.0;
-				}
-			}
+		&:hover,
+		&:focus {
+			background-color: $color__text-main;
+			color: #fff;
+			opacity: 1.0;
 		}
 	}
+
+	.menu-highlight a {
+		border: 0;
+	}
 }
+
+body.h-sb .nav3 .menu-highlight a {
+	&:hover,
+	&:focus {
+		background-color: $color__text-main;
+		color: #fff;
+	}
+}
+
 
 /* Posts and pages */
 

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -57,6 +57,17 @@
 	}
 }
 
+.mobile-sidebar .nav3 {
+	a {
+		background: transparent;
+		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
+	}
+
+	.menu-highlight a {
+		background-color: darken($color__primary, 10%);
+	}
+}
+
 
 /* Posts and pages */
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now if you change the Header Settings (eg. setting a solid background) while using the Default Style pack, the tertiary menu's appearance changes, and it's a bit confusing: You lose the button-like styles, and font weights -- for example:

![image](https://user-images.githubusercontent.com/177561/72283644-075c4000-35f4-11ea-842b-ed04758d3471.png)

This PR updates these styles so they're consistent across all header styles. It also makes the menu item using the `menu-highlight` class use the secondary colour when using the solid-background option. 

(This second bit may make sense to roll out to the other style packs; would be interested in feedback on that option, as it won't affect live sites). 

Edited to add: I've update the PR to take mobile styles into account. The button styles aren't applied exactly the same there, to try to keep things simple: the 'default' style in the mobile menu is a plain link, and links with the class `menu-highlight` have a darker version of the primary colour (which is always used as the background of the mobile menu). It's not as prominent as it appears on the desktop version, but seems less likely to be very clash-y, since it would otherwise always be the secondary colour against the primary colour, which may not sit side by side nicely.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Style Packs, and pick the default style pack.
3. Navigate to Customizer > Menus, and add a menu to the 'tertiary' location; add at least two menu items and give on the class `menu-highlight`.
4. View on the front-end, and confirm you have something like:

**Default colours:**

![image](https://user-images.githubusercontent.com/177561/72281902-5902cb80-35f0-11ea-9cbb-85db24c98690.png)

![image](https://user-images.githubusercontent.com/177561/72302482-02f94c80-361f-11ea-8d19-d76b723fbba0.png)

**Custom colours:**

![image](https://user-images.githubusercontent.com/177561/72282110-d3335000-35f0-11ea-8db4-bf1c5bee7005.png)

![image](https://user-images.githubusercontent.com/177561/72302528-2f14cd80-361f-11ea-9935-021f7c1231d4.png)

5. Navigate to Customizer > Header Settings and switch to 'Solid Background'. The 'default' tertiary menu links should still have a slight background, a darker shade of the header; the menu item with the `menu-highlight` class should use your secondary colour:

**Default colours:**

![image](https://user-images.githubusercontent.com/177561/72282367-5ce31d80-35f1-11ea-9010-1d2d3c2ca107.png)

**Custom colours:**

![image](https://user-images.githubusercontent.com/177561/72282171-f1994b80-35f0-11ea-8363-55aa3a191e51.png)

![image](https://user-images.githubusercontent.com/177561/72302577-5b304e80-361f-11ea-8e83-4a2bfa9acd30.png)

![image](https://user-images.githubusercontent.com/177561/72282787-45586480-35f2-11ea-9577-fdd25d0534aa.png)

![image](https://user-images.githubusercontent.com/177561/72302607-7602c300-361f-11ea-88ca-76c778b1d474.png)

6. Navigate to Customizer > Header Settings; uncheck 'solid background' and check 'short header' (another case where the button style was not being applied):

**Default colours:**

![image](https://user-images.githubusercontent.com/177561/72283103-f3640e80-35f2-11ea-9dbf-2b5f61c5d8de.png)

**Custom colours:**

![image](https://user-images.githubusercontent.com/177561/72283057-d2032280-35f2-11ea-9675-fde6a0a7564c.png)

![image](https://user-images.githubusercontent.com/177561/72283078-e21b0200-35f2-11ea-87f8-f17bd72e791b.png)

7. Navigate back to Customizer > Header Settings, and also check 'Solid Background' again; you should have something like:

**Default colours:** 

![image](https://user-images.githubusercontent.com/177561/72283284-4a69e380-35f3-11ea-9b63-b5484864516a.png)

**Custom colours:**

![image](https://user-images.githubusercontent.com/177561/72283312-59509600-35f3-11ea-95d9-b6bb0a4adb05.png)

![image](https://user-images.githubusercontent.com/177561/72283369-7be2af00-35f3-11ea-908a-6e59e4922b05.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
