### PR TITLE
Newspack Sacha: Correct child theme text domain

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -9,7 +9,7 @@ Version: 1.0.0-alpha.26
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme
-Text Domain: newspack-style-4
+Text Domain: newspack-sacha
 Tags:
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In a similar vein as #690, this PR corrects the text domain set in the Newspack Sacha styles. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that the text domain in the generated style.css is correctly `newspack-sacha` and not `newspack-style-4`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
