### PR TITLE
Default Style: Improve tertiary nav padding

### DIFF
--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -32,6 +32,7 @@
 		background-color: $color__primary;
 		border: 0;
 		color: #fff;
+		padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This one's a tiny one:

With the Default Style pack, if you add links to the tertiary menu, links with the `menu-highlight` class have less left/right padding than links without. 

### How to test the changes in this Pull Request:

1. Navigate to Customize > Style Packs, and pick Default Style.
2. Navigate to Customize > Menus, and add a menu with at least two links to the Tertiary Menu space. Add the class `menu-highlight` to one of the links.
3. Compare the padding on each link on the front end -- the link with the `menu-highlight` class has less padding on the right and left:

![image](https://user-images.githubusercontent.com/177561/72398533-188e7500-36f8-11ea-8445-e9de904627aa.png)

4. Apply the PR and run `npm run build`.
5. View on the front-end again; confirm that the padding is the same now:

![image](https://user-images.githubusercontent.com/177561/72398506-07456880-36f8-11ea-9a6b-6047728ff327.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
