### PR TITLE
Copy Theme Settings When Switching

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -539,6 +539,27 @@ function newspack_register_meta() {
 }
 add_action( 'init', 'newspack_register_meta' );
 
+
+/**
+ * Migrate theme settings when switching within the family of Newspack themes.
+ *
+ * @since Newspack Theme 1.0.0
+ */
+function newspack_migrate_settings( $old_name, $old_theme = false ) {
+	$theme           = wp_get_theme();
+	$old_stylesheet  = is_a( $old_theme, 'WP_Theme' ) ? $old_theme->get_stylesheet() : null;
+	$new_stylesheet  = $theme->get_stylesheet();
+	$newspack_prefix = 'newspack-';
+
+	if ( 0 === strrpos( $old_stylesheet, $newspack_prefix ) && 0 === strrpos( $new_stylesheet, $newspack_prefix ) ) {
+		$mods = get_option( 'theme_mods_' . $old_stylesheet, null );
+		if ( $mods ) {
+			update_option( 'theme_mods_' . $new_stylesheet, $mods );
+		}
+	}
+}
+add_action( 'after_switch_theme', 'newspack_migrate_settings', 10, 2 );
+
 /**
  * Display custom color CSS in customizer and on frontend.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

One problematic aspect of the switch from Style Packs to Child Themes is that most theme settings are lost when switching between two themes in the Newspack family. Most theme settings would be expected to persist, such as colors, typography, Author Bio settings, and Featured Image Settings. This branch is an attempt to solve this by copying over all theme mods when switching from one Newspack theme to another. Whenever a theme switch occurs, if the theme slug (or stylesheet) begins with `newspack-` then the settings will be duplicated from old to new.

### How to test the changes in this Pull Request:

1. On `master`, Install the Newspack Theme, and set up a complicated configuration in the customizer. 
2. Switch to Newspack Sacha. Verify the theme settings are  lost. 
3. Switch back to Newspack Theme and you should see all the settings from before.
4. Switch to this branch, then switch themes again to Newspack Sacha. This time all the settings should  carry over. 
5. Verify that switching to non-Newspack themes does not cause anything strange to happen. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
