### PR TITLE
Fix: Add wp_body_open right after the opening body tag.

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -18,7 +18,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-
+<?php do_action( 'wp_body_open' ); ?>
 <?php do_action( 'before_header' ); ?>
 
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `do_action( 'wp_body_open' );` after the opening `<body>` tag. It's a new body hook as of WordPress 5.2, and is used by `amp-ads`, and likely other things going forward.

Closes #701.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Make sure I've added the `do_action` that I'm claiming to have added :) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
