### PR TITLE
Fix: handle post subtitle in Code editor mode

### DIFF
--- a/newspack-theme/js/src/post-subtitle/index.js
+++ b/newspack-theme/js/src/post-subtitle/index.js
@@ -19,11 +19,11 @@ import { appendSubtitleToTitleDOMElement, connectWithSelect } from './utils';
  *
  * https://developer.wordpress.org/block-editor/developers/slotfills/plugin-document-setting-panel/
  */
-const NewspackSubtitlePanel = ( { subtitle } ) => {
-	// Update the DOM when subtitle value changes
+const NewspackSubtitlePanel = ( { subtitle, mode } ) => {
+	// Update the DOM when subtitle value changes or editor mode is switched
 	useEffect( () => {
-		appendSubtitleToTitleDOMElement( subtitle );
-	}, [ subtitle ] );
+		appendSubtitleToTitleDOMElement( subtitle, mode === 'text' );
+	}, [ subtitle, mode ] );
 
 	return (
 		<PluginDocumentSettingPanel

--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -11,13 +11,18 @@ export const META_FIELD_NAME = 'newspack_post_subtitle';
  *
  * @param  {string} subtitle Subtitle text
  */
-export const appendSubtitleToTitleDOMElement = subtitle => {
+export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
 	const titleEl = document.querySelector( '.editor-post-title__block > div' );
 	if ( titleEl && typeof subtitle === 'string' ) {
 		let subtitleEl = document.getElementById( SUBTITLE_ID );
 		if ( ! subtitleEl ) {
 			subtitleEl = document.createElement( 'div' );
 			subtitleEl.id = SUBTITLE_ID;
+			// special style for the code (raw text) editor
+			if ( isInCodeEditor ) {
+				subtitleEl.style.paddingLeft = '14px';
+				subtitleEl.style.marginBottom = '4px';
+			}
 			titleEl.appendChild( subtitleEl );
 		}
 		subtitleEl.innerText = subtitle;
@@ -26,4 +31,5 @@ export const appendSubtitleToTitleDOMElement = subtitle => {
 
 export const connectWithSelect = withSelect( select => ( {
 	subtitle: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ META_FIELD_NAME ],
+	mode: select( 'core/edit-post' ).getEditorMode(),
 } ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Post subtitle disappeared from the editor on editor mode change. It's fixed with these changes.

Closes #697 .

### How to test the changes in this Pull Request:

1. Edit a post subtitle 
2. Switch between visual and code editor
3. Post subtitle should be shown in both modes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
