### PR TITLE
Fix: Hide author, publish date on pages in search results

### DIFF
--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -34,8 +34,9 @@
 		margin: 0;
 	}
 
+	.entry-title,
 	.entry-meta {
-		margin: #{$size__spacing-unit * 0.5} 0;
+		margin-bottom: #{$size__spacing-unit * 0.5};
 	}
 
 	@include media( tablet ) {

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -15,7 +15,7 @@
 
 	<div class="entry-container">
 		<?php
-		if ( ! is_page() && ! is_archive() ) :
+		if ( 'page' !== get_post_type() && ! is_archive() ) :
 			newspack_categories();
 		endif;
 		?>
@@ -23,7 +23,7 @@
 			<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 		</header><!-- .entry-header -->
 
-		<?php if ( ! is_page() ) : ?>
+		<?php if ( 'page' !== get_post_type() ) : ?>
 			<div class="entry-meta">
 				<?php newspack_posted_by(); ?>
 				<?php newspack_posted_on(); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Through testing something unrelated, I noticed the search results displayed the publish author and date for pages. They should really only show for posts. This PR fixes that.

Closes #705.

### How to test the changes in this Pull Request:

1. Run a search for a generic term where you would get both posts and pages (the easiest way to tell them apart is that posts will have a category, and pages will not).
2. View the results; note the pages are showing a date and author -- below, both Donate and Home are pages:

![image](https://user-images.githubusercontent.com/177561/72655954-e9bd0c80-394c-11ea-9dd5-4d8a2820a44a.png)

3. Apply the PR and run `npm run build`.
4. View the search results again and confirm that only posts are displaying the date/author. Also confirm that the spacing between elements appear similar for both posts and pages:

![image](https://user-images.githubusercontent.com/177561/72655936-cbefa780-394c-11ea-995f-42c0d3b0c02a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
