### PR TITLE
Fix: Correct missing italicized version of font in Newspack Scott

### DIFF
--- a/newspack-scott/functions.php
+++ b/newspack-scott/functions.php
@@ -39,7 +39,7 @@ function newspack_scott_fonts_url() {
 	$fira_sans_condensed = esc_html_x( 'on', 'Fira Sans Condensed font: on or off', 'newspack-scott' );
 	if ( 'off' !== $fira_sans_condensed ) {
 		$font_families   = array();
-		$font_families[] = 'Fira Sans Condensed:400,400i,600,600';
+		$font_families[] = 'Fira Sans Condensed:400,400i,600,600i';
 
 		$query_args = array(
 			'family'  => urlencode( implode( '|', $font_families ) ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed a small typo in Newspack Scott: the italicized, 600 weight version of the Fira Sans Condensed isn't being included, instead the plain 600 weight version is listed twice. This PR fixes that :)

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that the formats listed for Fira Sans Condensed now are `400, 400i, 600, 600i`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
