### PR TITLE
Bump version number

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.26
+Version: 1.0.0-alpha.27
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme
@@ -19,8 +19,8 @@ Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 */
 
-@import "variables-style/variables-style";
-@import "../../newspack-theme/sass/style-base";
+@import 'variables-style/variables-style';
+@import '../../newspack-theme/sass/style-base';
 
 // Header Overlap
 // Header - Solid background

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.26
+Version: 1.0.0-alpha.27
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.26
+Version: 1.0.0-alpha.27
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme
@@ -19,8 +19,8 @@ Normalizing styles have been helped along thanks to the fine work of
 Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 */
 
-@import "variables-style/variables-style";
-@import "../../newspack-theme/sass/style-base";
+@import 'variables-style/variables-style';
+@import '../../newspack-theme/sass/style-base';
 
 /* Style pack-specific overrides */
 

--- a/newspack-theme/sass/style.scss
+++ b/newspack-theme/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.26
+Version: 1.0.0-alpha.27
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the version number of the main Newspack theme, and all committed child themes.

It also replaces `"` with `'`" in both the Scott and Nelson child themes -- I'm not sure how these were successfully committed as is with the SCSS linting before, but they needed to be fixed to commit the version bump. If it'd be better to do that in a separate PR then version bump, let me know!

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that the style.scss file in Newspack Theme, Newspack Sacha, Newspack Scott and Newspack Nelson all have the version `1.0.0-alpha.27`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
