### PR TITLE
Bump version number

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.27
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.26
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.27
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.27
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.27
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Template: newspack-theme

--- a/newspack-theme/sass/style.scss
+++ b/newspack-theme/sass/style.scss
@@ -5,7 +5,7 @@ Author: Automattic
 Author URI: https://newspack.blog
 Description:
 Requires at least: WordPress 4.9.6
-Version: 1.0.0-alpha.27
+Version: 1.0.0-alpha.28
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: newspack


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the version number of the Newspack parent theme, and the five child themes, to `1.0.0-alpha.28`.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that each theme's style.scss file (six in all) is now version `1.0.0-alpha.28`.

Aside, it might be good to store that in a variable so we don't miss one 😬 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
