### PR TITLE
Fix: Correct issue in Katharine's colour code that was throwing errors

### DIFF
--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -19,7 +19,7 @@ function newspack_katharine_custom_colors_css() {
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
-	$theme_css .= '
+	$theme_css = '
 		.archive .page-title,
 		.entry-meta .byline a, .entry-meta .byline a:visited,
 		.entry .entry-content .entry-meta .byline a, .entry .entry-content .entry-meta .byline a:visited,
@@ -71,7 +71,7 @@ function newspack_katharine_custom_colors_css() {
 		}
 	';
 
-	$editor_css .= '
+	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue in Newspack Katharine's colour code that throwing PHP errors.

Closes #730.

### How to test the changes in this Pull Request:

1. Switch to the Newspack Katharine theme.
2. Add or edit a post; note the PHP error that shows while the post is loading.
3. Apply the PR.
4. Confirm that the error is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
