### PR TITLE
Fix: Remove duplicate border on posts with Sacha theme

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -263,11 +263,8 @@ cite {
 		}
 	}
 
-	&:not( .has-featured-image ),
-	&.has-large-featured-image {
-		.entry-header {
-			border-bottom: 0;
-		}
+	&:not( .has-large-featured-image ) .entry-header {
+		border-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In most of the themes, a border is added after the title when there is not a large featured image.

With Newspack Sacha, there's already a border under the entry meta, so this second border isn't needed, but it's showing up anyway when you have a small featured image. This PR fixes that :) 

### How to test the changes in this Pull Request:

1. Switch to Newspack Sacha.
2. View a single post with a small featured image -- note the double border:

![image](https://user-images.githubusercontent.com/177561/73096749-66467280-3e9a-11ea-93cf-f383d942de45.png)

3. Apply the PR and run `npm run build`.
4. View the post again, confirm the extra border is gone:

![image](https://user-images.githubusercontent.com/177561/73096791-7fe7ba00-3e9a-11ea-8940-6c567c53a23d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
