### PR TITLE
Make sure site title and site description are always aligned to the baseline

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -28,11 +28,17 @@
 	}
 }
 
+// Site identity
+.site-identity {
+	align-items: baseline;
+	display: flex;
+}
+
 // Site title
 .site-title {
 	color: $color__text-main;
 	font-weight: 700;
-	margin: 0 $size__spacing-unit -3px 0;
+	margin: 0;
 
 	a {
 		color: $color__text-main;
@@ -52,11 +58,11 @@
 .site-description {
 	color: $color__text-light;
 	display: none;
-	//flex: 1 1 auto;
 	font-weight: normal;
 	font-size: $font__size-sm;
 	font-style: italic;
-	margin: 7px 0 0;
+	margin: 0;
+	padding: 0 $size__spacing-unit;
 
 	@include media( mobile ) {
 		display: block;
@@ -182,11 +188,19 @@
 			flex-wrap: wrap;
 		}
 
+		.site-identity {
+			flex-direction: column;
+		}
+
 		.site-header .custom-logo-link,
 		.site-title,
 		.site-description {
 			text-align: center;
 			width: 100%;
+		}
+
+		.site-description {
+			padding-top: #{0.25 * $size__spacing-unit};
 		}
 
 		.site-header .custom-logo-link {

--- a/newspack-theme/template-parts/header/site-branding.php
+++ b/newspack-theme/template-parts/header/site-branding.php
@@ -10,21 +10,25 @@
 	<?php if ( has_custom_logo() ) : ?>
 		<?php the_custom_logo(); ?>
 	<?php endif; ?>
-	<?php $blog_info = get_bloginfo( 'name' ); ?>
-	<?php if ( ! empty( $blog_info ) ) : ?>
-		<?php if ( is_front_page() && is_home() ) : ?>
-			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-		<?php else : ?>
-			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-		<?php endif; ?>
-	<?php endif; ?>
 
-	<?php
-	$description = get_bloginfo( 'description', 'display' );
-	if ( $description || is_customize_preview() ) :
-		?>
-			<p class="site-description">
-				<?php echo $description; /* WPCS: xss ok. */ ?>
-			</p>
-	<?php endif; ?>
+	<div class="site-identity">
+		<?php $blog_info = get_bloginfo( 'name' ); ?>
+		<?php if ( ! empty( $blog_info ) ) : ?>
+			<?php if ( is_front_page() && is_home() ) : ?>
+				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+			<?php else : ?>
+				<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+			<?php endif; ?>
+		<?php endif; ?>
+
+		<?php
+		$description = get_bloginfo( 'description', 'display' );
+		if ( $description || is_customize_preview() ) :
+			?>
+				<p class="site-description">
+					<?php echo $description; /* WPCS: xss ok. */ ?>
+				</p>
+		<?php endif; ?>
+	</div><!-- .site-identity -->
+
 </div><!-- .site-branding -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently the site title and site description are not always properly aligned and it looks a bit odd.

This PR wraps the 2 in a div that is using flexbox to align them to the baseline. This way avoid using things like `margin: 7px 0 0;` to align the description.

_Note: this is mostly visible when using the "Short header" setting where `margin: 7px 0 0;` gets overwritten._

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/73287867-d8e48480-41f1-11ea-875c-87695b4bf55d.jpg)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/73287880-dda93880-41f1-11ea-8de2-a428459f257d.jpg)

### How to test the changes in this Pull Request:

1. Check the alignment of the site title + description
2. Switch to this branch
3. Recheck
4. Test every header options and every child themes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
