### PR TITLE
Fix: Update footer logo code, to fix non-cropping issue

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -222,10 +222,10 @@ function newspack_customize_register( $wp_customize ) {
 				'section'     => 'title_tagline',
 				'settings'    => 'newspack_footer_logo',
 				'priority'    => 9,
-				'flex_width'  => true,
+				'flex_width'  => false,
 				'flex_height' => true,
-				'width'       => 800,
-				'height'      => 400,
+				'width'       => 400,
+				'height'      => 300,
 			)
 		)
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I started noticing an issue with cropping the footer logo in the theme -- regardless what I set for the footer, the end result would always be cropped, losing parts of the logo image.

This PR updates the settings, and reduces the default size of the footer logo (since the original is pretty over the top for how large it can actually display). 

### How to test the changes in this Pull Request:

1. Try adding a horizontal-orientation logo file for the Footer Logo, under Customizer > Site Identity.
2. Click 'Skip cropping'
3. Check the logo, confirm it has cropped anyway.
4. Try adding the same logo file again; try adjusting the cropping to fit the whole logo image and click 'Crop'.
5. Check the logo, confirm it has cropped, but not as expected.
6. Apply the PR.
7. Repeat steps 4 and 5; you won't have an option not to crop, so adjust the size of the cropping to fit the whole logo; click 'Crop'.
8. Check the logo; confirm it has actually cropped. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
