### PR TITLE
Fix: Correct JavaScript translation file path for new parent/child theme setup

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -355,11 +355,11 @@ add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
  */
 function newspack_enqueue_scripts() {
 	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks', 'wp-components' ), wp_get_theme()->get( 'Version' ) );
-	wp_set_script_translations( 'newspack-extend-featured-image-script', 'newspack', get_stylesheet_directory() . '/languages' );
+	wp_set_script_translations( 'newspack-extend-featured-image-script', 'newspack', get_parent_theme_file_path( '/languages' ) );
 
 	if ( 'post' === get_current_screen()->post_type ) {
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
-		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', get_stylesheet_directory() . '/languages' );
+		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', get_parent_theme_file_path( '/languages' ) );
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Since we've switched to the parent/child theme structure, the JavaScript translations -- used in the editor -- have not been loading, because the file path hasn't been correct. This PR fixes that.

### How to test the changes in this Pull Request:

1. Start on the Newspack parent theme.
2. Navigate to Settings > General and switch the language to Spanish.
3. Edit a post; view the featured image settings and confirm that labels for the 'Large' and 'Small' image options are translated:

![image](https://user-images.githubusercontent.com/177561/73407905-60dc9400-42af-11ea-97b0-a51e2b83fb49.png)

4. Switch to one of the child themes.
5. Refresh the post editor; note you've lost your translated labels:

![image](https://user-images.githubusercontent.com/177561/73407977-8e294200-42af-11ea-88e4-d896c22ba04f.png)

6. Apply the PR.
7. Refresh the post editor again; confirm the translated labels are back:

![image](https://user-images.githubusercontent.com/177561/73408049-ca5ca280-42af-11ea-9a10-1f7b47bebf57.png)

8. Switch back to the parent theme.
9. Refresh the post editor one more time and confirm the translations are still there. 

![image](https://user-images.githubusercontent.com/177561/73408100-ef511580-42af-11ea-8419-063b796d3a1b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
