### PR TITLE
Fix: Make sure correct colour is used for the category + Sacha theme

### DIFF
--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -21,6 +21,7 @@ function newspack_sacha_custom_colors_css() {
 
 	$theme_css = '
 		.archive .page-title,
+		.h-sb .featured-image-beside .cat-links,
 		.entry-meta .byline a, .entry-meta .byline a:visited,
 		.entry .entry-content .entry-meta .byline a, .entry .entry-content .entry-meta .byline a:visited,
 		.entry .entry-meta a:hover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue with the custom colour not being used when you have the Sacha theme, a solid header, and the beside-title featured image style.

This issue does not happen in the parent theme + style 4, likely due to the order that the styles are added in the header. 

Closes #739.

### How to test the changes in this Pull Request:

1. Switch to the Newspack Sacha theme.
2. Navigate to Customize > Colours, and pick a custom colours.
3. Navigate to Header Settings, and pick 'solid background.
4. Add or edit a post, and add a featured image and set it to use the 'Beside article title' setting.
5. View on the front-end; note that the category header is using Newspack blue, not your custom colour: 

![image](https://user-images.githubusercontent.com/177561/73498335-e759aa00-4371-11ea-8ef2-53f8ed3f6060.png)

6. Apply the PR.
7. Confirm that the correct colour is now being used:

![image](https://user-images.githubusercontent.com/177561/73498379-0c4e1d00-4372-11ea-9f8e-4f051f2c579d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
