### PR TITLE
Katharine: Correct custom colour usage on accent headers in the editor

### DIFF
--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -72,8 +72,17 @@ function newspack_katharine_custom_colors_css() {
 	';
 
 	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
+		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
+		.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+		}
+
+		.block-editor-block-list__layout .block-editor-block-list__block .accent-header:before,
+		.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before,
+		.block-editor-block-list__layout .block-editor-block-list__block figcaption:after,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-caption-text:after {
+			background-color: ' . esc_html( $primary_color ) . ';
 		}
 	';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some missing colour code to the Katharine child theme; it was used to make sure the Homepage Posts block's header and the accent header class use the primary custom colour in the editor.

Closes #740.

### How to test the changes in this Pull Request:

1. Switch to Newspack Kathraine.
2. Navigate to the Customizer and pick a custom colour.
3. Copy-paste the following test content into the editor: https://cloudup.com/cZrxbCUo4D5
4. View in the editor and on the front end. On the front-end, you'll see your custom colour, but in the editor it will still be Newspack blue:

![image](https://user-images.githubusercontent.com/177561/73503076-fb0c0d00-437f-11ea-9c71-f29fdbbbfb25.png)

5. Apply the PR.
6. Check the editor again and confirm that the titles are now using your custom colours:

![image](https://user-images.githubusercontent.com/177561/73503156-4f16f180-4380-11ea-891a-662df147ce8c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
