### PR TITLE
Fix AMP compatibility with Coral comments

### DIFF
--- a/newspack-theme/front-page.php
+++ b/newspack-theme/front-page.php
@@ -28,7 +28,7 @@ get_header();
 
 				// If comments are open or we have at least one comment, load up the comment template.
 				if ( comments_open() || get_comments_number() ) {
-					comments_template();
+					newspack_comments_template();
 				}
 
 			endwhile; // End of the loop.

--- a/newspack-theme/image.php
+++ b/newspack-theme/image.php
@@ -84,7 +84,7 @@ get_header();
 
 				// If comments are open or we have at least one comment, load up the comment template.
 				if ( comments_open() || get_comments_number() ) {
-					comments_template();
+					newspack_comments_template();
 				}
 
 				// End the loop.

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -290,6 +290,21 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'newspack_comments_template' ) ) {
+
+	/**
+	 * Output the comment template.
+	 */
+	function newspack_comments_template() {
+		// Add Coral AMP compatibility because they integrated with AMP for WP plugin instead of the official AMP plugin.
+		if ( newspack_is_amp() && function_exists( 'coral_talk_comments_amp_template' ) ) {
+			coral_talk_comments_amp_template();
+		} else {
+			comments_template();
+		}
+	}
+}
+
 if ( ! function_exists( 'newspack_the_posts_navigation' ) ) :
 	/**
 	 * Documentation for function.

--- a/newspack-theme/page.php
+++ b/newspack-theme/page.php
@@ -32,7 +32,7 @@ get_header();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
-						comments_template();
+						newspack_comments_template();
 					}
 					?>
 				</div><!-- .main-content -->

--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -48,7 +48,7 @@ get_header();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
-						comments_template();
+						newspack_comments_template();
 					}
 					?>
 				</div>

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -48,7 +48,7 @@ get_header();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
-						comments_template();
+						newspack_comments_template();
 					}
 					?>
 				</div>

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -45,7 +45,7 @@ get_header();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
-						comments_template();
+						newspack_comments_template();
 					}
 
 					?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR integrates Coral comments with the official AMP plugin. The Coral WP plugin integrated with AMP for WP instead of the official AMP plugin, so it wasn't properly handling AMP pages. This means that we'll need to manually integrate. Luckily it's pretty straightforward.


### How to test the changes in this Pull Request:

1. Have I missed anything or made incorrect assumptions? Is the logic in `newspack_comments_template` too ugly? :)
2. I'll set this up on Rivard's staging site for testing, since you need a Coral connection to test. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
