### PR TITLE
Only output AMP toolbar attributes for the mobile menu when the menu space exists

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -354,8 +354,15 @@ function newspack_secondary_menu() {
 	if ( ! has_nav_menu( 'secondary-menu' ) ) {
 		return;
 	}
+
+	// Only set the AMP toolbar attributes if the secondary menu container exists in the header.
+	$toolbar_attributes = '';
+	if ( false === get_theme_mod( 'header_simplified', false ) ) {
+		$toolbar_attributes = 'toolbar-target="secondary-nav-contain" toolbar="(min-width: 767px)"';
+	}
+
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="secondary-nav-contain" class="secondary-menu nav2" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>">
+	<nav class="secondary-menu nav2" aria-label="<?php esc_attr_e( 'Secondary Menu', 'newspack' ); ?>" <?php echo $toolbar_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
 		wp_nav_menu(
 			array(
@@ -417,8 +424,14 @@ function newspack_social_menu_header() {
 	if ( ! has_nav_menu( 'social' ) ) {
 		return;
 	}
+
+	// Only set a toolbar-target attributes if the social menu container exists in the header.
+	$toolbar_attributes = '';
+	if ( false === get_theme_mod( 'header_simplified', false ) ) {
+		$toolbar_attributes = 'toolbar="(min-width: 767px)" toolbar-target="social-nav-contain"';
+	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="social-nav-contain" class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>">
+	<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>" <?php echo $toolbar_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php newspack_social_menu_settings(); ?>
 	</nav><!-- .social-navigation -->
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In AMP's mobile menu code, we set a spot to output a copy of certain menus when displayed on desktop. 

For the Secondary and Social menus, they don't exist when the short-header is set, so AMP throws an error that it can't find them.

This PR only adds AMP's 'toobar' attributes (the code it uses to trigger copying over menus) when the short header is not enabled.

Closes #747 .

### How to test the changes in this Pull Request:

1. Using any theme, set a short header.
2. Make sure you have a social and secondary menus set.
3. Switch to AMP Standard mode.
4. View the console; note that you're getting errors about the toolbar, like:

![image](https://user-images.githubusercontent.com/177561/73798913-22405100-4769-11ea-8171-48179b77059b.png)

5. Apply the PR.
6. Confirm that the console errors are now gone.
7. Make sure the menus display in the mobile menu as expected.
8. Try 'turning off' the short header, and verify the menus display as expected on both desktop and mobile-sized screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
