### PR TITLE
Fix pre-commit hook

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,23 +8,17 @@
     "issues": "https://github.com/Automattic/newspack-theme/issues"
   },
   "require": {
-    "composer/installers": "~1.6"
+    "composer/installers": "~1.6",
+    "xwp/wp-dev-lib": "^1.5"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "brainmaestro/composer-git-hooks": "^2.6",
     "automattic/vipwpcs": "^2.0.0",
-    "xwp/wp-dev-lib": "^1.5.0",
     "wptrt/wpthemereview": "*",
     "phpstan/phpstan-shim": "^0.11.12",
     "szepeviktor/phpstan-wordpress": "^0.2.0"
   },
-  "repositories": [
-    {
-      "url": "git@github.com:adekbadek/wp-dev-lib.git",
-      "type": "git"
-    }
-  ],
   "scripts": {
     "phpcs-i": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -i",
     "lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
     "issues": "https://github.com/Automattic/newspack-theme/issues"
   },
   "require": {
-    "composer/installers": "~1.6",
-    "xwp/wp-dev-lib": "^1.5"
+    "composer/installers": "~1.6"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
@@ -17,7 +16,8 @@
     "automattic/vipwpcs": "^2.0.0",
     "wptrt/wpthemereview": "*",
     "phpstan/phpstan-shim": "^0.11.12",
-    "szepeviktor/phpstan-wordpress": "^0.2.0"
+    "szepeviktor/phpstan-wordpress": "^0.2.0",
+    "xwp/wp-dev-lib": "^1.5"
   },
   "scripts": {
     "phpcs-i": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -i",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,17 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "brainmaestro/composer-git-hooks": "^2.6",
     "automattic/vipwpcs": "^2.0.0",
-    "xwp/wp-dev-lib": "^1.4.0",
+    "xwp/wp-dev-lib": "^1.5.0",
     "wptrt/wpthemereview": "*",
     "phpstan/phpstan-shim": "^0.11.12",
     "szepeviktor/phpstan-wordpress": "^0.2.0"
   },
+  "repositories": [
+    {
+      "url": "git@github.com:adekbadek/wp-dev-lib.git",
+      "type": "git"
+    }
+  ],
   "scripts": {
     "phpcs-i": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs -i",
     "lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fdc481e6d19e88ff95c6ca4fa9306d3c",
+    "content-hash": "4f140c579eb1c507638534aef9dd5417",
     "packages": [
         {
             "name": "composer/installers",
@@ -1070,20 +1070,20 @@
         },
         {
             "name": "xwp/wp-dev-lib",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/xwp/wp-dev-lib.git",
-                "reference": "86cc5e69b072804c066d10e9008d1576e26aa3cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/86cc5e69b072804c066d10e9008d1576e26aa3cf",
-                "reference": "86cc5e69b072804c066d10e9008d1576e26aa3cf",
-                "shasum": ""
+                "url": "git@github.com:adekbadek/wp-dev-lib.git",
+                "reference": "0c5a18fbb47a83109ff493090b6f1cfb15bfdc09"
             },
             "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "test": [
+                    "find ./scripts -name *.php -print0 | xargs -0 -n1 -P8 php -l",
+                    "shellcheck **/*.sh || true",
+                    "shellcheck --format json **/*.sh | grep --quiet --invert-match '\"level\":\"error\"'"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -1102,9 +1102,13 @@
             "description": "Common code used during development of WordPress plugins and themes",
             "homepage": "https://github.com/xwp/wp-dev-lib",
             "keywords": [
-                "wordpress"
+                "WordPress"
             ],
-            "time": "2020-01-09T12:33:32+00:00"
+            "support": {
+                "issues": "https://github.com/xwp/wp-dev-lib/issues",
+                "source": "https://github.com/xwp/wp-dev-lib"
+            },
+            "time": "2020-01-17T09:26:20+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f140c579eb1c507638534aef9dd5417",
+    "content-hash": "2a558c469d22adf865a666ed9b8a5da7",
     "packages": [
         {
             "name": "composer/installers",
@@ -127,6 +127,54 @@
                 "zikula"
             ],
             "time": "2019-08-12T15:00:31+00:00"
+        },
+        {
+            "name": "xwp/wp-dev-lib",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xwp/wp-dev-lib.git",
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
+                "shasum": ""
+            },
+            "type": "library",
+            "scripts": {
+                "test": [
+                    "find ./scripts -name *.php -print0 | xargs -0 -n1 -P8 php -l",
+                    "shellcheck **/*.sh || true",
+                    "shellcheck --format json **/*.sh | grep --quiet --invert-match '\"level\":\"error\"'"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Weston Ruter",
+                    "email": "weston@xwp.co",
+                    "homepage": "https://weston.ruter.net"
+                },
+                {
+                    "name": "XWP",
+                    "email": "engage@xwp.co",
+                    "homepage": "https://xwp.co"
+                }
+            ],
+            "description": "Common code used during development of WordPress plugins and themes",
+            "homepage": "https://github.com/xwp/wp-dev-lib",
+            "keywords": [
+                "WordPress"
+            ],
+            "support": {
+                "issues": "https://github.com/xwp/wp-dev-lib/issues",
+                "source": "https://github.com/xwp/wp-dev-lib"
+            },
+            "time": "2020-01-17T09:26:20+00:00"
         }
     ],
     "packages-dev": [
@@ -1067,48 +1115,6 @@
                 "wordpress"
             ],
             "time": "2019-11-17T20:05:55+00:00"
-        },
-        {
-            "name": "xwp/wp-dev-lib",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:adekbadek/wp-dev-lib.git",
-                "reference": "0c5a18fbb47a83109ff493090b6f1cfb15bfdc09"
-            },
-            "type": "library",
-            "scripts": {
-                "test": [
-                    "find ./scripts -name *.php -print0 | xargs -0 -n1 -P8 php -l",
-                    "shellcheck **/*.sh || true",
-                    "shellcheck --format json **/*.sh | grep --quiet --invert-match '\"level\":\"error\"'"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Weston Ruter",
-                    "email": "weston@xwp.co",
-                    "homepage": "https://weston.ruter.net"
-                },
-                {
-                    "name": "XWP",
-                    "email": "engage@xwp.co",
-                    "homepage": "https://xwp.co"
-                }
-            ],
-            "description": "Common code used during development of WordPress plugins and themes",
-            "homepage": "https://github.com/xwp/wp-dev-lib",
-            "keywords": [
-                "WordPress"
-            ],
-            "support": {
-                "issues": "https://github.com/xwp/wp-dev-lib/issues",
-                "source": "https://github.com/xwp/wp-dev-lib"
-            },
-            "time": "2020-01-17T09:26:20+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a558c469d22adf865a666ed9b8a5da7",
+    "content-hash": "22d74d96360ca75a516c1f5f90180c52",
     "packages": [
         {
             "name": "composer/installers",
@@ -127,54 +127,6 @@
                 "zikula"
             ],
             "time": "2019-08-12T15:00:31+00:00"
-        },
-        {
-            "name": "xwp/wp-dev-lib",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/xwp/wp-dev-lib.git",
-                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
-                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
-                "shasum": ""
-            },
-            "type": "library",
-            "scripts": {
-                "test": [
-                    "find ./scripts -name *.php -print0 | xargs -0 -n1 -P8 php -l",
-                    "shellcheck **/*.sh || true",
-                    "shellcheck --format json **/*.sh | grep --quiet --invert-match '\"level\":\"error\"'"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Weston Ruter",
-                    "email": "weston@xwp.co",
-                    "homepage": "https://weston.ruter.net"
-                },
-                {
-                    "name": "XWP",
-                    "email": "engage@xwp.co",
-                    "homepage": "https://xwp.co"
-                }
-            ],
-            "description": "Common code used during development of WordPress plugins and themes",
-            "homepage": "https://github.com/xwp/wp-dev-lib",
-            "keywords": [
-                "WordPress"
-            ],
-            "support": {
-                "issues": "https://github.com/xwp/wp-dev-lib/issues",
-                "source": "https://github.com/xwp/wp-dev-lib"
-            },
-            "time": "2020-01-17T09:26:20+00:00"
         }
     ],
     "packages-dev": [
@@ -1115,6 +1067,54 @@
                 "wordpress"
             ],
             "time": "2019-11-17T20:05:55+00:00"
+        },
+        {
+            "name": "xwp/wp-dev-lib",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xwp/wp-dev-lib.git",
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
+                "reference": "3e3ced3fdc5c47bbb59cde2f693ce115f2865f82",
+                "shasum": ""
+            },
+            "type": "library",
+            "scripts": {
+                "test": [
+                    "find ./scripts -name *.php -print0 | xargs -0 -n1 -P8 php -l",
+                    "shellcheck **/*.sh || true",
+                    "shellcheck --format json **/*.sh | grep --quiet --invert-match '\"level\":\"error\"'"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Weston Ruter",
+                    "email": "weston@xwp.co",
+                    "homepage": "https://weston.ruter.net"
+                },
+                {
+                    "name": "XWP",
+                    "email": "engage@xwp.co",
+                    "homepage": "https://xwp.co"
+                }
+            ],
+            "description": "Common code used during development of WordPress plugins and themes",
+            "homepage": "https://github.com/xwp/wp-dev-lib",
+            "keywords": [
+                "WordPress"
+            ],
+            "support": {
+                "issues": "https://github.com/xwp/wp-dev-lib/issues",
+                "source": "https://github.com/xwp/wp-dev-lib"
+            },
+            "time": "2020-01-17T09:26:20+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the current official version of wp-dev-lib, `prettier`'s config is not handled in pre-commit hook script. This results in prettier's rules not applied when linting before commit.  
After xwp/wp-dev-lib#314 is merged and published, we can switch back to the official version.

### How to test the changes in this Pull Request:

1. (don't update git hooks yet)
1. add a line in a JS file which uses spaces instead of tabs for indentation
2. try to commit, it should pass 
3. now update the composer packages (`composer install`) and git hooks (`./vendor/brainmaestro/composer-git-hooks/cghooks update`)
1. repeat step 2.
1. try to commit, a warning with a linting message from prettier should be thrown 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
