### PR TITLE
Fixes author avatar sizing

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -19,20 +19,21 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 
 			if ( 'guest-author' === get_post_type( $author->ID ) ) {
 				if ( get_post_thumbnail_id( $author->ID ) ) {
-					$author_avatar = coauthors_get_avatar( $author, 80 );
+					$author_avatar = coauthors_get_avatar( $author, 160 );
 				} else {
 					// If there is no avatar, force it to return the current fallback image.
 					$author_avatar = get_avatar( ' ' );
 				}
 			} else {
-				$author_avatar = coauthors_get_avatar( $author, 80 );
+				$author_avatar = coauthors_get_avatar( $author, 160 );
 			}
+			$author_avatar = preg_replace('/(<img\b[^><]*)>/i', '$1 object-fit="cover">', $author_avatar);
 			?>
 
 			<div class="author-bio">
 				<div class="author-bio-text">
 					<div class="author-bio-header">
-						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
+						<?php echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>'; ?>
 
 						<div>
 							<h2 class="accent-header">
@@ -69,10 +70,10 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 	<div class="author-bio-text">
 		<div class="author-bio-header">
 			<?php
-				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
+				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 160, '', '', array( 'object-fit' => 'cover' ) );
 				if ( $author_avatar ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $author_avatar;
+					echo '<span class="author-avatar">' . $author_avatar . '</span>';
 				}
 			?>
 

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -100,7 +100,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 }
 
 /* Avatar */
-.avatar,
+.author-avatar,
 .entry-content .wpnbha .avatar {
 	border-radius: 0;
 }

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -101,6 +101,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 /* Avatar */
 .author-avatar,
+.comment .comment-author .avatar,
 .entry-content .wpnbha .avatar {
 	border-radius: 0;
 }

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -24,19 +24,19 @@ get_header();
 						if ( 'guest-author' === get_post_type( $queried->{ 'ID' } ) ) {
 							// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
 							if ( get_post_thumbnail_id( $queried->{ 'ID' } ) ) {
-								$author_avatar = coauthors_get_avatar( $queried, 120 );
+								$author_avatar = coauthors_get_avatar( $queried, 180 );
 							} else {
 								// If there is no avatar, force it to return the current fallback image.
 								$author_avatar = get_avatar( ' ' );
 							}
 						} else {
-							$author_avatar = coauthors_get_avatar( $queried, 120 );
+							$author_avatar = coauthors_get_avatar( $queried, 180 );
 						}
 						$author_avatar = preg_replace( '/(<img\b[^><]*)>/i', '$1 object-fit="cover">', $author_avatar );
 
 					} else {
 						$author_id     = get_query_var( 'author' );
-						$author_avatar = get_avatar( $author_id, 120, '', '', array( 'object-fit' => 'cover' ) );
+						$author_avatar = get_avatar( $author_id, 180, '', '', array( 'object-fit' => 'cover' ) );
 					}
 
 					if ( $author_avatar ) {

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -32,13 +32,15 @@ get_header();
 						} else {
 							$author_avatar = coauthors_get_avatar( $queried, 120 );
 						}
+						$author_avatar = preg_replace( '/(<img\b[^><]*)>/i', '$1 object-fit="cover">', $author_avatar );
+
 					} else {
 						$author_id     = get_query_var( 'author' );
-						$author_avatar = get_avatar( $author_id, 120 );
+						$author_avatar = get_avatar( $author_id, 120, '', '', array( 'object-fit' => 'cover' ) );
 					}
 
 					if ( $author_avatar ) {
-						echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
+						echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 					}
 				}
 			?>

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -65,6 +65,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_image_size( 'newspack-featured-image', 1200, 9999 );
 		add_image_size( 'newspack-archive-image', 800, 600, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999, true );
+		add_image_size( 'newspack-avatar', 200, 200, true );
 
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
@@ -658,13 +659,14 @@ function newspack_truncate_text( $content, $length, $after = '...' ) {
 function newspack_sanitize_avatars() {
 	$avatar_args = array(
 		'img' => array(
-			'class'  => true,
-			'src'    => true,
-			'alt'    => true,
-			'width'  => true,
-			'height' => true,
-			'data-*' => true,
-			'srcset' => true,
+			'class'      => true,
+			'src'        => true,
+			'alt'        => true,
+			'width'      => true,
+			'height'     => true,
+			'data-*'     => true,
+			'srcset'     => true,
+			'object-fit' => true,
 		),
 		'noscript' => array(),
 	);

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -65,7 +65,6 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_image_size( 'newspack-featured-image', 1200, 9999 );
 		add_image_size( 'newspack-archive-image', 800, 600, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999, true );
-		add_image_size( 'newspack-avatar', 200, 200, true );
 
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -78,6 +78,8 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 					$author_avatar = coauthors_get_avatar( $author, 80 );
 				}
 
+				$author_avatar = preg_replace( '/(<img\b[^><]*)>/i', '$1 object-fit="cover">', $author_avatar );
+
 				echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 			}
 			?>
@@ -113,7 +115,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 			printf(
 				/* translators: 1: Author avatar. 2: post author, only visible to screen readers. 3: author link. */
 				'<span class="author-avatar">%1$s</span><span class="byline"><span>%2$s</span> <span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',
-				get_avatar( get_the_author_meta( 'ID' ) ),
+				get_avatar( get_the_author_meta( 'ID' ), 96, '', '', array( 'object-fit' => 'cover' ) ),
 				esc_html__( 'by', 'newspack' ),
 				esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 				esc_html( get_the_author() )

--- a/newspack-theme/sass/media/_media.scss
+++ b/newspack-theme/sass/media/_media.scss
@@ -17,12 +17,24 @@ object {
 	display: inline-block;
 }
 
-.avatar {
+.author-avatar .avatar {
+	height: auto;
+	left: 50%;
+	min-height: 100%;
+	min-width: 100%;
+	position: absolute;
+	top: 50%;
+	transform: translate( -50%, -50% );
+	width: auto;
+	object-fit: cover;
+}
+
+.author-avatar {
 	border-radius: 100%;
-	display: block;
 	height: calc( 2.25 * #{$size__spacing-unit} );
-	min-height: inherit;
+	position: relative;
 	width: calc( 2.25 * #{$size__spacing-unit} );
+	overflow: hidden;
 }
 
 svg {

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -14,7 +14,7 @@
 		clear: both;
 	}
 
-	.author-avatar {
+	.entry-meta .author-avatar {
 		display: none;
 	}
 
@@ -89,7 +89,7 @@
 		display: flex;
 		justify-content: flex-start;
 
-		.avatar {
+		.author-avatar {
 			flex-shrink: 0;
 			height: 30px;
 			margin-right: $size__spacing-unit;
@@ -97,14 +97,14 @@
 		}
 
 		@include media( mobile ) {
-			.avatar {
+			.author-avatar {
 				height: 80px;
 				width: 80px;
 			}
 		}
 
 		@include media( tablet ) {
-			.avatar {
+			.author-avatar {
 				height: 120px;
 				width: 120px;
 			}

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -178,6 +178,7 @@
 
 	.comment-author {
 		.avatar {
+			border-radius: 100%;
 			float: left;
 			margin-right: $size__spacing-unit;
 			position: relative;

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -290,7 +290,7 @@ body.page {
 		}
 	}
 
-	.avatar {
+	.author-avatar {
 		height: #{1.75 * $size__spacing-unit};
 		width: #{1.75 * $size__spacing-unit};
 
@@ -362,7 +362,7 @@ body.page {
 	display: flex;
 	margin: calc( 2 * #{$size__spacing-unit} ) auto $size__spacing-unit;
 
-	.avatar {
+	.author-avatar {
 		height: 60px;
 		margin-right: $size__spacing-unit;
 		width: 60px;

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -291,12 +291,12 @@ body.page {
 	}
 
 	.author-avatar {
-		height: #{1.75 * $size__spacing-unit};
-		width: #{1.75 * $size__spacing-unit};
+		height: 36px;
+		width: 36px;
 
 		@include media( tablet ) {
-			height: #{2.25 * $size__spacing-unit};
-			width: #{2.25 * $size__spacing-unit};
+			height: 46px;
+			width: 46px;
 		}
 	}
 

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -19,20 +19,21 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 
 			if ( 'guest-author' === get_post_type( $author->ID ) ) {
 				if ( get_post_thumbnail_id( $author->ID ) ) {
-					$author_avatar = coauthors_get_avatar( $author, 80 );
+					$author_avatar = coauthors_get_avatar( $author, 160 );
 				} else {
 					// If there is no avatar, force it to return the current fallback image.
 					$author_avatar = get_avatar( ' ' );
 				}
 			} else {
-				$author_avatar = coauthors_get_avatar( $author, 80 );
+				$author_avatar = coauthors_get_avatar( $author, 160 );
 			}
+			$author_avatar = preg_replace( '/(<img\b[^><]*)>/i', '$1 object-fit="cover">', $author_avatar );
 			?>
 
 			<div class="author-bio">
 				<?php
 				if ( ! newspack_is_active_style_pack( 'style-4' ) && $author_avatar ) {
-					echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
+					echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 				}
 				?>
 
@@ -40,7 +41,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 					<div class="author-bio-header">
 						<?php
 						if ( newspack_is_active_style_pack( 'style-4' ) && $author_avatar ) {
-							echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
+							echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 						}
 						?>
 
@@ -78,10 +79,10 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 	<?php
 	if ( ! newspack_is_active_style_pack( 'style-4' ) ) {
-		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
+		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 160, '', '', array( 'object-fit' => 'cover' ) );
 		if ( $author_avatar ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $author_avatar;
+			echo '<span class="author-avatar">' . $author_avatar . '</span>';
 		}
 	}
 	?>
@@ -90,10 +91,10 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<div class="author-bio-header">
 			<?php
 			if ( newspack_is_active_style_pack( 'style-4' ) ) {
-				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
+				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 160, '', '', array( 'object-fit' => 'cover' ) );
 				if ( $author_avatar ) {
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $author_avatar;
+					echo '<span class="author-avatar">' . $author_avatar . '</span>';
 				}
 			}
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an avatar sizing issue that happens when you combine WP User Avatar, Jetpack's  site accelerations, and non-square avatars. This combination either causes edges of the image to show (AMP enabled), or cause the image to be stretched to fit (AMP disabled). 

As part of this PR I also increased the size of the images loaded, to improve their appearance when they were taller/wider, as well as corrected a directory name issue in Newspack Sacha, so that child theme's author-bio.php would actually be loaded. 

Note: I ended up using `preg_replace()` to add the `object-fit="cover"` to the coauthors plus avatars, as there isn't a proper way to add attributes like with `get_avatar()`, just classes. If there' as better way, please let me know!

Also, apologies in advance, this one is a bit of a pain to review!

Closes #752.

### How to test the changes in this Pull Request:

1. Start with a test site where you can enable Jetpack site acceleration. 
2. Under AMP settings, switch to 'transitional' for easier testing.
3. Using WP User Avatar, add a tall, skinny image as a user's profile image.
4. Using WP User Avatar, add a wide, short image as a user's profile image.
5. Assign those authors to a couple posts, include both to one post together as Co-Authors. 
6. View without AMP enabled - note how the avatars look -- the tall image will be a bit vertically smushed, and the wide image, a bit horizontally smushed:

![image](https://user-images.githubusercontent.com/177561/73889550-d357f180-4824-11ea-911a-a3bcec546e6f.png)

7. Enable AMP - note how you can now see the avatar edges:

![image](https://user-images.githubusercontent.com/177561/73889585-e7035800-4824-11ea-982f-6e27a991a14e.png)

8. Apply the PR and run `npm run build`.
9. Check the non-AMP version again and confirm the images look correct: 

![image](https://user-images.githubusercontent.com/177561/73889664-0ef2bb80-4825-11ea-89cd-9f845bc5b9cd.png)

10. Check again with AMP enabled: 

![image](https://user-images.githubusercontent.com/177561/73889673-174af680-4825-11ea-96f7-8d0defbeb59e.png)

11. Turn off Co-Authors plus, and check the single article byline with and without AMP enabled.
12. Switch focus to the author bio at the bottom of the post. Check it with Co-Authors Plus enabled, with and without AMP, and with Co-Authors Plus disabled, with and without AMP.
13. Switch to 'Newspack Sacha' and re-test the above again (the markup is a bit different for this child theme). 
14. Navigate to an author archive. Check it with Co-Authors Plus enabled, with and without AMP, and with Co-Authors Plus disabled, with and without AMP.
15. Check the comments and confirm they still have rounded avatars.
16. Switch to Newspack Scott, and confirm that avatars are square (not rounded).
17. Double-check that the regular avatars display correctly, with and without Co-Authors Plus; with and without WP User Avatar enabled, and with and without AMP. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
