### PR TITLE
Fix: Make Related Posts styles more consistent between formats

### DIFF
--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -209,9 +209,3 @@ hr {
 		}
 	}
 }
-
-// Jetpack Blocks
-.jp-relatedposts-i2 {
-	border-top: 1px dotted $color__text-main;
-	border-bottom: 1px dotted $color__text-main;
-}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -353,12 +353,6 @@ figcaption,
 	hr {
 		border-top: 1px dotted $color__text-main;
 	}
-
-	// Jetpack Blocks
-	.jp-relatedposts-i2 {
-		border-top: 1px dotted $color__text-main;
-		border-bottom: 1px dotted $color__text-main;
-	}
 }
 
 // Archives

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -114,9 +114,10 @@ function newspack_custom_typography_css() {
 		blockquote cite,
 
 		/* Jetpack */
-		.entry-content #jp-relatedposts h3.jp-relatedposts-headline,
-		.entry-content #jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post .jp-relatedposts-post-title a
-
+		.jp-relatedposts-i2,
+		#jp-relatedposts.jp-relatedposts,
+		.jp-relatedposts-i2 .jp-relatedposts-headline,
+		#jp-relatedposts.jp-relatedposts .jp-relatedposts-headline
 		{
 			font-family: $font_header;
 		}";
@@ -238,6 +239,8 @@ function newspack_custom_typography_css() {
 		/* Jetpack blocks */
 		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 a,
 		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 strong,
+		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 .jp-related-posts-i2__post-date,
+		.block-editor-block-list__layout .block-editor-block-list__block .jp-relatedposts-i2 .jp-related-posts-i2__post-context,
 
 		/* Classic Editor */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-caption dd,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -826,24 +826,6 @@
 		}
 	}
 
-	//! Jetpack Blocks
-	.jp-relatedposts-i2 {
-		border-top: 1px solid $color__border;
-		border-bottom: 1px solid $color__border;
-		padding: $size__spacing-unit 0;
-		a {
-			font-family: $font__heading;
-			font-size: $font__size-base;
-			font-weight: bold;
-			text-decoration: none;
-		}
-
-		.jp-related-posts-i2__post-date,
-		.jp-related-posts-i2__post-context {
-			font-size: $font__size-xs;
-		}
-	}
-
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -638,15 +638,45 @@ body.page {
 	}
 }
 
-.entry-content #jp-relatedposts {
-	h3.jp-relatedposts-headline {
-		font-family: $font__heading;
+/* Related Posts */
+
+.jp-relatedposts-i2 {
+	em {
+		font-style: normal;
+	}
+
+	a {
+		font: bold $font__size-base $font__heading;
+		text-decoration: none;
+	}
+
+	.jp-related-posts-i2__post-date,
+	.jp-related-posts-i2__post-context {
 		font-size: $font__size-xs;
+	}
+}
+
+.entry-content .jp-relatedposts-i2 a,
+.entry-content .jp-relatedposts-i2 a:visited {
+	color: $color__text-main;
+}
+
+.jp-related-posts-i2__row {
+	margin: 0 -10px;
+}
+
+.jp-relatedposts-i2,
+#jp-relatedposts.jp-relatedposts {
+	font-family: $font__heading;
+	.jp-relatedposts-headline {
+		font: bold $font__size-xs $font__heading;
 		em::before {
 			display: none;
 		}
 	}
+}
 
+#jp-relatedposts.jp-relatedposts {
 	.jp-relatedposts-items-visual .jp-relatedposts-post {
 		opacity: 1;
 
@@ -659,15 +689,17 @@ body.page {
 			margin-bottom: #{0.25 * $size__spacing-unit};
 			a {
 				color: $color__text-main;
-				font-family: $font__heading;
 				font-size: $font__size-base;
 				font-weight: bold;
 			}
 		}
 
-		.jp-relatedposts-post-context {
-			color: $color__text-light;
+		.jp-relatedposts-post-date,
+		.jp-relatedposts-post-content {
 			opacity: 1;
 		}
+	}
+	.jp-reltaedposts-post-title {
+		font-family: $font__heading;
 	}
 }

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -667,6 +667,7 @@ body.page {
 
 .jp-relatedposts-i2,
 #jp-relatedposts.jp-relatedposts {
+	clear: both;
 	font-family: $font__heading;
 	.jp-relatedposts-headline {
 		font: bold $font__size-xs $font__heading;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -669,9 +669,9 @@ ul.wp-block-archives,
 
 // Jetpack Blocks
 .jp-relatedposts-i2 {
-	border-top: 1px solid $color__border;
-	border-bottom: 1px solid $color__border;
-	padding: $size__spacing-unit 0;
+	a {
+		color: $color__text-main;
+	}
 	a,
 	strong {
 		font-family: $font__heading;
@@ -682,6 +682,7 @@ ul.wp-block-archives,
 
 	.jp-related-posts-i2__post-date,
 	.jp-related-posts-i2__post-context {
+		font-family: $font__heading;
 		font-size: $font__size-xs;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR improves visual consistency across the different Related Posts options (shortcode, block, and the one that appears in the theme), and the AMP and non-AMP versions (since the markup changes slightly between them).

As an added bonus, this update also consolidates the Related Posts block and not-block styles.

Closes #759 .

### How to test the changes in this Pull Request:

1. Start with a test site where you can enable Related Posts, and make sure they're displaying at the bottom of posts.
2. Apply the PR and run `npm run build`.
3. Select the default Newspack theme, with the default style pack.
4. Switch AMP to 'Transitional' mode, so it can be toggled on and off easier.
5. Edit a post and add a shortcode block with `[jetpack-related-posts]` in it, and a Related Posts block, then publish. 
6. Open three tabs: one with the editor for the above post, one for the front-end of the above post, and one for a second post that has the Related Posts at the bottom (I found in my testing when I added a Related Posts block/shortcode to a post's content, the one at the bottom of the content sometimes went away). 
7. Review each related post area with and without AMP enabled, and in the editor, for each of the child themes -- they should look roughly the same, and similar to the following screenshots:

**Newspack theme:**

Block:

![image](https://user-images.githubusercontent.com/177561/73973062-ba0f7d80-48d6-11ea-854f-dd309795345b.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73973070-bed43180-48d6-11ea-8581-0b9717a45bf0.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73973051-b4199c80-48d6-11ea-861e-05aeda8683db.png)

**Newspack Scott:**

Block:

![image](https://user-images.githubusercontent.com/177561/73973131-d6abb580-48d6-11ea-826a-759a5fa7de57.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73973137-dd3a2d00-48d6-11ea-9832-57cbcdeab4b3.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73973173-f17e2a00-48d6-11ea-801a-a9d9faf4d9d9.png)

**Newspack Nelson:**

Block:

![image](https://user-images.githubusercontent.com/177561/73973220-06f35400-48d7-11ea-961e-1b55160825c5.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73973234-0ce93500-48d7-11ea-8ffb-f9168d9b5134.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73973257-15da0680-48d7-11ea-8e35-765dd7ffac05.png)

**Newspack Katharine:**

Block:

![image](https://user-images.githubusercontent.com/177561/73973877-44a4ac80-48d8-11ea-9f34-805b1b4e795f.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73973884-4a01f700-48d8-11ea-8d90-2190ca9bd467.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73973901-538b5f00-48d8-11ea-9ec5-0077ca838724.png)

**Newspack Sacha:**

Block:

![image](https://user-images.githubusercontent.com/177561/73973925-60a84e00-48d8-11ea-96c4-22f953b90c6d.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73973947-6867f280-48d8-11ea-8491-8a2aa77042bf.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73973971-70c02d80-48d8-11ea-95eb-815970566710.png)

**Newspack Joseph:**

Block:

![image](https://user-images.githubusercontent.com/177561/73974047-83d2fd80-48d8-11ea-9c22-8f6c26e4ae65.png)

Shortcode:

![image](https://user-images.githubusercontent.com/177561/73974058-89c8de80-48d8-11ea-9fe6-98e78e0a344c.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/73974080-92211980-48d8-11ea-827e-0766659faea2.png)

8. Try changing the Header Font in the customizer; confirm that all the text in the related posts uses your new font:

![image](https://user-images.githubusercontent.com/177561/73974126-a7964380-48d8-11ea-9f12-5ad35f423a96.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
