### PR TITLE
Override Photon Avatar Downsizing

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -512,6 +512,26 @@ function newspack_front_page_template( $template ) {
 add_filter( 'frontpage_template', 'newspack_front_page_template' );
 
 /**
+ * Override Jetpack Image Accelerator (Photon) downsizing of avatars. If an image has a square aspect ratio and the width is between 1-120px, assume it is an avatar and block downsizing.
+ * https://developer.jetpack.com/hooks/jetpack_photon_override_image_downsize/
+ *
+ * @param boolean $default The default value, generally false.
+ * @param array   $args Array of image details.
+ *
+ * @return boolean Should Photon be stopped from downsizing.
+ */
+function newspack_override_avatar_downsizing( $default, $args ) {
+	if ( is_array( $args['size'] ) && 2 === count( $args['size'] ) ) {
+		list( $width, $height ) = $args['size'];
+		if ( $width === $height && $width <= 120 & $width > 0 ) {
+			return true;
+		}
+	}
+	return $default;
+}
+add_filter( 'jetpack_photon_override_image_downsize', 'newspack_override_avatar_downsizing', 10, 2 );
+
+/**
  * Register meta fields:
  * - Featured Image position option
  * - Article Subtitle


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Proposed alternative approach to https://github.com/Automattic/newspack-theme/pull/760. The `jetpack_photon_override_image_downsize` (https://developer.jetpack.com/hooks/jetpack_photon_override_image_downsize/) filter is used to block downsizing of avatars. The filter provides a size attribute. If the image has a square aspect ratio and the size is between 1-120px wide this assumes an avatar and blocks downsizing. This should resolve the issue in all settings (theme/blocks) without any further changes.

Question: could this lead to any false positives where images that should be downsized are not?

Closes https://github.com/Automattic/newspack-theme/issues/752.

### How to test the changes in this Pull Request:

- Follow the testing instructions in https://github.com/Automattic/newspack-theme/pull/760.
- Verify this works in all six Newspack themes.
- Verify this works with Jetpack Image Optimizer on and off.
- Verify this works with Jetpack disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
