### PR TITLE
Add classes for the category and tags to the primary `<section>`

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -167,6 +167,20 @@ function newspack_post_classes( $classes, $class, $post_id ) {
 add_filter( 'post_class', 'newspack_post_classes', 10, 3 );
 
 /**
+ * Gets the category and tag classes from the post.
+ */
+function newspack_get_category_tag_classes( $post_id ) {
+	$post_classes    = get_post_class( '', $post_id );
+	$cat_tag_classes = array();
+	foreach ( $post_classes as $post_class ) {
+		if ( 0 === strpos( $post_class, 'category-' ) || 0 === strpos( $post_class, 'tag-' ) ) {
+			$cat_tag_classes[] = $post_class;
+		}
+	}
+	return implode( ' ', $cat_tag_classes );
+}
+
+/**
  * Add a pingback url auto-discovery header for single posts, pages, or attachments.
  */
 function newspack_pingback_header() {

--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -13,7 +13,7 @@
 get_header();
 ?>
 
-	<section id="primary" class="content-area">
+	<section id="primary" class="content-area <?php echo esc_attr( newspack_get_category_tag_classes( get_the_ID() ) ); ?>">
 		<main id="main" class="site-main">
 
 			<?php

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -13,7 +13,7 @@
 get_header();
 ?>
 
-	<section id="primary" class="content-area">
+	<section id="primary" class="content-area <?php echo esc_attr( newspack_get_category_tag_classes( get_the_ID() ) ); ?>">
 		<main id="main" class="site-main">
 
 			<?php

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -10,7 +10,7 @@
 get_header();
 ?>
 
-	<section id="primary" class="content-area">
+	<section id="primary" class="content-area <?php echo esc_attr( newspack_get_category_tag_classes( get_the_ID() ) ); ?>">
 		<main id="main" class="site-main">
 
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a post's category and tag classes to the primary `<section>` tag of single posts. This lets us add styles for just posts in one category or tag. 

These are already on the `<article>` tag (along with some of WordPress's other standard classes), but the way I structured the single posts means the title is outside of the `<article>`. Ideally this will be refactored in the near future, but this will help for the near term.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. View a post with both tags and categories; confirm they're being added as classes to the `<section>` tag with the primary ID, prefaced with `category-` or `tag-` -- something like: 
`<section id="primary" class="content-area category-entertainment category-featured tag-testing-things tag-wondering">`
3. Test the same with the One Column template.
4. Test the same with the One Column Wide template.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
