### PR TITLE
Make sure highlight menu is using the correct colour for visited links

### DIFF
--- a/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
@@ -32,6 +32,11 @@
 		color: $color__primary;
 		font-weight: bold;
 	}
+
+	a,
+	a:visited {
+		color: $color__link;
+	}
 }
 
 // Header Center Logo


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you pair a 'highlight' menu with a solid background header with a dark colour, the visited links were appearing as white (on white!). This PR fixes that.

Closes: #769 

### How to test the changes in this Pull Request:

1. Start with any child theme but Newspack Nelson.
2. Set up a menu and add it to the 'highlight' menu location.
3. Pick a darker primary colour.
4. Set the header to use a solid background.
5. Click at least one of the links in the menu, then return to the page; note that the link is now 'invisible':

![image](https://user-images.githubusercontent.com/177561/74294849-005c4680-4cf4-11ea-88b5-3e5cfd65eb39.png)

6. Apply the PR and run `npm run build`.
7. Confirm that the links are all visible now:

![image](https://user-images.githubusercontent.com/177561/74294954-68129180-4cf4-11ea-8008-ddf7ff2f8297.png)

8. Try also switching to Newspack Nelson, and confirm the links are still white (correct in this case):

![image](https://user-images.githubusercontent.com/177561/74295028-a60fb580-4cf4-11ea-9a87-b409b211fae6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
