### PR TITLE
Fix: Correct link colours for the carousel block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -152,6 +152,12 @@
 	}
 }
 
+//! Newspack Carousel Block
+.wp-block-newspack-blocks-carousel h3 a,
+.wp-block-newspack-blocks-carousel h3 a:visited {
+	color: #fff;
+}
+
 //! Columns
 .wp-block-columns {
 	.wp-block-cover,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -172,6 +172,12 @@ figcaption,
 	}
 }
 
+/** === Newspack Carousel === */
+.wp-block-newspack-blocks-carousel h3 a,
+.wp-block-newspack-blocks-carousel h3 a:visited {
+	color: #fff;
+}
+
 /** === Table === */
 
 .wp-block-table {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The visited link styles are being a bit too aggressive, and overriding the Article Carousel block links. 

This PR fixes that by adding a style specifically for the block, but ultimately the link styles should be lightened up.

Closes https://github.com/Automattic/newspack-blocks/issues/369.

### How to test the changes in this Pull Request:

1. Add a carousel block to a page.
2. Click on a link; note that it turns black:

![image](https://user-images.githubusercontent.com/177561/74472303-8c867f00-4e56-11ea-93d6-48fa10925360.png)

3. Apply the PR and run `npm run build`.
4. Verify that the link is now the correct colour:

![image](https://user-images.githubusercontent.com/177561/74472366-a922b700-4e56-11ea-9d84-b63cee48a73c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
