### PR TITLE
Fix: Active menu toggle button colour

### DIFF
--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -7,6 +7,7 @@
 	&:hover,
 	&:focus {
 		background-color: transparent;
+		color: inherit;
 	}
 
 	.svg-icon {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you have the default header background colour, and toggle the menu toggle on and off, the menu toggle "disappers" because the focus colour is white. This PR makes sure the correct `:focus` styles are applied.


Closes #778.

### How to test the changes in this Pull Request:

1. Set the header to use the default background under Customizer > Header Settings.
2. Shrink down the browser window until the mobile menu appears. 
3. Toggle the menu opened and closed; note that the 'Menu' button is invisible when you close the mobile menu, until you focus on something else (like clicking on the body background). You should be able to see it on hover:

![image](https://user-images.githubusercontent.com/177561/74694294-7b19db80-51a4-11ea-8272-08f3668b24b0.png)

4. Apply the PR and run `npm run build`.
5. Repeat step 3 and confirm that the menu button is visible:

![image](https://user-images.githubusercontent.com/177561/74694329-97b61380-51a4-11ea-8538-965d24d11bb2.png)

6. Try switching to a solid header background and confim that the button is still visible when repeating step 3. (Note: I spotted some contrast issues with lighter coloured header backgrounds that I need to investigate further and address in a separate PR -- it's best to test this with a darker colour. Edited to add: it looks like this should be resolved once #698 is merged).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
