### PR TITLE
Hide widget titles from 'Above Copyright' widget areas.

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -266,7 +266,7 @@ function newspack_widgets_init() {
 			'description'   => __( 'Add widgets here to appear below the footer, above the copyright information.', 'newspack' ),
 			'before_widget' => '<section id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</section>',
-			'before_title'  => '<h2 class="widget-title">',
+			'before_title'  => '<h2 class="widget-title screen-reader-text">',
 			'after_title'   => '</h2>',
 		)
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the widget titles from the Above Copyright widget area. I'd originally left them visible, thinking if someone didn't want them to display they could leave the title field empty, but realized a) this isn't very intuitive, and b) they just don't look good, even if you wanted them there.  The area is intended for simple strings, menus and images recognizing sponsors -- widgets that logically should have a title should really be in the widget footer area. 

Closes #773

### How to test the changes in this Pull Request:

1. Add at least one widget to the 'Above Copyright' widget area; give it a title.
2. View on the front-end -- note the titles, which stick out:

![image](https://user-images.githubusercontent.com/177561/74698082-7dcefd80-51b1-11ea-9c8d-a040f5c266bf.png)

3. Apply the PR.
4. Confirm the titles are now not visible:

![image](https://user-images.githubusercontent.com/177561/74698104-917a6400-51b1-11ea-8a59-cebc419c6289.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
