### PR TITLE
Fix: Add warning about style pack code being removed

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -738,3 +738,72 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 if ( class_exists( 'WooCommerce' ) ) {
 	require get_template_directory() . '/inc/woocommerce.php';
 }
+
+// TODO: Start remove with style pack code.
+/**
+ * Displays warning about style packs.
+ */
+function newspack_stylepack_warning() {
+	$current_style_pack = get_theme_mod( 'active_style_pack', 'default' );
+	if ( is_child_theme() === false && 'default' !== $current_style_pack && current_user_can( 'administrator' ) ) :
+		if ( 'style-1' === $current_style_pack ) {
+			$child_theme = 'Scott';
+		} elseif ( 'style-2' === $current_style_pack ) {
+			$child_theme = 'Nelson';
+		} elseif ( 'style-3' === $current_style_pack ) {
+			$child_theme = 'Katharine';
+		} elseif ( 'style-4' === $current_style_pack ) {
+			$child_theme = 'Sacha';
+		} else {
+			$child_theme = 'Joseph';
+		}
+
+		$args = array(
+			'strong' => array(),
+			'a'      => array(
+				'href'  => array(),
+				'style' => array(),
+			),
+		);
+	?>
+		<div style="background: #ffde00; padding: 5px 20px; font-size: 90%; position: fixed; z-index: 99999; bottom: 0;">
+			<p>
+			<strong>WARNING:</strong> The style pack code will be removed from the Newspack Theme in a future release. If you would like to keep
+			<strong><?php echo esc_html( newspack_stylepack( $current_style_pack ) ); ?>'s</strong> styles, please download and activate the
+			<?php echo wp_kses( newspack_return_child_theme( $current_style_pack ), $args ); ?> child theme before upgrading to the next Newspack Theme version.</p>
+			<p><strong>This warning is only visible to site administrators.</strong></p>
+		</div>
+	<?php
+	endif;
+}
+
+/**
+ * Returns corresponding child theme name and GitHub link for each style pack.
+ */
+function newspack_return_child_theme( $stylepack ) {
+	if ( 'style-1' === $stylepack ) {
+		$child_name     = 'Newspack Scott';
+		$child_download = 'newspack-scott.zip';
+	} elseif ( 'style-2' === $stylepack ) {
+		$child_name     = 'Newspack Nelson';
+		$child_download = 'newspack-nelson.zip';
+	} elseif ( 'style-3' === $stylepack ) {
+		$child_name     = 'Newspack Katharine';
+		$child_download = 'newspack-katharine.zip';
+	} elseif ( 'style-4' === $stylepack ) {
+		$child_name     = 'Newspack Sacha';
+		$child_download = 'newspack-sacha.zip';
+	} else {
+		$child_name     = 'Newspack Joseph';
+		$child_download = 'newspack-joseph.zip';
+	}
+	return '<strong><a style="color: #000" href="https://github.com/Automattic/newspack-theme/releases/latest/download/' . esc_attr( $child_download ) . '">' . esc_html( $child_name ) . '</a></strong>';
+}
+
+/**
+ * Returns style pack name for each style pack ID.
+ */
+function newspack_stylepack( $stylepack ) {
+	return str_replace( 'style-', 'Style ', $stylepack );
+}
+// TODO: End remove with style pack code.

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -18,6 +18,10 @@
 </head>
 
 <body <?php body_class(); ?>>
+<?php // TODO: Start remove with style pack code. ?>
+	<?php newspack_stylepack_warning(); ?>
+<?php // TODO: End remove with style pack code. ?>
+
 <?php do_action( 'wp_body_open' ); ?>
 <?php do_action( 'before_header' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a simple (ugly) message to the front end of the site if you're still using a style pack. It will only display for logged in admins, and will instruct the site owner to download and install the appropriate child theme before upgrading the Newspack theme again (so we can eventually remove that code!). 

It's very basic -- you can't dismiss the notice, for example -- to limit how much code is added. Open to feedback on whether it should be built out/enhanced, though!

Closes #735 -- kind of! It's not a dashboard warning.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Switch to the default Newspack theme, and pick a Style Pack.
3. View on the front end; confirm you see a yellow warning at the bottom of the screen:

![image](https://user-images.githubusercontent.com/177561/74708794-56d4f380-51d2-11ea-96de-a5eb5aa9a610.png)

4. Confirm that the child theme suggested maps to your current Style Pack, and the link to download is correct. The style packs should link as follows:
   * Style 1 > Newspack Scott
   * Style 2 > Newspack Nelson
   * Style 3 > Newspack Katharine
   * Style 4 > Newspack Sacha
   * Style 5 > Newspack Joseph
5. View the site in an incognito window; confirm you don't see the warning.
6. Switch to the default style pack; confirm you don't see the warning.
7. Try one or two child themes; confirm you don't see the warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?