### PR TITLE
Remove Style Pack files if using the default theme and default style packs

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -705,7 +705,7 @@ require get_template_directory() . '/classes/class-newspack-walker-comment.php';
 /**
  * Style pack class.
  */
-if ( ! is_child_theme() ) {
+if ( ! is_child_theme() && ! newspack_is_active_style_pack( 'default' ) ) {
 	require get_template_directory() . '/classes/class-newspack-style-packs-core.php';
 	require get_template_directory() . '/inc/style-packs.php';
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a small incremental update moving towards removing the child theme code: it removes the "Style Packs" option if you're using the default theme and default style pack, so you can't switch them any more.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Test a couple child themes; confirm that the Style Packs option doesn't appear in the Customizer.
3. Switch to the default theme and check a couple style packs; confirm that the Style Packs option in the Customizer does display.
4. Switch to the Default style pack and refresh; confirm that the Style Packs panel disappears from the customizer. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
