### PR TITLE
fix: Correct font used by AMP lightbox overlays for the gallery block

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -64,6 +64,7 @@ function newspack_custom_typography_css() {
 		/* _captions.scss */
 		.wp-caption-text,
 		.gallery-caption,
+		.amp-image-lightbox-caption,
 
 		/* _infinite_scroll.scss */
 		.site-main #infinite-handle span button,

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -11,13 +11,18 @@
 figcaption,
 .wp-caption-text {
 	color: $color__text-light;
-	font-size: $font__size-xs;
-	font-family: $font__heading;
-	line-height: $font__line-height-pre;
 	margin: 0 auto;
 	max-width: 780px;
 	padding: 0;
 	text-align: left;
+}
+
+figcaption,
+.wp-caption-text,
+.amp-image-lightbox-caption {
+	font-size: $font__size-xs;
+	font-family: $font__heading;
+	line-height: $font__line-height-pre;
 }
 
 .newspack-front-page,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the font used by the AMP gallery lightbox captions.

Closes #787.

### How to test the changes in this Pull Request:

1. Set up a Gallery block; add a caption to at least one of the captions.
2. In the sidebar, turn on the 'AMP lightbox' for the Gallery block.
3. Save and publish.
4. View on front end; click one of the photos with captions and note the caption -- it uses the body font, rather than the header font like other captions:

![image](https://user-images.githubusercontent.com/177561/74865436-f5ae3c80-5305-11ea-8553-ccf54b1dd334.png)

5. Apply the PR and run `npm run build`.
6. Click on the same image again and confirm it's using the Header font:

![image](https://user-images.githubusercontent.com/177561/74865609-3f972280-5306-11ea-9021-7bdc7f479647.png)

7. Navigate to Customize > Typography and try changing the header font; click the image a third time and confirm the caption is using your new header font choice. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
