### PR TITLE
Fix: Improve Latest Comments font styles

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -388,24 +388,36 @@
 .wp-block-latest-comments {
 	padding-left: 0;
 
+	.wp-block-latest-comments__comment {
+		font-size: $font__size-sm;
+		line-height: $font__line-height-body;
+	}
+
 	.wp-block-latest-comments__comment-meta {
 		font-family: $font__heading;
 		font-weight: bold;
 
+		a,
+		a:visited {
+			color: $color__text-main;
+			text-decoration: none;
+		}
+
+		a:hover {
+			text-decoration: underline;
+		}
+
 		.wp-block-latest-comments__comment-date {
 			color: $color__text-light;
+			font-size: 0.9em;
 			font-weight: normal;
-			margin: #{0.25 * $size__spacing-unit} 0;
+			margin: #{0.15 * $size__spacing-unit} 0 0;
 		}
 	}
 
-	.wp-block-latest-comments__comment {
-		line-height: $font__line-height-body;
-	}
-
 	.wp-block-latest-comments__comment-excerpt p {
-		font-size: 1.1em;
-		line-height: $font__line-height-body;
+		font-size: 1.05em;
+		margin-top: 0;
 	}
 }
 

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -643,24 +643,32 @@ ul.wp-block-archives,
 	margin-left: 0;
 	padding-left: 0;
 
-	.wp-block-latest-comments__comment-meta {
-		font-family: $font__heading;
-		font-weight: bold;
-
-		.wp-block-latest-comments__comment-date {
-			color: $color__text-light;
-			font-weight: normal;
-		}
-	}
-
 	.wp-block-latest-comments__comment {
+		font-size: $font__size-sm;
 		line-height: $font__line-height-body;
 		margin-bottom: $size__spacing-unit;
 	}
 
+	.wp-block-latest-comments__comment-meta {
+		font-family: $font__heading;
+		font-weight: bold;
+
+		a,
+		a:visited {
+			color: $color__text-main;
+			text-decoration: none;
+		}
+
+		.wp-block-latest-comments__comment-date {
+			color: $color__text-light;
+			font-size: 0.9em;
+			font-weight: normal;
+			margin: #{0.5 * $size__spacing-unit} 0;
+		}
+	}
+
 	.wp-block-latest-comments__comment-excerpt p {
-		font-size: 1.1em;
-		line-height: $font__line-height-body;
+		font-size: 1.05em;
 		margin: 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR includes some small font size/style improvements to the Latest Comments block, based on feedback.

Closes #785.

### How to test the changes in this Pull Request:

1. Copy-paste [this test code](https://cloudup.com/cpkjbkldTSd) into the editor -- it adds a column block with four different Latest Comments blocks, with different settings.
2. Note the current appearance -- the links to the author and post title are quite pronounced with their underlines, and the date is rather small:

![image](https://user-images.githubusercontent.com/177561/74892124-953af180-533d-11ea-98a9-79a6eb9ffc92.png)

3. Apply the PR and run `npm run build`.
4. Confirm the author/post title is now black, and only underlined when hovered over; confirm the date is larger: 

![image](https://user-images.githubusercontent.com/177561/74892175-b865a100-533d-11ea-9961-133f2b5ee1e7.png)

5. Also check the block's appearance in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
