### PR TITLE
Add separate custom colour control for the Header Background

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -37,11 +37,11 @@ function newspack_joseph_custom_colors_css() {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .middle-header-contain {
-				background-color: ' . $header_color . ';
+				background-color: ' . esc_html( $header_color ) . ';
 			}
 			.h-sb .top-header-contain {
-				background-color: ' . newspack_adjust_brightness( $header_color, -10 ) . ';
-				border-bottom-color: ' . newspack_adjust_brightness( $header_color, -15 ) . ';
+				background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
 			}
 
 			/* Header solid background */
@@ -56,7 +56,7 @@ function newspack_joseph_custom_colors_css() {
 			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
 			.h-sb .top-header-contain,
 			.h-sb .middle-header-contain {
-				color: ' . $header_color_contrast . ';
+				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';
 	}

--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -14,8 +14,14 @@ function newspack_joseph_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
@@ -26,6 +32,34 @@ function newspack_joseph_custom_colors_css() {
 			}
 		}
 	';
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) && 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+		$theme_css .= '
+			/* Header solid background */
+			.h-sb .middle-header-contain {
+				background-color: ' . $header_color . ';
+			}
+			.h-sb .top-header-contain {
+				background-color: ' . newspack_adjust_brightness( $header_color, -10 ) . ';
+				border-bottom-color: ' . newspack_adjust_brightness( $header_color, -15 ) . ';
+			}
+
+			/* Header solid background */
+			.h-sb .site-header,
+			.h-sb .site-title,
+			.h-sb .site-title a:link,
+			.h-sb .site-title a:visited,
+			.h-sb .site-description,
+			/* Header solid background; short height */
+			.h-sb.h-sh .nav1 .main-menu > li,
+			.h-sb.h-sh .nav1 ul.main-menu > li > a,
+			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+			.h-sb .top-header-contain,
+			.h-sb .middle-header-contain {
+				color: ' . $header_color_contrast . ';
+			}
+		';
+	}
 
 	$editor_css = '';
 

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -81,7 +81,7 @@ function newspack_katharine_custom_colors_css() {
 
 			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
 			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
+				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 			}
 		';
 
@@ -90,11 +90,11 @@ function newspack_katharine_custom_colors_css() {
 			$theme_css .= '
 				/* Header solid background */
 				.h-sb .middle-header-contain {
-					background-color: ' . $header_color . ';
+					background-color: ' . esc_html( $header_color ) . ';
 				}
 				.h-sb .top-header-contain {
-					background-color: ' . newspack_adjust_brightness( $header_color, -10 ) . ';
-					border-bottom-color: ' . newspack_adjust_brightness( $header_color, -15 ) . ';
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+					border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
 				}
 
 				/* Header solid background */
@@ -109,7 +109,7 @@ function newspack_katharine_custom_colors_css() {
 				.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
 				.h-sb .top-header-contain,
 				.h-sb .middle-header-contain {
-					color: ' . $header_color_contrast . ';
+					color: ' . esc_html( $header_color_contrast ) . ';
 				}
 			';
 		}

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -14,8 +14,14 @@ function newspack_katharine_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
@@ -47,12 +53,6 @@ function newspack_katharine_custom_colors_css() {
 		}
 
 		@media only screen and (min-width: 782px) {
-			.h-sb .featured-image-beside {
-				background-color: ' . esc_html( $primary_color ) . ';
-			}
-
-			.h-sb .featured-image-beside,
-			.h-sb .featured-image-beside a,
 			.featured-image-beside a,
 			.featured-image-beside a:visited,
 			.featured-image-beside .cat-links a {
@@ -63,13 +63,57 @@ function newspack_katharine_custom_colors_css() {
 				background-color: ' . esc_html( $primary_color_contrast ) . ';
 			}
 		}
-
-		/* Header solid background; short height */
-		.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-		.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-		}
 	';
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+		$theme_css .= '
+			/* Featured Image Beside styles */
+			@media only screen and (min-width: 782px) {
+				.h-sb .featured-image-beside {
+					background-color: ' . esc_html( $primary_color ) . ';
+				}
+
+				.h-sb .featured-image-beside,
+				.h-sb .featured-image-beside a {
+					color: ' . esc_html( $primary_color_contrast ) . ';
+				}
+			}
+
+			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
+			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
+				background-color: ' . newspack_adjust_brightness( $primary_color, -30 ) . ';
+			}
+		';
+
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$theme_css .= '
+				/* Header solid background */
+				.h-sb .middle-header-contain {
+					background-color: ' . $header_color . ';
+				}
+				.h-sb .top-header-contain {
+					background-color: ' . newspack_adjust_brightness( $header_color, -10 ) . ';
+					border-bottom-color: ' . newspack_adjust_brightness( $header_color, -15 ) . ';
+				}
+
+				/* Header solid background */
+				.h-sb .site-header,
+				.h-sb .site-title,
+				.h-sb .site-title a:link,
+				.h-sb .site-title a:visited,
+				.h-sb .site-description,
+				/* Header solid background; short height */
+				.h-sb.h-sh .nav1 .main-menu > li,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+				.h-sb .top-header-contain,
+				.h-sb .middle-header-contain {
+					color: ' . $header_color_contrast . ';
+				}
+			';
+		}
+	}
 
 	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -14,17 +14,21 @@ function newspack_nelson_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color          = $primary_color;
+			$header_color_contrast = newspack_get_color_contrast( $primary_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
 	$theme_css = '
-		/* Header solid background */
-		.h-sb .site-header {
-			background-color: ' . esc_html( $primary_color ) . ';
-		}
-
 		.site-header,
 		/* Header default background */
 		.h-db .site-header,
@@ -33,12 +37,6 @@ function newspack_nelson_custom_colors_css() {
 		.site-content #primary,
 		#page .site-header {
 			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-		}
-
-		/* Header solid background */
-		.h-sb .site-header .highlight-menu .menu-label,
-		.h-sb .site-header .highlight-menu a {
-			color: ' . esc_html( $primary_color_contrast ) . ';
 		}
 
 		.site-footer {
@@ -54,15 +52,27 @@ function newspack_nelson_custom_colors_css() {
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
 			/* Header solid background */
+			.h-sb .site-header,
 			.h-sb .middle-header-contain {
-				background-color: ' . esc_html( $primary_color ) . ';
-			}
-			.h-sb .top-header-contain {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -10 ) ) . ';
-				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -15 ) ) . ';
+				background-color: ' . esc_html( $header_color ) . ';
 			}
 
-			/* Header solif background */
+			.h-sb .top-header-contain {
+				background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+			}
+
+			.site-header,
+			/* Header default background */
+			.h-db .site-header,
+			/* Header short height; default background */
+			.h-sh.h-db .site-header,
+			.site-content #primary,
+			#page .site-header {
+				border-color: ' . esc_html( newspack_adjust_brightness( $header_color, -40 ) ) . ';
+			}
+
+			/* Header solid background */
 			.h-sb .site-header,
 			.h-sb .site-title,
 			.h-sb .site-title a:link,
@@ -74,8 +84,10 @@ function newspack_nelson_custom_colors_css() {
 			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
 			.h-sb .top-header-contain,
 			.h-sb .middle-header-contain,
-			.nav1 .sub-menu a {
-				color: ' . esc_html( $primary_color_contrast ) . ';
+			.nav1 .sub-menu a,
+			.h-sb .site-header .highlight-menu .menu-label,
+			.h-sb .site-header .highlight-menu a {
+				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';
 	}

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -14,8 +14,14 @@ function newspack_sacha_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
@@ -37,13 +43,44 @@ function newspack_sacha_custom_colors_css() {
 			background-color: ' . esc_html( $primary_color ) . ';
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}
-
-		/* Header solid background; short height */
-		.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-		.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-		}
 	';
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+		$theme_css .= '
+			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
+			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
+				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+			}
+		';
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$theme_css .= '
+				/* Header solid background */
+				.h-sb .middle-header-contain {
+					background-color: ' . esc_html( $header_color ) . ';
+				}
+				.h-sb .top-header-contain {
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+					border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+				}
+
+				/* Header solid background */
+				.h-sb .site-header,
+				.h-sb .site-title,
+				.h-sb .site-title a:link,
+				.h-sb .site-title a:visited,
+				.h-sb .site-description,
+				/* Header solid background; short height */
+				.h-sb.h-sh .nav1 .main-menu > li,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+				.h-sb .top-header-contain,
+				.h-sb .middle-header-contain {
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+			';
+		}
+	}
 
 	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -14,8 +14,17 @@ function newspack_scott_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color          = $primary_color;
+			$header_color_contrast = newspack_get_color_contrast( $primary_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
@@ -43,11 +52,11 @@ function newspack_scott_custom_colors_css() {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .middle-header-contain {
-				background-color: ' . esc_html( $primary_color ) . ';
+				background-color: ' . esc_html( $header_color ) . ';
 			}
 			.h-sb .top-header-contain {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -10 ) ) . ';
-				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -15 ) ) . ';
+				background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
 			}
 
 			/* Header solid background */
@@ -61,9 +70,8 @@ function newspack_scott_custom_colors_css() {
 			.h-sb.h-sh .nav1 ul.main-menu > li > a,
 			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
 			.h-sb .top-header-contain,
-			.h-sb .middle-header-contain,
-			.nav1 .sub-menu a {
-				color: ' . esc_html( $primary_color_contrast ) . ';
+			.h-sb .middle-header-contain {
+				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';
 	}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -209,7 +209,7 @@ function newspack_custom_colors_css() {
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
 			.mobile-sidebar {
-				background: ' . $header_color . ';
+				background: ' . esc_html( $header_color ) . ';
 			}
 
 			.mobile-sidebar,
@@ -218,7 +218,7 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar a:visited,
 			.mobile-sidebar .nav1 .sub-menu > li > a,
 			.mobile-sidebar .nav1 ul.main-menu > li > a {
-				color: ' . $header_color_contrast . ';
+				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';
 	}
@@ -250,7 +250,7 @@ function newspack_custom_colors_css() {
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
 				.mobile-sidebar .nav3 .menu-highlight a {
-					background: ' . newspack_adjust_brightness( $header_color, -20 ) . ';
+					background: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
 				}
 				.h-sb .site-header .nav3 a {
 					background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -10,14 +10,23 @@
  */
 function newspack_custom_colors_css() {
 
-	$primary_color = newspack_get_primary_color();
+	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color = get_theme_mod( 'primary_color_hex', $primary_color );
+		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color          = $primary_color;
+			$header_color_contrast = newspack_get_color_contrast( $primary_color );
+		}
 	}
 
+	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 
@@ -205,14 +214,6 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar .nav3 .menu-highlight a {
 				background: ' . esc_html( newspack_adjust_brightness( $primary_color, -20 ) ) . ';
 			}
-			.h-sb .site-header .nav3 a {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -17 ) ) . ';
-				color: ' . esc_html( $primary_color_contrast ) . ';
-			}
-			.h-sb .site-header .nav3 .menu-highlight a {
-				background-color: ' . esc_html( $secondary_color ) . ';
-				color: ' . esc_html( $secondary_color_contrast ) . ';
-			}
 			.cat-links a,
 			.cat-links a:visited,
 			.site-header .nav3 .menu-highlight a {
@@ -228,6 +229,19 @@ function newspack_custom_colors_css() {
 				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 			}
 		';
+
+		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+			$theme_css .= '
+				.h-sb .site-header .nav3 a {
+					background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+				.h-sb .site-header .nav3 .menu-highlight a {
+					background-color: ' . $secondary_color . ';
+					color: ' . esc_html( $secondary_color_contrast ) . ';
+				}
+			';
+		}
 	}
 
 	if ( newspack_is_active_style_pack( 'default', 'style-3', 'style-4' ) ) {
@@ -265,11 +279,6 @@ function newspack_custom_colors_css() {
 
 	if ( newspack_is_active_style_pack( 'style-2' ) ) {
 		$theme_css .= '
-			/* Header solid background */
-			.h-sb .site-header {
-				background-color: ' . esc_html( $primary_color ) . ';
-			}
-
 			.site-header,
 			/* Header default background */
 			.h-db .site-header,
@@ -278,12 +287,6 @@ function newspack_custom_colors_css() {
 			.site-content #primary,
 			#page .site-header {
 				border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-			}
-
-			/* Header solid background */
-			.h-sb .site-header .highlight-menu .menu-label,
-			.h-sb .site-header .highlight-menu a {
-				color: ' . esc_html( $primary_color_contrast ) . ';
 			}
 
 			.site-footer {
@@ -295,6 +298,27 @@ function newspack_custom_colors_css() {
 				color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 			}
 		';
+
+		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+			$theme_css .= '
+				/* Header solid background */
+				.h-sb .site-header,
+				.h-sb .site-header .highlight-menu .menu-label,
+				.h-sb .site-header .highlight-menu a {
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+
+				.site-header,
+				/* Header default background */
+				.h-db .site-header,
+				/* Header short height; default background */
+				.h-sh.h-db .site-header,
+				.site-content #primary,
+				#page .site-header {
+					border-color: ' . esc_html( newspack_adjust_brightness( $header_color, -40 ) ) . ';
+				}
+			';
+		}
 	}
 
 	if ( newspack_is_active_style_pack( 'style-3' ) ) {
@@ -322,12 +346,6 @@ function newspack_custom_colors_css() {
 			}
 
 			@media only screen and (min-width: 782px) {
-				.h-sb .featured-image-beside {
-					background-color: ' . esc_html( $primary_color ) . ';
-				}
-
-				.h-sb .featured-image-beside,
-				.h-sb .featured-image-beside a,
 				.featured-image-beside a,
 				.featured-image-beside a:visited,
 				.featured-image-beside .cat-links a {
@@ -338,13 +356,56 @@ function newspack_custom_colors_css() {
 					background-color: ' . esc_html( $primary_color_contrast ) . ';
 				}
 			}
-
-			/* Header solid background; short height */
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-			}
 		';
+
+		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+			$theme_css .= '
+				@media only screen and (min-width: 782px) {
+					.h-sb .featured-image-beside {
+						background-color: ' . esc_html( $primary_color ) . ';
+					}
+
+					.h-sb .featured-image-beside,
+					.h-sb .featured-image-beside a {
+						color: ' . esc_html( $primary_color_contrast ) . ';
+					}
+				}
+
+				/* Header solid background; short height */
+				.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
+				.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
+				}
+			';
+
+			if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+				$theme_css .= '
+					/* Header solid background */
+					.h-sb .middle-header-contain {
+						background-color: ' . esc_html( $header_color ) . ';
+					}
+					.h-sb .top-header-contain {
+						background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+						border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+					}
+
+					/* Header solid background */
+					.h-sb .site-header,
+					.h-sb .site-title,
+					.h-sb .site-title a:link,
+					.h-sb .site-title a:visited,
+					.h-sb .site-description,
+					/* Header solid background; short height */
+					.h-sb.h-sh .nav1 .main-menu > li,
+					.h-sb.h-sh .nav1 ul.main-menu > li > a,
+					.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+					.h-sb .top-header-contain,
+					.h-sb .middle-header-contain {
+						color: ' . esc_html( $header_color_contrast ) . ';
+					}
+				';
+			}
+		}
 	}
 
 	if ( newspack_is_active_style_pack( 'style-4' ) ) {
@@ -356,12 +417,6 @@ function newspack_custom_colors_css() {
 				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 			}
 
-			@media only screen and (min-width: 782px) {
-				.h-sb .featured-image-beside .cat-links {
-					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-				}
-			}
-
 			.has-drop-cap:not(:focus)::first-letter {
 				background-color: ' . esc_html( $primary_color ) . ';
 				color: ' . esc_html( $primary_color_contrast ) . ';
@@ -370,13 +425,51 @@ function newspack_custom_colors_css() {
 			.site-footer .widget .widget-title {
 				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 			}
-
-			/* Header solid background; short height */
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-			}
 		';
+
+		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+			$theme_css .= '
+				/* Header solid background; short height */
+				.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
+				.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
+				}
+
+				@media only screen and (min-width: 782px) {
+					.h-sb .featured-image-beside .cat-links {
+						color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+					}
+				}
+			';
+
+			if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+				$theme_css .= '
+					/* Header solid background */
+					.h-sb .middle-header-contain {
+						background-color: ' . esc_html( $header_color ) . ';
+					}
+					.h-sb .top-header-contain {
+						background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+						border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+					}
+
+					/* Header solid background */
+					.h-sb .site-header,
+					.h-sb .site-title,
+					.h-sb .site-title a:link,
+					.h-sb .site-title a:visited,
+					.h-sb .site-description,
+					/* Header solid background; short height */
+					.h-sb.h-sh .nav1 .main-menu > li,
+					.h-sb.h-sh .nav1 ul.main-menu > li > a,
+					.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+					.h-sb .top-header-contain,
+					.h-sb .middle-header-contain {
+						color: ' . esc_html( $header_color_contrast ) . ';
+					}
+				';
+			}
+		}
 	}
 
 	if ( newspack_is_active_style_pack( 'style-5' ) ) {
@@ -387,20 +480,48 @@ function newspack_custom_colors_css() {
 				}
 			}
 		';
+
+		if ( true === get_theme_mod( 'header_solid_background', false ) && 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$theme_css .= '
+				/* Header solid background */
+				.h-sb .middle-header-contain {
+					background-color: ' . esc_html( $header_color ) . ';
+				}
+				.h-sb .top-header-contain {
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+					border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+				}
+
+				/* Header solid background */
+				.h-sb .site-header,
+				.h-sb .site-title,
+				.h-sb .site-title a:link,
+				.h-sb .site-title a:visited,
+				.h-sb .site-description,
+				/* Header solid background; short height */
+				.h-sb.h-sh .nav1 .main-menu > li,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a,
+				.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+				.h-sb .top-header-contain,
+				.h-sb .middle-header-contain {
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+			';
+		}
 	}
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) && newspack_is_active_style_pack( 'default', 'style-1', 'style-2' ) ) {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .middle-header-contain {
-				background-color: ' . esc_html( $primary_color ) . ';
+				background-color: ' . esc_html( $header_color ) . ';
 			}
 			.h-sb .top-header-contain {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -10 ) ) . ';
-				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -15 ) ) . ';
+				background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
 			}
 
-			/* Header solif background */
+			/* Header solid background */
 			.h-sb .site-header,
 			.h-sb .site-title,
 			.h-sb .site-title a:link,
@@ -411,9 +532,8 @@ function newspack_custom_colors_css() {
 			.h-sb.h-sh .nav1 ul.main-menu > li > a,
 			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
 			.h-sb .top-header-contain,
-			.h-sb .middle-header-contain,
-			.nav1 .sub-menu a {
-				color: ' . esc_html( $primary_color_contrast ) . ';
+			.h-sb .middle-header-contain {
+				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';
 	}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -206,6 +206,23 @@ function newspack_custom_colors_css() {
 
 		';
 
+	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+		$theme_css .= '
+			.mobile-sidebar {
+				background: ' . $header_color . ';
+			}
+
+			.mobile-sidebar,
+			.mobile-sidebar button:hover,
+			.mobile-sidebar a,
+			.mobile-sidebar a:visited,
+			.mobile-sidebar .nav1 .sub-menu > li > a,
+			.mobile-sidebar .nav1 ul.main-menu > li > a {
+				color: ' . $header_color_contrast . ';
+			}
+		';
+	}
+
 	if ( newspack_is_active_style_pack( 'default' ) ) {
 		$theme_css .= '
 			.mobile-sidebar .nav3 a {
@@ -232,6 +249,9 @@ function newspack_custom_colors_css() {
 
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
+				.mobile-sidebar .nav3 .menu-highlight a {
+					background: ' . newspack_adjust_brightness( $header_color, -20 ) . ';
+				}
 				.h-sb .site-header .nav3 a {
 					background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';
 					color: ' . esc_html( $header_color_contrast ) . ';

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -74,7 +74,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Solid Background', 'newspack' ),
-			'description' => esc_html__( 'Check to use the primary color as the header background.', 'newspack' ),
+			'description' => esc_html__( 'Check to use the primary color as the header background. Can be changed under "Colors".', 'newspack' ),
 			'section'     => 'newspack_header_options',
 		)
 	);
@@ -111,14 +111,13 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'theme_colors',
 		array(
-			'type'     => 'radio',
-			'label'    => __( 'Primary Color', 'newspack' ),
+			'type'    => 'radio',
+			'label'   => __( 'Colors', 'newspack' ),
 			'choices'  => array(
 				'default' => _x( 'Default', 'primary color', 'newspack' ),
 				'custom'  => _x( 'Custom', 'primary color', 'newspack' ),
 			),
-			'section'  => 'colors',
-			'priority' => 5,
+			'section' => 'colors',
 		)
 	);
 
@@ -157,6 +156,50 @@ function newspack_customize_register( $wp_customize ) {
 			'secondary_color_hex',
 			array(
 				'description' => __( 'Apply a secondary custom color.', 'newspack' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
+	/**
+	 * Header background_color
+	 */
+	$wp_customize->add_setting(
+		'header_color',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_color_option',
+		)
+	);
+
+	$wp_customize->add_control(
+		'header_color',
+		array(
+			'type'    => 'radio',
+			'label'   => __( 'Header Background Color', 'newspack' ),
+			'choices' => array(
+				'default' => _x( 'Default', 'header background color', 'newspack' ),
+				'custom'  => _x( 'Custom', 'header background color', 'newspack' ),
+			),
+			'section' => 'colors',
+		)
+	);
+
+	// Add header color hexidecimal setting and control.
+	$wp_customize->add_setting(
+		'header_color_hex',
+		array(
+			'default'           => '#666',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'header_color_hex',
+			array(
+				'description' => __( 'Apply a background color to the header.', 'newspack' ),
 				'section'     => 'colors',
 			)
 		)

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -72,7 +72,9 @@
 			wp.customize.control( 'header_color', function( control ) {
 				const visibility = function() {
 					if ( true === setting.get() ) {
-						control.container.slideDown( 180 );
+						if ( 'custom' === wp.customize.value( 'theme_colors' )() ) {
+							control.container.slideDown( 180 );
+						}
 					} else {
 						control.container.slideUp( 180 );
 					}
@@ -84,7 +86,10 @@
 			wp.customize.control( 'header_color_hex', function( control ) {
 				const visibility = function() {
 					if ( true === setting.get() ) {
-						if ( 'custom' === wp.customize.value( 'header_color' )() ) {
+						if (
+							'custom' === wp.customize.value( 'header_color' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )()
+						) {
 							control.container.slideDown( 180 );
 						}
 					} else {
@@ -101,7 +106,10 @@
 			wp.customize.control( 'header_color_hex', function( control ) {
 				const visibility = function() {
 					if ( 'custom' === setting.get() ) {
-						if ( true === wp.customize.value( 'header_solid_background' )() ) {
+						if (
+							true === wp.customize.value( 'header_solid_background' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )()
+						) {
 							control.container.slideDown( 180 );
 						}
 					} else {

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -48,6 +48,23 @@
 				visibility();
 				setting.bind( visibility );
 			} );
+			wp.customize.control( 'header_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						// Make sure the site is set to use a solid header background.
+						if (
+							true === wp.customize.value( 'header_solid_background' )() &&
+							'custom' === wp.customize.value( 'header_color' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
 		} );
 
 		// Controls to show/hide when the Solid Background is toggled.

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -34,6 +34,66 @@
 				visibility();
 				setting.bind( visibility );
 			} );
+			wp.customize.control( 'header_color', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						// Make sure the site is set to use a solid header background.
+						if ( true === wp.customize.value( 'header_solid_background' )() ) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
+		// Controls to show/hide when the Solid Background is toggled.
+		wp.customize( 'header_solid_background', function( setting ) {
+			wp.customize.control( 'header_color', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+
+			wp.customize.control( 'header_color_hex', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						if ( 'custom' === wp.customize.value( 'header_color' )() ) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
+		// Controls to show/hide when the Solid Background is toggled.
+		wp.customize( 'header_color', function( setting ) {
+			wp.customize.control( 'header_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						if ( true === wp.customize.value( 'header_solid_background' )() ) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
 		} );
 
 		// Only show the rest of the author controls when the bio is visible.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a separate option to change the header background colour independent of the child theme's default -- right now, the default theme, Scott and Nelson will us the primary colour, and Katharine, Sacha and Joseph use grey or black. 

Unfortunately, the control is a bit convoluted, in an attempt to not impact existing sites. I'm hoping once it's rolled out, and settings updated on each site, we can strip out some of the child theme specific code (like the grey/black defaults -- payback for my own 'cleverness' there), and any instance of a theme still using the primary colour. This may not be the best approach, and I'm definitely open to chatting with anyone about it, and making as many improvements as possible before it goes out there. 

It's possible that this should also impact how the colours work for the 'featured image beside' style after it's merged -- right now they use the primary colour, but if the header also uses the primary colour as a background colour, they'll switch to dark grey. This is more confusing cleverness, and should be switched to something more straight-forward -- a light-grey/dark grey/primary colour toggle as an option, or yet another colour picker, since there will be no simple way to avoid clashes with any-possible-header-colour. 

Note: this PR needs #698 to land first, and after that will need to be updated to remove any merge conflicts. That issue fixes the CSS escaping that's currently causing selectors to get messed up, and causing contrast issues in the header in some cases -- without it, you could see issues in this PR that are actually fixed there. 

As expected, this one will be a bit hellacious to test -- apologies in advance!

Closes #645.

### How to test the changes in this Pull Request:

First, test the behaviour of the new options in the Customizer:

1. Apply the PR and run `npm run build`. 
2. Switch to the default theme, default style pack, default header settings, default colour settings. 
3. View the 'Colors' panel:

![image](https://user-images.githubusercontent.com/177561/74991431-c7f6ef80-53fa-11ea-99e5-157a974e92b2.png)

4. Switch to 'Custom' and note the typical appearance:

![image](https://user-images.githubusercontent.com/177561/74991440-cdecd080-53fa-11ea-9c02-f444baf01510.png)

5. Switch to the 'Header Settings' panel and toggle on Solid Header'.
6. Switch back to the 'Colors' panel, and you should see:

![image](https://user-images.githubusercontent.com/177561/74991468-d7763880-53fa-11ea-8677-17a9848c58fb.png)

The 'default' setting will keep the theme's default behaviour -- either using the primary colour, or a grey/black. 

7. Toggle this option to 'Custom' and confirm you have a colour picker for the header: 

![image](https://user-images.githubusercontent.com/177561/74991504-f8d72480-53fa-11ea-93ac-67d05de8fb2c.png)

8. To make sure these panels show/hide as expected, try changing the settings on the Colors panel at random, and go back and forth to the Header Settings to toggle 'Solid Background' on and off. The purpose is to see if you can catch something showing when it shouldn't, eg. just the Header Background Color picker when the default colour palette is picked, or anything to do with the header colour when 'Solid Background' is unchecked. 

Next, check that the options actually work:

1. Return the settings to Solid Background for the header, and pick the 'Custom' Header background colour option. It should default to grey:

![image](https://user-images.githubusercontent.com/177561/74991808-e6a9b600-53fb-11ea-9af5-0cec1ccd24c2.png)

2. Try a couple colour options to make sure the contrast is working (one dark, one light):

![image](https://user-images.githubusercontent.com/177561/74991846-017c2a80-53fc-11ea-82e8-60b4754576bc.png)

![image](https://user-images.githubusercontent.com/177561/74991868-1953ae80-53fc-11ea-913d-2bc470f8c08a.png)

3. Try the same with the short header option selected:

![image](https://user-images.githubusercontent.com/177561/74992255-66d01b80-53fc-11ea-922f-7e14ee52bb04.png)

![image](https://user-images.githubusercontent.com/177561/74992073-5029c480-53fc-11ea-9821-85517c08f580.png)

4. Test the mobile menu:

![image](https://user-images.githubusercontent.com/177561/74996528-a270e280-5408-11ea-850e-bb146fc4b02e.png)

5. Silently curse Laurel for getting you to review this PR as you look at step 6.
6. Repeat steps 1-3 with the child themes (no need to test step 4, as the child themes don't do anything unique to its colours). There are screenshots below for what each should look like:

_(The contrast issues in these screenshots is fixed by #698; I can update screenshots once that's merged)._

**Scott:**

Default (primary colour):

![image](https://user-images.githubusercontent.com/177561/74992541-3e94ec80-53fd-11ea-8387-b01fdeb97a90.png)

Custom light:

![image](https://user-images.githubusercontent.com/177561/74992595-6be19a80-53fd-11ea-874c-2f408dd805df.png)

![image](https://user-images.githubusercontent.com/177561/74992607-7439d580-53fd-11ea-816a-4938159acfa9.png)

Custom dark:

![image](https://user-images.githubusercontent.com/177561/74992650-96335800-53fd-11ea-8149-5331180dbe81.png)

![image](https://user-images.githubusercontent.com/177561/74992676-ab0feb80-53fd-11ea-85e3-68747438aa08.png)

**Nelson:**

Default (primary colour):

![image](https://user-images.githubusercontent.com/177561/74993034-a7309900-53fe-11ea-8005-82269f821a71.png)

Custom light: 

![image](https://user-images.githubusercontent.com/177561/74993062-bd3e5980-53fe-11ea-8ef6-7ed63e2c93c7.png)

![image](https://user-images.githubusercontent.com/177561/74993088-d21aed00-53fe-11ea-852c-7f46d0e9f99c.png)

Custom dark:

![image](https://user-images.githubusercontent.com/177561/74993122-ea8b0780-53fe-11ea-8efb-09e467f038b7.png)

![image](https://user-images.githubusercontent.com/177561/74993200-1f975a00-53ff-11ea-867a-c9c12b1f598b.png)

**Katharine:**

Default (dark grey - #333):

![image](https://user-images.githubusercontent.com/177561/74993316-77ce5c00-53ff-11ea-9bdb-40c0fc934a48.png)

Custom light:

![image](https://user-images.githubusercontent.com/177561/74993371-a2201980-53ff-11ea-8774-4d24355c6c2b.png)

![image](https://user-images.githubusercontent.com/177561/74993428-c845b980-53ff-11ea-8cd2-f84811479f4a.png)

Custom dark:

![image](https://user-images.githubusercontent.com/177561/74994205-4a36e200-5402-11ea-8dc7-b2ebdc6de97c.png)

![image](https://user-images.githubusercontent.com/177561/74994239-6044a280-5402-11ea-9376-97da48287c47.png)

**Sacha:**

Default (dark grey - #333):

![image](https://user-images.githubusercontent.com/177561/74995336-72741000-5405-11ea-8a45-77106180a12e.png)

Custom light:

![image](https://user-images.githubusercontent.com/177561/74995423-b6ffab80-5405-11ea-960d-b00000accf74.png)

![image](https://user-images.githubusercontent.com/177561/74995505-ef9f8500-5405-11ea-8db8-5179b94aff01.png)

Custom dark:

![image](https://user-images.githubusercontent.com/177561/74995558-18c01580-5406-11ea-8750-393114df0269.png)

![image](https://user-images.githubusercontent.com/177561/74995589-2fff0300-5406-11ea-87a3-094a11c3e933.png)

**Joseph:**

Default (black):

![image](https://user-images.githubusercontent.com/177561/74995786-b4518600-5406-11ea-9258-c2f919b468e7.png)

Custom light:

![image](https://user-images.githubusercontent.com/177561/74995918-085c6a80-5407-11ea-9bfb-5bee7d0617d3.png)

![image](https://user-images.githubusercontent.com/177561/74996016-4bb6d900-5407-11ea-8138-3c5bc759712c.png)

Custom dark:

![image](https://user-images.githubusercontent.com/177561/74996138-9afd0980-5407-11ea-905f-1fecc8f8d58f.png)

![image](https://user-images.githubusercontent.com/177561/74996264-fc24dd00-5407-11ea-8922-941315eade1a.png)

I did make the same updates in the style packs code, but I think outside of making sure it's not throwing errors, I don't think it needs the same level of testing -- if we do have reports of issues outside of the cohort, it's a good opportunity to get someone switched to a child theme :) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
