### PR TITLE
Fix: Make sure CAP guest authors are also used in RSS feed

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -693,6 +693,19 @@ function newspack_sanitize_avatars() {
 }
 
 /**
+ * Co-authors in RSS and other feeds
+ * /wp-includes/feed-rss2.php uses the_author(), so we selectively filter the_author value
+ */
+function newspack_coauthors_in_rss( $the_author ) {
+	if ( ! is_feed() || ! function_exists( 'coauthors' ) ) {
+		return $the_author;
+	} else {
+		return coauthors( null, null, null, null, false );
+	}
+}
+add_filter( 'the_author', 'newspack_coauthors_in_rss' );
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the guest author defined by the Co-Authors Plus plugin was not being used in the RSS feed.

Closes #794.

### How to test the changes in this Pull Request:

1. Create a couple posts - one with just a Guest Author assigned, and another with a couple authors (guest and otherwise) are assigned using the Co-Authors Plus plugin.
2. View the RSS feed at www.testsite.com/feed (you can view the raw feed in Chrome); note that the new posts are all attributed to your user in the `<dc:creator>` tag, as opposed to multiple authors or a guest author.
3. Apply the PR.
4. View the RSS feed again; confirm that the correct authors are now displaying with each post in the `<dc:creator>` tag.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
