### PR TITLE
Remove unneeded escaping from Katharine, Scott custom typography and colours code

### DIFF
--- a/newspack-katharine/functions.php
+++ b/newspack-katharine/functions.php
@@ -64,7 +64,7 @@ function newspack_katharine_custom_colors_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-colors-katharine">
-		<?php echo esc_html( newspack_katharine_custom_colors_css() ); ?>
+		<?php echo newspack_katharine_custom_colors_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 	<?php
 }
@@ -80,7 +80,7 @@ function newspack_katharine_typography_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-fonts-katharine">
-		<?php echo wp_kses( newspack_katharine_custom_typography_css(), '' ); ?>
+		<?php echo newspack_katharine_custom_typography_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 
 <?php

--- a/newspack-scott/functions.php
+++ b/newspack-scott/functions.php
@@ -64,7 +64,7 @@ function newspack_scott_custom_colors_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-colors-scott">
-		<?php echo esc_html( newspack_scott_custom_colors_css() ); ?>
+		<?php echo newspack_scott_custom_colors_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 	<?php
 }
@@ -80,7 +80,7 @@ function newspack_scott_typography_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-fonts-scott">
-		<?php echo wp_kses( newspack_scott_custom_typography_css(), '' ); ?>
+		<?php echo newspack_scott_custom_typography_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes two issues I missed in #698:

There was still escaping around the CSS output for the custom typography and colours in Newspack Scott and Newspack Katharine, causing some CSS selectors (like `>`) to be escaped and stop working.

This was primarily noticeable when setting a lighter header colour.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that the functions outputting the custom colours or typography CSS are no longer escaped.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
