### PR TITLE
Fix: Add dashboard notification for the upcoming removal of the Style Packs

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -700,6 +700,46 @@ function newspack_coauthors_in_rss( $the_author ) {
 add_filter( 'the_author', 'newspack_coauthors_in_rss' );
 
 /**
+ * Notify about child theme deprecation.
+ * TODO: Remove after child theme code is removed.
+ */
+function newspack_child_theme_deprecation_notification() {
+	$theme = get_option( 'stylesheet', null );
+	if ( 'newspack-theme' !== $theme ) {
+		return;
+	}
+	$style_pack         = get_theme_mod( 'active_style_pack', 'default' );
+	$style_pack_mapping = array(
+		'style-1' => 'scott',
+		'style-2' => 'nelson',
+		'style-3' => 'katharine',
+		'style-4' => 'sacha',
+		'style-5' => 'joseph',
+	);
+	if ( ! isset( $style_pack_mapping[ $style_pack ] ) ) {
+		return;
+	}
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					/* translators: warning about upcoming feature deprecation. */
+					__( 'The style pack code will be removed from the Newspack Theme in a future release. If you would like to keep <strong>%1$s</strong> styles, please download and activate the <strong><a href="%2$s">%3$s</a></strong> child theme before upgrading to the next Newspack Theme version.', 'newspack' ),
+					ucfirst( str_replace( '-', ' ', $style_pack ) ),
+					'https://github.com/Automattic/newspack-theme/releases/latest/download/newspack-' . $style_pack_mapping[ $style_pack ] . '.zip',
+					ucfirst( $style_pack_mapping[ $style_pack ] )
+				)
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'newspack_child_theme_deprecation_notification' );
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR acts as a replacement for #782 -- rather than using the front-end banner, it uses the suggested dashboard notification instead.

Closes #735.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Switch to the default Newspack theme, and pick a Style Pack.
3. View the WP Admin Dashboard -- confirm you see a warning about the style pack:

![image](https://user-images.githubusercontent.com/177561/75220399-31a52f80-5754-11ea-8849-0c2d90854118.png)

4. Confirm that the child theme suggested maps to your current Style Pack, and the link to download is correct. The style packs should link as follows:
        Style 1 > Newspack Scott
        Style 2 > Newspack Nelson
        Style 3 > Newspack Katharine
        Style 4 > Newspack Sacha
        Style 5 > Newspack Joseph
5. Switch to the default style pack; confirm you don't see the warning.
6. Try one or two child themes; confirm you don't see the warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
