### PR TITLE
Refine the German translation of "Join the conversation"

### DIFF
--- a/newspack-theme/languages/de_DE.po
+++ b/newspack-theme/languages/de_DE.po
@@ -62,7 +62,7 @@ msgstr "Ihr Kommentar wartet auf Moderation."
 
 #: comments.php:31
 msgid "Join the Conversation"
-msgstr "Nehmen Sie an der Konversation teil"
+msgstr "Reden Sie mit!"
 
 #: comments.php:33 comments.php:101
 msgid "Leave a comment"


### PR DESCRIPTION
Our only German publisher mentioned the translation was not quite right here.

> „Nehmen Sie an der Konversation teil” should be „Reden Sie mit!”

So this PR makes that change.