### PR TITLE
CI: fix release assets paths

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -44,7 +44,7 @@ module.exports = {
 			'@semantic-release/github',
 			{
 				assets: THEMES.map( name => ( {
-					path: `./assets/release/${ name }.zip`,
+					path: `./release/${ name }.zip`,
 					label: `${ name }.js`,
 				} ) ),
 			},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The path to built files was wrong, so in the [last release](https://github.com/Automattic/newspack-theme/releases/tag/v1.0.0) the assets were have to be added manually. This fixes that.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
