### PR TITLE
fix: apply custom header color background to Newspack Nelson's footer

### DIFF
--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -53,7 +53,8 @@ function newspack_nelson_custom_colors_css() {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .site-header,
-			.h-sb .middle-header-contain {
+			.h-sb .middle-header-contain,
+			.h-sb .site-footer {
 				background-color: ' . esc_html( $header_color ) . ';
 			}
 
@@ -86,7 +87,8 @@ function newspack_nelson_custom_colors_css() {
 			.h-sb .middle-header-contain,
 			.nav1 .sub-menu a,
 			.h-sb .site-header .highlight-menu .menu-label,
-			.h-sb .site-header .highlight-menu a {
+			.h-sb .site-header .highlight-menu a,
+			.h-sb .site-footer {
 				color: ' . esc_html( $header_color_contrast ) . ';
 			}
 		';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -324,8 +324,13 @@ function newspack_custom_colors_css() {
 				/* Header solid background */
 				.h-sb .site-header,
 				.h-sb .site-header .highlight-menu .menu-label,
-				.h-sb .site-header .highlight-menu a {
+				.h-sb .site-header .highlight-menu a,
+				.h-sb .site-footer {
 					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+
+				.h-sb site-footer {
+					background-color: ' . esc_html( $header_color ) . ';
 				}
 
 				.site-header,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Newspack Nelson currently uses the primary colour as the footer background, so it's possible to have it match the header if it uses the solid background.

Now that there is a separate control for the header background colour, the footer should also use this colour when set; this PR does that. 

Closes #803.

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. If not already, set your test site to use Newspack Nelson. 
3. Navigate to Customize > Header Settings, and disable Solid Background.
4. Navigate to Customize > Colours, and set a custom primary colour; set Header Background Color to 'Default'.
5. Confirm that that colour is used in the footer:

My settings: 
![image](https://user-images.githubusercontent.com/177561/75723181-a1557600-5c90-11ea-920e-0c09953da1e2.png)

Footer: 
![image](https://user-images.githubusercontent.com/177561/75723222-af0afb80-5c90-11ea-86ce-2ba6fd8550ef.png)

7. Navigate to Customize > Header Settings, and pick Solid Background.
8. Navigate to Customize > Colors, and switch Header Background Color to 'Custom' and pick a colour:

![image](https://user-images.githubusercontent.com/177561/75723272-cf3aba80-5c90-11ea-92a6-46f01ad1e739.png)

9. Confirm that the footer is now using this Custom Header color:

![image](https://user-images.githubusercontent.com/177561/75723297-df529a00-5c90-11ea-8770-62299c5d5c1f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
