### PR TITLE
Add desktop slideout menu

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -69,11 +69,12 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
-				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
-				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
-				'highlight-menu' => __( 'Topic Highlight Menu', 'newspack' ),
-				'social'         => __( 'Social Links Menu', 'newspack' ),
+				'primary-menu'         => __( 'Primary Menu', 'newspack' ),
+				'secondary-menu'       => __( 'Secondary Menu', 'newspack' ),
+				'tertiary-menu'        => __( 'Tertiary Menu', 'newspack' ),
+				'highlight-menu'       => __( 'Topic Highlight Menu', 'newspack' ),
+				'social'               => __( 'Social Links Menu', 'newspack' ),
+				'desktop-sidebar-menu' => __( 'Desktop Sidebar Menu', 'newspack' ),
 			)
 		);
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -69,12 +69,11 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(
-				'primary-menu'         => __( 'Primary Menu', 'newspack' ),
-				'secondary-menu'       => __( 'Secondary Menu', 'newspack' ),
-				'tertiary-menu'        => __( 'Tertiary Menu', 'newspack' ),
-				'highlight-menu'       => __( 'Topic Highlight Menu', 'newspack' ),
-				'social'               => __( 'Social Links Menu', 'newspack' ),
-				'desktop-sidebar-menu' => __( 'Desktop Sidebar Menu', 'newspack' ),
+				'primary-menu'   => __( 'Primary Menu', 'newspack' ),
+				'secondary-menu' => __( 'Secondary Menu', 'newspack' ),
+				'tertiary-menu'  => __( 'Tertiary Menu', 'newspack' ),
+				'highlight-menu' => __( 'Topic Highlight Menu', 'newspack' ),
+				'social'         => __( 'Social Links Menu', 'newspack' ),
 			)
 		);
 
@@ -244,6 +243,18 @@ function newspack_widgets_init() {
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title accent-header"><span>',
 			'after_title'   => '</span></h2>',
+		)
+	);
+
+	register_sidebar(
+		array(
+			'name'          => __( 'Slide-out Sidebar', 'newspack' ),
+			'id'            => 'header-1',
+			'description'   => __( 'Add widgets here to appear in an off-screen sidebar.', 'newspack' ),
+			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
 		)
 	);
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -250,7 +250,11 @@ function newspack_widgets_init() {
 		array(
 			'name'          => __( 'Slide-out Sidebar', 'newspack' ),
 			'id'            => 'header-1',
-			'description'   => __( 'Add widgets here to appear in an off-screen sidebar.', 'newspack' ),
+			'description'   => sprintf(
+				/* translators: %s: link to Header Settings panel in Customizer. */
+				__( 'Add widgets here to appear in an off-screen sidebar when it is enabled under %s.', 'newspack' ),
+				'<a rel="goto-control" href="#header_show_slideout">' . __( 'Header Settings', 'newspack' ) . '</a>'
+			),
 			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -30,17 +30,18 @@
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
 		<?php
-			$header_simplified  = get_theme_mod( 'header_simplified', false );
-			$header_center_logo = get_theme_mod( 'header_center_logo', false );
+			$header_simplified     = get_theme_mod( 'header_simplified', false );
+			$header_center_logo    = get_theme_mod( 'header_center_logo', false );
+			$show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
 		?>
 
 		<?php
 		// If header is NOT short, or if header is short and there's a Secondary Menu or Slide-out Sidebar widget.
-		if ( false === $header_simplified && ( true === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) ) :
+		if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) :
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
-					<?php if ( is_active_sidebar( 'header-1' ) ) : ?>
+					<?php if ( true === $show_slideout_sidebar ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
@@ -73,7 +74,7 @@
 
 		<div class="middle-header-contain">
 			<div class="wrapper">
-				<?php if ( true === $header_simplified && is_active_sidebar( 'header-1' ) ) : ?>
+				<?php if ( true === $header_simplified && true === $show_slideout_sidebar ) : ?>
 					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 						<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -35,17 +35,18 @@
 		?>
 
 		<?php
-		// Header is NOT short:
-		if ( false === $header_simplified ) :
+		// If header is NOT short, or if header is short and there's a Secondary Menu or Slide-out Sidebar widget.
+		if ( false === $header_simplified || ( true === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) ) :
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
-					<?php if ( has_nav_menu( 'desktop-sidebar-menu' ) ) : ?>
+					<?php if ( is_active_sidebar( 'header-1' ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+							<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
 						</button>
 					<?php endif; ?>
+
 					<div id="secondary-nav-contain">
 						<?php
 						if ( ! newspack_is_amp() ) {

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -41,7 +41,7 @@
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
-					<?php if ( true === $show_slideout_sidebar ) : ?>
+					<?php if ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
@@ -74,7 +74,7 @@
 
 		<div class="middle-header-contain">
 			<div class="wrapper">
-				<?php if ( true === $header_simplified && true === $show_slideout_sidebar ) : ?>
+				<?php if ( true === $header_simplified && true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
 					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 						<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -36,7 +36,7 @@
 
 		<?php
 		// If header is NOT short, or if header is short and there's a Secondary Menu or Slide-out Sidebar widget.
-		if ( false === $header_simplified || ( true === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) ) :
+		if ( false === $header_simplified && ( true === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) ) :
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
@@ -73,6 +73,13 @@
 
 		<div class="middle-header-contain">
 			<div class="wrapper">
+				<?php if ( true === $header_simplified && is_active_sidebar( 'header-1' ) ) : ?>
+					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
+					</button>
+				<?php endif; ?>
+
 				<?php
 				// Centered logo AND NOT short header.
 				if ( true === $header_center_logo && false === $header_simplified ) :

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -22,6 +22,7 @@
 <?php do_action( 'before_header' ); ?>
 
 <?php get_template_part( 'template-parts/header/mobile', 'sidebar' ); ?>
+<?php get_template_part( 'template-parts/header/desktop', 'sidebar' ); ?>
 
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
@@ -39,6 +40,11 @@
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
+					<!-- toggle for desktop menu -->
+					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<?php esc_html_e( 'Menu', 'newspack' ); ?>
+					</button>
 					<div id="secondary-nav-contain">
 						<?php
 						if ( ! newspack_is_amp() ) {

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -40,11 +40,12 @@
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">
-					<!-- toggle for desktop menu -->
-					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
-						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-						<?php esc_html_e( 'Menu', 'newspack' ); ?>
-					</button>
+					<?php if ( has_nav_menu( 'desktop-sidebar-menu' ) ) : ?>
+						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+						</button>
+					<?php endif; ?>
 					<div id="secondary-nav-contain">
 						<?php
 						if ( ! newspack_is_amp() ) {

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -107,7 +107,7 @@ function newspack_custom_colors_css() {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
-		.mobile-sidebar .nav1 + nav.secondary-menu {
+		.mobile-sidebar nav + nav {
 			border-color: ' . esc_html( $primary_color_contrast ) . ';
 		}
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -107,7 +107,9 @@ function newspack_custom_colors_css() {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
-		.mobile-sidebar nav + nav {
+		.mobile-sidebar nav + nav,
+		.mobile-sidebar nav + .widget,
+		.mobile-sidebar .widget + .widget {
 			border-color: ' . esc_html( $primary_color_contrast ) . ';
 		}
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -97,6 +97,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - label for slide out menu
+	$wp_customize->add_setting(
+		'slideout_label',
+		array(
+			'default'           => esc_html__( 'Menu', 'newspack' ),
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+	$wp_customize->add_control(
+		'slideout_label',
+		array(
+			'type'        => 'text',
+			'label'       => esc_html__( 'Slide-out Sidebar Text', 'newspack' ),
+			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. At least one widget has to be added to the Slide-out Sidebar area for it to appear.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
 	/**
 	 * Primary color.
 	 */

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -110,7 +110,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'text',
 			'label'       => esc_html__( 'Slide-out Sidebar Text', 'newspack' ),
-			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. At least one widget has to be added to the Slide-out Sidebar area for it to appear.', 'newspack' ),
+			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. At least one widget has to be added to the Slide-out Sidebar area for the toggle to appear. The text is hidden when using the short header, but always visible to screen readers.', 'newspack' ),
 			'section'     => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -97,7 +97,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Header - label for slide out menu
+	// Header - label for slide out sidebar
 	$wp_customize->add_setting(
 		'slideout_label',
 		array(
@@ -111,6 +111,24 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => esc_html__( 'Slide-out Sidebar Text', 'newspack' ),
 			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. At least one widget has to be added to the Slide-out Sidebar area for it to appear.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
+	// Header - label for slide out menu
+	$wp_customize->add_setting(
+		'slideout_widget_mobile',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'slideout_widget_mobile',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Add slide-out widgets to mobile menu', 'newspack' ),
+			'description' => esc_html__( 'Adds the widgets assigned to the Slide-out Sidebar area to the mobile menu, too.', 'newspack' ),
 			'section'     => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -97,6 +97,28 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - add option to center logo.
+	$wp_customize->add_setting(
+		'header_show_slideout',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_show_slideout',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Show Slide-out Sidebar', 'newspack' ),
+			'description' => sprintf(
+				/* translators: %s: link to Slide Out Sidebar widget panel in Customizer. */
+				esc_html__( 'Show a Slide-out sidebar in the header, which you can populate by adding widgets %1$s.', 'newspack' ),
+				'<a rel="goto-section" href="#sidebar-widgets-header-1">' . __( 'here', 'newspack' ) . '</a>'
+			),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
 	// Header - label for slide out sidebar
 	$wp_customize->add_setting(
 		'slideout_label',
@@ -110,7 +132,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'text',
 			'label'       => esc_html__( 'Slide-out Sidebar Text', 'newspack' ),
-			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. At least one widget has to be added to the Slide-out Sidebar area for the toggle to appear. The text is hidden when using the short header, but always visible to screen readers.', 'newspack' ),
+			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. The text is not visible when using the short header, but can always be read by screen readers.', 'newspack' ),
 			'section'     => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -465,3 +465,26 @@ function newspack_social_menu_footer() {
 	</nav><!-- .social-navigation -->
 <?php
 }
+
+/**
+ * Displays desktop sidebar menu; created a function to reduce duplication.
+ */
+function newspack_desktop_sidebar_menu() {
+	if ( ! has_nav_menu( 'desktop-sidebar-menu' ) ) {
+		return;
+	}
+	?>
+		<nav class="desktop-sidebar-menu" aria-label="<?php esc_attr_e( 'Desktop Sidebar Menu', 'newspack' ); ?>">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'desktop-sidebar-menu',
+					'container'      => false,
+					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+					'depth'          => 2,
+				)
+			);
+			?>
+		</nav>
+<?php
+}

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -465,26 +465,3 @@ function newspack_social_menu_footer() {
 	</nav><!-- .social-navigation -->
 <?php
 }
-
-/**
- * Displays desktop sidebar menu; created a function to reduce duplication.
- */
-function newspack_desktop_sidebar_menu() {
-	if ( ! has_nav_menu( 'desktop-sidebar-menu' ) ) {
-		return;
-	}
-	?>
-		<nav class="desktop-sidebar-menu" aria-label="<?php esc_attr_e( 'Desktop Sidebar Menu', 'newspack' ); ?>">
-			<?php
-			wp_nav_menu(
-				array(
-					'theme_location' => 'desktop-sidebar-menu',
-					'container'      => false,
-					'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-					'depth'          => 2,
-				)
-			);
-			?>
-		</nav>
-<?php
-}

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -36,7 +36,6 @@
 	);
 
 	// Mobile menu fallback.
-
 	const menuToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
 		body = document.getElementsByTagName( 'body' )[ 0 ],
 		mobileSidebar = document.getElementById( 'mobile-sidebar-fallback' ),
@@ -53,6 +52,28 @@
 				} else {
 					body.classList.add( 'menu-opened' );
 					menuCloseButton.focus();
+				}
+			},
+			false
+		);
+	}
+
+	// Desktop menu fallback.
+	const desktopToggle = document.getElementsByClassName( 'desktop-menu-toggle' ),
+		desktopSidebar = document.getElementById( 'desktop-sidebar-fallback' ),
+		desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
+		desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ];
+
+	for ( let i = 0; i < desktopToggle.length; i++ ) {
+		desktopToggle[ i ].addEventListener(
+			'click',
+			function() {
+				if ( body.classList.contains( 'desktop-menu-opened' ) ) {
+					body.classList.remove( 'desktop-menu-opened' );
+					desktopOpenButton.focus();
+				} else {
+					body.classList.add( 'desktop-menu-opened' );
+					desktopCloseButton.focus();
 				}
 			},
 			false

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -6,7 +6,7 @@
  * Contains handlers to make Theme Customizer preview reload changes asynchronously.
  */
 
-( function() {
+( function( $ ) {
 	wp.customize.bind( 'ready', function() {
 		// Only show the color hue control when there's a custom primary color.
 		wp.customize( 'theme_colors', function( setting ) {
@@ -133,6 +133,45 @@
 				};
 				visibility();
 				setting.bind( visibility );
+			} );
+		} );
+
+		// Only show Slide-out Sidebar options when enabled.
+		wp.customize( 'header_show_slideout', function( setting ) {
+			wp.customize.control( 'slideout_label', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+			wp.customize.control( 'slideout_widget_mobile', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
+		// Lets you jump to specific sections in the Customizer
+		$( [ 'control', 'section', 'panel' ] ).each( function( i, type ) {
+			$( 'a[rel="goto-' + type + '"]' ).click( function( e ) {
+				e.preventDefault();
+				const id = $( this )
+					.attr( 'href' )
+					.replace( '#', '' );
+				if ( wp.customize[ type ].has( id ) ) {
+					wp.customize[ type ].instance( id ).focus();
+				}
 			} );
 		} );
 	} );

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -39,6 +39,14 @@
 	padding: #{0.125 * $size__spacing-unit} 0;
 }
 
+.middle-header-contain .desktop-menu-toggle {
+	margin-right: $size__spacing-unit;
+	span {
+		left: -99999em;
+		position: absolute;
+	}
+}
+
 @include media( tablet ) {
 	// Header default height
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -105,9 +105,10 @@
 	}
 }
 
+// Desktop Sidebar and Widget styles
 .desktop-sidebar {
 	background-color: #fff;
-	max-width: 500px;
+	max-width: 400px;
 
 	@include media( tablet ) {
 		width: 50vw;
@@ -118,34 +119,23 @@
 		color: $color__text-main;
 	}
 
-	ul.menu > li {
-		border-bottom: 1px solid $color__border;
-		clear: both;
-		font-weight: bold;
-		padding: $size__spacing-unit 0;
+	.widget {
+		border-top: 1px solid $color__border;
+		font-size: 0.9em;
+		margin-bottom: #{1.5 * $size__spacing-unit};
 
-		> ul li {
-			display: block;
-			font-weight: normal;
-
-			@include media( tablet ) {
-				float: left;
-				width: 48%;
-
-				&:nth-child( odd ) {
-					padding-right: 4%;
-				}
-			}
+		&:last-child {
+			margin-bottom: #{1.5 * $size__spacing-unit};
 		}
+	}
 
-		&::after {
-			clear: both;
-			content: '';
-			display: table;
-		}
+	.widget-title {
+		font-size: $font__size-md;
+		margin: #{1.5 * $size__spacing-unit} 0 #{0.5 * $size__spacing-unit};
 	}
 }
 
+// Modile Sidebar and Menu styles
 .mobile-sidebar {
 	background-color: $color__primary;
 	color: #fff;

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -1,8 +1,10 @@
 // Menu Toggles
 .mobile-menu-toggle,
 .desktop-menu-toggle {
+	align-items: center;
 	background-color: transparent;
 	color: inherit;
+	display: flex;
 	padding: 0;
 
 	&:hover,
@@ -11,9 +13,12 @@
 		color: inherit;
 	}
 
-	.svg-icon {
-		position: relative;
-		top: 5px;
+	&:focus {
+		outline-offset: 0;
+	}
+
+	svg {
+		margin-right: #{0.25 * $size__spacing-unit};
 	}
 }
 
@@ -57,7 +62,7 @@
 
 	// Desktop Menu toggle
 	.h-dh .site-header .desktop-menu-toggle {
-		display: block;
+		display: flex;
 	}
 }
 
@@ -71,7 +76,7 @@
 
 	// Desktop Menu toggle
 	.h-sh .site-header .desktop-menu-toggle {
-		display: block;
+		display: flex;
 	}
 }
 
@@ -111,6 +116,10 @@
 		background: transparent;
 		text-decoration: underline;
 	}
+
+	.widget-title {
+		margin: 0 0 #{0.5 * $size__spacing-unit};
+	}
 }
 
 // Desktop Sidebar and Widget styles
@@ -131,6 +140,7 @@
 		border-top: 1px solid $color__border;
 		font-size: 0.9em;
 		margin-bottom: #{1.5 * $size__spacing-unit};
+		padding-top: #{1.5 * $size__spacing-unit};
 
 		&:last-child {
 			margin-bottom: #{1.5 * $size__spacing-unit};
@@ -139,7 +149,6 @@
 
 	.widget-title {
 		font-size: $font__size-md;
-		margin: #{1.5 * $size__spacing-unit} 0 #{0.5 * $size__spacing-unit};
 	}
 }
 
@@ -173,7 +182,15 @@
 	nav + .widget,
 	.widget + .widget {
 		border-top: 1px solid #fff;
+	}
+
+	nav + nav {
 		padding-top: #{0.75 * $size__spacing-unit};
+	}
+
+	nav + .widget,
+	.widget + .widget {
+		padding-top: $size__spacing-unit;
 	}
 
 	.nav1 .main-menu > li.menu-item-has-children .submenu-expand svg,
@@ -241,6 +258,11 @@
 .desktop-menu-opened #desktop-sidebar-fallback {
 	> * {
 		display: block;
+	}
+
+	> .desktop-menu-toggle,
+	> .mobile-menu-toggle {
+		display: flex;
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -161,7 +161,9 @@
 		padding-right: 0;
 	}
 
-	nav + nav {
+	nav + nav,
+	nav + .widget,
+	.widget + .widget {
 		border-top: 1px solid #fff;
 		padding-top: #{0.75 * $size__spacing-unit};
 	}
@@ -181,6 +183,18 @@
 		a {
 			padding: #{0.125 * $size__spacing-unit} #{0.5 * $size__spacing-unit};
 		}
+	}
+
+	.widget {
+		font-size: 1em;
+
+		&:last-child {
+			margin-bottom: #{1.5 * $size__spacing-unit};
+		}
+	}
+
+	.widget-title {
+		font-size: 1.1em;
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -1,7 +1,8 @@
-.mobile-menu-toggle {
+// Menu Toggles
+.mobile-menu-toggle,
+.desktop-menu-toggle {
 	background-color: transparent;
 	color: inherit;
-	margin-left: auto;
 	padding: 0;
 
 	&:hover,
@@ -12,61 +13,84 @@
 
 	.svg-icon {
 		position: relative;
-		top: 4px;
+		top: 5px;
 	}
 }
 
-.site-header .mobile-menu-toggle {
+.site-header .mobile-menu-toggle,
+.site-header .desktop-menu-toggle {
 	&:hover {
 		color: inherit;
 	}
 }
 
+// Place mobile menu on far right.
+.mobile-menu-toggle {
+	margin-left: auto;
+}
+
+// Hide desktop menu toggle on smaller screens
+.site-header .desktop-menu-toggle {
+	display: none;
+	font-size: $font__size-xs;
+	font-weight: normal;
+	line-height: 2;
+	margin-right: #{1.5 * $size__spacing-unit};
+	padding: #{0.125 * $size__spacing-unit} 0;
+}
+
 @include media( tablet ) {
 	// Header default height
+
+	// Mobile Menu toggle
 	.h-dh .site-header .mobile-menu-toggle {
 		display: none;
+	}
+
+	// Desktop Menu toggle
+	.h-dh .site-header .desktop-menu-toggle {
+		display: block;
 	}
 }
 
 @include media( narrowdesktop ) {
 	// Header - short height
+
+	// Mobile Menu toggle
 	.h-sh .site-header .mobile-menu-toggle {
 		display: none;
 	}
+
+	// Desktop Menu toggle
+	.h-sh .site-header .desktop-menu-toggle {
+		display: block;
+	}
 }
 
-.mobile-sidebar {
-	background-color: $color__primary;
-	color: #fff;
+.mobile-sidebar,
+.desktop-sidebar {
 	font-size: $font__size-sm;
-	width: 90vw;
 	padding: $size__spacing-unit;
-
-	@include media( tablet ) {
-		width: 33vw;
-	}
+	width: 90vw;
 
 	> * {
 		clear: both;
 		margin-bottom: $size__spacing-unit;
 	}
 
-	.mobile-menu-toggle {
+	.mobile-menu-toggle,
+	.desktop-menu-toggle {
 		font-size: 1em;
 		float: right;
 		margin: 0 0 $size__spacing-unit;
 		padding: 0;
 	}
 
-	ul ul {
-		margin-left: $size__spacing-unit;
-	}
-
-	a,
-	a:visited,
-	.nav1 .sub-menu > li > a {
-		color: #fff;
+	ul,
+	li {
+		list-style: none;
+		margin: 0;
+		padding: 0;
 	}
 
 	a {
@@ -79,14 +103,75 @@
 		background: transparent;
 		text-decoration: underline;
 	}
+}
 
+.desktop-sidebar {
+	background-color: #fff;
+	max-width: 500px;
+
+	@include media( tablet ) {
+		width: 50vw;
+	}
+
+	a,
+	a:visited {
+		color: $color__text-main;
+	}
+
+	ul.menu > li {
+		border-bottom: 1px solid $color__border;
+		clear: both;
+		font-weight: bold;
+		padding: $size__spacing-unit 0;
+
+		> ul li {
+			display: block;
+			font-weight: normal;
+
+			@include media( tablet ) {
+				float: left;
+				width: 48%;
+
+				&:nth-child( odd ) {
+					padding-right: 4%;
+				}
+			}
+		}
+
+		&::after {
+			clear: both;
+			content: '';
+			display: table;
+		}
+	}
+}
+
+.mobile-sidebar {
+	background-color: $color__primary;
+	color: #fff;
+
+	@include media( tablet ) {
+		width: 33vw;
+	}
+
+	a,
+	a:visited,
+	.nav1 .sub-menu > li > a {
+		color: #fff;
+	}
+
+	ul ul {
+		margin-left: $size__spacing-unit;
+	}
+
+	// Styles specific to menus moved from the header
 	nav.secondary-menu a,
 	.nav1 .main-menu > li > a {
 		padding-left: 0;
 		padding-right: 0;
 	}
 
-	nav.nav1 + nav.secondary-menu {
+	nav + nav {
 		border-top: 1px solid #fff;
 		padding-top: #{0.75 * $size__spacing-unit};
 	}
@@ -109,13 +194,12 @@
 	}
 }
 
+#desktop-sidebar-fallback,
 #mobile-sidebar-fallback {
 	bottom: 0;
 	overflow: auto;
 	position: fixed;
-	right: -100%;
 	top: 0;
-	transition: right 0.2s;
 	z-index: 999999;
 
 	> * {
@@ -123,15 +207,33 @@
 	}
 }
 
+#desktop-sidebar-fallback {
+	left: -100%;
+	transition: left 0.2s;
+}
+
+#mobile-sidebar-fallback {
+	right: -100%;
+	transition: right 0.2s;
+}
+
 .menu-opened #mobile-sidebar-fallback {
 	right: 0;
+}
 
+.desktop-menu-opened #desktop-sidebar-fallback {
+	left: 0;
+}
+
+.menu-opened #mobile-sidebar-fallback,
+.desktop-menu-opened #desktop-sidebar-fallback {
 	> * {
 		display: block;
 	}
 }
 
-.menu-opened::after {
+.menu-opened::after,
+.desktop-menu-opened::after {
 	background-color: rgba( 0, 0, 0, 0.2 );
 	bottom: 0;
 	content: '';

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -79,9 +79,17 @@
 	background-color: #4a4a4a;
 	color: #fff;
 
+	.wrapper {
+		justify-content: flex-start;
+	}
+
 	nav {
 		padding-bottom: #{0.3 * $size__spacing-unit};
 		padding-top: #{0.3 * $size__spacing-unit};
+	}
+
+	#social-nav-contain {
+		margin-left: auto;
 	}
 }
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -38,12 +38,15 @@
 
 		li {
 			font-family: $font__heading;
-			margin-bottom: #{0.25 * $size__spacing-unit};
 
 			ul {
 				margin-left: 1.5em;
-				margin-top: #{0.5 * $size__spacing-unit};
 			}
+		}
+
+		a {
+			display: inline-block;
+			padding: #{0.125 * $size__spacing-unit} 0;
 		}
 	}
 }

--- a/newspack-theme/template-parts/header/desktop-sidebar.php
+++ b/newspack-theme/template-parts/header/desktop-sidebar.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Template to display a menu 'sidebar' on desktop.
+ *
+ * @package Newspack
+ */
+
+if ( newspack_is_amp() ) : ?>
+	<amp-sidebar id="desktop-sidebar" layout="nodisplay" side="left" class="desktop-sidebar">
+		<button class="desktop-menu-toggle" on='tap:desktop-sidebar.toggle'>
+			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
+			<?php esc_html_e( 'Close', 'newspack' ); ?>
+		</button>
+<?php else : ?>
+	<aside id="desktop-sidebar-fallback" class="desktop-sidebar">
+		<button class="desktop-menu-toggle">
+			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
+			<?php esc_html_e( 'Close', 'newspack' ); ?>
+		</button>
+<?php
+endif;
+
+	newspack_desktop_sidebar_menu();
+
+if ( newspack_is_amp() ) :
+?>
+	</amp-sidebar>
+<?php else : ?>
+	</aside>
+<?php endif; ?>

--- a/newspack-theme/template-parts/header/desktop-sidebar.php
+++ b/newspack-theme/template-parts/header/desktop-sidebar.php
@@ -20,7 +20,7 @@ if ( newspack_is_amp() ) : ?>
 <?php
 endif;
 
-	newspack_desktop_sidebar_menu();
+dynamic_sidebar( 'header-1' );
 
 if ( newspack_is_amp() ) :
 ?>

--- a/newspack-theme/template-parts/header/mobile-sidebar.php
+++ b/newspack-theme/template-parts/header/mobile-sidebar.php
@@ -19,15 +19,21 @@ if ( newspack_is_amp() ) : ?>
 		</button>
 <?php endif; ?>
 
-		<?php newspack_tertiary_menu(); ?>
+		<?php
+		newspack_tertiary_menu();
 
-		<?php get_search_form(); ?>
+		get_search_form();
 
-		<?php newspack_primary_menu(); ?>
+		newspack_primary_menu();
 
-		<?php newspack_secondary_menu(); ?>
+		newspack_secondary_menu();
 
-		<?php newspack_social_menu_header(); ?>
+		newspack_social_menu_header();
+
+		if ( true === get_theme_mod( 'slideout_widget_mobile', false ) && is_active_sidebar( 'header-1' ) ) {
+			dynamic_sidebar( 'header-1' );
+		}
+		?>
 
 <?php if ( newspack_is_amp() ) : ?>
 	</amp-sidebar>

--- a/newspack-theme/template-parts/header/mobile-sidebar.php
+++ b/newspack-theme/template-parts/header/mobile-sidebar.php
@@ -27,8 +27,6 @@ if ( newspack_is_amp() ) : ?>
 
 		<?php newspack_secondary_menu(); ?>
 
-		<?php newspack_desktop_sidebar_menu(); ?>
-
 		<?php newspack_social_menu_header(); ?>
 
 <?php if ( newspack_is_amp() ) : ?>

--- a/newspack-theme/template-parts/header/mobile-sidebar.php
+++ b/newspack-theme/template-parts/header/mobile-sidebar.php
@@ -27,6 +27,8 @@ if ( newspack_is_amp() ) : ?>
 
 		<?php newspack_secondary_menu(); ?>
 
+		<?php newspack_desktop_sidebar_menu(); ?>
+
 		<?php newspack_social_menu_header(); ?>
 
 <?php if ( newspack_is_amp() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR starts the process of adding a 'slide out' menu to the header (#766).

It's opened up some questions for me, so I wanted to push up an in-progress PR and get some feedback. CCing @philipjohn (since you're working with the publications asking for this functionality), and @thomasguillot for a second opinion on how to handle it.

**How do we work yet another button into the menu?**

In working with the code, I think the best spot is to the left of the secondary menu. Unfortunately, at the moment, that secondary menu is not visible if you pick the 'Short Header' option. So if we went with this placement, I think that secondary menu space would need to be visible if you have a secondary menu and/or desktop slide out menu. The header overall would still be shorter -- the primary menu would still be in line with the logo -- but it will make the header taller.

Is there another placement I'm not thinking of? 

**Should this space allow more than menus?** 

Right now, the PR adds just one menu to this desktop space, and moves it into the mobile menu when viewed on smaller screens. 

I don't want to over-complicate it, but I feel like we'll be asked about adding other simple things to this space -- like text, or other widget-like content. Which makes me wonder:

* Should this area have a widget area?
* Should it only have widget areas, and no menu (since there is a Navigation Menu widget)? 
* Can we/should we try to do something hacky with a page/gutenberg editor instead? On one hand: freedom! On the other hand: I feel like this could get very ugly, very quickly.
* What should happen with this content on mobile, knowing it could be very complicated? I'm leaning towards it being hidden (similar to the Highlight Menu), but realize that could be different than expected.

### How to test the changes in this Pull Request:

To test what's currently in this PR:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Menus, and add a Menu to the "Desktop Sidebar Menu" (note to self: this should be changed to be less specific).
3. If not already, navigate to Customize > Header Settings and uncheck 'Short Header'.
4. View on front-end; note there's a Menu link in line with the Secondary Menu:

![image](https://user-images.githubusercontent.com/177561/75815647-a37b0b80-5d48-11ea-9fff-048ece10141a.png)

5. Click to open the menu -- it is currently set up to display two levels of a menu, treating the top level links like headers. This could also be updated to act more like the Primary menu on mobile, allowing multiple levels:

![image](https://user-images.githubusercontent.com/177561/75815694-b55cae80-5d48-11ea-85b5-8100c69a80b6.png)

6. Scale down the browser window, and open the regular mobile menu. Confirm that your Desktop Sidebar menu is there, too, under the Secondary menu:

![image](https://user-images.githubusercontent.com/177561/75815762-d1f8e680-5d48-11ea-94e1-0f85e3af2145.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
