### PR TITLE
Pages: fix issue with featured images not displaying for one col templates

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -168,6 +168,10 @@ body.page {
 	}
 }
 
+.page .post-thumbnail {
+	text-align: center;
+}
+
 .entry-content {
 	p {
 		word-wrap: break-word;

--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -25,6 +25,8 @@ get_header();
 				// Template part for large featured images.
 				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
+				elseif ( is_page() ) :
+					newspack_post_thumbnail();
 				else :
 				?>
 					<header class="entry-header">

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -25,6 +25,8 @@ get_header();
 				// Template part for large featured images.
 				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
+				elseif ( is_page() ) :
+					newspack_post_thumbnail();
 				else :
 				?>
 					<header class="entry-header">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you add a featured image to a page using the One Column or One Column Wide templates, the featured images don't display.

This PR adds the featured images. Placeholder fix until #751 is fixed (which will better flesh out the page featured image options, to match posts)

### How to test the changes in this Pull Request:

1. Set up a page with the One Column template, and another with the One Column Wide template. Add a featured template to each.
2. Save and publish; view on the front end and note that the featured images don't display.
3. Apply the PR and run `npm run build`.
4. Confirm that the featured image is now displaying on both of your pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
