### PR TITLE
Adds option to collapse comments

### DIFF
--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -20,6 +20,7 @@ if ( post_password_required() ) {
 }
 
 $discussion = newspack_get_discussion_data();
+$collapse_comments = get_theme_mod( 'collapse_comments', false );
 ?>
 
 <div id="comments" class="<?php echo comments_open() ? 'comments-area' : 'comments-area comments-closed'; ?>">
@@ -68,7 +69,11 @@ $discussion = newspack_get_discussion_data();
 			newspack_comment_form( 'desc' );
 		}
 		?>
-		<div id="comments-wrapper" class="comments-wrapper comments-hide" [class]="showComments ? 'comments-wrapper' : 'comments-wrapper comments-hide'">
+
+		<?php if ( $collapse_comments ) : ?>
+			<div id="comments-wrapper" class="comments-wrapper comments-hide" [class]="showComments ? 'comments-wrapper' : 'comments-wrapper comments-hide'">
+		<?php endif; ?>
+
 			<ol class="comment-list">
 				<?php
 				wp_list_comments(
@@ -96,10 +101,13 @@ $discussion = newspack_get_discussion_data();
 				);
 			endif;
 			?>
-			<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
-				<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>
-			</button>
-		</div><!-- .comments-wrapper -->
+
+				<?php if ( $collapse_comments ) : ?>
+					<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
+						<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>
+					</button>
+				</div><!-- .comments-wrapper -->
+			<?php endif; ?>
 
 		<?php
 		// Show comment form at bottom if showing newest comments at the bottom.

--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -67,35 +67,41 @@ $discussion = newspack_get_discussion_data();
 		if ( comments_open() ) {
 			newspack_comment_form( 'desc' );
 		}
-
 		?>
-		<ol class="comment-list">
+		<div id="comments-wrapper" class="comments-wrapper comments-hide" [class]="showComments ? 'comments-wrapper' : 'comments-wrapper comments-hide'">
+			<ol class="comment-list">
+				<?php
+				wp_list_comments(
+					array(
+						'walker'      => new newspack_Walker_Comment(),
+						'avatar_size' => newspack_get_avatar_size(),
+						'short_ping'  => true,
+						'style'       => 'ol',
+					)
+				);
+				?>
+			</ol><!-- .comment-list -->
 			<?php
-			wp_list_comments(
-				array(
-					'walker'      => new newspack_Walker_Comment(),
-					'avatar_size' => newspack_get_avatar_size(),
-					'short_ping'  => true,
-					'style'       => 'ol',
-				)
-			);
+
+			// Show comment navigation
+			if ( have_comments() ) :
+				$prev_icon     = newspack_get_icon_svg( 'chevron_left', 22 );
+				$next_icon     = newspack_get_icon_svg( 'chevron_right', 22 );
+				$comments_text = apply_filters( 'newspack_comments_name_plural', __( 'Comments', 'newspack' ) );
+				the_comments_navigation(
+					array(
+						'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'newspack' ), $comments_text ),
+						'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'newspack' ), $comments_text, $next_icon ),
+					)
+				);
+			endif;
 			?>
-		</ol><!-- .comment-list -->
+			<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
+				<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>
+			</button>
+		</div><!-- .comments-wrapper -->
+
 		<?php
-
-		// Show comment navigation
-		if ( have_comments() ) :
-			$prev_icon     = newspack_get_icon_svg( 'chevron_left', 22 );
-			$next_icon     = newspack_get_icon_svg( 'chevron_right', 22 );
-			$comments_text = apply_filters( 'newspack_comments_name_plural', __( 'Comments', 'newspack' ) );
-			the_comments_navigation(
-				array(
-					'prev_text' => sprintf( '%s <span class="nav-prev-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span>', $prev_icon, __( 'Previous', 'newspack' ), $comments_text ),
-					'next_text' => sprintf( '<span class="nav-next-text"><span class="primary-text">%s</span> <span class="secondary-text">%s</span></span> %s', __( 'Next', 'newspack' ), $comments_text, $next_icon ),
-				)
-			);
-		endif;
-
 		// Show comment form at bottom if showing newest comments at the bottom.
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
 			$leave_comment_text = apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) );

--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -19,8 +19,25 @@ if ( post_password_required() ) {
 	return;
 }
 
-$discussion = newspack_get_discussion_data();
-$collapse_comments = get_theme_mod( 'collapse_comments', false );
+$discussion         = newspack_get_discussion_data();
+$collapse_comments  = get_theme_mod( 'collapse_comments', false );
+$on_first_page      = true;
+$comments_collapsed = false;
+$url_end            = '';
+
+if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+	$url_end = basename( sanitize_text_field( $_SERVER['REQUEST_URI'] ) );
+}
+
+// Figure out if we're into comment pagination, to check if there's a new comment, or we're in subpages:
+if ( false !== strpos( $url_end, 'cpage=' ) || false !== strpos( $url_end, 'comment-page-' ) || false !== strpos( $url_end, 'moderation-hash=' ) ) {
+	$on_first_page = false;
+}
+
+// Collapse comments if that's set, if there's more than one, and if we're on the first page:
+if ( $collapse_comments && 1 < (int) $discussion->responses && $on_first_page ) {
+	$comments_collapsed = true;
+}
 ?>
 
 <div id="comments" class="<?php echo comments_open() ? 'comments-area' : 'comments-area comments-closed'; ?>">
@@ -70,7 +87,7 @@ $collapse_comments = get_theme_mod( 'collapse_comments', false );
 		}
 		?>
 
-		<?php if ( $collapse_comments && 1 < (int) $discussion->responses ) : ?>
+		<?php if ( $comments_collapsed ) : ?>
 			<div id="comments-wrapper" class="comments-wrapper comments-hide" [class]="showComments ? 'comments-wrapper' : 'comments-wrapper comments-hide'">
 		<?php endif; ?>
 
@@ -102,7 +119,7 @@ $collapse_comments = get_theme_mod( 'collapse_comments', false );
 			endif;
 			?>
 
-		<?php if ( $collapse_comments && 1 < (int) $discussion->responses ) : ?>
+		<?php if ( $comments_collapsed ) : ?>
 			</div><!-- .comments-wrapper -->
 			<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
 				<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>

--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -70,7 +70,7 @@ $collapse_comments = get_theme_mod( 'collapse_comments', false );
 		}
 		?>
 
-		<?php if ( $collapse_comments ) : ?>
+		<?php if ( $collapse_comments && 1 < (int) $discussion->responses ) : ?>
 			<div id="comments-wrapper" class="comments-wrapper comments-hide" [class]="showComments ? 'comments-wrapper' : 'comments-wrapper comments-hide'">
 		<?php endif; ?>
 
@@ -102,12 +102,12 @@ $collapse_comments = get_theme_mod( 'collapse_comments', false );
 			endif;
 			?>
 
-				<?php if ( $collapse_comments ) : ?>
-					<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
-						<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>
-					</button>
-				</div><!-- .comments-wrapper -->
-			<?php endif; ?>
+		<?php if ( $collapse_comments && 1 < (int) $discussion->responses ) : ?>
+			</div><!-- .comments-wrapper -->
+			<button class="comments-toggle" id="comments-toggle" on="tap:AMP.setState({showComments: !showComments})">
+				<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?><span [text]="showComments ? '<?php esc_html_e( 'Collapse comments', 'newspack' ); ?>' : '<?php esc_html_e( 'Expand comments', 'newspack' ); ?>'"><?php esc_html_e( 'Expand comments', 'newspack' ); ?></span>
+			</button>
+		<?php endif; ?>
 
 		<?php
 		// Show comment form at bottom if showing newest comments at the bottom.

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -344,8 +344,10 @@ function newspack_scripts() {
 		}
 
 		$newspack_l10n = array(
-			'open_search'  => esc_html__( 'Open Search', 'newspack' ),
-			'close_search' => esc_html__( 'Close Search', 'newspack' ),
+			'open_search'       => esc_html__( 'Open Search', 'newspack' ),
+			'close_search'      => esc_html__( 'Close Search', 'newspack' ),
+			'expand_comments'   => esc_html__( 'Expand Comments', 'newspack' ),
+			'collapse_comments' => esc_html__( 'Collapse Comments', 'newspack' ),
 		);
 
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), '1.0', true );

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -62,7 +62,8 @@ function newspack_custom_colors_css() {
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,
-		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
+		.comments-toggle:hover, .comments-toggle:focus {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -430,6 +430,35 @@ function newspack_customize_register( $wp_customize ) {
 			'section' => 'featured_image_options',
 		)
 	);
+
+	/**
+	 * Comments settings
+	 */
+	$wp_customize->add_section(
+		'comments_options',
+		array(
+			'title' => esc_html__( 'Comments Settings', 'newspack' ),
+		)
+	);
+
+	// Add option to collapse the comments.
+	$wp_customize->add_setting(
+		'collapse_comments',
+		array(
+			'default'           => false,
+			'transport'         => 'postMessage',
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'collapse_comments',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Collapse Comments', 'newspack' ),
+			'description' => esc_html__( 'Collapse the comments on each post and display a button to open.', 'newspack' ),
+			'section'     => 'comments_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -446,7 +446,6 @@ function newspack_customize_register( $wp_customize ) {
 		'collapse_comments',
 		array(
 			'default'           => false,
-			'transport'         => 'postMessage',
 			'sanitize_callback' => 'newspack_sanitize_checkbox',
 		)
 	);
@@ -455,7 +454,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Collapse Comments', 'newspack' ),
-			'description' => esc_html__( 'Collapse the comments on each post and display a button to open.', 'newspack' ),
+			'description' => esc_html__( 'When using the WordPress default comments, this option will collapse the comments down and display a button to expand.', 'newspack' ),
 			'section'     => 'comments_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -454,7 +454,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Collapse Comments', 'newspack' ),
-			'description' => esc_html__( 'When using the WordPress default comments, this option will collapse the comments down and display a button to expand.', 'newspack' ),
+			'description' => esc_html__( 'When using WordPress\'s default comments, checking this option will collapse the comments section when there is more than one comment, and display a button to expand.', 'newspack' ),
 			'section'     => 'comments_options',
 		)
 	);

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -81,21 +81,25 @@
 	}
 
 	// Comments toggle fallback.
-	const commentsToggle = document.getElementById( 'comments-toggle' ),
-		commentsWrapper = document.getElementById( 'comments-wrapper' ),
+	const commentsToggle = document.getElementById( 'comments-toggle' );
+
+	// Make sure comments exist before going any further.
+	if ( null !== commentsToggle ) {
+		const commentsWrapper = document.getElementById( 'comments-wrapper' ),
 		commentsToggleTextContain = commentsToggle.getElementsByTagName( 'span' )[ 0 ];
 
-	commentsToggle.addEventListener(
-		'click',
-		function() {
-			if ( commentsWrapper.classList.contains( 'comments-hide' ) ) {
-				commentsWrapper.classList.remove( 'comments-hide' );
-				commentsToggleTextContain.innerText = newspackScreenReaderText.collapse_comments;
-			} else {
-				commentsWrapper.classList.add( 'comments-hide' );
-				commentsToggleTextContain.innerText = newspackScreenReaderText.expand_comments;
-			}
-		},
-		false
-	);
+		commentsToggle.addEventListener(
+			'click',
+			function() {
+				if ( commentsWrapper.classList.contains( 'comments-hide' ) ) {
+					commentsWrapper.classList.remove( 'comments-hide' );
+					commentsToggleTextContain.innerText = newspackScreenReaderText.collapse_comments;
+				} else {
+					commentsWrapper.classList.add( 'comments-hide' );
+					commentsToggleTextContain.innerText = newspackScreenReaderText.expand_comments;
+				}
+			},
+			false
+		);
+	}
 } )();

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -79,4 +79,23 @@
 			false
 		);
 	}
+
+	// Comments toggle fallback.
+	const commentsToggle = document.getElementById( 'comments-toggle' ),
+		commentsWrapper = document.getElementById( 'comments-wrapper' ),
+		commentsToggleTextContain = commentsToggle.getElementsByTagName( 'span' )[ 0 ];
+
+	commentsToggle.addEventListener(
+		'click',
+		function() {
+			if ( commentsWrapper.classList.contains( 'comments-hide' ) ) {
+				commentsWrapper.classList.remove( 'comments-hide' );
+				commentsToggleTextContain.innerText = newspackScreenReaderText.collapse_comments;
+			} else {
+				commentsWrapper.classList.add( 'comments-hide' );
+				commentsToggleTextContain.innerText = newspackScreenReaderText.expand_comments;
+			}
+		},
+		false
+	);
 } )();

--- a/newspack-theme/sass/navigation/_next-previous.scss
+++ b/newspack-theme/sass/navigation/_next-previous.scss
@@ -79,6 +79,7 @@
 		width: 100%;
 		font-family: $font__heading;
 		font-weight: bold;
+		padding: #{0.5 * $size__spacing-unit} 0;
 
 		.secondary-text {
 			display: none;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -42,7 +42,6 @@
 
 		.discussion-meta {
 			@include media( tablet ) {
-				flex: 0 0 calc( 2 * ( 100vw / 12 ) );
 				margin-left: #{$size__spacing-unit};
 				text-align: right;
 			}

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -391,24 +391,26 @@
 }
 
 .comments-toggle {
+	align-items: center;
 	background: transparent;
 	border-radius: 0;
 	border-top: 1px solid $color__border;
 	color: $color__text-main;
+	display: flex;
 	font-size: $font__size-sm;
+	justify-content: center;
 	margin-top: 0;
 	position: relative;
 	width: 100%;
 
 	svg {
-		position: relative;
-		top: 5px;
 		transform: rotate( 90deg );
 	}
 
-	&:hover {
+	&:hover,
+	&:focus {
 		background: transparent;
-		color: $color__text-main;
+		color: $color__primary;
 	}
 }
 

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -375,60 +375,56 @@
 	}
 }
 
-.comments-title-wrap {
-	margin-bottom: 0;
-}
-
 .comments-wrapper {
-	margin-top: 0;
+	margin: 0;
+	min-height: 200px;
 
 	&.comments-hide {
-		max-height: 30vh;
+		height: 200px;
 		overflow: hidden;
-		position: relative;
-
-		@include media( tablet ) {
-			max-height: 300px;
-		}
-
-		&::after {
-			background-image: linear-gradient(
-				rgba( 255, 255, 255, 0 ),
-				rgba( 255, 255, 255, 0 ) 25%,
-				rgba( 255, 255, 255, 1 ) 75%
-			);
-			bottom: 0;
-			content: '';
-			left: 0;
-			position: absolute;
-			right: 0;
-			top: 0;
-			z-index: 2;
-		}
-
-		.comments-toggle {
-			bottom: 0;
-			position: absolute;
-			z-index: 5;
-
-			svg {
-				transform: rotate( 270deg );
-			}
-		}
 	}
 
-	.comments-toggle {
-		background: #fff;
-		border-radius: 0;
-		border-top: 1px solid $color__border;
-		color: $color__text-main;
-		font-size: $font__size-sm;
-		width: 100%;
+	.comment-list,
+	.comment-list > li:first-child article {
+		margin-top: 0;
+	}
+}
 
-		svg {
-			position: relative;
-			top: 5px;
-			transform: rotate( 90deg );
-		}
+.comments-toggle {
+	background: transparent;
+	border-radius: 0;
+	border-top: 1px solid $color__border;
+	color: $color__text-main;
+	font-size: $font__size-sm;
+	margin-top: 0;
+	position: relative;
+	width: 100%;
+
+	svg {
+		position: relative;
+		top: 5px;
+		transform: rotate( 90deg );
+	}
+
+	&:hover {
+		background: transparent;
+		color: $color__text-main;
+	}
+}
+
+.comments-hide + .comments-toggle {
+	svg {
+		transform: rotate( 270deg );
+	}
+
+	&::after {
+		background-image: linear-gradient( rgba( 255, 255, 255, 0 ), rgba( 255, 255, 255, 1 ) );
+		content: '';
+		height: 150px;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: -151px;
+		z-index: 2;
 	}
 }

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -375,3 +375,61 @@
 		width: 100%;
 	}
 }
+
+.comments-title-wrap {
+	margin-bottom: 0;
+}
+
+.comments-wrapper {
+	margin-top: 0;
+
+	&.comments-hide {
+		max-height: 30vh;
+		overflow: hidden;
+		position: relative;
+
+		@include media( tablet ) {
+			max-height: 300px;
+		}
+
+		&::after {
+			background-image: linear-gradient(
+				rgba( 255, 255, 255, 0 ),
+				rgba( 255, 255, 255, 0 ) 25%,
+				rgba( 255, 255, 255, 1 ) 75%
+			);
+			bottom: 0;
+			content: '';
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+			z-index: 2;
+		}
+
+		.comments-toggle {
+			bottom: 0;
+			position: absolute;
+			z-index: 5;
+
+			svg {
+				transform: rotate( 270deg );
+			}
+		}
+	}
+
+	.comments-toggle {
+		background: #fff;
+		border-radius: 0;
+		border-top: 1px solid $color__border;
+		color: $color__text-main;
+		font-size: $font__size-sm;
+		width: 100%;
+
+		svg {
+			position: relative;
+			top: 5px;
+			transform: rotate( 90deg );
+		}
+	}
+}

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -99,7 +99,6 @@ h3 {
 
 .site-title,
 .site-description,
-.nav-links,
 .comment-author .fn,
 .no-comments,
 h2.author-title,
@@ -118,7 +117,7 @@ h4 {
 }
 
 .entry-meta,
-.pagination .nav-links,
+.nav-links,
 .comment-content,
 h5 {
 	font-size: $font__size-sm;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to collapse comments to the Customizer.

The way WordPress handles comments makes this a bit tricky -- I had to do some hacky stuff to work around making sure a new comment, for example, wasn't hidden when added, or to make sure users saw the 'awaiting moderation' message.

I'm sure there are still some issues with this approach; I tried to be extensive in my testing steps, but please, hammer it has hard as you can.

Closes #804 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Comment Options, and turn on 'Collapse Comments'.

3. If it's not already, turn AMP mode to standard. 
4. As a logged in user, view a post with one -- the comments should not be collapsed with only one comment:

![image](https://user-images.githubusercontent.com/177561/76034745-a3b80a00-5ef4-11ea-987d-36d4ba4500d0.png)

5. Add a second comment. Verify that comments are not collapsed when you first add the second comment. The code is figuring out when to do this by checking the URL -- it will contain `cpage` or `comment-page-`, depending on your permalinks settings, when you add a comment:

![image](https://user-images.githubusercontent.com/177561/76034803-cd713100-5ef4-11ea-9c33-30d29f402542.png)

6. Remove the comment part of the URL (returning it to its normal state), and test the post again -- comments should now be collapsed:

![image](https://user-images.githubusercontent.com/177561/76034836-deba3d80-5ef4-11ea-83f5-3ce24a0da309.png)

7. Test the toggle to make sure the comments open and close as expected:

![image](https://user-images.githubusercontent.com/177561/76034857-e843a580-5ef4-11ea-922b-d7d72245f743.png)

**Note:** At this point you may see a double title, which is unrelated to these changes, and can be recreated on `master` by toggling the search. This will be fixed when #821 lands:

![image](https://user-images.githubusercontent.com/177561/76034620-49b74480-5ef4-11ea-81f4-67ba5ee990f8.png)

8. Try switching to an incognito window, and add a comment as a non-logged in user; confirm that comments don't collapse after your comment is submitted, and you can see your comment awaiting moderation:

![image](https://user-images.githubusercontent.com/177561/76034946-1de88e80-5ef5-11ea-8bfd-5ae37966a8a3.png)

9. Continue adding a few comments to the post as both new comments and replies, repeating steps 5-7 with each one, confirming things work as expected, until you have more than five top-level comments.
10. Navigate to Dashboard > Settings > Discussion, and check the box to "Break comments into pages with"; set it to 5 top level comments:

![image](https://user-images.githubusercontent.com/177561/76034427-baaa2c80-5ef3-11ea-940c-58ff8e5285f4.png)

11. Navigate back to the post, and try adding a comment, as both logged in and logged out users and confirm it still works the same way (not collapsed).
12. Expand the comments, and scroll to the bottom, then click "Previous Comments". Confirm the next page is not collapsed.
13. Turn off AMP, and confirm the comments toggle still works (opening/closing on click). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
