### PR TITLE
Comments: Fix double header, temporarily fix changing header

### DIFF
--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -98,14 +98,7 @@ $discussion = newspack_get_discussion_data();
 
 		// Show comment form at bottom if showing newest comments at the bottom.
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
-			$leave_comment_text = apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) );
-			?>
-			<div class="comment-form-flex">
-				<span class="screen-reader-text"><?php echo esc_html( $leave_comment_text ); ?></span>
-				<?php newspack_comment_form( 'asc' ); ?>
-				<h2 class="comments-title" aria-hidden="true"><?php echo esc_html( $leave_comment_text ); ?></h2>
-			</div>
-			<?php
+			newspack_comment_form( 'asc' );
 		endif;
 
 		// If comments are closed and there are comments, let's leave a little note, shall we?

--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -98,6 +98,7 @@ $discussion = newspack_get_discussion_data();
 
 		// Show comment form at bottom if showing newest comments at the bottom.
 		if ( comments_open() && 'asc' === strtolower( get_option( 'comment_order', 'asc' ) ) ) :
+			echo '<h3 class="comment-reply-title">' . esc_html( apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) ) ) . '</h3>';
 			newspack_comment_form( 'asc' );
 		endif;
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -283,7 +283,6 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 			comment_form(
 				array(
 					'logged_in_as' => null,
-					'title_reply'  => apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) ),
 				)
 			);
 		}

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -283,7 +283,7 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 			comment_form(
 				array(
 					'logged_in_as' => null,
-					'title_reply'  => null,
+					'title_reply'  => apply_filters( 'newspack_comments_leave_comment', __( 'Leave a comment', 'newspack' ) ),
 				)
 			);
 		}

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -71,6 +71,10 @@
 		padding-left: 0;
 	}
 
+	.comment-reply-title {
+		display: none;
+	}
+
 	> small {
 		display: block;
 		font-size: $font__size_base;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -87,25 +87,6 @@
 	}
 }
 
-.comment-form-flex {
-	display: flex;
-	flex-direction: column;
-
-	.comments-title {
-		display: none;
-		margin: 0;
-		order: 1;
-	}
-
-	#respond {
-		order: 2;
-
-		+ .comments-title {
-			display: block;
-		}
-	}
-}
-
 .comment-list {
 	list-style: none;
 	padding: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a double header issue that was happening with the comments form and AMP, and includes a temporary fix for making sure the comment form header -- which can be customized with https://github.com/Automattic/newspack-rename-comments -- is not changed back to Leave a Reply.

Related: https://github.com/ampproject/amp-wp/issues/2489

### How to test the changes in this Pull Request:

1. On a site with AMP enabled, navigate to a page with a comments form and view it:

![image](https://user-images.githubusercontent.com/177561/76038569-c64f2080-5efe-11ea-997c-5bd03f3dc174.png)

2. Scroll to the top and toggle on/off the search, then view the comment form again:

![image](https://user-images.githubusercontent.com/177561/76038579-ce0ec500-5efe-11ea-9f0c-73a0702d3399.png)

3. Apply the PR and run `npm run build`
4. Repeat steps 1 and 2; confirm that only the one title shows:

![image](https://user-images.githubusercontent.com/177561/76038713-31005c00-5eff-11ea-8509-f1cf68a448c5.png)

5. Install and enable https://github.com/Automattic/newspack-rename-comments.
6. Navigate to Dashboard > Settings > Discussion; scroll to the bottom and add new names for all of the fields under the "Rename Comments" header.
7. Confirm that this text is applied correctly, both on load and after toggling the search:

![image](https://user-images.githubusercontent.com/177561/76038823-7ae94200-5eff-11ea-99e1-fe5bee275148.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
