### PR TITLE
Correct position of comment icon indicating current author

### DIFF
--- a/newspack-theme/classes/class-newspack-walker-comment.php
+++ b/newspack-theme/classes/class-newspack-walker-comment.php
@@ -44,22 +44,6 @@ class Newspack_Walker_Comment extends Walker_Comment {
 							}
 						}
 
-						/*
-						 * Using the `check` icon instead of `check_circle`, since we can't add a
-						 * fill color to the inner check shape when in circle form.
-						 */
-						if ( newspack_is_comment_by_post_author( $comment ) ) {
-							printf( '<span class="post-author-badge" aria-hidden="true">%s</span>', newspack_get_icon_svg( 'check', 24 ) );
-						}
-
-						/*
-						 * Using the `check` icon instead of `check_circle`, since we can't add a
-						 * fill color to the inner check shape when in circle form.
-						 */
-						if ( newspack_is_comment_by_post_author( $comment ) ) {
-							printf( '<span class="post-author-badge" aria-hidden="true">%s</span>', newspack_get_icon_svg( 'check', 24 ) );
-						}
-
 						printf(
 							wp_kses(
 								/* translators: %s: comment author link */
@@ -72,6 +56,11 @@ class Newspack_Walker_Comment extends Walker_Comment {
 							),
 							'<b class="fn">' . get_comment_author_link( $comment ) . '</b>'
 						);
+
+						/* Display icon if the commenter is the current post's author. */
+						if ( newspack_is_comment_by_post_author( $comment ) ) {
+							printf( '<span class="post-author-badge" aria-hidden="true">%s</span>', wp_kses( newspack_get_icon_svg( 'check', 24 ), newspack_sanitize_svgs() ) );
+						}
 
 						if ( ! empty( $comment_author_url ) ) {
 							echo '</a>';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -42,7 +42,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 		.entry .entry-content .wp-block-file .wp-block-file__button,
-		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
+		.comment .comment-author .post-author-badge {
 			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
@@ -58,6 +59,7 @@ function newspack_custom_colors_css() {
 		.nav1 .main-menu > li > a + svg,
 		.search-form button:active, .search-form button:hover, .search-form button:focus,
 		.entry-footer a,
+		.comment .comment-author .post-author-badge,
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -59,7 +59,6 @@ function newspack_custom_colors_css() {
 		.nav1 .main-menu > li > a + svg,
 		.search-form button:active, .search-form button:hover, .search-form button:focus,
 		.entry-footer a,
-		.comment .comment-author .post-author-badge,
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,
@@ -89,6 +88,7 @@ function newspack_custom_colors_css() {
 		.highlight-menu .menu-label,
 		/* Header default background; default height */
 		body.h-db.h-dh .site-header .nav3 .menu-highlight a,
+		.comment .comment-author .post-author-badge,
 		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -185,7 +185,7 @@
 
 		.fn {
 			position: relative;
-			display: block;
+			display: inline-block;
 
 			a {
 				color: inherit;
@@ -197,25 +197,28 @@
 		}
 
 		.post-author-badge {
+			background: $color__primary;
 			border-radius: 100%;
-			display: block;
-			height: 18px;
-			position: absolute;
-			background: lighten( $color__primary, 8% );
-			right: calc( 100% - #{$size__spacing-unit * 2.5} );
-			top: -3px;
-			width: 18px;
+			color: #fff;
+			display: inline-block;
+			height: 16px;
+			line-height: 16px;
+			margin-left: #{0.25 * $size__spacing-unit};
+			text-align: center;
+			width: 16px;
 
 			@include media( tablet ) {
-				right: calc( 100% + #{$size__spacing-unit * 0.75} );
+				height: 18px;
+				line-height: 18px;
+				width: 18px;
 			}
 
 			svg {
-				width: inherit;
+				display: inline-block;
+				fill: currentColor;
 				height: inherit;
-				display: block;
-				fill: white;
 				transform: scale( 0.875 );
+				width: inherit;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme adds an icon to comments made by the current post author. 

Right now, that icon is oddly placed and it's always using Newspack's default blue -- this PR updates the position, and changes it to use the custom primary colour. It also removes some duplicate code that doesn't seem to do anything (the duplicate icons would just be stacked on top of each other).

Closes #819

### How to test the changes in this Pull Request:

1. Add a comment to a post your current user authored, and view on front-end:

![image](https://user-images.githubusercontent.com/177561/76246338-bedb9000-61fa-11ea-89f8-993099e02903.png)

2. Apply the PR and run `npm run build`
3. Confirm that the icon placement is next to the author's name, and that it's using your current primary colour:

![image](https://user-images.githubusercontent.com/177561/76246478-07934900-61fb-11ea-9333-7ccc34735fa7.png)

4. Try changing your custom colour to a dark colour if it's lighter, or a light colour if it's darker, to make sure the contrast works as expected:

![image](https://user-images.githubusercontent.com/177561/76246686-71135780-61fb-11ea-95f5-ac6b8b94f27c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
