### PR TITLE
fix: set max width for nested full and wide blocks

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1117,6 +1117,21 @@
 			padding-right: $size__spacing-unit;
 		}
 	}
+
+	// keep nested align-full elements from overflowing the container.
+	.entry .entry-content {
+		.wp-block-column,
+		.wp-block-group,
+		.wp-block-cover {
+			.alignwide,
+			.alignfull {
+				margin-left: 0;
+				margin-right: 0;
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
 }
 
 //! Mailchimp block


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes sure nested full and wide-align blocks can't escape their containing blocks.

Closes #774.

### How to test the changes in this Pull Request:

1. Copy-paste this test content into the editor: https://cloudup.com/cfcmNomYh1N -- it's a wide and full-align homepage posts block nested in a group, column, and cover block.
2. View on the front end; note that the blocks are coming out of their containers, or getting cut off in the case of the cover block.
3. Apply the PR and run `npm run build`.
4. Confirm that the blocks are now being contained by their parent blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
