### PR TITLE
Set size for above copyright widget titles

### DIFF
--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -162,3 +162,8 @@
 		}
 	}
 }
+
+#colophon .site-info .widget-title {
+	color: inherit;
+	font-size: 1em;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the Above Copyright widget titles in some of the theme is inheriting the styles from the footer widget, leaving it a bit large/wrong colour.

This PR sets them all to a consistent smaller size. 

Closes #773 

### How to test the changes in this Pull Request:

1. Add a widget with a title to the Above Copyright area.
2. View on the front end for each of the following themes:

**Joseph:**

![image](https://user-images.githubusercontent.com/177561/76650915-c4014d80-6520-11ea-98bd-d84f52277806.png)

**Sacha:**

![image](https://user-images.githubusercontent.com/177561/76651054-0f1b6080-6521-11ea-9ac6-972be29a8a6b.png)

**Scott:**

![image](https://user-images.githubusercontent.com/177561/76651152-340fd380-6521-11ea-9524-839058f3815b.png)

2. Apply the PR and run `npm run build`.
3. Cycle through the themes again and confirm that the Above Copyright widget titles appear to have a better scale:

**Joseph:**

![image](https://user-images.githubusercontent.com/177561/76651314-79340580-6521-11ea-95b8-068c54f6f910.png)

**Sacha:**

![image](https://user-images.githubusercontent.com/177561/76651270-64577200-6521-11ea-94aa-da87905ce360.png)

**Scott:**

![image](https://user-images.githubusercontent.com/177561/76651236-4ee24800-6521-11ea-8ca3-dfc3e5456e3c.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
