### PR TITLE
Homepage Posts: Remove top margin on accent-header with AMP

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -172,7 +172,7 @@
 		margin-top: 32px;
 
 		&:first-child,
-		&.wpnbha:first-child .article-section-title,
+		&:first-child .article-section-title, // when Load More is enabled.
 		&.accent-header + div.wpnbha {
 			margin-top: 0;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the theme adds margins to the top and bottom of every block, but does remove them in a few cases -- one example is when they're at the top of a column. 

The homepage posts also have the top margin removed from the section title when populated; this is done by checking for the article block being the first child. 

When AMP and Load More are both enabled, an extra container is added to the block, screwing up these styles; this PR fixes that. 

Closes #791

### How to test the changes in this Pull Request:

1. Set up a column block; in each column, add a homepage article block with 'Load More' turned on. Add a section title to each block. Save and publish.
2. Navigate to Dashboard > AMP, and set AMP mode to transitional.
3. Open your saved page in two tabs; one in AMP mode and one without. Compare the top spacing and note that the one with AMP enabled has a top margin:

**Without AMP:**

![image](https://user-images.githubusercontent.com/177561/76668211-ca0a2500-6546-11ea-9a6a-e927ab7038b8.png)

![image](https://user-images.githubusercontent.com/177561/76668408-df7f4f00-6546-11ea-890a-435761a3126e.png)

**With AMP:**

![image](https://user-images.githubusercontent.com/177561/76668262-ceced900-6546-11ea-87c9-a6f46812b495.png)

![image](https://user-images.githubusercontent.com/177561/76668341-d7bfaa80-6546-11ea-94eb-7d08c48c27c6.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the AMP version no longer has the top margin on the section header:

![image](https://user-images.githubusercontent.com/177561/76668823-0d649380-6547-11ea-9dc7-306f00fee5c1.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
