### PR TITLE
Correct issues in where custom typography is applied

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -19,7 +19,7 @@ function newspack_custom_typography_css() {
 	if ( get_theme_mod( 'font_header', '' ) ) {
 		$css_blocks .= '
 		/* _headings.scss */
-		.author-description .author-link,
+		.author-bio .author-link,
 		.comment-metadata,
 		.comment-reply-link,
 		.comments-title,
@@ -54,14 +54,15 @@ function newspack_custom_typography_css() {
 		/* _buttons.scss */
 		.button,
 		button,
-		input[type=\"button\"],
-		input[type=\"reset\"],
-		input[type=\"submit\"],
+		input[type="button"],
+		input[type="reset"],
+		input[type="submit"],
 
 		/* _blocks.scss */
 		.entry .entry-content .wp-block-button .wp-block-button__link,
 
 		/* _captions.scss */
+		figcaption,
 		.wp-caption-text,
 		.gallery-caption,
 		.amp-image-lightbox-caption,
@@ -98,8 +99,10 @@ function newspack_custom_typography_css() {
 
 		/* _blocks.scss */
 		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
+		.wp-block-pullquote cite,
 
 		/* _widgets.scss */
+		.widget,
 		.widget_archive ul li,
 		.widget_categories ul li,
 		.widget_meta ul li,
@@ -314,7 +317,6 @@ function newspack_custom_typography_css() {
 		$css_blocks .= '
 		/* _typography.scss */
 		body,
-		button,
 		input,
 		select,
 		optgroup,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple noticeable areas where the custom fonts aren't being applied in the themes. 

It will affect all themes, though some (Nelson, Scott) need additional tweaks to make sure fonts are inheriting correctly. I'd recommend testing this with the default theme. 

### How to test the changes in this Pull Request:

1. Add a navigation widget and a regular Text widget to the sidebar and footer.
2. In a post, add an image block with a caption, and a pullquote block with a citation.
3. Navigate to Customize > Typography, and enter two very distinct fonts to the fields -- I've been using Chalkboard and Impact, since they don't look anything like anything in the themes.
4. Note the appearance of the following elements:
* The text widget (compared to the navigation widget)

![image](https://user-images.githubusercontent.com/177561/76806449-a6d9b280-679e-11ea-8056-cbfb0c1860df.png)

* The comments button

![image](https://user-images.githubusercontent.com/177561/76806454-ae00c080-679e-11ea-83d1-c487cdef052c.png)

* The author bio link to their archives

![image](https://user-images.githubusercontent.com/177561/76806465-b527ce80-679e-11ea-8cac-32f49a8b04fd.png)

* The Pullquote citation

![image](https://user-images.githubusercontent.com/177561/76806445-a17c6800-679e-11ea-88aa-98865016ae9c.png)

* The image caption

![image](https://user-images.githubusercontent.com/177561/76806486-bd800980-679e-11ea-9681-97cc8a2c9be8.png)

5. Apply the PR.
6. Double check the above and confirm that they're using the right font (should be the one you have picked for your headers):
* The text widget (compared to the navigation widget)

![image](https://user-images.githubusercontent.com/177561/76805940-5c0b6b00-679d-11ea-9df3-504392e1ec07.png)

* The comments button

![image](https://user-images.githubusercontent.com/177561/76805954-6463a600-679d-11ea-85b8-41d95919bcf9.png)

* The author bio link to their archives

![image](https://user-images.githubusercontent.com/177561/76805965-6af21d80-679d-11ea-89de-c28934c75524.png)

* The Pullquote citation

![image](https://user-images.githubusercontent.com/177561/76806010-83623800-679d-11ea-8ce4-29b54240fe01.png)

* The image caption

![image](https://user-images.githubusercontent.com/177561/76805996-7cd3c080-679d-11ea-9455-b12f45ddda80.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
