### PR TITLE
Prevent id selector format error in pre-commit checks

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1125,7 +1125,7 @@
 		width: 100%;
 	}
 
-	#wp-block-jetpack-mailchimp_consent-text {
+	p[id^='wp-block-jetpack-mailchimp'] {
 		font-size: $font__size-sm;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The SCSS formatting checks are not liking the underscore in the `#wp-block-jetpack-mailchimp_consent-text` ID selector, so this PR updates the selector to use an attribute selector instead with part of the ID.

### How to test the changes in this Pull Request:

1. Add a Mailchimp block to a test site, and note the text size in the paragraph disclaimer:

![image](https://user-images.githubusercontent.com/177561/76915573-04433180-687b-11ea-9c1b-b09d8cfd8198.png)

2. Apply the PR and run `npm run build`.
3. Refresh the block; confirm the paragraph font size has not changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
