### PR TITLE
Remove style overrides from h2 in cover blocks

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -216,12 +216,6 @@
 		width: 100%;
 	}
 
-	h2 {
-		max-width: 100%;
-		padding-left: 0;
-		text-align: left;
-	}
-
 	article .entry-meta,
 	article .entry-meta a,
 	article .entry-meta a:visited,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally the Cover block only allowed specific blocks -- like the Header block -- and added styles for them (like centring them). 

The theme originally included override styles for the h2 to align it left that are no longer needed. On top of that, they're also currently preventing you from being able to centre the h2. It's time to remove these.

### How to test the changes in this Pull Request:

1. Add a cover block to a post; inside add a h2 and centre it.
2. Save and publish, and view on the front-end -- the centring styles will be ignored, and the text will be align left:

![image](https://user-images.githubusercontent.com/177561/76915777-b1b64500-687b-11ea-81ee-43dcb0c222be.png)

3. Apply the PR and run `npm run build`.
4. Confirm the h2 is now aligned centre:

![image](https://user-images.githubusercontent.com/177561/76915708-7d428900-687b-11ea-942c-f5cf33c02333.png)

5. Edit the block and remove alignment from the `h2` (by clicking align center again). Confirm that it now aligns in the default way, to the left. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
