### PR TITLE
Change way featured images are added to fix missing titles

### DIFF
--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -25,8 +25,6 @@ get_header();
 				// Template part for large featured images.
 				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
-				elseif ( is_page() ) :
-					newspack_post_thumbnail();
 				else :
 				?>
 					<header class="entry-header">
@@ -46,7 +44,11 @@ get_header();
 						newspack_post_thumbnail();
 					}
 
-					get_template_part( 'template-parts/content/content', 'single' );
+					if ( is_page() ) {
+						get_template_part( 'template-parts/content/content', 'page' );
+					} else {
+						get_template_part( 'template-parts/content/content', 'single' );
+					}
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -25,8 +25,6 @@ get_header();
 				// Template part for large featured images.
 				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
-				elseif ( is_page() ) :
-					newspack_post_thumbnail();
 				else :
 				?>
 					<header class="entry-header">
@@ -46,7 +44,11 @@ get_header();
 						newspack_post_thumbnail();
 					}
 
-					get_template_part( 'template-parts/content/content', 'single' );
+					if ( is_page() ) {
+						get_template_part( 'template-parts/content/content', 'page' );
+					} else {
+						get_template_part( 'template-parts/content/content', 'single' );
+					}
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue that was introduced with #818 

The one column wide and one column templates are no longer showing page titles.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Test the following combinations:
* Page with one column template and featured image
* Page with one column template and no featured image
* Page with one column wide template and featured image
* Page with one column wide template and no featured image
... and make sure that the page title always displays, and the featured image displays when added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
