### PR TITLE
Make sure social links block doesn't inherit link color

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1195,3 +1195,13 @@
 		}
 	}
 }
+
+//! Social Links block
+.entry-content .wp-social-link {
+	a,
+	a:active,
+	a:hover,
+	a:visited {
+		color: currentColor;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The social icons block currently inherits the theme's link colours, which causes contrast/visual issues. This PR makes sure they inherit the correct colours. 

Closes #845 

### How to test the changes in this Pull Request:

1. Add the social links block to a post or page. 
2. In the editor, add URLs to a couple of the services that appear (click on them to get the field) -- this makes sure they open on the front end.
3. Click the `+` icon next to the last social icon, and pick an icon that has a light background, like RSS feed to add -- once in the editor, add a URL to that icon, too. This helps test that both white and dark icons are working correctly:

![image](https://user-images.githubusercontent.com/177561/77462101-d9983200-6dc0-11ea-9f9f-97a0076e4447.png)

4. Save and publish, and view on front-end; note the icon colour is inheriting the current secondary colour:

![image](https://user-images.githubusercontent.com/177561/77462246-1b28dd00-6dc1-11ea-8f6e-134c3da4ea65.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the icons are now either white or dark grey, depending on the background colour they're against:

![image](https://user-images.githubusercontent.com/177561/77462898-fb45e900-6dc1-11ea-9ad3-7a5a4ae7a7c0.png)

7. If you're already using a custom colour, try the default colour scheme; if you're using the default colour scheme, try a custom colour, just to make sure it works in both cases.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
