### PR TITLE
Only apply RSS icon to /feed

### DIFF
--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -52,7 +52,7 @@ class Newspack_SVG_Icons {
 				$domains            = array_key_exists( $icon, $map ) ? $map[ $icon ] : array( sprintf( '%s.com', $icon ) );
 				$domains            = array_map( 'trim', $domains ); // Remove leading/trailing spaces, to prevent regex from failing to match.
 				$domains            = array_map( 'preg_quote', $domains );
-				$regex_map[ $icon ] = sprintf( '/(%s)/i', implode( '|', $domains ) );
+				$regex_map[ $icon ] = sprintf( '#(%s)#i', implode( '|', $domains ) );
 			}
 		}
 		foreach ( $regex_map as $icon => $regex ) {
@@ -221,7 +221,7 @@ class Newspack_SVG_Icons {
 			'fb.me',
 		),
 		'feed'        => array(
-			'feed',
+			'/feed',
 		),
 		'google-plus' => array(
 			'plus.google.com',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the URL matching used for the social links icons looks for the term 'feed' in a URL to add the RSS link.

Unfortunately, it's pretty common, and could occur in another social media URL. This PR adds `/` to the front of the matching term, to line up with WordPress's default RSS URL, and limit how often it could crop up by accident. 

Closes #844

### How to test the changes in this Pull Request:

1. Set up a social links menu with a variety of links; make sure to include a link to the site's `/feed` and a second link to https://www.linkedin.com/company/hong-kong-free-press-news-feed, a real example of where this matching is failing.
2. View on the front-end; note the double RSS icons:

![image](https://user-images.githubusercontent.com/177561/77478922-0d348580-6ddc-11ea-9a72-27e96501dc80.png)

3. Apply the PR.
4. Refresh the page and check again; confirm that your LinkedIn link is now using the correct icon, and your RSS Feed and other icons are still working as expected:

![image](https://user-images.githubusercontent.com/177561/77478985-2e957180-6ddc-11ea-9dd4-514b8ed7abfa.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
