### PR TITLE
Releases: fix setting version in release files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9811,7 +9811,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -10374,7 +10374,7 @@
     },
     "commander": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
       "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
       "dev": true
     },
@@ -18258,7 +18258,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -18911,7 +18911,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -19079,7 +19079,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -19187,7 +19187,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -19369,7 +19369,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -23479,7 +23479,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -25973,7 +25973,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -27336,9 +27336,9 @@
       }
     },
     "semantic-release-version-bump": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-version-bump/-/semantic-release-version-bump-1.3.0.tgz",
-      "integrity": "sha512-K0/PvQbFAgCw1p73MlF11jDLnc5rbXUj2PVywVtGXGZuU6rwq5quJ7R8SrPBDrAOtcmtJVsIuDctha9t75e2SQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-release-version-bump/-/semantic-release-version-bump-1.4.1.tgz",
+      "integrity": "sha512-LxsDRdTj7vQKUh6jn5XKo2beFP2nyGZWpbowxVG01s6sR/K2Anod4k/aS/rkCnyf8GHEa7zADL3W4+7Z6ZhCqQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6"
@@ -28305,7 +28305,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -30646,7 +30646,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-router-dom": "^5.0.1",
     "rtlcss": "^2.4.0",
     "semantic-release": "^17.0.2",
-    "semantic-release-version-bump": "^1.3.0",
+    "semantic-release-version-bump": "^1.4.1",
     "stylelint": "^13.0.0",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-wordpress": "^16.0.0",

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,9 @@ module.exports = {
 		[
 			'semantic-release-version-bump',
 			{
-				files: 'newspack-*/sass/style.scss',
+				// build script is run before semantic-release, so the version in *.css files
+				// have to be updated explicitly
+				files: [ 'newspack-*/sass/style.scss', 'newspack-*/style.css' ],
 				callback: 'npm run release:archive',
 			},
 		],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixed two issues caught in the last release. The assets there were fixed and replaced manually, this PR ensures this will not happen again.

1. The version was not set in `*.css` files, only in `*.scss` files. The former are the ones actually read by WP.
2. `semantic-release-version-bump` had a bug which made the CSS code update unfortunately while updating the version string in CSS files. It's fixed now so this sets it to the new version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
