### PR TITLE
Fix release files: CSS changed by release process

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -118,7 +118,7 @@ input[type='submit'] {
 		&::after {
 			background-color: currentColor;
 			content: '';
-			flex: 1.3.0.25rem;
+			flex: 1 0 0.25rem;
 			height: 1px;
 			margin: 0 0 0 0.25rem;
 		}
@@ -146,7 +146,7 @@ input[type='submit'] {
 	&::after {
 		background-color: currentColor;
 		content: '';
-		flex: 1.3.0.25rem;
+		flex: 1 0 0.25rem;
 		height: 1px;
 		margin: 0 0 0 0.25rem;
 	}


### PR DESCRIPTION
NOTE: This is a special PR, because it's **directly** to `release` branch and merging it will trigger **a new release**.

This is all because of a but in `semantic-release-version-bump`, [fixed](https://github.com/Automattic/semantic-release-version-bump/commit/9151dbe23c6e0e0137313186721d1842b7e54462) in v1.4.0. The bug caused some strings in CSS to be treated as version strings. This turned `flex: 1 0 0.25rem` to `flex: 1.3.0.25rem`. This PR fixes them manually, while #852 ensures this will not happen again.
