### PR TITLE
Add support for Yoast Breadcrumbs

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -68,6 +68,21 @@ body {
 	}
 }
 
+// Yoast Breadcrumbs
+.site-breadcrumb {
+	border-bottom: 1px solid;
+
+	.has-highlight-menu & {
+		border-top: 1px solid;
+		margin-top: 0.25rem;
+		padding-top: 0;
+
+		.wrapper {
+			border: 0;
+		}
+	}
+}
+
 /* Font Family */
 figcaption,
 .entry-meta,

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -48,7 +48,8 @@ function newspack_katharine_custom_colors_css() {
 		.cat-links:before,
 		.archive .page-title:before,
 		figcaption:after,
-		.wp-caption-text:after {
+		.wp-caption-text:after,
+		.has-highlight-menu .site-breadcrumb .wrapper > span:before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -49,7 +49,7 @@ function newspack_katharine_custom_colors_css() {
 		.archive .page-title:before,
 		figcaption:after,
 		.wp-caption-text:after,
-		.has-highlight-menu .site-breadcrumb .wrapper > span:before {
+		.has-highlight-menu .site-breadcrumb .wrapper > span::before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -413,19 +413,9 @@ figcaption,
 
 .site-breadcrumb {
 	.has-highlight-menu & {
-		padding-top: 0;
-
 		.wrapper {
-			border-top: 0;
-
-			> span::before {
-				background-color: $color__primary;
-				content: '';
-				display: block;
-				height: 5px;
-				margin: 0 0 #{0.5 * $size__spacing-unit};
-				width: 32px;
-			}
+			border-top-color: currentColor;
+			border-top-style: dotted;
 		}
 	}
 }

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -408,3 +408,24 @@ figcaption,
 		color: inherit;
 	}
 }
+
+// Yoast Breadcrumbs
+
+.site-breadcrumb {
+	.has-highlight-menu & {
+		padding-top: 0;
+
+		.wrapper {
+			border-top: 0;
+
+			& > span:before {
+				background-color: $color__primary;
+				content: '';
+				display: block;
+				height: 5px;
+				margin: 0 0 #{0.5 * $size__spacing-unit};
+				width: 32px;
+			}
+		}
+	}
+}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -418,7 +418,7 @@ figcaption,
 		.wrapper {
 			border-top: 0;
 
-			& > span:before {
+			> span::before {
 				background-color: $color__primary;
 				content: '';
 				display: block;

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -88,6 +88,9 @@ function newspack_nelson_custom_colors_css() {
 			.nav1 .sub-menu a,
 			.h-sb .site-header .highlight-menu .menu-label,
 			.h-sb .site-header .highlight-menu a,
+			.h-sb .site-breadcrumb,
+			.h-sb .site-breadcrumb a,
+			.h-sb .site-breadcrumb .breadcrumb_last,
 			.h-sb .site-footer {
 				color: ' . esc_html( $header_color_contrast ) . ';
 			}

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -35,7 +35,9 @@ function newspack_nelson_custom_colors_css() {
 		/* Header short height; default background */
 		.h-sh.h-db .site-header,
 		.site-content #primary,
-		#page .site-header {
+		#page .site-header,
+		/* Yoast Breadcrumb */
+		.has-highlight-menu .site-breadcrumb .wrapper {
 			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 		}
 

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -35,9 +35,7 @@ function newspack_nelson_custom_colors_css() {
 		/* Header short height; default background */
 		.h-sh.h-db .site-header,
 		.site-content #primary,
-		#page .site-header,
-		/* Yoast Breadcrumb */
-		.has-highlight-menu .site-breadcrumb .wrapper {
+		#page .site-header {
 			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 		}
 
@@ -71,7 +69,9 @@ function newspack_nelson_custom_colors_css() {
 			/* Header short height; default background */
 			.h-sh.h-db .site-header,
 			.site-content #primary,
-			#page .site-header {
+			#page .site-header,
+			/* Yoast Breadcrumb */
+			.has-highlight-menu .site-breadcrumb .wrapper {
 				border-color: ' . esc_html( newspack_adjust_brightness( $header_color, -40 ) ) . ';
 			}
 

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -535,3 +535,13 @@ blockquote {
 		}
 	}
 }
+
+// Yoast Breadcrumb
+
+.site-breadcrumb {
+	.has-highlight-menu & {
+		.wrapper {
+			border-top-color: $color__primary-variation;
+		}
+	}
+}

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -75,31 +75,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-.site-breadcrumb {
-	@include media( tablet ) {
-		margin-bottom: #{3.5 * $size__spacing-unit};
-	}
-
-	@include media( desktop ) {
-		margin-bottom: #{6 * $size__spacing-unit};
-	}
-
-	.h-sb & {
-		color: $color__background-body;
-
-		a,
-		.breadcrumb_last {
-			color: inherit;
-		}
-
-		a:active,
-		a:focus,
-		a:hover {
-			opacity: 0.75;
-		}
-	}
-}
-
 // Header
 
 .site-header,
@@ -539,6 +514,29 @@ blockquote {
 // Yoast Breadcrumb
 
 .site-breadcrumb {
+	@include media( tablet ) {
+		margin-bottom: #{3.5 * $size__spacing-unit};
+	}
+
+	@include media( desktop ) {
+		margin-bottom: #{6 * $size__spacing-unit};
+	}
+
+	.h-sb & {
+		color: $color__background-body;
+
+		a,
+		.breadcrumb_last {
+			color: inherit;
+		}
+
+		a:active,
+		a:focus,
+		a:hover {
+			opacity: 0.75;
+		}
+	}
+
 	.has-highlight-menu & {
 		.wrapper {
 			border-top-color: $color__primary-variation;

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -64,13 +64,39 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 }
 
 .site-content,
-.newspack-front-page.hide-homepage-title .site-content {
+.newspack-front-page.hide-homepage-title .site-content,
+.site-breadcrumb {
 	@include media( tablet ) {
 		margin-top: #{-3.5 * $size__spacing-unit};
 	}
 
 	@include media( desktop ) {
 		margin-top: #{-6 * $size__spacing-unit};
+	}
+}
+
+.site-breadcrumb {
+	@include media( tablet ) {
+		margin-bottom: #{3.5 * $size__spacing-unit};
+	}
+
+	@include media( desktop ) {
+		margin-bottom: #{6 * $size__spacing-unit};
+	}
+
+	.h-sb & {
+		color: $color__background-body;
+
+		a,
+		.breadcrumb_last {
+			color: inherit;
+		}
+
+		a:active,
+		a:focus,
+		a:hover {
+			opacity: 0.75;
+		}
 	}
 }
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -465,6 +465,14 @@ cite {
 	}
 }
 
+// Yoast Breadcrumbs
+
+.site-breadcrumb {
+	.wrapper {
+		justify-content: center;
+	}
+}
+
 // Pop-up
 
 .entry-content {

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -33,7 +33,7 @@ function newspack_scott_custom_colors_css() {
 		.article-section-title:before,
 		.cat-links:before,
 		.page-title:before,
-		.site-breadcrumb .wrapper > span:before {
+		.site-breadcrumb .wrapper > span::before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -32,7 +32,8 @@ function newspack_scott_custom_colors_css() {
 		.accent-header:not(.widget-title):before,
 		.article-section-title:before,
 		.cat-links:before,
-		.page-title:before {
+		.page-title:before,
+		.site-breadcrumb .wrapper > span:before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -301,7 +301,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 .site-breadcrumb {
 	.wrapper > span {
-		&:before {
+		::before {
 			background-color: $color__primary;
 			content: '';
 			display: inline-block;

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -300,8 +300,8 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 /* Yoast Breadcrumbs */
 
 .site-breadcrumb {
-	.wrapper > span {
-		::before {
+	.wrapper {
+		> span::before {
 			background-color: $color__primary;
 			content: '';
 			display: inline-block;

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -296,3 +296,18 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 .site-info {
 	font-family: $font__heading;
 }
+
+/* Yoast Breadcrumbs */
+
+.site-breadcrumb {
+	.wrapper > span {
+		&:before {
+			background-color: $color__primary;
+			content: '';
+			display: inline-block;
+			height: 0.75em;
+			margin: 0 0.5em 0 0;
+			width: 0.75em;
+		}
+	}
+}

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -217,6 +217,12 @@
 
 	</header><!-- #masthead -->
 
+	<?php
+	if ( function_exists('yoast_breadcrumb') ) {
+		yoast_breadcrumb( '<div class="site-breadcrumb"><div class="wrapper">','</div></div>' );
+	}
+	?>
+
 	<?php do_action( 'after_header' ); ?>
 
 	<div id="content" class="site-content">

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -219,7 +219,7 @@
 
 	<?php
 	if ( function_exists('yoast_breadcrumb') ) {
-		yoast_breadcrumb( '<div class="site-breadcrumb"><div class="wrapper">','</div></div>' );
+		yoast_breadcrumb( '<div class="site-breadcrumb desktop-only"><div class="wrapper">','</div></div>' );
 	}
 	?>
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -112,6 +112,10 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-tertiary-menu';
 	}
 
+	if ( has_nav_menu( 'highlight-menu' ) ) {
+		$classes[] = 'has-highlight-menu';
+	}
+
 	// Adds a class of has-sidebar when there is a sidebar present.
 	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
 		$classes[] = 'has-sidebar';

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -121,7 +121,10 @@ function newspack_custom_typography_css() {
 		.jp-relatedposts-i2,
 		#jp-relatedposts.jp-relatedposts,
 		.jp-relatedposts-i2 .jp-relatedposts-headline,
-		#jp-relatedposts.jp-relatedposts .jp-relatedposts-headline
+		#jp-relatedposts.jp-relatedposts .jp-relatedposts-headline,
+
+		/* Yoast Breadcrumbs */
+		.site-breadcrumb .wrapper > span
 		{
 			font-family: ' . wp_kses( $font_header, null ) . ';
 		}';

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -86,7 +86,7 @@
 	// Make sure comments exist before going any further.
 	if ( null !== commentsToggle ) {
 		const commentsWrapper = document.getElementById( 'comments-wrapper' ),
-		commentsToggleTextContain = commentsToggle.getElementsByTagName( 'span' )[ 0 ];
+			commentsToggleTextContain = commentsToggle.getElementsByTagName( 'span' )[ 0 ];
 
 		commentsToggle.addEventListener(
 			'click',

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -1,13 +1,9 @@
 .site-breadcrumb {
 	color: $color__text-light;
-	display: none;
-	padding: 0.5em 0;
-
-	@include media( tablet ) {
-		display: block;
-	}
 
 	.wrapper {
+		padding: 0.5em 0;
+
 		> span {
 			font-size: $font__size-xxs;
 			line-height: $font__line-height-heading;
@@ -21,5 +17,14 @@
 	// Hide on homepage
 	.home & {
 		display: none;
+	}
+
+	// Has Highlight Menu
+	.has-highlight-menu & {
+		padding-top: 0.25rem;
+
+		.wrapper {
+			border-top: 1px solid $color__border;
+		}
 	}
 }

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -1,0 +1,21 @@
+.site-breadcrumb {
+	color: $color__text-light;
+	padding: 0.5em 0;
+
+	.wrapper {
+		> span {
+			font-family: $font__heading;
+			font-size: $font__size-xxs;
+			line-height: $font__line-height-heading;
+		}
+	}
+
+	.breadcrumb_last {
+		color: $color__text-main;
+	}
+
+	// Hide on homepage
+	.home & {
+		display: none;
+	}
+}

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -15,8 +15,10 @@
 		color: $color__text-main;
 	}
 
-	// Hide on homepage
-	.home & {
+	// Hide on homepage and if the Featured Image is Behind or Beside
+	.home &,
+	.single-featured-image-behind &,
+	.single-featured-image-beside & {
 		display: none;
 	}
 
@@ -26,15 +28,6 @@
 
 		.wrapper {
 			border-top: 1px solid $color__border;
-		}
-	}
-
-	.single-featured-image-behind.has-highlight-menu &,
-	.single-featured-image-beside.has-highlight-menu & {
-		padding-top: 0;
-
-		.wrapper {
-			border-top: 0;
 		}
 	}
 }

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -5,6 +5,7 @@
 		padding: 0.5em 0;
 
 		> span {
+			font-family: $font__heading;
 			font-size: $font__size-xxs;
 			line-height: $font__line-height-heading;
 		}

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -27,4 +27,13 @@
 			border-top: 1px solid $color__border;
 		}
 	}
+
+	.single-featured-image-behind.has-highlight-menu &,
+	.single-featured-image-beside.has-highlight-menu & {
+		padding-top: 0;
+
+		.wrapper {
+			border-top: 0;
+		}
+	}
 }

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -1,6 +1,11 @@
 .site-breadcrumb {
 	color: $color__text-light;
+	display: none;
 	padding: 0.5em 0;
+
+	@include media( tablet ) {
+		display: block;
+	}
 
 	.wrapper {
 		> span {

--- a/newspack-theme/sass/plugins/yoast-breadcrumb.scss
+++ b/newspack-theme/sass/plugins/yoast-breadcrumb.scss
@@ -9,7 +9,6 @@
 
 	.wrapper {
 		> span {
-			font-family: $font__heading;
 			font-size: $font__size-xxs;
 			line-height: $font__line-height-heading;
 		}

--- a/newspack-theme/sass/style-base.scss
+++ b/newspack-theme/sass/style-base.scss
@@ -55,3 +55,6 @@
 
 /* Newspack Ads support */
 @import 'plugins/newspack-ads';
+
+/* Yoast Breadcrumb support */
+@import 'plugins/yoast-breadcrumb';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since we require Yoast and it has a built-in breadcrumbs functionality, it'd make sense to add support for it.

I also noticed that quite a few news sites are actually using breadcrumbs.

![Screenshot 2020-04-01 at 10 31 29](https://user-images.githubusercontent.com/177929/78121984-02917600-7404-11ea-954d-73b32e25b178.png)

_Note: this would only be visible for tablet >= screens_

### How to test the changes in this Pull Request:

1. Enable breadcrumbs via: wp-admin > SEO > Search Appearance > Breadcrumbs
2. Navigate to a post
3. Notice the breadcrumbs below the header

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
