### PR TITLE
Fix editor color palettes and secondary color by adding full, 6-digits, hex codes

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -16,7 +16,7 @@ function newspack_joseph_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
 	}

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -16,7 +16,7 @@ function newspack_katharine_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
 	}

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -16,7 +16,7 @@ function newspack_nelson_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		} else {
 			$header_color          = $primary_color;

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -16,7 +16,7 @@ function newspack_sacha_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
 	}

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -16,7 +16,7 @@ function newspack_scott_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		} else {
 			$header_color          = $primary_color;

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -190,7 +190,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'  => __( 'Dark Gray', 'newspack' ),
 					'slug'  => 'dark-gray',
-					'color' => '#111', // color__text-main
+					'color' => '#111111', // color__text-main
 				),
 				array(
 					'name'  => __( 'Medium Gray', 'newspack' ),
@@ -200,12 +200,12 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'  => __( 'Light Gray', 'newspack' ),
 					'slug'  => 'light-gray',
-					'color' => '#eee', // color__background-pre
+					'color' => '#EEEEEE', // color__background-pre
 				),
 				array(
 					'name'  => __( 'White', 'newspack' ),
 					'slug'  => 'white',
-					'color' => '#FFF',
+					'color' => '#FFFFFF',
 				),
 			)
 		);

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -18,7 +18,7 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666' );
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		} else {
 			$header_color          = $primary_color;

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -247,7 +247,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'header_color_hex',
 		array(
-			'default'           => '#666',
+			'default'           => '#666666',
 			'sanitize_callback' => 'sanitize_hex_color',
 		)
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The function `newspack_get_color_contrast()` in inc/template-functions.php requires hex codes with a 6 digits. Hex codes with 3 digits wouldn't work and we wouldn't get the correct contrast color.

### How to test the changes in this Pull Request:

I randomly found the issue with Newspack Popups but it can be replicated like so:

* Activate Nelson
* Set header to solid background
* Change default colours to whatever you want
* In themes/newspack-nelson/inc/child-color-patterns.php, L22-23, replace `$header_color          = $primary_color;
			$header_color_contrast = newspack_get_color_contrast( $primary_color );` with `$header_color          = '#fff';
			$header_color_contrast = newspack_get_color_contrast( '#fff' );`
* Check your theme. You shouldn't be able to see any text in your header.
* Change `$header_color          = '#fff';
			$header_color_contrast = newspack_get_color_contrast( '#fff' );` to `$header_color          = '#ffffff';
			$header_color_contrast = newspack_get_color_contrast( '#ffffff' );`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
