### PR TITLE
Remove popup styles

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -413,32 +413,15 @@ textarea {
 			padding-right: 0.5rem;
 
 			.newspack-popup-wrapper {
-				box-shadow: 0 0 0 1px $color__text-main;
+				box-shadow: 0 0 0 1px;
 				max-height: calc( 100% - 1rem );
 			}
 		}
 
 		.newspack-lightbox__close {
-			background: transparent;
-			border: 1px solid $color__text-main;
-			border-radius: 0;
+			border: 1px solid;
 			border-right: 0;
 			border-top: 0;
-			color: inherit;
-			padding: 5px;
-			right: 0;
-			top: 0;
-
-			&:active,
-			&:focus,
-			&:hover {
-				background: $color__text-main;
-				color: white;
-			}
-
-			svg {
-				transition: fill 150ms ease-in-out;
-			}
 		}
 	}
 }

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -408,37 +408,3 @@ figcaption,
 		color: inherit;
 	}
 }
-
-// Pop-up
-
-.entry-content {
-	.newspack-lightbox {
-		.newspack-popup-wrapper {
-			border: 1px solid $color__border;
-		}
-
-		&.newspack-lightbox-placement-bottom,
-		&.newspack-lightbox-placement-top {
-			.newspack-popup-wrapper {
-				border-left: 0;
-				border-right: 0;
-			}
-		}
-
-		&.newspack-lightbox-placement-bottom {
-			.newspack-popup-wrapper {
-				border-bottom: 0;
-			}
-		}
-
-		&.newspack-lightbox-placement-top {
-			.newspack-popup-wrapper {
-				border-top: 0;
-			}
-		}
-
-		.newspack-lightbox__close {
-			border-radius: 5px;
-		}
-	}
-}

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -507,11 +507,5 @@ blockquote {
 				border-width: 10px;
 			}
 		}
-
-		.newspack-lightbox__close {
-			border-radius: 0;
-			right: 1px;
-			top: 1px;
-		}
 	}
 }

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -472,18 +472,5 @@ cite {
 		.newspack-popup-title {
 			font-weight: normal;
 		}
-
-		.newspack-lightbox__close {
-			background: transparent;
-			border: 1px solid $color__border;
-			color: inherit;
-			padding: 5px;
-
-			&:active,
-			&:focus,
-			&:hover {
-				background: $color__border;
-			}
-		}
 	}
 }

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -296,13 +296,3 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 .site-info {
 	font-family: $font__heading;
 }
-
-/* Pop-up */
-
-.entry-content {
-	.newspack-lightbox {
-		.newspack-lightbox__close {
-			border-radius: 5px;
-		}
-	}
-}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

These styles became irrelevant when we took a simpler and more generic approach for the pop up styles (see https://github.com/Automattic/newspack-popups/pull/54)

### How to test the changes in this Pull Request:

1. Load a page with a pop-up
2. Does it look broken or out of place?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
