### PR TITLE
Secondary Menu: Correct menu name when checking for it in header

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -37,7 +37,7 @@
 
 		<?php
 		// If header is NOT short, or if header is short and there's a Secondary Menu or Slide-out Sidebar widget.
-		if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary' ) ) ) :
+		if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary-menu' ) ) ) :
 		?>
 			<div class="top-header-contain desktop-only">
 				<div class="wrapper">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

An issue was introduced with #816 -- I used the wrong ID for the secondary menu when checking for it, so if you don't have the slideout menu enabled in any way, the secondary menu won't display 😬 

### How to test the changes in this Pull Request:

1. If not already, turn off the short header option in the header. 
2. Navigate to Customize > Menus and add a Secondary menu.
3. If it's on, Navigate to Customize > Header Settings, and turn off the slide out menu.
4. If they're populated, remove the widgets from the Slide-out widgets area.
5. View on the front-end; note your Secondary menu is not displaying.
6. Apply the PR.
7. Confirm the Secondary menu now shows.
8. Turn back on the slide-out menu under Customize > Header Settings, and add widgets to the Slide-out widget area.
9. Confirm the Slide-out menu toggle shows as expected, and that it still opens/closes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
