### PR TITLE
Author Bio: Add ability to turn off truncate and allow HTML

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -337,8 +337,11 @@ cite {
 
 	h2 {
 		color: $color__text-main;
-		text-align: left;
 		margin: 0;
+
+		@include media( tablet ) {
+			text-align: left;
+		}
 	}
 
 	.avatar {

--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -45,10 +45,9 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 						</div>
 					</div><!-- .author-bio-header -->
 
-					<?php
-					if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
-							<?php echo strip_tags( newspack_truncate_text( $author->description, $author_bio_length ) ); ?>
+							<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( $author->description, $author_bio_length ) ) ); ?>
 							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 							<?php
 								/* translators: %s is the current author's name. */
@@ -57,7 +56,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 							</a>
 						</p>
 					<?php else : ?>
-						<?php echo wpautop( wp_kses_post( $author->description ) ); ?>
+						<?php echo wp_kses_post( wpautop( $author->description ) ); ?>
 
 						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 							<?php
@@ -100,10 +99,9 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			</div>
 		</div><!-- .author-bio-header -->
 
-		<?php
-		if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+		<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 			<p>
-				<?php echo strip_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ); ?>
+				<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ) ); ?>
 				<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */
@@ -112,7 +110,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 				</a>
 			</p>
 		<?php else : ?>
-			<?php echo wpautop( wp_kses_post( get_the_author_meta( 'description' ) ) ); ?>
+			<?php echo wp_kses_post( wpautop( get_the_author_meta( 'description' ) ) ); ?>
 
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 				<?php
@@ -121,6 +119,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 				?>
 			</a>
 		<?php endif; ?>
+
 	</div><!-- .author-bio-text -->
 </div><!-- .author-bio -->
 <?php endif; ?>

--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -45,15 +45,28 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 						</div>
 					</div><!-- .author-bio-header -->
 
-					<p>
-						<?php echo esc_html( newspack_truncate_text( $author->description, $author_bio_length ) ); ?>
+					<?php
+					if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+						<p>
+							<?php echo strip_tags( newspack_truncate_text( $author->description, $author_bio_length ) ); ?>
+							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+							<?php
+								/* translators: %s is the current author's name. */
+								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+							?>
+							</a>
+						</p>
+					<?php else : ?>
+						<?php echo wpautop( wp_kses_post( $author->description ) ); ?>
+
 						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-						<?php
-							/* translators: %s is the current author's name. */
-							printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-						?>
+							<?php
+								/* translators: %s is the current author's name. */
+								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+							?>
 						</a>
-					</p><!-- .author-description -->
+					<?php endif; ?>
+
 				</div><!-- .author-bio-text -->
 
 			</div><!-- .author-bio -->
@@ -87,15 +100,27 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			</div>
 		</div><!-- .author-bio-header -->
 
-		<p>
-			<?php echo esc_html( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ); ?>
-			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+		<?php
+		if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+			<p>
+				<?php echo strip_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ); ?>
+				<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+				<?php
+					/* translators: %s is the current author's name. */
+					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
+				?>
+				</a>
+			</p>
+		<?php else : ?>
+			<?php echo wpautop( wp_kses_post( get_the_author_meta( 'description' ) ) ); ?>
+
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */
 					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
 				?>
 			</a>
-		</p><!-- .author-description -->
+		<?php endif; ?>
 	</div><!-- .author-bio-text -->
 </div><!-- .author-bio -->
 <?php endif; ?>

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -45,7 +45,13 @@ get_header();
 			<span>
 				<?php
 					the_archive_title( '<h1 class="page-title">', '</h1>' );
-					the_archive_description( '<div class="taxonomy-description">', '</div>' );
+					if ( '' !== get_the_archive_description() ) :
+					?>
+						<div class="taxonomy-description">
+							<?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?>
+						</div>
+					<?php
+					endif;
 				?>
 			</span>
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -379,6 +379,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to hide author email address.
+	$wp_customize->add_setting(
+		'author_bio_truncate',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'author_bio_truncate',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Truncate Author Bio', 'newspack' ),
+			'description' => esc_html__( 'Set a specific length for author bios displayed on single posts.', 'newspack' ),
+			'section'     => 'author_bio_options',
+		)
+	);
+
 	// Add option to hide the whole author bio.
 	$wp_customize->add_setting(
 		'author_bio_length',
@@ -392,7 +410,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'number',
 			'label'       => esc_html__( 'Author Bio Length (in characters)', 'newspack' ),
-			'description' => esc_html__( 'Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page.', 'newspack' ),
+			'description' => esc_html__( 'Truncates the author bio on single posts to this approximate character length, but without breaking a word.', 'newspack' ),
 			'section'     => 'author_bio_options',
 		)
 	);

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -162,6 +162,21 @@
 			} );
 		} );
 
+		// Only show Author Bio truncate options when enabled.
+		wp.customize( 'author_bio_truncate', function( setting ) {
+			wp.customize.control( 'author_bio_length', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
 		// Lets you jump to specific sections in the Customizer
 		$( [ 'control', 'section', 'panel' ] ).each( function( i, type ) {
 			$( 'a[rel="goto-' + type + '"]' ).click( function( e ) {

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -123,6 +123,14 @@
 .taxonomy-description {
 	color: $color__text-light;
 	font-style: italic;
+
+	a {
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
 }
 
 .search {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -377,6 +377,14 @@ body.page {
 		}
 	}
 
+	a {
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
 	.author-bio-text {
 		width: calc( 100% - 60px - 1em );
 		@include media( mobile ) {
@@ -416,6 +424,7 @@ body.page {
 	.author-link {
 		color: $color__primary;
 		font-weight: bold;
+		text-decoration: none;
 		&:hover {
 			color: $color__primary-variation;
 		}

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -55,15 +55,27 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
 						</div>
 					</div><!-- .author-bio-header -->
 
-					<p>
-						<?php echo esc_html( newspack_truncate_text( $author->description, $author_bio_length ) ); ?>
+					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+						<p>
+							<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( $author->description, $author_bio_length ) ) ); ?>
+							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+							<?php
+								/* translators: %s is the current author's name. */
+								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+							?>
+							</a>
+						</p>
+					<?php else : ?>
+						<?php echo wp_kses_post( wpautop( $author->description ) ); ?>
+
 						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-						<?php
-							/* translators: %s is the current author's name. */
-							printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-						?>
+							<?php
+								/* translators: %s is the current author's name. */
+								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+							?>
 						</a>
-					</p><!-- .author-description -->
+					<?php endif; ?>
+
 				</div><!-- .author-bio-text -->
 
 			</div><!-- .author-bio -->
@@ -109,15 +121,27 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			</div>
 		</div><!-- .author-bio-header -->
 
-		<p>
-			<?php echo esc_html( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ); ?>
-			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+		<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
+			<p>
+				<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ) ); ?>
+				<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+				<?php
+					/* translators: %s is the current author's name. */
+					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
+				?>
+				</a>
+			</p>
+		<?php else : ?>
+			<?php echo wp_kses_post( wpautop( get_the_author_meta( 'description' ) ) ); ?>
+
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */
 					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );
 				?>
 			</a>
-		</p><!-- .author-description -->
+		<?php endif; ?>
+
 	</div><!-- .author-bio-text -->
 </div><!-- .author-bio -->
 <?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the ability to turn off the author bio truncation on single posts; it also allows HTML on the author archive pages, and when the author bio is not truncated on single posts. 

It also fixes an error in Newspack Sacha -- the directory name wasn't correct for the author-bio.php file, so the child theme wasn't using it. 

Unfortunately, because Newspack Sacha has its own author-bio.php file, some of the test steps have to be repeated with any of the other themes (since they all share the same author-bio.php file), and with Newspack Sacha. 

Closes #644 .

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Author Bio; confirm that there is now an option to check/uncheck 'Truncate Author Bio', and that it defaults to checked:

![image](https://user-images.githubusercontent.com/177561/78309914-3900eb00-7501-11ea-9ec5-9a93b787e056.png)

3. Try unchecking 'Truncate Author Bio' and confirm that the text field for bio length disappears:

![image](https://user-images.githubusercontent.com/177561/78310805-d8bf7880-7503-11ea-8b5c-7ea2ca20ffa0.png)

4. Edit one of your author bios to add some HTML -- things like links, bold tags, italics, and line breaks. (Some tags appear to be stripped out by WordPress on save, including paragraph
5. View on the front-end; confirm the author bio is not truncated, and that your basic HTML is respected:

![image](https://user-images.githubusercontent.com/177561/78310470-ec1e1400-7502-11ea-845f-f8fdd22a3691.png)

6. View the author's archive page, and confirm the HTML is being displayed:

![image](https://user-images.githubusercontent.com/177561/78310670-79616880-7503-11ea-8ef1-c26a5172ff02.png)

7. Repeat step 4, 5 and 6 with a guest author, and confirm it's still working.
8. Try deactivating the Co-Authors plus plugin, and confirm the bio is still allowing the HTML on both the single post and the archive post.
9. Navigate back to Customize > Author Bio, and turn back on 'Truncate Author Bio'; confirm that the text field becomes visible again. Update the truncate text value and Publish.
10. View the author on the single post and confirm that the bio is now truncated, and HTML is stripped. 
11. Turn back on Co-Authors Plus, and re-check the regular author and guest author, and confirm that the HTML is stripped out, and that the bio is truncated.
12. Switch to 'Newspack Sacha', which (unfortunately!!) has slightly different author bio markup.
13. For your regular author and guest authors, and confirm that the bio is truncated still, and HTML is stripped.
14. Navigate to Customize > Author Bio, and turn back off truncate. 
15. For your regular author and guest author, confirm the bio is truncated and HTML is stripped.
16. Lastly, turn back off Co-Authors Plus, and check your author with and without the bio truncated, and confirm it's acting as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
