### PR TITLE
Checkout: Option to hide order details table

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -344,10 +344,12 @@ function newspack_scripts() {
 		}
 
 		$newspack_l10n = array(
-			'open_search'       => esc_html__( 'Open Search', 'newspack' ),
-			'close_search'      => esc_html__( 'Close Search', 'newspack' ),
-			'expand_comments'   => esc_html__( 'Expand Comments', 'newspack' ),
-			'collapse_comments' => esc_html__( 'Collapse Comments', 'newspack' ),
+			'open_search'        => esc_html__( 'Open Search', 'newspack' ),
+			'close_search'       => esc_html__( 'Close Search', 'newspack' ),
+			'expand_comments'    => esc_html__( 'Expand Comments', 'newspack' ),
+			'collapse_comments'  => esc_html__( 'Collapse Comments', 'newspack' ),
+			'show_order_details' => esc_html__( 'Show details', 'newspack' ),
+			'hide_order_details' => esc_html__( 'Hide details', 'newspack' ),
 		);
 
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), '1.0', true );

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -476,6 +476,39 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'comments_options',
 		)
 	);
+
+	/**
+	 * Comments settings
+	 */
+	$wp_customize->add_section(
+		'woocommerce_cart_options',
+		array(
+			'title' => esc_html__( 'Order Details', 'newspack' ),
+			'panel' => 'woocommerce',
+		)
+	);
+
+	// Add option to collapse the comments.
+	$wp_customize->add_setting(
+		'collapse_order_details',
+		array(
+			'default'           => 'hide',
+			'sanitize_callback' => 'newspack_sanitize_radio',
+		)
+	);
+	$wp_customize->add_control(
+		'collapse_order_details',
+		array(
+			'type'    => 'radio',
+			'label'   => esc_html__( 'Collapse Order Details', 'newspack' ),
+			'choices' => array(
+				'display' => esc_html__( 'Show', 'newspack' ),
+				'hide'    => esc_html__( 'Hide', 'newspack' ),
+				'toggle'  => esc_html__( 'Hide, with ability to toggle open', 'newspack' ),
+			),
+			'section' => 'woocommerce_cart_options',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 
@@ -716,6 +749,21 @@ function newspack_sanitize_checkbox( $input ) {
 	} else {
 		return false;
 	}
+}
+
+/**
+ * Sanitize the radio buttons.
+ */
+function newspack_sanitize_radio( $input, $setting ) {
+
+	// Ensure input is a slug.
+	$input = sanitize_key( $input );
+
+	// Get list of choices from the control associated with the setting.
+	$choices = $setting->manager->get_control( $setting->id )->choices;
+
+	// If the input is a valid key, return it; otherwise, return the default.
+	return ( array_key_exists( $input, $choices ) ? $input : $setting->default );
 }
 
 /**

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -502,9 +502,9 @@ function newspack_customize_register( $wp_customize ) {
 			'type'    => 'radio',
 			'label'   => esc_html__( 'Collapse Order Details', 'newspack' ),
 			'choices' => array(
-				'display' => esc_html__( 'Show', 'newspack' ),
 				'hide'    => esc_html__( 'Hide', 'newspack' ),
 				'toggle'  => esc_html__( 'Hide, with ability to toggle open', 'newspack' ),
+				'display' => esc_html__( 'Show', 'newspack' ),
 			),
 			'section' => 'woocommerce_cart_options',
 		)

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -478,7 +478,7 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	/**
-	 * Comments settings
+	 * WooCommerce Order Details settings
 	 */
 	$wp_customize->add_section(
 		'woocommerce_cart_options',
@@ -488,7 +488,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Add option to collapse the comments.
+	// Add order details visibility options.
 	$wp_customize->add_setting(
 		'collapse_order_details',
 		array(
@@ -500,7 +500,7 @@ function newspack_customize_register( $wp_customize ) {
 		'collapse_order_details',
 		array(
 			'type'    => 'radio',
-			'label'   => esc_html__( 'Collapse Order Details', 'newspack' ),
+			'label'   => esc_html__( 'Order Details Visibility', 'newspack' ),
 			'choices' => array(
 				'hide'    => esc_html__( 'Hide', 'newspack' ),
 				'toggle'  => esc_html__( 'Hide, with ability to toggle open', 'newspack' ),

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -102,4 +102,29 @@
 			false
 		);
 	}
+
+	// Checkout toggle fallback.
+	const orderDetailToggle = document.getElementById( 'toggle-order-details' );
+
+	// Make sure checkout details exist before going any further.
+	if ( null !== orderDetailToggle ) {
+		const orderDetailWrapper = document.getElementById( 'order-details-wrapper' ),
+			orderDetailToggleTextContain = orderDetailToggle.getElementsByTagName( 'span' )[ 0 ];
+
+		orderDetailToggle.addEventListener(
+			'click',
+			function() {
+				if ( orderDetailWrapper.classList.contains( 'order-details-hidden' ) ) {
+					orderDetailWrapper.classList.remove( 'order-details-hidden' );
+					orderDetailToggle.classList.remove( 'order-details-hidden' );
+					orderDetailToggleTextContain.innerText = newspackScreenReaderText.hide_order_details;
+				} else {
+					orderDetailWrapper.classList.add( 'order-details-hidden' );
+					orderDetailToggle.classList.add( 'order-details-hidden' );
+					orderDetailToggleTextContain.innerText = newspackScreenReaderText.show_order_details;
+				}
+			},
+			false
+		);
+	}
 } )();

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1513,3 +1513,15 @@ table.variations {
 .order-details-hidden {
 	display: none;
 }
+
+.order-details-summary {
+	h4 {
+		font-size: 0.95em;
+		font-weight: normal;
+
+		> span {
+			color: $color__text-light;
+			display: block;
+		}
+	}
+}

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -154,8 +154,8 @@ a.button {
 	color: $body-color;
 }
 
-.woocommerce-error,
-.woocommerce-info {
+.woocommerce-error {
+	background: firebrick;
 	color: #fff;
 
 	a {
@@ -169,14 +169,6 @@ a.button {
 			background: #111;
 		}
 	}
-}
-
-.woocommerce-error {
-	background: firebrick;
-}
-
-.woocommerce-info {
-	background: $highlights-color;
 }
 
 .woocommerce-store-notice {
@@ -1193,8 +1185,13 @@ table.variations {
 }
 
 .woocommerce-checkout-review-order-table {
-	td {
-		padding: 1rem 0.5rem;
+	border-top: 1px solid $color__border;
+
+	td,
+	th {
+		border-color: $color__border;
+		border-width: 0 0 1px;
+		padding: 0.5rem;
 	}
 
 	dl.variation {
@@ -1472,4 +1469,47 @@ table.variations {
 			}
 		}
 	}
+}
+
+/* Toggle order details */
+
+.cart-summary-header {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+
+	h3 {
+		margin-top: 1rem;
+	}
+}
+
+#toggle-order-details {
+	align-items: center;
+	background: transparent;
+	color: $color__text-main;
+	display: flex;
+	padding: 0;
+
+	&:hover {
+		background: transparent;
+		color: $color__text-light;
+	}
+
+	svg {
+		transform: rotate( 90deg );
+	}
+
+	&.order-details-hidden svg {
+		transform: rotate( -90deg );
+	}
+}
+
+#order-details-wrapper {
+	h3 {
+		margin-top: 3rem;
+	}
+}
+
+.order-details-hidden {
+	display: none;
 }

--- a/newspack-theme/woocommerce/checkout/form-checkout.php
+++ b/newspack-theme/woocommerce/checkout/form-checkout.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$order_details_display = get_theme_mod( 'collapse_order_details', 'hide' );
+
 do_action( 'woocommerce_before_checkout_form', $checkout );
 
 // If checkout registration is disabled and not logged in, the user cannot checkout.
@@ -28,42 +30,86 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 }
 ?>
 
+<?php if ( 'toggle' === $order_details_display ) : ?>
+	<div class="cart-summary-header">
+		<h3><?php esc_html_e( 'Summary', 'newspack' ); ?></h3>
+		<button id="toggle-order-details" class="order-details-hidden" on="tap:AMP.setState( { orderVisible: !orderVisible } )" [class]="orderVisible ? '' : 'order-details-hidden'" aria-controls="full-order-details" [aria-expanded]="orderVisible ? 'true' : 'false'" aria-expanded="false">
+			<?php echo wp_kses( newspack_get_icon_svg( 'chevron_left', 24 ), newspack_sanitize_svgs() ); ?>
+			<span [text]="orderVisible ? '<?php esc_html_e( 'Hide details', 'newspack' ); ?>' : '<?php esc_html_e( 'Show details', 'newspack' ); ?>'"><?php esc_html_e( 'Show details', 'newspack' ); ?></span>
+		</button>
+	</div>
+<?php endif; ?>
+
+<?php if ( 'display' !== $order_details_display ) : ?>
+	<?php
+	// Simplified output of order
+	foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+		$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+
+		if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+		?>
+			<p>
+				<strong>
+					<?php
+						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' ' . sprintf( '&times;&nbsp;%s', $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
+				</strong>
+				<?php
+					echo ' - ';
+					echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
+			</p>
+			<?php
+		}
+	}
+	?>
+<?php endif; ?>
+
 <form name="checkout" method="post" class="checkout woocommerce-checkout" action="<?php echo esc_url( wc_get_checkout_url() ); ?>" enctype="multipart/form-data">
 
-	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
-	
-	<h3 id="order_review_heading"><?php esc_html_e( 'Order details', 'newspack' ); ?></h3>
-	
-	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
+	<?php if ( 'display' === $order_details_display ) : ?>
+		<div id="order-details-wrapper">
+	<?php else : ?>
+		<div id="order-details-wrapper" class="order-details-hidden" [class]="orderVisible ? '' : 'order-details-hidden'">
+	<?php endif; ?>
+		<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
 
-	<div id="order_review" class="woocommerce-checkout-review-order">
-		<?php do_action( 'woocommerce_checkout_order_review' ); ?>
-	</div>
+		<h3 id="order_review_heading" class="screen-reader-text"><?php esc_html_e( 'Order Details', 'newspack' ); ?></h3>
 
-	<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
+		<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
-	<?php if ( $checkout->get_checkout_fields() ) : ?>
-
-		<?php do_action( 'woocommerce_checkout_before_customer_details' ); ?>
-
-		<div class="col2-set" id="customer_details">
-			<?php if ( wc_shipping_enabled() && WC()->cart->get_shipping_total() > 0 ) : ?>
-				<div class="col-1">
-					<?php do_action( 'woocommerce_checkout_billing' ); ?>
-				</div>
-
-				<div class="col-2">
-					<?php do_action( 'woocommerce_checkout_shipping' ); ?>
-				</div>
-			<?php else : ?>
-					<?php do_action( 'woocommerce_checkout_billing' ); ?>
-			<?php endif; ?>
+		<div id="order_review" class="woocommerce-checkout-review-order">
+			<?php do_action( 'woocommerce_checkout_order_review' ); ?>
 		</div>
 
-		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
+		<?php do_action( 'woocommerce_checkout_after_order_review' ); ?>
 
-	<?php endif; ?>
-	
+	</div><!-- .full-order-details -->
+
+<?php if ( $checkout->get_checkout_fields() ) : ?>
+
+	<?php do_action( 'woocommerce_checkout_before_customer_details' ); ?>
+
+	<div class="col2-set" id="customer_details">
+		<?php if ( wc_shipping_enabled() && WC()->cart->get_shipping_total() > 0 ) : ?>
+			<div class="col-1">
+				<?php do_action( 'woocommerce_checkout_billing' ); ?>
+			</div>
+
+			<div class="col-2">
+				<?php do_action( 'woocommerce_checkout_shipping' ); ?>
+			</div>
+		<?php else : ?>
+				<?php do_action( 'woocommerce_checkout_billing' ); ?>
+		<?php endif; ?>
+	</div>
+
+	<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
+
+<?php endif; ?>
+
 </form>
 
 <?php do_action( 'woocommerce_after_checkout_form', $checkout ); ?>

--- a/newspack-theme/woocommerce/checkout/form-checkout.php
+++ b/newspack-theme/woocommerce/checkout/form-checkout.php
@@ -41,6 +41,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 <?php endif; ?>
 
 <?php if ( 'display' !== $order_details_display ) : ?>
+	<div class="order-details-summary">
 	<?php
 	// Simplified output of order
 	foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
@@ -48,23 +49,25 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 		if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
 		?>
-			<p>
+			<h4>
+				<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' ' . sprintf( '%s&nbsp;&times;', $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<strong>
 					<?php
 						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' ' . sprintf( '&times;&nbsp;%s', $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					?>
 				</strong>
+				<span>
 				<?php
-					echo ' - ';
 					echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				?>
-			</p>
+				</span>
+			</h4>
 			<?php
 		}
 	}
 	?>
+	</div><!-- .order-details-summary -->
 <?php endif; ?>
 
 <form name="checkout" method="post" class="checkout woocommerce-checkout" action="<?php echo esc_url( wc_get_checkout_url() ); ?>" enctype="multipart/form-data">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the 'Orders' table on the WooCommerce checkout screen is large, space-consuming, and makes little sense when used strictly for donations.

I'm not sure we want to remove this entirely, say, for sites that may use WooCommerce for a store as well, but we can at least add an option to hide it. This PR adds a Customizer option to show, hide, or toggle the Orders table on the checkout page. 

### How to test the changes in this Pull Request:

1. On a Newspack site with donations set up, add a recurring donation to your cart using the Donate block.
2. You should be taken to the Donation page automatically; note the large Order details table:

![image](https://user-images.githubusercontent.com/177561/78730922-0a18b980-78f3-11ea-8477-2500a2f9321f.png)

3. Apply the PR and run `npm run build`. 
4. View the page again and note that the table is gone, replaced with a simple one liner describing your order: 

![image](https://user-images.githubusercontent.com/177561/78731201-e609a800-78f3-11ea-809a-c62fa317e068.png)

5. Navigate to Customizer > WooCommerce > Order Details, and confirm you have the following options:

![image](https://user-images.githubusercontent.com/177561/78731222-f457c400-78f3-11ea-8c5e-c6a0b9078628.png)

6. Switch to 'Hide, with ability to toggle open', and click Publish. 
7. View the checkout page again; confirm that you have a 'Show Details' toggle:

![image](https://user-images.githubusercontent.com/177561/78731262-13eeec80-78f4-11ea-9155-a3d7a7e06071.png)

8. Click the toggle and confirm it opens and closes the Order Details table, sans 'Order Details' header:

![image](https://user-images.githubusercontent.com/177561/78731281-25d08f80-78f4-11ea-98ab-0a42ad42d72c.png)

9. I believe this form will typically be used with AMP disabled on the page, so the form details update better, but this should be tested both with and without AMP enabled. So either enable or disable AMP (depending on your current setting), and repeat testing step 8.
10. Navigate back to Customizer > WooCommerce > Order Details, and pick "Show"
11. Confirm that the table now displays by default, with no toggle:

![image](https://user-images.githubusercontent.com/177561/78731425-8e1f7100-78f4-11ea-91bf-efa9b5362a42.png)
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
