### PR TITLE
Checkout Page: Make some fields more compact

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -154,3 +154,16 @@ if ( ! function_exists( 'newspack_woocommerce_wrapper_after' ) ) {
 	}
 }
 add_action( 'woocommerce_after_main_content', 'newspack_woocommerce_wrapper_after' );
+
+/**
+ * Replace .form-row-wide classes with classes to style fields narrower.
+ */
+function newspack_checkout_fields_styling( $fields ) {
+	$fields['billing']['billing_city']['class'][0]     = 'form-row-first';
+	$fields['billing']['billing_postcode']['class'][0] = 'form-row-first';
+	$fields['billing']['billing_state']['class'][0]    = 'form-row-last';
+	$fields['billing']['billing_phone']['class'][0]    = 'form-row-last';
+	return $fields;
+}
+add_filter( 'woocommerce_checkout_fields', 'newspack_checkout_fields_styling', 9999 );
+

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -77,6 +77,10 @@ a.button {
 		.optional {
 			visibility: visible;
 		}
+
+		&.form-row-first {
+			clear: left;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now a lot of the billing fields on the Checkout page -- Town, Province/State, Postal Code/Zip and Phone -- are 100% of the available width, when they really could be 50%. 

This PR updates that to tighten things up a bit. 

### How to test the changes in this Pull Request:

1. View the Checkout page (usually /checkout) on a testing site.
2. Note the size/scale of all the fields: 

![image](https://user-images.githubusercontent.com/177561/78731748-65e44200-78f5-11ea-9f5a-c9913b32244b.png)

3. Apply the PR and run `npm run build`
4. View the Checkout page, and confirm that some fields are now side-by-side:

![image](https://user-images.githubusercontent.com/177561/78731827-aa6fdd80-78f5-11ea-9c2f-d8f716a9e660.png)

Note: If you're testing with AMP enabled, the Country/Region field will also have a big button; I believe for right now we'll be disabling AMP on this page when used so it's a better customer experience, but I can circle back and address that separately if it's an issue. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
