### PR TITLE
Paragraph block: Correct dropcap preview in editor

### DIFF
--- a/newspack-joseph/inc/child-typography.php
+++ b/newspack-joseph/inc/child-typography.php
@@ -45,7 +45,7 @@ function newspack_joseph_custom_typography_css() {
 			}';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p {
 				font-family: ' . wp_kses( $font_header, null ) . ';

--- a/newspack-joseph/inc/child-typography.php
+++ b/newspack-joseph/inc/child-typography.php
@@ -45,7 +45,7 @@ function newspack_joseph_custom_typography_css() {
 			}';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p {
 				font-family: ' . wp_kses( $font_header, null ) . ';

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -8,11 +8,9 @@ Newspack Sacha Editor Styles
 @import '../../newspack-theme/sass/style-editor-base';
 
 /* Paragraph */
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
+.has-drop-cap:not( :focus )::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
 }
 
 /* Columns */

--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -23,7 +23,7 @@ function newspack_katharine_custom_typography_css() {
 			}';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
+			.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}
 			';

--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -23,7 +23,7 @@ function newspack_katharine_custom_typography_css() {
 			}';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}
 			';

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -28,11 +28,9 @@ Newspack Katharine Editor Styles
 	font-size: $font__size-xs;
 }
 
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
+.has-drop-cap:not( :focus )::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
 }
 
 .wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not( .show-caption ):not( .show-category )

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -100,7 +100,7 @@ function newspack_nelson_custom_colors_css() {
 	}
 
 	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
 			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 		}
 	';

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -100,7 +100,7 @@ function newspack_nelson_custom_colors_css() {
 	}
 
 	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
 			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 		}
 	';

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -24,7 +24,7 @@ function newspack_nelson_custom_typography_css() {
 
 		$editor_css_blocks .= '
 		.block-editor-block-list__layout .block-editor-block-list__block blockquote,
-		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
 			font-family: ' . wp_kses( $font_header, null ) . ';
 		}
 		';

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -24,7 +24,7 @@ function newspack_nelson_custom_typography_css() {
 
 		$editor_css_blocks .= '
 		.block-editor-block-list__layout .block-editor-block-list__block blockquote,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
 			font-family: ' . wp_kses( $font_header, null ) . ';
 		}
 		';

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -60,12 +60,10 @@ blockquote {
 	}
 }
 
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		color: $color__secondary;
-		font-family: $font__heading;
-		font-weight: 800;
-	}
+.has-drop-cap:not( :focus )::first-letter {
+	color: $color__secondary;
+	font-family: $font__heading;
+	font-weight: 800;
 }
 
 .wp-block[data-type='core/pullquote'] {

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -89,7 +89,7 @@ function newspack_sacha_custom_colors_css() {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
-		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
 			background-color: ' . esc_html( $primary_color ) . ';
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -89,7 +89,7 @@ function newspack_sacha_custom_colors_css() {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter {
+		.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter {
 			background-color: ' . esc_html( $primary_color ) . ';
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}

--- a/newspack-sacha/inc/child-typography.php
+++ b/newspack-sacha/inc/child-typography.php
@@ -25,6 +25,7 @@ function newspack_sacha_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
+			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p,

--- a/newspack-sacha/inc/child-typography.php
+++ b/newspack-sacha/inc/child-typography.php
@@ -25,7 +25,7 @@ function newspack_sacha_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .block-library-pullquote__content .editor-rich-text__tinymce[data-is-empty="true"]::before,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p,

--- a/newspack-sacha/sass/style-editor.scss
+++ b/newspack-sacha/sass/style-editor.scss
@@ -43,15 +43,13 @@ Newspack Sacha Editor Styles
 	}
 }
 
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		background-color: $color__primary;
-		color: #fff;
-		font-family: $font__heading;
-		font-weight: bold;
-		font-size: $font__size-xxl;
-		padding: 0.4em;
-	}
+.has-drop-cap:not( :focus )::first-letter {
+	background-color: $color__primary;
+	color: #fff;
+	font-family: $font__heading;
+	font-weight: bold;
+	font-size: $font__size-xxl;
+	padding: 0.4em;
 }
 
 figcaption,

--- a/newspack-scott/inc/child-typography.php
+++ b/newspack-scott/inc/child-typography.php
@@ -24,7 +24,7 @@ function newspack_scott_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation,

--- a/newspack-scott/inc/child-typography.php
+++ b/newspack-scott/inc/child-typography.php
@@ -24,7 +24,7 @@ function newspack_scott_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-paragraph.has-drop-cap:not(:focus)::first-letter,
+			.block-editor-block-list__layout .block-editor-block-list__block .has-drop-cap:not(:focus)::first-letter,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation,

--- a/newspack-scott/sass/style-editor.scss
+++ b/newspack-scott/sass/style-editor.scss
@@ -37,11 +37,9 @@ Newspack Scott Editor Styles
 
 /** === Paragraph === */
 
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		font-family: $font__heading;
-		font-weight: bold;
-	}
+.has-drop-cap:not( :focus )::first-letter {
+	font-family: $font__heading;
+	font-weight: bold;
 }
 
 .wp-block[data-type='core/pullquote'] {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -161,15 +161,13 @@ figcaption,
 		font-weight: bolder;
 	}
 }
-/** === Paragraph === */
 
-.wp-block-paragraph {
-	&.has-drop-cap:not( :focus )::first-letter {
-		font-size: 4em;
-		line-height: 0.75;
-		margin: 0.125em #{0.75 * $size__spacing-unit} 0 0;
-		position: relative;
-	}
+/** === Paragraph === */
+.has-drop-cap:not( :focus )::first-letter {
+	font-size: 4em;
+	line-height: 0.75;
+	margin: 0.125em #{0.75 * $size__spacing-unit} 0 0;
+	position: relative;
 }
 
 /** === Newspack Carousel === */


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `.wp-block-paragraph` class has been removed from the paragraph block in the editor, causing all of our themes dropcap style previews to stop working.

Unfortunately, it's a doozy to test because all of the themes needed to have their styles updated. 

Closes #864.

### How to test the changes in this Pull Request:

1. Start with the default theme, and default typography and colours. 
2. Add a paragraph to a post or page, and turn on the drop-cap option. Note the appearance in the editor:

![image](https://user-images.githubusercontent.com/177561/78842897-24679b80-79b6-11ea-8723-88cb28018a49.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the font size has been corrected:

![image](https://user-images.githubusercontent.com/177561/78842957-4eb95900-79b6-11ea-9e7f-0bc446b3e8a0.png)

5. Navigate to Customize > Typography, and change the body font. 
6. Confirm it's being picked up by the dropcap in the editor:

![image](https://user-images.githubusercontent.com/177561/78843088-ace63c00-79b6-11ea-9909-f9beea458d00.png)

7. Reset the Typography settings, and switch to Newspack Joseph. 
8. Confirm that the dropcap looks good in the editor, and is using the header font:

![image](https://user-images.githubusercontent.com/177561/78843557-f97e4700-79b7-11ea-876f-c13c69625e9d.png)

9. Navigate to Customize > Typography, and change the header font. 
10. Confirm it's being picked up by the dropcap in the editor:

![image](https://user-images.githubusercontent.com/177561/78843686-6265bf00-79b8-11ea-9967-1a36531466da.png)

11. Reset the Typography settings, and switch to Newspack Katharine. 
12. Confirm that the dropcap looks good in the editor, and is using the header font:

![image](https://user-images.githubusercontent.com/177561/78843880-fd5e9900-79b8-11ea-9654-f02e891314ae.png)

13. Navigate to Customize > Typography, and change the header font. 
14. Confirm it's being picked up by the dropcap in the editor:

![image](https://user-images.githubusercontent.com/177561/78843959-30089180-79b9-11ea-88eb-db5c45cfbf88.png)

15. Reset the Typography settings, and switch to Newspack Nelson. 
16. Confirm that the dropcap looks good in the editor, and is using the header font and the secondary colour:

![image](https://user-images.githubusercontent.com/177561/78844261-1ddb2300-79ba-11ea-9cd0-00fa074fb7c7.png)

17. Navigate to Customize > Typography, and change the header font. 
18. Confirm it's being picked up by the dropcap in the editor:

![image](https://user-images.githubusercontent.com/177561/78844442-9c37c500-79ba-11ea-8857-765788036a92.png)

19. Reset the Typography settings, and switch to Newspack Sacha.
20. Confirm that the dropcap looks good in the editor, and is using the header font and the secondary color:

![image](https://user-images.githubusercontent.com/177561/78844685-52031380-79bb-11ea-9699-8a07142c9627.png)

21. Navigate to Customize > Typography, and change the header font. 
22. Confirm it's being picked up by the dropcap in the editor:

![image](https://user-images.githubusercontent.com/177561/78845435-5c261180-79bd-11ea-8200-c60469eae82b.png)

23. Reset the Typography settings, and switch to Newspack Scott.
24. Confirm that the dropcap looks good in the editor, and is using the header font:

![image](https://user-images.githubusercontent.com/177561/78845617-e2425800-79bd-11ea-899f-57b60bd9a70d.png)

25. Navigate to Customize > Typography and change the header font.
26. Confirm it's being picked up by the dropcap in the editor:

![Uploading image.png…]()

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
