### PR TITLE
One Column template: Make max width a px value, not %

### DIFF
--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -64,8 +64,7 @@
 .blog #main,
 .search #main,
 .page .main-content,
-.single .main-content,
-.newspack-front-page.page-template-single-feature .site-main {
+.single .main-content {
 	@include media( tablet ) {
 		width: 65%;
 	}
@@ -94,6 +93,8 @@
 .newspack-front-page.page-template-single-feature .site-main {
 	margin-left: auto;
 	margin-right: auto;
+	max-width: 780px;
+	width: 100%;
 }
 
 .page-template-single-feature {
@@ -101,7 +102,8 @@
 		.entry-header {
 			margin-left: auto;
 			margin-right: auto;
-			width: 65%;
+			max-width: 780px;
+			width: 100%;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the one column template has a content area of 65% of the site's 1200px width, with makes it 780px wide. This matches how this is done for the default two column template.

This means that the content area of the one column template shrinks as you make the browser window narrower -- however, this doesn't make sense when you don't have a sidebar to make room for, and leads to weirdly narrow content at some tablet screen sizes. 

This PR changes this template's styles, so the content area has a max-width of 780px, meaning it will fill up more space on tablet-sized screens.

Closes #870 .

### How to test the changes in this Pull Request:

1. Apply the one-column template to a post and a page.
2. View on the front end; confirm that the content width is 780px wide when the browser window is large, but shrinks as you scale down the browser window.
3. Apply the PR and run `npm run build`.
4. Confirm that the post and page have not changed in appearance when the browser window is wide.
5. Try sizing down the browser window again; confirm that the content area remains at 780px wide, until the window becomes narrower than that, at which point, it fills the available space. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
