### PR TITLE
Improve icon used to indicate comments by the post author

### DIFF
--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -22,7 +22,7 @@ class Newspack_SVG_Icons {
 	/**
 	 * Gets the SVG code for a given icon.
 	 */
-	public static function get_svg( $group, $icon, $size, $title ) {
+	public static function get_svg( $group, $icon, $size, $title = '' ) {
 		if ( 'ui' == $group ) {
 			$arr = self::$ui_icons;
 		} elseif ( 'social' == $group ) {

--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -22,7 +22,7 @@ class Newspack_SVG_Icons {
 	/**
 	 * Gets the SVG code for a given icon.
 	 */
-	public static function get_svg( $group, $icon, $size ) {
+	public static function get_svg( $group, $icon, $size, $title ) {
 		if ( 'ui' == $group ) {
 			$arr = self::$ui_icons;
 		} elseif ( 'social' == $group ) {
@@ -33,6 +33,9 @@ class Newspack_SVG_Icons {
 		if ( array_key_exists( $icon, $arr ) ) {
 			$repl = sprintf( '<svg class="svg-icon" width="%d" height="%d" aria-hidden="true" role="img" focusable="false" ', $size, $size );
 			$svg  = preg_replace( '/^<svg /', $repl, trim( $arr[ $icon ] ) ); // Add extra attributes to SVG code.
+			if ( '' !== $title ) {
+				$svg = preg_replace( '/<\/svg>/', '<title>' . $title . '</title></svg>', $svg ); // Add title tag to SVG if populated.
+			}
 			$svg  = preg_replace( "/([\n\t]+)/", ' ', $svg ); // Remove newlines & tabs.
 			$svg  = preg_replace( '/>\s*</', '><', $svg ); // Remove white space between SVG tags.
 			return $svg;
@@ -85,7 +88,6 @@ class Newspack_SVG_Icons {
     </clipPath>
     <path clip-path="url(#b)" d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm4.2 14.2L11 13V7h1.5v5.2l4.5 2.7-.8 1.3z"></path>
 </svg>',
-
 		'archive'                  => /* material-design – folder */ '
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"></path>

--- a/newspack-theme/classes/class-newspack-walker-comment.php
+++ b/newspack-theme/classes/class-newspack-walker-comment.php
@@ -59,7 +59,7 @@ class Newspack_Walker_Comment extends Walker_Comment {
 
 						/* Display icon if the commenter is the current post's author. */
 						if ( newspack_is_comment_by_post_author( $comment ) ) {
-							printf( '<span class="post-author-badge" aria-hidden="true">%s</span>', wp_kses( newspack_get_icon_svg( 'check', 24 ), newspack_sanitize_svgs() ) );
+							printf( '<span class="post-author-badge" aria-hidden="true">%s</span>', wp_kses( newspack_get_icon_svg( 'person', 24, esc_html__( 'Article author', 'newspack' ) ), newspack_sanitize_svgs() ) );
 						}
 
 						if ( ! empty( $comment_author_url ) ) {

--- a/newspack-theme/inc/icon-functions.php
+++ b/newspack-theme/inc/icon-functions.php
@@ -8,22 +8,22 @@
 /**
  * Gets the SVG code for a given icon.
  */
-function newspack_get_icon_svg( $icon, $size = 24 ) {
-	return Newspack_SVG_Icons::get_svg( 'ui', $icon, $size );
+function newspack_get_icon_svg( $icon, $size = 24, $title = '' ) {
+	return Newspack_SVG_Icons::get_svg( 'ui', $icon, $size, $title );
 }
 
 /**
  * Gets the SVG code for a given social icon.
  */
-function newspack_get_social_icon_svg( $icon, $size = 24 ) {
-	return Newspack_SVG_Icons::get_svg( 'social', $icon, $size );
+function newspack_get_social_icon_svg( $icon, $size = 24, $title = '' ) {
+	return Newspack_SVG_Icons::get_svg( 'social', $icon, $size, $title );
 }
 
 /**
  * Detects the social network from a URL and returns the SVG code for its icon.
  */
-function newspack_get_social_link_svg( $uri, $size = 24 ) {
-	return Newspack_SVG_Icons::get_social_link_svg( $uri, $size );
+function newspack_get_social_link_svg( $uri, $size = 24, $title = '' ) {
+	return Newspack_SVG_Icons::get_social_link_svg( $uri, $size, $title );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the icon that indicates comments by the post author, and adds the ability to include a title attribute for SVGs, that will show up when a visitor hovers over a SVG.

Closes #856.

### How to test the changes in this Pull Request:

1. Create a post and add a comment to that post, using the same author for both.
2. View on the front-end; note the SVG checkbox next to the author name:

![image](https://user-images.githubusercontent.com/177561/78932876-233d7980-7a5d-11ea-8e7a-d2c25d7af596.png)

3. Apply PR.
4. View the comment on the front-end again; confirm the SVG is now a person icon:

![image](https://user-images.githubusercontent.com/177561/78932777-f9845280-7a5c-11ea-9ed0-3a0074d14ec3.png)

5. Hover over the icon; confirm that the title displays to explain the icon:

![image](https://user-images.githubusercontent.com/177561/78932788-fee19d00-7a5c-11ea-952f-b5c5ae7c2b96.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
