### PR TITLE
Pullquote Block: Correct width in editor

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -467,23 +467,23 @@ figcaption,
 
 .wp-block[data-type='core/pullquote'][data-align='left'],
 .wp-block[data-type='core/pullquote'][data-align='right'] {
+	.is-block-content {
+		max-width: 50%;
+		width: 50%;
+	}
+
 	.wp-block-pullquote {
 		@include media( tablet ) {
 			border-bottom: 0;
 		}
 	}
 
-	.editor-block-list__block-edit {
-		max-width: 50%;
-		width: 50%;
+	.wp-block-pullquote:not( .is-style-solid-color ) {
+		padding: 0;
+	}
 
-		.wp-block-pullquote:not( .is-style-solid-color ) {
-			padding: 0;
-		}
-
-		.wp-block-pullquote.is-style-solid-color {
-			padding: $size__spacing-unit #{2 * $size__spacing-unit};
-		}
+	.wp-block-pullquote.is-style-solid-color {
+		padding: $size__spacing-unit #{2 * $size__spacing-unit};
 	}
 
 	blockquote


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The pullquote block is not respecting the max-width when floated left or right in the editor.

It looks like the markup might have changed a bit; this PR updates the styles to match.

Closes #874

### How to test the changes in this Pull Request:

1. Add a pullquote block to the editor, and give it a fair bit of text (at least a full line).
2. Align the block left or right.
3. Note the editor preview -- it still takes up all the available space (though if you have one of the one-column templates, it should be popping out of the side):

![image](https://user-images.githubusercontent.com/177561/78948693-0ebda900-7a7e-11ea-87ca-d126ee8f1f99.png)

4. Apply the PR and run `npm run build`.
5. Refresh the editor; confirm that the pullquote is only taking up half the space:

![image](https://user-images.githubusercontent.com/177561/78948565-ac64a880-7a7d-11ea-9ca6-9e56ff290321.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
