### PR TITLE
Latest Posts Block: Correct custom fonts

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -100,6 +100,8 @@ function newspack_custom_typography_css() {
 		/* _blocks.scss */
 		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 		.wp-block-pullquote cite,
+		.entry .entry-content .wp-block-latest-posts li > a,
+		.entry .entry-content .wp-block-latest-posts time,
 
 		/* _widgets.scss */
 		.widget,
@@ -238,7 +240,8 @@ function newspack_custom_typography_css() {
 		/* Widget blocks */
 		.block-editor-block-list__layout .block-editor-block-list__block ul.wp-block-archives li,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-categories li,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-posts li,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-posts li > a,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-posts time,
 
 		/* Latest Comments blocks */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-latest-comments .wp-block-latest-comments__comment-meta,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -562,10 +562,6 @@
 		list-style: none;
 
 		li {
-			color: $color__text-light;
-			font-family: $font__heading;
-			font-weight: bold;
-			line-height: $font__line-height-heading;
 			padding-bottom: ( 0.75 * $size__spacing-unit );
 
 			&.menu-item-has-children,
@@ -581,6 +577,12 @@
 
 	.wp-block-archives,
 	.wp-block-categories {
+		li {
+			font-family: $font__heading;
+			font-weight: bold;
+			line-height: $font__line-height-heading;
+		}
+
 		&.aligncenter {
 			text-align: center;
 		}
@@ -600,21 +602,35 @@
 		@include nestedSubMenuPadding();
 	}
 
-	//! Latest posts grid view
-	.wp-block-latest-posts.is-grid {
-		li {
-			border-top: 2px solid $color__border;
-			padding-top: ( 1 * $size__spacing-unit );
-			margin-bottom: ( 2 * $size__spacing-unit );
-			a {
-				&::after {
-					content: '';
+	.wp-block-latest-posts {
+		li > a {
+			font-family: $font__heading;
+			font-weight: bold;
+			line-height: $font__line-height-heading;
+		}
+		time {
+			color: $color__text-light;
+			font-family: $font__heading;
+		}
+		.wp-block-latest-posts__post-excerpt {
+			font-size: 0.8em;
+		}
+
+		&.is-grid {
+			li {
+				border-top: 2px solid $color__border;
+				padding-top: ( 1 * $size__spacing-unit );
+				margin-bottom: ( 2 * $size__spacing-unit );
+				a {
+					&::after {
+						content: '';
+					}
 				}
-			}
-			&:last-child {
-				margin-bottom: auto;
-				a::after {
-					content: '';
+				&:last-child {
+					margin-bottom: auto;
+					a::after {
+						content: '';
+					}
 				}
 			}
 		}

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -588,11 +588,6 @@ ul.wp-block-archives,
 	}
 
 	li {
-		color: $color__text-light;
-		font-family: $font__heading;
-		font-size: calc( #{$font__size_base} * #{$font__size-ratio} );
-		font-weight: bold;
-		line-height: $font__line-height-heading;
 		padding-bottom: ( 0.75 * $size__spacing-unit );
 
 		&.menu-item-has-children,
@@ -610,6 +605,16 @@ ul.wp-block-archives,
 	}
 }
 
+ul.wp-block-archives,
+.wp-block-categories {
+	li {
+		font-family: $font__heading;
+		font-size: calc( #{$font__size_base} * #{$font__size-ratio} );
+		font-weight: bold;
+		line-height: $font__line-height-heading;
+	}
+}
+
 .wp-block-categories {
 	ul {
 		padding-top: ( 0.75 * $size__spacing-unit );
@@ -623,21 +628,38 @@ ul.wp-block-archives,
 	}
 }
 
-/** === Latest Posts grid view === */
-.wp-block-latest-posts.is-grid {
-	li {
-		border-top: 2px solid $color__border;
-		padding-top: ( 1 * $size__spacing-unit );
-		margin-bottom: ( 2 * $size__spacing-unit );
-		a {
-			&::after {
-				content: '';
+/** === Latest Posts === */
+.wp-block-latest-posts {
+	li > a {
+		font-family: $font__heading;
+		font-size: calc( #{$font__size_base} * #{$font__size-ratio} );
+		font-weight: bold;
+		line-height: $font__line-height-heading;
+	}
+
+	time {
+		color: $color__text-light;
+		font-family: $font__heading;
+	}
+	.wp-block-latest-posts__post-excerpt {
+		font-size: 0.8em;
+	}
+
+	&.is-grid {
+		li {
+			border-top: 2px solid $color__border;
+			padding-top: ( 1 * $size__spacing-unit );
+			margin-bottom: ( 2 * $size__spacing-unit );
+			a {
+				&::after {
+					content: '';
+				}
 			}
-		}
-		&:last-child {
-			margin-bottom: auto;
-			a::after {
-				content: '';
+			&:last-child {
+				margin-bottom: auto;
+				a::after {
+					content: '';
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Latest Posts block inherits the custom typography correctly.

Closes #869.

### How to test the changes in this Pull Request:

1. Add the Latest Posts block to the editor, and turn on the date and excerpt in the sidebar.
2. Save and publish.
3. View on the front-end and in the editor; everything is using the header font:

![image](https://user-images.githubusercontent.com/177561/79011414-d6b77400-7b18-11ea-9cd2-b9c7fc8cbbc0.png)

4: Navigate to Customize > Typography and change the title and body font.
5. View on front-end and in the editor; note that nothing has changed.
6. Apply the PR and run `npm run build`.
7. Confirm that the block is picking up the custom fonts (header for title and date; body for excerpt):

![image](https://user-images.githubusercontent.com/177561/79011551-25650e00-7b19-11ea-912d-e854b3b6f997.png)

8. Navigate back to Customize > Typography, and confirm that the correct default header and body fonts are being applied on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/79011625-43cb0980-7b19-11ea-9be5-bb7ef97b46d7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
