### PR TITLE
Add Featured Images to RSS output

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -792,6 +792,19 @@ function newspack_theme_newspack_ads_maybe_use_responsive_placement( $responsive
 add_filter( 'newspack_ads_maybe_use_responsive_placement', 'newspack_theme_newspack_ads_maybe_use_responsive_placement', 10, 3 );
 
 /**
+ * Display Featured Images in RSS feed.
+ */
+function newspack_thumbnails_in_rss( $content ) {
+	global $post;
+	if ( has_post_thumbnail( $post->ID ) ) {
+		$content = '<figure>' . get_the_post_thumbnail( $post->ID, 'medium' ) . '</figure>' . $content;
+	}
+	return $content;
+}
+add_filter( 'the_excerpt_rss', 'newspack_thumbnails_in_rss' );
+add_filter( 'the_content_feed', 'newspack_thumbnails_in_rss' );
+
+/**
  * Notify about child theme deprecation.
  * TODO: Remove after child theme code is removed.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If present, add a medium-sized version of the featured image to the RSS feed.

Closes #795

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Make sure you have at least one recent post with a featured image.
3. View the RSS feed (/feed) and confirm you see the image markup at the top of post's description and content (you can see raw RSS feeds using Chrome):

![image](https://user-images.githubusercontent.com/177561/79016149-1daa6700-7b23-11ea-8978-10833f44cde5.png)

4. Ideally, also check in an RSS feed reader. To do so, you'll need to test the PR on a non-localhost site, so it can pick up the feed. Please note that some RSS readers (like Feedly), will pick up the first image in a post as well, so make sure to test a post with no images in the body.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
