### PR TITLE
Featured Image: improve appearance of caption with beside featured image setting

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -540,7 +540,7 @@ body.page {
 }
 
 .featured-image-behind + figcaption,
-.featured-image-beside + figcaption {
+.featured-image-beside figcaption {
 	margin: #{0.25 * $size__spacing-unit} auto 0;
 	width: 1200px;
 	max-width: 100%;
@@ -647,6 +647,41 @@ body.page {
 
 		.entry-title {
 			font-size: $font__size-xxl;
+		}
+
+		figcaption {
+			bottom: 0;
+			color: #fff;
+			left: 50%;
+			position: absolute;
+			width: 50%;
+
+			a,
+			a:visited {
+				color: #fff;
+				text-decoration: underline;
+			}
+
+			a:hover {
+				text-decoration: none;
+			}
+
+			> span {
+				display: inline-block;
+				max-width: 780px;
+				padding: #{2 * $size__spacing-unit} $size__spacing-unit $size__spacing-unit;
+				position: relative;
+			}
+
+			&::before {
+				background-image: linear-gradient( rgba( 0, 0, 0, 0 ), rgba( 0, 0, 0, 0.5 ) 50% );
+				bottom: 0;
+				content: '';
+				height: 100%;
+				left: 0;
+				position: absolute;
+				width: 100%;
+			}
 		}
 	}
 }

--- a/newspack-theme/template-parts/post/large-featured-image.php
+++ b/newspack-theme/template-parts/post/large-featured-image.php
@@ -33,12 +33,11 @@ if ( 'behind' === newspack_featured_image_position() ) :
 		</div><!-- .wrapper -->
 
 		<?php newspack_post_thumbnail(); ?>
+
+		<?php if ( $caption ) : ?>
+			<figcaption><span><?php echo wp_kses_post( $caption ); ?></span></figcaption>
+		<?php endif; ?>
 	</div><!-- .featured-image-behind -->
-
-	<?php if ( $caption ) : ?>
-		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
-	<?php endif; ?>
-
 <?php else : ?>
 
 	<header class="entry-header">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the 'beside post title' option is selected for the featured image, this update moves the caption from below the featured image to overlaying the bottom of it.

This creates better connection between the featured image and the caption, as it doesn't run wider than the image, and sits directly on top of it.

Closes #880

### How to test the changes in this Pull Request:

1. Set up a post with a featured image; add a caption and select the 'beside post title' option.
2. View on the front end and note the position:

![image](https://user-images.githubusercontent.com/177561/79178269-a2aeae00-7db9-11ea-9f70-67508e02cd2f.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the caption placement is now on top of the featured image, and is legible:

![image](https://user-images.githubusercontent.com/177561/79178309-c2de6d00-7db9-11ea-8bb8-2af5e1929dd2.png)

5. Size down the browser window; confirm that the caption moves below the featured image when it no longer sits next to the post title:

![image](https://user-images.githubusercontent.com/177561/79178320-ce319880-7db9-11ea-98ee-0da8e80df411.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
