### PR TITLE
Centred Logo: Primary menu is slightly off

### DIFF
--- a/newspack-theme/sass/navigation/_menu-main-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-main-navigation.scss
@@ -260,6 +260,10 @@
 		.nav1 .main-menu > li:last-child {
 			margin-right: 0;
 
+			a {
+				padding-right: 0;
+			}
+
 			.submenu-expand {
 				margin-right: -5px; // offset spacing next to svg icon.
 			}

--- a/newspack-theme/sass/navigation/_menu-main-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-main-navigation.scss
@@ -57,10 +57,6 @@
 				}
 			}
 
-			&:last-child {
-				margin-right: 0;
-			}
-
 			&.menu-item-has-children {
 				position: inherit;
 
@@ -250,12 +246,24 @@
 }
 
 // Header Center Logo; default height
-.h-cl.h-dh .site-header #site-navigation {
-	flex-basis: 100%;
-	text-align: center;
+.h-cl.h-dh {
+	.site-header {
+		#site-navigation {
+			flex-basis: 100%;
+			text-align: center;
 
-	ul ul {
-		text-align: left;
+			ul ul {
+				text-align: left;
+			}
+		}
+
+		.nav1 .main-menu > li:last-child {
+			margin-right: 0;
+
+			.submenu-expand {
+				margin-right: -5px; // offset spacing next to svg icon.
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now when you have a centred logo and standard header height, the primary menu is slightly off-center. This is because the last menu item had a right margin, and if the last menu item has a dropdown, the empty space around the down-chevron svg also falsely makes it look off.

Closes #883.

### How to test the changes in this Pull Request:

1. Set up a primary menu, and add dropdown items to the last menu item. 
2. Navigate to Customize > Header Settings, and check Center Logo and uncheck Short Header.
3. View on the front-end; you may need to take a screenshot and measure, but the primary menu has about a 10px offset to the left:

![centered-logo-before](https://user-images.githubusercontent.com/177561/79370945-663d9800-7f08-11ea-9833-73b86050febd.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the primary menu is more properly centred:

![centered-logo-after](https://user-images.githubusercontent.com/177561/79370970-72295a00-7f08-11ea-99ae-76b1d66a0584.png)

6. Try moving the menu item with the dropdown away from the last item, and confirm that it still looks centred with a one level menu item at the end:

![centered-logo-after-2](https://user-images.githubusercontent.com/177561/79371934-05af5a80-7f0a-11ea-93b0-dc1cf19e2e1d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
