### PR TITLE
Make sure amp styles work with logo centering

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -216,6 +216,7 @@
 
 			img {
 				height: auto;
+				margin: auto;
 				max-width: 100%;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There is a weird case where AMP will add the following CSS to a site, and it will cause the centred logo not to work when they have a width, height and sizes attribute:

```
[width][height][sizes]:not(.i-amphtml-layout-responsive) {
    display: block;
    position: relative;
}
```

This PR adds some 'backup' CSS in this cases, so rather than relying on the `img` to be `display: inline-block`, it will also work when it's display block.

### How to test the changes in this Pull Request:

1. Test on a site that's displaying this issue.
2. Confirm that the logo is not centring.
3. Apply the PR and run `npm run build`.
4. Confirm that it fixes the issue.
5. If possible, test on a site that is not displaying this issue on master and confirm that it doesn't cause any issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
