### PR TITLE
Fix make subtitle appear in Gutenberg >v7.8.1

### DIFF
--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -12,7 +12,7 @@ export const META_FIELD_NAME = 'newspack_post_subtitle';
  * @param  {string} subtitle Subtitle text
  */
 export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
-	const titleEl = document.querySelector( '.editor-post-title__block > div' );
+	const titleEl = document.querySelector( '.editor-post-title__block' );
 	if ( titleEl && typeof subtitle === 'string' ) {
 		let subtitleEl = document.getElementById( SUBTITLE_ID );
 		if ( ! subtitleEl ) {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -825,6 +825,5 @@ ul.wp-block-archives,
 /** === Post Subtitle === */
 
 #newspack-post-subtitle-element {
-	padding-left: 14px;
 	font-style: italic;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Due to a change in HTML structure, the code that placed the subtitle in the editor was not working
properly. This updates it to handle the new HTML layout.

Closes #886

### How to test the changes in this Pull Request:

1. Ensure Gutenberg version is 7.8.1
1. Add new post or edit one
2. Add a subtitle (Sidebar -> Article Subtitle)
3. Observe subtitle being displayed
1. Ensure Gutenberg version is 7.9.0
3. Observe subtitle being displayed

Note: the subtitle will be slightly misaligned on Gutenberg 7.8.1:
![image](https://user-images.githubusercontent.com/7383192/79846555-e22f5880-83be-11ea-94b1-df07671160b4.png)
I don't think this should be handled, because 7.8.1->7.9.0 is not a major version change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
