### PR TITLE
Feat: Add options to WooCommerce thank you page

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -525,7 +525,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'woocommerce_thank_you_title',
 		array(
-			'default'           => esc_html__( 'Thank you!', 'newspack' ),
+			'default'           => esc_html__( 'Thank you', 'newspack' ),
 			'sanitize_callback' => 'sanitize_text_field',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -521,7 +521,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Thank you message page title.
+	// Thank you page title.
 	$wp_customize->add_setting(
 		'woocommerce_thank_you_title',
 		array(
@@ -556,25 +556,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Thank you - display order details
-	$wp_customize->add_setting(
-		'thank_you_order_details_display',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'thank_you_order_details_display',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Display Order Details', 'newspack' ),
-			'description' => esc_html__( 'Display an order details table below your thank you message.', 'newspack' ),
-			'section'     => 'woocommerce_thank_you',
-		)
-	);
-
-	// Thank you - display order details
+	// Thank you - display customer details
 	$wp_customize->add_setting(
 		'thank_you_customer_details_display',
 		array(
@@ -582,12 +564,13 @@ function newspack_customize_register( $wp_customize ) {
 			'sanitize_callback' => 'newspack_sanitize_checkbox',
 		)
 	);
+
 	$wp_customize->add_control(
 		'thank_you_customer_details_display',
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Display Customer Details', 'newspack' ),
-			'description' => esc_html__( 'Display billing and shipping addresses.', 'newspack' ),
+			'description' => esc_html__( 'Display the customer\'s billing address below their transaction details.', 'newspack' ),
 			'section'     => 'woocommerce_thank_you',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -509,6 +509,88 @@ function newspack_customize_register( $wp_customize ) {
 			'section' => 'woocommerce_cart_options',
 		)
 	);
+
+	/**
+	 * WooCommerce Thank You page details
+	 */
+	$wp_customize->add_section(
+		'woocommerce_thank_you',
+		array(
+			'title' => esc_html__( 'Thank You Page', 'newspack' ),
+			'panel' => 'woocommerce',
+		)
+	);
+
+	// Thank you message page title.
+	$wp_customize->add_setting(
+		'woocommerce_thank_you_title',
+		array(
+			'default'           => esc_html__( 'Thank you!', 'newspack' ),
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+	$wp_customize->add_control(
+		'woocommerce_thank_you_title',
+		array(
+			'type'    => 'text',
+			'label'   => esc_html__( 'Thank You page title', 'newspack' ),
+			'section' => 'woocommerce_thank_you',
+		)
+	);
+
+	// Thank you message text.
+	$wp_customize->add_setting(
+		'woocommerce_thank_you_message',
+		array(
+			'default'           => esc_html__( 'We appreciate your contribution!', 'newspack' ),
+			'sanitize_callback' => 'sanitize_textarea_field',
+		)
+	);
+	$wp_customize->add_control(
+		'woocommerce_thank_you_message',
+		array(
+			'type'        => 'textarea',
+			'label'       => esc_html__( 'Thank You message', 'newspack' ),
+			'description' => esc_html__( 'Text message that displays at the top of the "Thank You" page.' ),
+			'section'     => 'woocommerce_thank_you',
+		)
+	);
+
+	// Thank you - display order details
+	$wp_customize->add_setting(
+		'thank_you_order_details_display',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'thank_you_order_details_display',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display Order Details', 'newspack' ),
+			'description' => esc_html__( 'Display an order details table below your thank you message.', 'newspack' ),
+			'section'     => 'woocommerce_thank_you',
+		)
+	);
+
+	// Thank you - display order details
+	$wp_customize->add_setting(
+		'thank_you_customer_details_display',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'thank_you_customer_details_display',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display Customer Details', 'newspack' ),
+			'description' => esc_html__( 'Display billing and shipping addresses.', 'newspack' ),
+			'section'     => 'woocommerce_thank_you',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -543,7 +543,7 @@ function newspack_customize_register( $wp_customize ) {
 		'woocommerce_thank_you_message',
 		array(
 			'default'           => esc_html__( 'We appreciate your contribution!', 'newspack' ),
-			'sanitize_callback' => 'sanitize_textarea_field',
+			'sanitize_callback' => 'sanitize_text_field',
 		)
 	);
 	$wp_customize->add_control(

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -525,7 +525,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'woocommerce_thank_you_title',
 		array(
-			'default'           => esc_html__( 'Thank you', 'newspack' ),
+			'default'           => esc_html__( 'Order received', 'newspack' ),
 			'sanitize_callback' => 'sanitize_text_field',
 		)
 	);
@@ -542,7 +542,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'woocommerce_thank_you_message',
 		array(
-			'default'           => esc_html__( 'We appreciate your contribution!', 'newspack' ),
+			'default'           => esc_html__( 'Thank you. Your order has been received.', 'newspack' ),
 			'sanitize_callback' => 'sanitize_text_field',
 		)
 	);

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -156,6 +156,17 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-author-email';
 	}
 
+	// Adds classes for WooCommerce options
+	$thankyou_display_order_details    = get_theme_mod( 'thank_you_order_details_display', false );
+	$thankyou_display_customer_details = get_theme_mod( 'thank_you_customer_details_display', false );
+	// Check for thank you page:
+	if ( false === $thankyou_display_order_details ) {
+		$classes[] = 'hide-thankyou-order-details';
+	}
+	if ( false === $thankyou_display_customer_details ) {
+		$classes[] = 'hide-thankyou-customer-details';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -156,17 +156,6 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'hide-author-email';
 	}
 
-	// Adds classes for WooCommerce options
-	$thankyou_display_order_details    = get_theme_mod( 'thank_you_order_details_display', false );
-	$thankyou_display_customer_details = get_theme_mod( 'thank_you_customer_details_display', false );
-	// Check for thank you page:
-	if ( false === $thankyou_display_order_details ) {
-		$classes[] = 'hide-thankyou-order-details';
-	}
-	if ( false === $thankyou_display_customer_details ) {
-		$classes[] = 'hide-thankyou-customer-details';
-	}
-
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -173,7 +173,7 @@ add_filter( 'woocommerce_checkout_fields', 'newspack_checkout_fields_styling', 9
 function newspack_thankyou_page_title( $title, $id ) {
 	if ( function_exists( 'is_order_received_page' ) &&
 		is_order_received_page() && get_the_ID() === $id ) {
-		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Thank you', 'newspack' ) );
+		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Order received', 'newspack' ) );
 	}
 	return esc_html( $title );
 }
@@ -183,7 +183,7 @@ add_filter( 'the_title', 'newspack_thankyou_page_title', 10, 2 );
  * Filters the 'message' for the Thank You page.
  */
 function newspack_thankyou_order_message() {
-	$thank_you_msg = get_theme_mod( 'woocommerce_thank_you_message', esc_html__( 'We appreciate your contribution!', 'newspack' ) );
+	$thank_you_msg = get_theme_mod( 'woocommerce_thank_you_message', esc_html__( 'Thank you. Your order has been received.', 'newspack' ) );
 	return esc_html( $thank_you_msg );
 }
 add_filter( 'woocommerce_thankyou_order_received_text', 'newspack_thankyou_order_message' );

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -173,7 +173,7 @@ add_filter( 'woocommerce_checkout_fields', 'newspack_checkout_fields_styling', 9
 function newspack_thankyou_page_title( $title, $id ) {
 	if ( function_exists( 'is_order_received_page' ) &&
 		is_order_received_page() && get_the_ID() === $id ) {
-		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Thank you!', 'newspack' ) );
+		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Thank you', 'newspack' ) );
 	}
 	return esc_html( $title );
 }

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -175,7 +175,7 @@ function newspack_thankyou_page_title( $title, $id ) {
 		is_order_received_page() && get_the_ID() === $id ) {
 		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Thank you!', 'newspack' ) );
 	}
-	return $title;
+	return esc_html( $title );
 }
 add_filter( 'the_title', 'newspack_thankyou_page_title', 10, 2 );
 
@@ -184,17 +184,14 @@ add_filter( 'the_title', 'newspack_thankyou_page_title', 10, 2 );
  */
 function newspack_thankyou_order_message() {
 	$thank_you_msg = get_theme_mod( 'woocommerce_thank_you_message', esc_html__( 'We appreciate your contribution!', 'newspack' ) );
-	return $thank_you_msg;
+	return esc_html( $thank_you_msg );
 }
 add_filter( 'woocommerce_thankyou_order_received_text', 'newspack_thankyou_order_message' );
 
 /**
- * Change the subscription thank you message after purchase to empty for the time being.
+ * Remove the subscription 'thank you' message.
  */
 function newspack_subscription_thank_you() {
-	$thank_you_message = '';
-	return $thank_you_message;
-
+	return '';
 }
 add_filter( 'woocommerce_subscriptions_thank_you_message', 'newspack_subscription_thank_you' );
-

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -167,3 +167,34 @@ function newspack_checkout_fields_styling( $fields ) {
 }
 add_filter( 'woocommerce_checkout_fields', 'newspack_checkout_fields_styling', 9999 );
 
+/**
+ * Filters the page title for the Thank You page.
+ */
+function newspack_thankyou_page_title( $title, $id ) {
+	if ( function_exists( 'is_order_received_page' ) &&
+		is_order_received_page() && get_the_ID() === $id ) {
+		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Thank you!', 'newspack' ) );
+	}
+	return $title;
+}
+add_filter( 'the_title', 'newspack_thankyou_page_title', 10, 2 );
+
+/**
+ * Filters the 'message' for the Thank You page.
+ */
+function newspack_thankyou_order_message() {
+	$thank_you_msg = get_theme_mod( 'woocommerce_thank_you_message', esc_html__( 'We appreciate your contribution!', 'newspack' ) );
+	return $thank_you_msg;
+}
+add_filter( 'woocommerce_thankyou_order_received_text', 'newspack_thankyou_order_message' );
+
+/**
+ * Change the subscription thank you message after purchase to empty for the time being.
+ */
+function newspack_subscription_thank_you() {
+	$thank_you_message = '';
+	return $thank_you_message;
+
+}
+add_filter( 'woocommerce_subscriptions_thank_you_message', 'newspack_subscription_thank_you' );
+

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1186,11 +1186,6 @@ table.variations {
 	.select2-container--focus .select2-selection {
 		border-color: black;
 	}
-
-	&.hide-thankyou-order-details .woocommerce-order-details,
-	&.hide-thankyou-customer-details .woocommerce-customer-details {
-		display: none;
-	}
 }
 
 .woocommerce-checkout-review-order-table,
@@ -1542,5 +1537,14 @@ table.woocommerce-table--order-details.shop_table,
 			color: $color__text-light;
 			display: block;
 		}
+	}
+}
+
+.woocommerce-customer-details {
+	border-top: 1px solid $color__border;
+	padding-top: $size__spacing-unit;
+	address {
+		font-size: 90%;
+		font-style: normal;
 	}
 }

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1194,9 +1194,13 @@ table.variations {
 }
 
 .woocommerce-checkout-review-order-table,
-.woocommerce-table--order-details,
+table.woocommerce-table--order-details.shop_table,
 .my_account_orders {
 	border-top: 1px solid $color__border;
+
+	td {
+		font-weight: normal;
+	}
 
 	td,
 	th {
@@ -1235,6 +1239,10 @@ table.variations {
 
 	.cart-subtotal.recurring-total {
 		font-weight: bold;
+	}
+
+	tfoot th {
+		font-weight: normal;
 	}
 }
 

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1186,9 +1186,16 @@ table.variations {
 	.select2-container--focus .select2-selection {
 		border-color: black;
 	}
+
+	&.hide-thankyou-order-details .woocommerce-order-details,
+	&.hide-thankyou-customer-details .woocommerce-customer-details {
+		display: none;
+	}
 }
 
-.woocommerce-checkout-review-order-table {
+.woocommerce-checkout-review-order-table,
+.woocommerce-table--order-details,
+.my_account_orders {
 	border-top: 1px solid $color__border;
 
 	td,

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Thankyou page
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/checkout/thankyou.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.2.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+
+<div class="woocommerce-order">
+
+	<?php
+	if ( $order ) :
+
+		do_action( 'woocommerce_before_thankyou', $order->get_id() );
+		?>
+
+		<?php if ( $order->has_status( 'failed' ) ) : ?>
+
+			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed">
+				<?php esc_html_e( 'Unfortunately your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'newspack' ); ?>
+			</p>
+
+			<p class="woocommerce-notice woocommerce-notice--error woocommerce-thankyou-order-failed-actions">
+				<a href="<?php echo esc_url( $order->get_checkout_payment_url() ); ?>" class="button pay"><?php esc_html_e( 'Pay', 'newspack' ); ?></a>
+				<?php if ( is_user_logged_in() ) : ?>
+					<a href="<?php echo esc_url( wc_get_page_permalink( 'myaccount' ) ); ?>" class="button pay"><?php esc_html_e( 'My account', 'newspack' ); ?></a>
+				<?php endif; ?>
+			</p>
+
+		<?php else : ?>
+
+			<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+				<?php echo esc_html( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), $order ) ); ?>
+			</p>
+
+			<h4><?php esc_html_e( 'Summary', 'newspack' ); ?></h4>
+
+			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+
+				<li class="woocommerce-order-overview__date date">
+					<?php esc_html_e( 'Date:', 'newspack' ); ?>
+					<strong><?php echo wc_format_datetime( $order->get_date_created() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+				</li>
+
+				<?php if ( is_user_logged_in() && $order->get_user_id() === get_current_user_id() && $order->get_billing_email() ) : ?>
+					<li class="woocommerce-order-overview__email email">
+						<?php esc_html_e( 'Email:', 'newspack' ); ?>
+						<strong><?php echo $order->get_billing_email(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+					</li>
+				<?php endif; ?>
+
+				<li class="woocommerce-order-overview__total total">
+					<?php esc_html_e( 'Total:', 'newspack' ); ?>
+					<strong><?php echo $order->get_formatted_order_total(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+				</li>
+
+				<?php if ( $order->get_payment_method_title() ) : ?>
+					<li class="woocommerce-order-overview__payment-method method">
+						<?php esc_html_e( 'Payment method:', 'newspack' ); ?>
+						<strong><?php echo wp_kses_post( $order->get_payment_method_title() ); ?></strong>
+					</li>
+				<?php endif; ?>
+
+				<li class="woocommerce-order-overview__order order">
+					<?php esc_html_e( 'Transaction:', 'newspack' ); ?>
+					<strong><?php echo $order->get_order_number(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></strong>
+				</li>
+
+			</ul>
+
+			<?php
+				// Copied from templates/order/order-details.php
+				$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
+				if ( false === get_theme_mod( 'thank_you_customer_details_display', false ) ) {
+					$show_customer_details = false;
+				}
+				if ( $show_customer_details ) {
+					wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
+				}
+			?>
+		<?php endif; ?>
+	<?php else : ?>
+
+		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
+			<?php echo esc_html( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), null ) ); ?>
+		</p>
+
+	<?php endif; ?>
+
+</div>

--- a/newspack-theme/woocommerce/order/order-details-customer.php
+++ b/newspack-theme/woocommerce/order/order-details-customer.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Order Customer Details
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/order/order-details-customer.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.4.4
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
+// temporarily hide shipping for all:
+$show_shipping = false;
+?>
+<section class="woocommerce-customer-details">
+
+	<h4><?php esc_html_e( 'Your Information', 'newspack' ); ?></h4>
+
+	<?php if ( $show_shipping ) : ?>
+
+	<section class="woocommerce-columns woocommerce-columns--2 woocommerce-columns--addresses col2-set addresses">
+		<div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
+
+	<?php endif; ?>
+
+	<?php if ( $show_shipping ) : ?>
+		<h5 class="woocommerce-column__title"><?php esc_html_e( 'Billing address', 'newspack' ); ?></h5>
+	<?php endif; ?>
+
+	<address>
+		<?php echo wp_kses_post( $order->get_formatted_billing_address( esc_html__( 'N/A', 'newspack' ) ) ); ?>
+
+		<?php if ( $order->get_billing_phone() ) : ?>
+			<p class="woocommerce-customer-details--phone"><?php echo esc_html( $order->get_billing_phone() ); ?></p>
+		<?php endif; ?>
+
+		<?php if ( $order->get_billing_email() ) : ?>
+			<p class="woocommerce-customer-details--email"><?php echo esc_html( $order->get_billing_email() ); ?></p>
+		<?php endif; ?>
+	</address>
+
+	<?php if ( $show_shipping ) : ?>
+
+		</div><!-- /.col-1 -->
+
+		<div class="woocommerce-column woocommerce-column--2 woocommerce-column--shipping-address col-2">
+			<h5 class="woocommerce-column__title"><?php esc_html_e( 'Shipping address', 'newspack' ); ?></h5>
+			<address>
+				<?php echo wp_kses_post( $order->get_formatted_shipping_address( esc_html__( 'N/A', 'newspack' ) ) ); ?>
+			</address>
+		</div><!-- /.col-2 -->
+
+	</section><!-- /.col2-set -->
+
+	<?php endif; ?>
+
+	<?php do_action( 'woocommerce_order_details_after_customer_details', $order ); ?>
+
+</section>

--- a/newspack-theme/woocommerce/order/order-details-customer.php
+++ b/newspack-theme/woocommerce/order/order-details-customer.php
@@ -18,8 +18,6 @@
 defined( 'ABSPATH' ) || exit;
 
 $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
-// temporarily hide shipping for all:
-$show_shipping = false;
 ?>
 <section class="woocommerce-customer-details">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Based on some customer feedback, this PR adds options to simplify the WooCommerce 'Thank You' page. Specifically, it:

1. Adds an option to change the page title (it uses the same 'page' as the checkout page, so you can't just change the page title normally).
2. Adds an option to change the 'thank you' text.
3. Strips down the content of the page to just the transaction details (date, price, payment method...)
4. Adds an option to show the customer's billing information under the transaction details, but hides it by default.

Understandably, this may not cover what everyone wants to do. One step further would be to also add an option to redirect the 'thank you' page to a specific static page that a publisher could set up. So a publication that was only doing donations could build a page that went into a lot of detail about where the money went, and how else people could get involved, and redirect the 'thank you' page there. There's a filter we can use to do this, and I think it could be a pretty quick easy win for publishers who'd like to craft a specific message for this page.

Taking it even further, there's also a WooCommerce extension that will let you do this same thing, on a product-by-product basis: https://woocommerce.com/products/custom-thank-pages/. This could be helpful for publishers who want to sell multiple different products, and have unique thank you messages for each (donations, access to limited products, physical products, etc). 

### How to test the changes in this Pull Request:

1. Start with a site with donations set up for easier testing, and Stripe in testing mode. 
2. Set up a page with the Donate block.
3. On that block, click 'Donate Now'. 
4. Fill out the billing information, and submit the order.
5. View the Thank You page:

![image](https://user-images.githubusercontent.com/177561/79917005-92f92000-83de-11ea-975d-053ddfec8e7c.png)

6. Apply the PR and run `npm run build`.
7. Refresh the page:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/177561/80004745-9096d480-8477-11ea-82c2-7c3a6c4ee039.png">

8. Navigate to Customize > WooCommerce > Thank You Page:

<img width="301" alt="image" src="https://user-images.githubusercontent.com/177561/80004819-a60bfe80-8477-11ea-96ed-998ae351c29e.png">

10. Try changing the page title, the "Thank You" message, and check Display Customer Details. Publish.
11. View the page again; confirm that your title and message appear, and that the customer details appear at the bottom:

<img width="835" alt="image" src="https://user-images.githubusercontent.com/177561/80004988-dbb0e780-8477-11ea-9d96-a9080a614ab9.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
