### PR TITLE
Add hook above comments render

### DIFF
--- a/newspack-theme/comments.php
+++ b/newspack-theme/comments.php
@@ -78,6 +78,7 @@ if ( $collapse_comments && 1 < (int) $discussion->responses && $on_first_page ) 
 		}
 		?>
 	</div><!-- .comments-title-flex -->
+	<?php do_action( 'newspack_comments_above_comments' ); ?>
 	<?php
 	if ( have_comments() ) :
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to https://github.com/Automattic/newspack-rename-comments/pull/2. This PR adds a hook that will allow that PR to do stuff right above the comments.

### How to test the changes in this Pull Request:

1. If you want to test the full integration, instructions are at https://github.com/Automattic/newspack-rename-comments/pull/2, otherwise this PR should do nothing and break nothing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
