### PR TITLE
Update classes for custom typography

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -201,21 +201,23 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= '
-		.block-editor-block-list__layout .block-editor-block-list__block h1,
-		.block-editor-block-list__layout .block-editor-block-list__block h2,
-		.block-editor-block-list__layout .block-editor-block-list__block h3,
-		.block-editor-block-list__layout .block-editor-block-list__block h4,
-		.block-editor-block-list__layout .block-editor-block-list__block h5,
-		.block-editor-block-list__layout .block-editor-block-list__block h6,
-		.block-editor-block-list__layout .block-editor-block-list__block figcaption,
-		.block-editor-block-list__layout .block-editor-block-list__block .gallery-caption,
-		.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
+		.block-editor-block-list__layout h1.block-editor-block-list__block,
+		.block-editor-block-list__layout h2.block-editor-block-list__block,
+		.block-editor-block-list__layout h3.block-editor-block-list__block,
+		.block-editor-block-list__layout h4.block-editor-block-list__block,
+		.block-editor-block-list__layout h5.block-editor-block-list__block,
+		.block-editor-block-list__layout h6.block-editor-block-list__block,
+		.block-editor-block-list__layout figcaption,
+		.block-editor-block-list__layout .gallery-caption,
+		.block-editor-block-list__layout .cat-links,
 
 		/* Post Title */
-		.editor-styles-wrapper .editor-post-title .editor-post-title__block .editor-post-title__input,
+		.edit-post-visual-editor.editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
 
 		/* Table Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table td,
 
 		/* Cover Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover h2,
@@ -346,7 +348,7 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block,
+			.block-editor-block-list__layout,
 			.editor-default-block-appender .editor-default-block-appender__content
 			{
 				font-family: ' . wp_kses( $font_body, null ) . ';

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -100,8 +100,12 @@ function newspack_custom_typography_css() {
 		/* _blocks.scss */
 		.wp-block-latest-comments .wp-block-latest-comments__comment-meta,
 		.wp-block-pullquote cite,
+		.entry .entry-content .wp-block-categories li,
+		.entry .entry-content .wp-block-archives li,
 		.entry .entry-content .wp-block-latest-posts li > a,
 		.entry .entry-content .wp-block-latest-posts time,
+		.entry .entry-content .wp-block-file,
+		.entry .entry-content .wp-block-file .wp-block-file__button,
 
 		/* _widgets.scss */
 		.widget,
@@ -201,12 +205,12 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= '
-		.block-editor-block-list__layout h1.block-editor-block-list__block,
-		.block-editor-block-list__layout h2.block-editor-block-list__block,
-		.block-editor-block-list__layout h3.block-editor-block-list__block,
-		.block-editor-block-list__layout h4.block-editor-block-list__block,
-		.block-editor-block-list__layout h5.block-editor-block-list__block,
-		.block-editor-block-list__layout h6.block-editor-block-list__block,
+		.edit-post-visual-editor.editor-styles-wrapper h1,
+		.edit-post-visual-editor.editor-styles-wrapper h2,
+		.edit-post-visual-editor.editor-styles-wrapper h3,
+		.edit-post-visual-editor.editor-styles-wrapper h4,
+		.edit-post-visual-editor.editor-styles-wrapper h5,
+		.edit-post-visual-editor.editor-styles-wrapper h6,
 		.editor-styles-wrapper .wp-block figcaption,
 		.block-editor-block-list__layout .gallery-caption,
 
@@ -219,12 +223,12 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout .wpnbha .cat-links,
 
 		/* Table Block */
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table td,
 
 		/* Button Block */
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link,
+		.edit-post-visual-editor.editor-styles-wrapper .wp-block-button__link,
+		.edit-post-visual-editor.editor-styles-wrapper .wp-block-button .wp-block-button__link,
 
 		/* Blockquote Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote cite,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -211,8 +211,9 @@ function newspack_custom_typography_css() {
 		.edit-post-visual-editor.editor-styles-wrapper h4,
 		.edit-post-visual-editor.editor-styles-wrapper h5,
 		.edit-post-visual-editor.editor-styles-wrapper h6,
-		.editor-styles-wrapper .wp-block figcaption,
-		.block-editor-block-list__layout .gallery-caption,
+		.block-editor-block-list__layout .block-editor-block-list__block figcaption,
+		.block-editor-block-list__layout .block-editor-block-list__block .gallery-caption,
+		.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
 
 		/* Post Title */
 		.edit-post-visual-editor.editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
@@ -220,7 +221,6 @@ function newspack_custom_typography_css() {
 		/* Homepage Posts Block */
 		.block-editor-block-list__layout .wpnbha .entry-title,
 		.block-editor-block-list__layout .wpnbha .entry-meta,
-		.block-editor-block-list__layout .wpnbha .cat-links,
 
 		/* Table Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -207,24 +207,24 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout h4.block-editor-block-list__block,
 		.block-editor-block-list__layout h5.block-editor-block-list__block,
 		.block-editor-block-list__layout h6.block-editor-block-list__block,
-		.block-editor-block-list__layout figcaption,
+		.editor-styles-wrapper .wp-block figcaption,
 		.block-editor-block-list__layout .gallery-caption,
-		.block-editor-block-list__layout .cat-links,
 
 		/* Post Title */
 		.edit-post-visual-editor.editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
+
+		/* Homepage Posts Block */
+		.block-editor-block-list__layout .wpnbha .entry-title,
+		.block-editor-block-list__layout .wpnbha .entry-meta,
+		.block-editor-block-list__layout .wpnbha .cat-links,
 
 		/* Table Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table td,
 
-		/* Cover Block */
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover h2,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover .wp-block-cover-text,
-
 		/* Button Block */
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button .wp-block-button__link,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link,
 
 		/* Blockquote Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote cite,
@@ -348,6 +348,7 @@ function newspack_custom_typography_css() {
 		}
 
 		$editor_css_blocks .= '
+			#newspack-post-subtitle-element,
 			.block-editor-block-list__layout,
 			.editor-default-block-appender .editor-default-block-appender__content
 			{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Gutenberg 7.9, how some classes were applied in the editor has changed, which has broken some of the custom typography. 

This PR fixes that in the parent theme's custom typography code. If there are issues in the child themes, I'll address them in seperate PRs.

This PR also includes a fix for fonts on the front end for the categories, archives and file blocks. 

Lastly, there's some pretty gnarly issues with the button block as of 7.9 that I'll be addressing separately; only that block's custom typography in the editor needs to be checked with this PR.

See #893.

### How to test the changes in this Pull Request:

1. Copy-paste the following content into a page: https://cloudup.com/cEUOHTlPNza -- it includes a selection of blocks and settings that have been updated. 
2. For the Homepage Posts block, add a subtitle to at least one of the posts that display there. 
3. Navigate to Customize > Typography, and pick very noticeably different fonts.
4. View your page in the editor, and the post you added a subtitle to; note a lot of things aren't picking up the custom fonts, or if they are, they're picking up the wrong ones (like the headers inheriting the body font).
5. Apply the PR.
6. Confirm that the blocks are using the proper fonts. 

In my examples, the titles should be using Impact, and the body should be using Chalkboard -- specific blocks I noticed issues with, include:

**Post/Page title:**

Before - using the theme default: 

![image](https://user-images.githubusercontent.com/177561/80154627-d71e2900-8574-11ea-990d-356ca454b487.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155832-64627d00-8577-11ea-8333-0b58e18f74f3.png)

**Header Blocks**

Before - using the body font:

![image](https://user-images.githubusercontent.com/177561/80154683-eef5ad00-8574-11ea-8700-322be4dd78a9.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155842-69273100-8577-11ea-8953-7e25c0a80b9d.png)

**Table block:**

Before - using theme's default body font: 

![image](https://user-images.githubusercontent.com/177561/80154740-164c7a00-8575-11ea-8c22-78e3f1d477ff.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155856-6f1d1200-8577-11ea-952a-78ecc779d151.png)

**Button Block:**

Before - using body font:

![image](https://user-images.githubusercontent.com/177561/80154766-1fd5e200-8575-11ea-8af5-a719341b24a9.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155936-983da280-8577-11ea-8996-534f8566c775.png)

**Homepage Posts block:**

Before - entry meta using theme's default:

![image](https://user-images.githubusercontent.com/177561/80155244-2f095f80-8576-11ea-9c59-14a03ee473a1.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155877-780de380-8577-11ea-8c21-afb145cac6ed.png)

**Subtitle (on single post):**

Before - using theme's default body font:

![image](https://user-images.githubusercontent.com/177561/80155402-81e31700-8576-11ea-84e9-73548f1bf8de.png)

After:

![image](https://user-images.githubusercontent.com/177561/80155909-852ad280-8577-11ea-902b-9e7f0229db2d.png)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
