### PR TITLE
Add color classes to the editor styles

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -586,7 +586,6 @@ function newspack_custom_colors_css() {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
-		.has-primary-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -586,6 +586,7 @@ function newspack_custom_colors_css() {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
+		.has-primary-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
@@ -593,6 +594,22 @@ function newspack_custom_colors_css() {
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . esc_html( $primary_color_contrast ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color {
+			color: ' . esc_html( $primary_color ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color {
+			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-background-color {
+			background-color: ' . esc_html( $primary_color ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-background-color {
+			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 		}
 
 		/* Secondary color */
@@ -640,6 +657,22 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover .article-section-title {
 			color: inherit;
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-color {
+			color: ' . esc_html( $secondary_color ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color {
+			color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-background-color {
+			background-color: ' . esc_html( $secondary_color ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-background-color {
+			background-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
 		}
 		';
 

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -827,3 +827,69 @@ ul.wp-block-archives,
 #newspack-post-subtitle-element {
 	font-style: italic;
 }
+
+/** === Custom Colors === */
+
+.has-primary-background-color {
+	background-color: $color__primary;
+}
+
+.has-primary-variation-background-color {
+	background-color: $color__primary-variation;
+}
+
+.has-secondary-background-color {
+	background-color: $color__secondary;
+}
+
+.has-secondary-variation-background-color {
+	background-color: $color__secondary-variation;
+}
+
+.has-dark-gray-background-color {
+	background-color: #111;
+}
+
+.has-medium-gray-background-color {
+	background-color: #767676;
+}
+
+.has-light-gray-background-color {
+	background-color: #eee;
+}
+
+.has-white-background-color {
+	background-color: #fff;
+}
+
+.has-primary-color {
+	color: $color__primary;
+}
+
+.has-primary-variation-color {
+	color: $color__primary-variation;
+}
+
+.has-secondary-color {
+	color: $color__secondary;
+}
+
+.has-secondary-variation-color {
+	color: $color__secondary-variation;
+}
+
+.has-dark-gray-color {
+	color: #111;
+}
+
+.has-medium-gray-color {
+	color: #767676;
+}
+
+.has-light-gray-color {
+	color: #eee;
+}
+
+.has-white-color {
+	color: #fff;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prior to Gutenberg 7.9, the editor styles didn't need the colour classes for the editor colour palette supplied by the theme, but now it does. 

This PR adds those classes to the editor styles, and the custom colour files. 

See #893.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Colors, and pick the default palette.
2. Copy-paste this test content into the editor: https://cloudup.com/cvdunVleCZF
3. Note the appearance -- none of the custom colours are being picked up:

![image](https://user-images.githubusercontent.com/177561/80160798-5d416c00-8583-11ea-9c03-8a8e8a28562b.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the colours are being applied in the editor:

![image](https://user-images.githubusercontent.com/177561/80161003-eb1d5700-8583-11ea-99ee-c85eae1b56e8.png)

6. Navigate to Customize > Colors, and pick a new primary and secondary colour.
7. Return to the editor and confirm they're now being applied to the blocks marked 'primary' and 'secondary':

![image](https://user-images.githubusercontent.com/177561/80161051-0ab47f80-8584-11ea-8e4d-55af2ca96308.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
