### PR TITLE
Update button styles to work with new markup

### DIFF
--- a/newspack-joseph/inc/child-typography.php
+++ b/newspack-joseph/inc/child-typography.php
@@ -35,7 +35,7 @@ function newspack_joseph_custom_typography_css() {
 			.widget,
 			.widget-title.accent-header,
 			.accent-header,
-			.entry .entry-content .wp-block-button .wp-block-button__link,
+			.entry .entry-content .wp-block-button__link,
 			.entry .article-section-title,
 			button,
 			input[type="button"],

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -71,7 +71,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .has-primary-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p {
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
 			color: ' . esc_html( $primary_color ) . ';
 		}
 
@@ -141,7 +142,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .has-secondary-color,
 		.entry .entry-content *[class^="wp-block-"] .has-secondary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p {
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
 			color:' . esc_html( $secondary_color ) . '; /* base: #666 */
 		}
 
@@ -167,7 +169,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color {
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color,
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
 			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . '; /* base: #005177; */
 		}
 
@@ -203,7 +206,8 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .has-secondary-variation-color,
 		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p {
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p,
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
 			color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
 		}
 		';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -169,8 +169,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
 		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color,
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
+		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color  {
 			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . '; /* base: #005177; */
 		}
 
@@ -185,7 +184,8 @@ function newspack_custom_colors_css() {
 		.comment-reply-link:hover,
 		.comment-navigation .nav-previous a:hover,
 		.comment-navigation .nav-next a:hover,
-		#cancel-comment-reply-link:hover {
+		#cancel-comment-reply-link:hover,
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
 			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
 		}
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -72,6 +72,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"] .has-primary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
+		.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-color:not(:hover), /* legacy styles */
 		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
 			color: ' . esc_html( $primary_color ) . ';
 		}
@@ -143,6 +144,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"] .has-secondary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
+		.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-color:not(:hover), /* legacy styles */
 		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
 			color:' . esc_html( $secondary_color ) . '; /* base: #666 */
 		}
@@ -185,7 +187,8 @@ function newspack_custom_colors_css() {
 		.comment-navigation .nav-previous a:hover,
 		.comment-navigation .nav-next a:hover,
 		#cancel-comment-reply-link:hover,
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
+		.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-variation-color:not(:hover), /* legacy styles */
+		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-variation-color:not(:hover) {
 			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
 		}
 
@@ -207,6 +210,7 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p,
+		.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
 		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
 			color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
 		}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -62,7 +62,6 @@ function newspack_custom_colors_css() {
 		.comment .comment-metadata > a:hover,
 		.comment .comment-metadata .comment-edit-link:hover,
 		.site-info a:hover,
-		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
 		.comments-toggle:hover, .comments-toggle:focus {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
@@ -122,7 +121,7 @@ function newspack_custom_colors_css() {
 
 		/* Set secondary background color */
 
-		.entry .entry-content .wp-block-button .wp-block-button__link:not(.has-background),
+		.entry .entry-content .wp-block-button__link:not(.has-background),
 		.button, button, input[type="button"], input[type="reset"], input[type="submit"],
 		.entry .entry-content .has-secondary-background-color,
 		.entry .entry-content *[class^="wp-block-"].has-secondary-background-color,
@@ -132,7 +131,6 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Set colour that contrasts against the secondary background */
-
 		.entry .entry-content .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background),
 		.button, .button:visited, .entry .entry-content .button, .entry .entry-content .button:visited, button, input[type="button"], input[type="reset"], input[type="submit"] {
 			color: ' . esc_html( $secondary_color_contrast ) . ';
@@ -150,9 +148,9 @@ function newspack_custom_colors_css() {
 		/* Set secondary color with contrast */
 		.site-header .highlight-menu .menu-label,
 		.entry-content a,
-		.entry-content a:visited,
 		.author-bio .author-link,
-		.entry .entry-content .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color) {
+		.entry .entry-content .is-style-outline .wp-block-button__link, /* legacy selector */
+		.entry .entry-content .wp-block-button__link.is-style-outline {
 			color:' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 		}
 
@@ -208,7 +206,6 @@ function newspack_custom_colors_css() {
 		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p {
 			color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
 		}
-
 		';
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -59,7 +59,7 @@ function newspack_custom_typography_css() {
 		input[type="submit"],
 
 		/* _blocks.scss */
-		.entry .entry-content .wp-block-button .wp-block-button__link,
+		.entry .entry-content .wp-block-button__link,
 
 		/* _captions.scss */
 		figcaption,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -227,8 +227,7 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table td,
 
 		/* Button Block */
-		.edit-post-visual-editor.editor-styles-wrapper .wp-block-button__link,
-		.edit-post-visual-editor.editor-styles-wrapper .wp-block-button .wp-block-button__link,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link,
 
 		/* Blockquote Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote cite,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -483,74 +483,63 @@
 	}
 
 	//! Button
-	.wp-block-button {
-		.wp-block-button__link {
-			@include button-transition;
-			border: none;
-			font-family: $font__heading;
-			font-size: $font__size-sm;
-			line-height: $font__line-height-heading;
-			box-sizing: border-box;
-			font-weight: bold;
-			text-decoration: none;
-			padding: ( $size__spacing-unit * 0.76 ) $size__spacing-unit;
-			outline: none;
+	.wp-block-button__link {
+		background-color: $color__background-button;
+		@include button-transition;
+		border: none;
+		border-radius: 5px;
+		color: #fff;
+		font-family: $font__heading;
+		font-size: $font__size-sm;
+		line-height: $font__line-height-heading;
+		box-sizing: border-box;
+		font-weight: bold;
+		text-decoration: none;
+		padding: ( $size__spacing-unit * 0.76 ) $size__spacing-unit;
+		outline: none;
 
-			&:not( .has-background ) {
-				background-color: $color__background-button;
-			}
-
-			&:not( .has-text-color ) {
-				color: white;
-			}
-
-			&:not( .has-background ):hover,
-			&:hover {
-				color: white;
-				background: $color__background-button-hover;
-				cursor: pointer;
-			}
-
-			&:not( .has-background ):focus,
-			&:focus {
-				color: white;
-				background: $color__background-button-hover;
-				outline: thin dotted;
-				outline-offset: -4px;
-			}
-		}
-
-		&:not( .is-style-outline ) .wp-block-button__link:not( .has-background ):hover {
+		&:hover,
+		&.has-background:hover {
 			color: white;
+			background: $color__background-button-hover;
+			cursor: pointer;
 		}
 
-		&:not( .is-style-squared ) .wp-block-button__link {
-			border-radius: 5px;
-		}
-
-		&.is-style-outline .wp-block-button__link,
-		&.is-style-outline .wp-block-button__link:focus,
-		&.is-style-outline .wp-block-button__link:active {
-			@include button-all-transition;
-			border-width: 2px;
-			border-style: solid;
-
-			&:not( .has-background ) {
-				background: transparent;
-			}
-
-			&:not( .has-text-color ) {
-				color: $color__background-button;
-				border-color: currentColor;
-			}
-		}
-
-		&.is-style-outline .wp-block-button__link:hover {
+		&:focus,
+		&.has-background:hover {
 			color: white;
-			border-color: $color__background-button-hover;
-			&:not( .has-background ) {
-				color: $color__background-button-hover;
-			}
+			background: $color__background-button-hover;
+			outline: thin dotted;
+			outline-offset: -4px;
+		}
+	}
+
+	.wp-button-block.is-style-outline .wp-block-button__link,
+	.wp-block-button__link.is-style-outline,
+	.wp-button-block.is-style-outline .wp-block-button__link:focus,
+	.wp-block-button__link.is-style-outline:focus,
+	.wp-button-block.is-style-outline .wp-block-button__link:active,
+	.wp-block-button__link.is-style-outline:active {
+		@include button-all-transition;
+		border-width: 2px;
+		border-style: solid;
+
+		&:not( .has-background ) {
+			background: transparent;
+		}
+
+		&:not( .has-text-color ) {
+			color: $color__background-button;
+			border-color: currentColor;
+		}
+	}
+
+	.wp-block-button.is-style-outline .wp-block-button__link:hover,
+	.wp-block-button__link.is-style-outline:hover {
+		color: white;
+		border-color: $color__background-button-hover;
+		&:not( .has-background ) {
+			color: $color__background-button-hover;
 		}
 	}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -895,45 +895,53 @@
 	//! Custom foreground colors
 	.has-primary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p,
+	.wp-block-button.has-primary-color {
 		color: $color__primary;
 	}
 
 	.has-primary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p,
+	.wp-block-button.has-primary-variation-color {
 		color: $color__primary-variation;
 	}
 
 	.has-secondary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p,
+	.wp-block-button.has-secondary-color {
 		color: $color__secondary;
 	}
 
 	.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p,
+	.wp-block-button.has-secondary-variation-color {
 		color: $color__secondary-variation;
 	}
 
 	.has-dark-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
+	.wp-block-button.has-dark-gray-color {
 		color: #111;
 	}
 
 	.has-medium-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color,
+	.wp-block-button.has-medium-gray-color {
 		color: #767676;
 	}
 
 	.has-light-gray-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
+	.wp-block-button.has-light-gray-color {
 		color: #eee;
 	}
 
 	.has-white-color,
-	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color {
+	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
+	.wp-block-button.has-white-color {
 		color: #fff;
 	}
 }

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -497,49 +497,41 @@
 		text-decoration: none;
 		padding: ( $size__spacing-unit * 0.76 ) $size__spacing-unit;
 		outline: none;
-
-		&:hover,
-		&.has-background:hover {
-			color: white;
-			background: $color__background-button-hover;
-			cursor: pointer;
-		}
-
-		&:focus,
-		&.has-background:hover {
-			color: white;
-			background: $color__background-button-hover;
-			outline: thin dotted;
-			outline-offset: -4px;
-		}
 	}
 
-	.wp-button-block.is-style-outline .wp-block-button__link,
-	.wp-block-button__link.is-style-outline,
-	.wp-button-block.is-style-outline .wp-block-button__link:focus,
-	.wp-block-button__link.is-style-outline:focus,
-	.wp-button-block.is-style-outline .wp-block-button__link:active,
-	.wp-block-button__link.is-style-outline:active {
+	.is-style-outline .wp-block-button__link, // legacy selector
+	.wp-block-button__link.is-style-outline {
 		@include button-all-transition;
 		border-width: 2px;
 		border-style: solid;
+		color: $color__background-button;
+		border-color: currentColor;
 
 		&:not( .has-background ) {
 			background: transparent;
 		}
-
-		&:not( .has-text-color ) {
-			color: $color__background-button;
-			border-color: currentColor;
-		}
 	}
 
-	.wp-block-button.is-style-outline .wp-block-button__link:hover,
-	.wp-block-button__link.is-style-outline:hover {
-		color: white;
-		border-color: $color__background-button-hover;
-		&:not( .has-background ) {
-			color: $color__background-button-hover;
+	.wp-block-button {
+		.wp-block-button__link, // legacy selector
+		&.wp-block-button__link {
+			&:hover,
+			&:active,
+			&:focus {
+				color: white;
+				background: $color__background-button-hover;
+			}
+
+			&:focus {
+				outline: thin dotted;
+				outline-offset: -4px;
+			}
+
+			&.is-style-outline:hover,
+			&.is-style-outline:active,
+			&.is-style-outline:focus {
+				border-color: $color__background-button-hover;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -923,25 +923,29 @@
 
 	.has-dark-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-	.wp-block-button.has-dark-gray-color {
+	.wp-block-button.has-dark-gray-color,
+	.wp-block-button__link.is-style-outline.has-dark-gray-color {
 		color: #111;
 	}
 
 	.has-medium-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color,
-	.wp-block-button.has-medium-gray-color {
+	.wp-block-button.has-medium-gray-color,
+	.wp-block-button__link.is-style-outline.has-medium-gray-color {
 		color: #767676;
 	}
 
 	.has-light-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-	.wp-block-button.has-light-gray-color {
+	.wp-block-button.has-light-gray-color,
+	.wp-block-button__link.is-style-outline.has-light-gray-color {
 		color: #eee;
 	}
 
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
-	.wp-block-button.has-white-color {
+	.wp-block-button.has-white-color,
+	.wp-block-button__link.is-style-outline.has-white-color {
 		color: #fff;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -331,36 +331,22 @@ figcaption,
 
 /** === Button === */
 
-.wp-block-button {
-	.wp-block-button__link {
-		line-height: 1.8;
-		font-family: $font__heading;
-		font-size: $font__size-sm;
-		font-weight: bold;
-	}
+.wp-block-button__link {
+	background: $color__background-button;
+	border-radius: 5px;
+	line-height: 1.8;
+	font-family: $font__heading;
+	font-size: $font__size-sm;
+	font-weight: bold;
+}
 
-	&:not( .is-style-outline ) .wp-block-button__link {
-		background: $color__background-button;
-	}
+.is-style-outline .wp-block-button__link, // legacy selector
+.wp-block-button__link.is-style-outline {
+	background: transparent;
+	color: $color__background-button;
 
-	&:not( .is-style-squared ) .wp-block-button__link {
-		border-radius: 5px;
-	}
-
-	&.is-style-outline,
-	&.is-style-outline:hover,
-	&.is-style-outline:focus,
-	&.is-style-outline:active {
-		background: transparent;
+	&:not( .has-text-color ) {
 		color: $color__background-button;
-
-		.wp-block-button__link {
-			background: transparent;
-
-			&:not( .has-text-color ) {
-				color: $color__background-button;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Gutenberg 7.9, the button block was updated to remove the `.wp-block-button` container around each link, and add that class to the link itself instead. Unfortunately, the theme relied on that class structure to apply the button styles correctly; this PR updates the styles to work with the new button markup, as well as the old button markup.

The custom colours are not being applied in the editor, even with this fix; #893 may fix this in part but I think I'll need to circle back and do a separate PR for the buttons to fine tune after that's merged. In the meantime, please disregard!

Closes #894 and #871.

### How to test the changes in this Pull Request:

1. Make sure you have the latest version of the Gutenberg plugin.
2. Set a custom colour, and a custom typeface.
3. Add button blocks to the editor with the following settings: default; custom text and background color; gradient background; outline styles with default; outline styles with custom text, and outline styles with custom text and background color. 
4. View on the front-end; be disappointed:

![image](https://user-images.githubusercontent.com/177561/80246243-ef4b8200-8620-11ea-933f-d75adf5da9eb.png)

5. Apply the PR and run `npm run build`.
6. Confirm the front end now looks correct:

![image](https://user-images.githubusercontent.com/177561/80246304-09856000-8621-11ea-91d2-4218ae0c528b.png)

7. Confirm the editor is at least picking up the right fonts and shapes, but not the colours:

![image](https://user-images.githubusercontent.com/177561/80246409-38033b00-8621-11ea-800a-13a6709a3f97.png)

8. Turn off the Gutenberg plugin.
9. Edit the page again; add the same types of buttons again. Your original buttons will now be throwing an error, but that can be ignored; the new buttons you're adding will use the old markup, to make sure the styles are backwards compatible. When sites are updated to 7.9+, this will no longer be needed, as the markup gets updated too, but it'll be needed to keep buttons styles working on older versions of the editor.
10. View on the front-end and confirm both sets of buttons are applying custom styles:

![image](https://user-images.githubusercontent.com/177561/80246973-29695380-8622-11ea-95f9-071e0c3477cc.png)

11. When you turn Gutenberg back on, you'll note the "old" buttons have extra outlines when using the outline style, but this will be fixed Gutenberg (https://github.com/WordPress/gutenberg/pull/21816)

![image](https://user-images.githubusercontent.com/177561/80247092-5cabe280-8622-11ea-86f3-e6b006440b0d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
