### PR TITLE
Header: Add simplied header option for subpages

### DIFF
--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -105,9 +105,9 @@ function newspack_katharine_custom_colors_css() {
 				.h-sb .site-title a:visited,
 				.h-sb .site-description,
 				/* Header solid background; short height */
-				.h-sb.h-sh .nav1 .main-menu > li,
-				.h-sb.h-sh .nav1 ul.main-menu > li > a,
-				.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+				.h-sb.h-sh .site-header .nav1 .main-menu > li,
+				.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a,
+				.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a:hover,
 				.h-sb .top-header-contain,
 				.h-sb .middle-header-contain {
 					color: ' . esc_html( $header_color_contrast ) . ';

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -94,7 +94,8 @@ body:not( .h-sb ) .site-header {
 .single-featured-image-beside,
 .single-featured-image-behind {
 	@include media( tablet ) {
-		&.h-sub.h-db {
+		&.h-sub.h-db,
+		&.h-sub.h-sb {
 			.site-header,
 			.middle-header-contain,
 			&:not( .h-sb ) .site-header {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -76,7 +76,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 }
 
 // Header
-
 .site-header,
 .h-db .middle-header-contain, // Header default background
 .h-sh.h-db .site-header, // Header short height; header default background
@@ -86,8 +85,23 @@ body:not( .h-sb ) .site-header {
 }
 
 // Header short height; Header default bg
-.h-sh.h-db .middle-header-contain {
+.h-sh.h-db .middle-header-contain,
+.h-sub.h-db .middle-header-contain {
 	border-bottom: 0;
+}
+
+// Featured templates - Short header on subpages
+.single-featured-image-beside,
+.single-featured-image-behind {
+	@include media( tablet ) {
+		&.h-sub.h-db {
+			.site-header,
+			.middle-header-contain,
+			&:not( .h-sb ) .site-header {
+				background: transparent;
+			}
+		}
+	}
 }
 
 #page .site-header {
@@ -174,11 +188,6 @@ body:not( .h-sb ) .site-header {
 		#primary {
 			border-top: 0;
 			padding-top: 0;
-		}
-
-		.entry-header {
-			padding-left: $size__spacing-unit;
-			padding-right: $size__spacing-unit;
 		}
 	}
 }

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -57,8 +57,24 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-// Accent headers
+// Subpage header with a solid background
+.h-sub.h-sb.single-featured-image-beside {
+	@include media( tablet ) {
+		.middle-header-contain {
+			color: $color__text-main;
+		}
 
+		.alternative-logo {
+			display: none;
+
+			~ .custom-logo-link {
+				display: inline-block;
+			}
+		}
+	}
+}
+
+// Accent headers
 .accent-header,
 .article-section-title,
 .cat-links {

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -18,49 +18,94 @@
 </head>
 
 <body <?php body_class(); ?>>
-<?php do_action( 'wp_body_open' ); ?>
-<?php do_action( 'before_header' ); ?>
+<?php
 
-<?php get_template_part( 'template-parts/header/mobile', 'sidebar' ); ?>
-<?php get_template_part( 'template-parts/header/desktop', 'sidebar' ); ?>
+do_action( 'wp_body_open' );
+do_action( 'before_header' );
+
+// Header Settings
+$header_simplified     = get_theme_mod( 'header_simplified', false );
+$header_center_logo    = get_theme_mod( 'header_center_logo', false );
+$show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
+$header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
+
+get_template_part( 'template-parts/header/mobile', 'sidebar' );
+get_template_part( 'template-parts/header/desktop', 'sidebar' );
+
+if ( true === $header_sub_simplified ) :
+	get_template_part( 'template-parts/header/fullmenu', 'sidebar' );
+endif;
+?>
 
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
-		<?php
-			$header_simplified     = get_theme_mod( 'header_simplified', false );
-			$header_center_logo    = get_theme_mod( 'header_center_logo', false );
-			$show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
-		?>
-
-		<?php
-		// If header is NOT short, or if header is short and there's a Secondary Menu or Slide-out Sidebar widget.
-		if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary-menu' ) ) ) :
-		?>
-			<div class="top-header-contain desktop-only">
+		<?php if ( true === $header_sub_simplified ) : ?>
+			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
+					<button class="fullmenu-toggle" on="tap:fullmenu-sidebar.toggle">
+						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+						<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
+					</button>
+					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
+					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+				</div>
+			</div>
+		<?php else : ?>
+
+			<?php
+			// If header is NOT short, and if there's a Secondary Menu or Slide-out Sidebar widget.
+			if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary-menu' ) ) ) :
+			?>
+				<div class="top-header-contain desktop-only">
+					<div class="wrapper">
+						<?php if ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
+							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
+							</button>
+						<?php endif; ?>
+
+						<div id="secondary-nav-contain">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_secondary_menu();
+							}
+							?>
+						</div>
+
+						<?php
+						// Logo is NOT centered:
+						if ( false === $header_center_logo ) :
+						?>
+							<div id="social-nav-contain">
+								<?php
+								if ( ! newspack_is_amp() ) {
+									newspack_social_menu_header();
+								}
+								?>
+							</div>
+						<?php endif; ?>
+					</div><!-- .wrapper -->
+				</div><!-- .top-header-contain -->
+			<?php endif; ?>
+
+			<div class="middle-header-contain">
+				<div class="wrapper">
+					<?php if ( true === $header_simplified && true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-							<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
+							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
 						</button>
 					<?php endif; ?>
 
-					<div id="secondary-nav-contain">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_secondary_menu();
-						}
-						?>
-					</div>
-
 					<?php
-					// Logo is NOT centered:
-					if ( false === $header_center_logo ) :
+					// Centered logo AND NOT short header.
+					if ( true === $header_center_logo && false === $header_simplified ) :
 					?>
-						<div id="social-nav-contain">
+						<div id="social-nav-contain" class="desktop-only">
 							<?php
 							if ( ! newspack_is_amp() ) {
 								newspack_social_menu_header();
@@ -68,151 +113,126 @@
 							?>
 						</div>
 					<?php endif; ?>
-				</div><!-- .wrapper -->
-			</div><!-- .top-header-contain -->
-		<?php endif; ?>
 
-		<div class="middle-header-contain">
-			<div class="wrapper">
-				<?php if ( true === $header_simplified && true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
-					<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
-						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-						<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
-					</button>
-				<?php endif; ?>
+					<?php
+					// Centered logo AND short header.
+					if ( true === $header_center_logo && true === $header_simplified ) :
+					?>
 
-				<?php
-				// Centered logo AND NOT short header.
-				if ( true === $header_center_logo && false === $header_simplified ) :
-				?>
-					<div id="social-nav-contain" class="desktop-only">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_social_menu_header();
-						}
-						?>
-					</div>
-				<?php endif; ?>
+						<div class="nav-wrapper desktop-only">
+							<div id="site-navigation">
+								<?php
+								if ( ! newspack_is_amp() ) {
+									newspack_primary_menu();
+								}
+								?>
+							</div><!-- #site-navigation -->
+						</div><!-- .nav-wrapper -->
 
-				<?php
-				// Centered logo AND short header.
-				if ( true === $header_center_logo && true === $header_simplified ) :
-				?>
+					<?php endif; ?>
+
+					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
+
+					<?php
+					// Short header:
+					if ( true === $header_simplified && false === $header_center_logo ) :
+					?>
+
+						<div class="nav-wrapper desktop-only">
+							<div id="site-navigation">
+								<?php
+								if ( ! newspack_is_amp() ) {
+									newspack_primary_menu();
+								}
+								?>
+							</div><!-- #site-navigation -->
+
+							<?php
+							// Centered logo:
+							if ( true === $header_center_logo ) {
+								get_template_part( 'template-parts/header/header', 'search' );
+							}
+							?>
+						</div><!-- .nav-wrapper -->
+
+					<?php endif; ?>
+
 
 					<div class="nav-wrapper desktop-only">
+						<div id="tertiary-nav-contain">
+							<?php
+							if ( ! newspack_is_amp() ) {
+								newspack_tertiary_menu();
+							}
+							?>
+						</div><!-- #tertiary-nav-contain -->
+
+						<?php
+							// Header is simplified OR logo is centered:
+							if ( true === $header_simplified || true === $header_center_logo ) :
+								get_template_part( 'template-parts/header/header', 'search' );
+							endif;
+						?>
+					</div><!-- .nav-wrapper -->
+
+					<?php if ( newspack_has_menus() ) : ?>
+						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
+							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+						</button>
+					<?php endif; ?>
+
+				</div><!-- .wrapper -->
+			</div><!-- .middle-header-contain -->
+
+
+			<?php
+			// Header is NOT short:
+			if ( false === $header_simplified ) :
+			?>
+				<div class="bottom-header-contain desktop-only">
+					<div class="wrapper">
 						<div id="site-navigation">
 							<?php
 							if ( ! newspack_is_amp() ) {
 								newspack_primary_menu();
 							}
 							?>
-						</div><!-- #site-navigation -->
-					</div><!-- .nav-wrapper -->
+						</div>
 
-				<?php endif; ?>
+						<?php
+						// If logo is not centered.
+						if ( false === $header_center_logo && has_nav_menu( 'primary-menu' ) ) {
+							get_template_part( 'template-parts/header/header', 'search' );
+						}
+						?>
+					</div><!-- .wrapper -->
+				</div><!-- .bottom-header-contain -->
+			<?php
+			endif;
 
-
-				<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
-
-				<?php
-				// Short header:
-				if ( true === $header_simplified && false === $header_center_logo ) :
-				?>
-
-					<div class="nav-wrapper desktop-only">
-						<div id="site-navigation">
+			/**
+			 * Displays 'highlight' menu; created a function to reduce duplication.
+			 */
+			if ( has_nav_menu( 'highlight-menu' ) ) :
+			?>
+				<div class="highlight-menu-contain desktop-only">
+					<div class="wrapper">
+						<nav class="highlight-menu" aria-label="<?php esc_attr_e( 'Highlight Menu', 'newspack' ); ?>">
 							<?php
-							if ( ! newspack_is_amp() ) {
-								newspack_primary_menu();
-							}
+							wp_nav_menu(
+								array(
+									'theme_location' => 'highlight-menu',
+									'container'      => false,
+									'items_wrap'     => '<ul id="%1$s" class="%2$s"><li><span class="menu-label">' . esc_html( wp_get_nav_menu_name( 'highlight-menu' ) ) . '</span></li>%3$s</ul>',
+									'depth'          => 1,
+								)
+							);
 							?>
-						</div><!-- #site-navigation -->
-
-						<?php
-						// Centered logo:
-						if ( true === $header_center_logo ) {
-							get_template_part( 'template-parts/header/header', 'search' );
-						}
-						?>
-					</div><!-- .nav-wrapper -->
-
-				<?php endif; ?>
-
-
-				<div class="nav-wrapper desktop-only">
-					<div id="tertiary-nav-contain">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_tertiary_menu();
-						}
-						?>
-					</div><!-- #tertiary-nav-contain -->
-
-					<?php
-						// Header is simplified OR logo is centered:
-						if ( true === $header_simplified || true === $header_center_logo ) :
-							get_template_part( 'template-parts/header/header', 'search' );
-						endif;
-					?>
-				</div><!-- .nav-wrapper -->
-
-				<?php if ( newspack_has_menus() ) : ?>
-					<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
-						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-						<?php esc_html_e( 'Menu', 'newspack' ); ?>
-					</button>
-				<?php endif; ?>
-
-			</div><!-- .wrapper -->
-		</div><!-- .middle-header-contain -->
-
-
-		<?php
-		// Header is NOT short:
-		if ( false === $header_simplified ) :
-		?>
-			<div class="bottom-header-contain desktop-only">
-				<div class="wrapper">
-					<div id="site-navigation">
-						<?php
-						if ( ! newspack_is_amp() ) {
-							newspack_primary_menu();
-						}
-						?>
-					</div>
-
-					<?php
-					// If logo is not centered.
-					if ( false === $header_center_logo && has_nav_menu( 'primary-menu' ) ) {
-						get_template_part( 'template-parts/header/header', 'search' );
-					}
-					?>
-				</div><!-- .wrapper -->
-			</div><!-- .bottom-header-contain -->
-		<?php
-		endif;
-
-		/**
-		 * Displays 'highlight' menu; created a function to reduce duplication.
-		 */
-		if ( has_nav_menu( 'highlight-menu' ) ) :
-		?>
-			<div class="highlight-menu-contain desktop-only">
-				<div class="wrapper">
-					<nav class="highlight-menu" aria-label="<?php esc_attr_e( 'Highlight Menu', 'newspack' ); ?>">
-						<?php
-						wp_nav_menu(
-							array(
-								'theme_location' => 'highlight-menu',
-								'container'      => false,
-								'items_wrap'     => '<ul id="%1$s" class="%2$s"><li><span class="menu-label">' . esc_html( wp_get_nav_menu_name( 'highlight-menu' ) ) . '</span></li>%3$s</ul>',
-								'depth'          => 1,
-							)
-						);
-						?>
-					</nav>
-				</div><!-- .wrapper -->
-			</div><!-- .highlight-menu-contain -->
+						</nav>
+					</div><!-- .wrapper -->
+				</div><!-- .highlight-menu-contain -->
+			<?php endif; ?>
 		<?php endif; ?>
 
 	</header><!-- #masthead -->

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -52,16 +52,19 @@ endif;
 							<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
 						</button>
 					</div>
+
 					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
-					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<?php esc_html_e( 'Menu', 'newspack' ); ?>
 						</button>
 					<?php endif; ?>
+
+					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
 				</div>
-			</div>
+			</div><!-- .wrapper -->
 		<?php else : ?>
 
 			<?php

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -45,12 +45,20 @@ endif;
 		<?php if ( true === $header_sub_simplified ) : ?>
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<button class="fullmenu-toggle" on="tap:fullmenu-sidebar.toggle">
-						<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-						<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
-					</button>
+					<div class="fullmenu-toggle-contain">
+						<button class="fullmenu-toggle" on="tap:fullmenu-sidebar.toggle">
+							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+							<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
+						</button>
+					</div>
 					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 					<?php get_template_part( 'template-parts/header/header', 'search' ); ?>
+					<?php if ( newspack_has_menus() ) : ?>
+						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
+							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+						</button>
+					<?php endif; ?>
 				</div>
 			</div>
 		<?php else : ?>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -30,10 +30,11 @@ $show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
 $header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
 
 get_template_part( 'template-parts/header/mobile', 'sidebar' );
-get_template_part( 'template-parts/header/desktop', 'sidebar' );
 
-if ( true === $header_sub_simplified ) :
+if ( true === $header_sub_simplified && ! is_front_page() ) :
 	get_template_part( 'template-parts/header/fullmenu', 'sidebar' );
+else :
+	get_template_part( 'template-parts/header/desktop', 'sidebar' );
 endif;
 ?>
 
@@ -42,7 +43,7 @@ endif;
 
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
-		<?php if ( true === $header_sub_simplified ) : ?>
+		<?php if ( true === $header_sub_simplified && ! is_front_page() ) : ?>
 			<div class="middle-header-contain">
 				<div class="wrapper">
 					<div class="fullmenu-toggle-contain">

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -33,7 +33,7 @@ get_template_part( 'template-parts/header/mobile', 'sidebar' );
 get_template_part( 'template-parts/header/desktop', 'sidebar' );
 
 if ( true === $header_sub_simplified && ! is_front_page() ) :
-	get_template_part( 'template-parts/header/fullmenu', 'sidebar' );
+	get_template_part( 'template-parts/header/subpage', 'sidebar' );
 endif;
 ?>
 
@@ -45,8 +45,8 @@ endif;
 		<?php if ( true === $header_sub_simplified && ! is_front_page() ) : ?>
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<div class="fullmenu-toggle-contain">
-						<button class="fullmenu-toggle" on="tap:fullmenu-sidebar.toggle">
+					<div class="subpage-toggle-contain">
+						<button class="subpage-toggle" on="tap:subpage-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
 						</button>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -30,11 +30,10 @@ $show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
 $header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
 
 get_template_part( 'template-parts/header/mobile', 'sidebar' );
+get_template_part( 'template-parts/header/desktop', 'sidebar' );
 
 if ( true === $header_sub_simplified && ! is_front_page() ) :
 	get_template_part( 'template-parts/header/fullmenu', 'sidebar' );
-else :
-	get_template_part( 'template-parts/header/desktop', 'sidebar' );
 endif;
 ?>
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -563,9 +563,9 @@ function newspack_custom_colors_css() {
 			.h-sb .site-title a:visited,
 			.h-sb .site-description,
 			/* Header solid background; short height */
-			.h-sb.h-sh .nav1 .main-menu > li,
-			.h-sb.h-sh .nav1 ul.main-menu > li > a,
-			.h-sb.h-sh .nav1 ul.main-menu > li > a:hover,
+			.h-sb.h-sh .site-header .nav1 .main-menu > li,
+			.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a,
+			.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a:hover,
 			.h-sb .top-header-contain,
 			.h-sb .middle-header-contain {
 				color: ' . esc_html( $header_color_contrast ) . ';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -97,7 +97,8 @@ function newspack_custom_colors_css() {
 
 		@media only screen and (min-width: 782px) {
 			/* Header default background */
-			.h-db .featured-image-beside .entry-header {
+			.h-db .featured-image-beside .entry-header,
+			.h-db.h-sub.single-featured-image-beside .middle-header-contain {
 				color: ' . esc_html( $primary_color_contrast ) . ';
 			}
 		}

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -97,7 +97,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Header - add option to center logo.
+	// Header - option for v. simplified header on subpages.
+	$wp_customize->add_setting(
+		'header_sub_simplified',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_sub_simplified',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Simple header on subpages', 'newspack' ),
+			'section' => 'newspack_header_options',
+		)
+	);
+
+	// Header - option to add slideout.
 	$wp_customize->add_setting(
 		'header_show_slideout',
 		array(

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -109,7 +109,7 @@ function newspack_customize_register( $wp_customize ) {
 		'header_sub_simplified',
 		array(
 			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Simple header on subpages', 'newspack' ),
+			'label'   => esc_html__( 'Subpage Simple Header', 'newspack' ),
 			'section' => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -36,10 +36,21 @@ function newspack_customize_register( $wp_customize ) {
 	/**
 	 * Header Options
 	 */
-	$wp_customize->add_section(
+	$wp_customize->add_panel(
 		'newspack_header_options',
 		array(
 			'title' => esc_html__( 'Header Settings', 'newspack' ),
+		)
+	);
+
+	/**
+	 * Header Appearance
+	 */
+	$wp_customize->add_section(
+		'header_section_appearance',
+		array(
+			'title' => esc_html__( 'Header Appearance', 'newspack' ),
+			'panel' => 'newspack_header_options',
 		)
 	);
 
@@ -57,7 +68,7 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Center Logo', 'newspack' ),
 			'description' => esc_html__( 'Check to center the logo in the header.', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_appearance',
 		)
 	);
 
@@ -75,7 +86,7 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Solid Background', 'newspack' ),
 			'description' => esc_html__( 'Check to use the primary color as the header background. Can be changed under "Colors".', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_appearance',
 		)
 	);
 
@@ -93,7 +104,18 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Short Header', 'newspack' ),
 			'description' => esc_html__( 'Displays header as a shorter, simpler version.', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_appearance',
+		)
+	);
+
+	/**
+	 * Header Slideouts
+	 */
+	$wp_customize->add_section(
+		'header_section_slideout',
+		array(
+			'title' => esc_html__( 'Header Slideout Sidebar', 'newspack' ),
+			'panel' => 'newspack_header_options',
 		)
 	);
 
@@ -115,7 +137,7 @@ function newspack_customize_register( $wp_customize ) {
 				esc_html__( 'Show a Slide-out sidebar in the header, which you can populate by adding widgets %1$s.', 'newspack' ),
 				'<a rel="goto-section" href="#sidebar-widgets-header-1">' . __( 'here', 'newspack' ) . '</a>'
 			),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_slideout',
 		)
 	);
 
@@ -133,7 +155,7 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'text',
 			'label'       => esc_html__( 'Slide-out Sidebar Text', 'newspack' ),
 			'description' => esc_html__( 'Use this field to change the text on the Slide-out Sidebar toggle. The text is not visible when using the short header, but can always be read by screen readers.', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_slideout',
 		)
 	);
 
@@ -151,11 +173,22 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Add slide-out widgets to mobile menu', 'newspack' ),
 			'description' => esc_html__( 'Adds the widgets assigned to the Slide-out Sidebar area to the mobile menu, too.', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_slideout',
 		)
 	);
 
-		// Header - option for v. simplified header on subpages.
+	/**
+	 * Header Slideouts
+	 */
+	$wp_customize->add_section(
+		'header_section_subpages',
+		array(
+			'title' => esc_html__( 'Header for Subpages', 'newspack' ),
+			'panel' => 'newspack_header_options',
+		)
+	);
+
+	// Header - option for v. simplified header on subpages.
 	$wp_customize->add_setting(
 		'header_sub_simplified',
 		array(
@@ -169,7 +202,7 @@ function newspack_customize_register( $wp_customize ) {
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Use simple header on subpages', 'newspack' ),
 			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
-			'section'     => 'newspack_header_options',
+			'section'     => 'header_section_subpages',
 		)
 	);
 
@@ -189,7 +222,7 @@ function newspack_customize_register( $wp_customize ) {
 			array(
 				'label'       => esc_html__( 'Alternative Logo', 'newspack' ),
 				'description' => esc_html__( 'Upload a flipped "light" version of your logo if your logo is dark.', 'newspack' ),
-				'section'     => 'newspack_header_options',
+				'section'     => 'header_section_subpages',
 				'settings'    => 'newspack_alternative_logo',
 				'flex_width'  => false,
 				'flex_height' => true,

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -108,10 +108,10 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'header_sub_simplified',
 		array(
-			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Subpage Simple Header', 'newspack' ),
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Use simple header on subpages', 'newspack' ),
 			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
-			'section' => 'newspack_header_options',
+			'section'     => 'newspack_header_options',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -114,7 +114,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'header_section_slideout',
 		array(
-			'title' => esc_html__( 'Header Slideout Sidebar', 'newspack' ),
+			'title' => esc_html__( 'Slideout Sidebar', 'newspack' ),
 			'panel' => 'newspack_header_options',
 		)
 	);
@@ -183,7 +183,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'header_section_subpages',
 		array(
-			'title' => esc_html__( 'Header for Subpages', 'newspack' ),
+			'title' => esc_html__( 'Subpage Options', 'newspack' ),
 			'panel' => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -97,24 +97,6 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Header - option for v. simplified header on subpages.
-	$wp_customize->add_setting(
-		'header_sub_simplified',
-		array(
-			'default'           => false,
-			'sanitize_callback' => 'newspack_sanitize_checkbox',
-		)
-	);
-	$wp_customize->add_control(
-		'header_sub_simplified',
-		array(
-			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Use simple header on subpages', 'newspack' ),
-			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
-			'section'     => 'newspack_header_options',
-		)
-	);
-
 	// Header - option to add slideout.
 	$wp_customize->add_setting(
 		'header_show_slideout',
@@ -170,6 +152,50 @@ function newspack_customize_register( $wp_customize ) {
 			'label'       => esc_html__( 'Add slide-out widgets to mobile menu', 'newspack' ),
 			'description' => esc_html__( 'Adds the widgets assigned to the Slide-out Sidebar area to the mobile menu, too.', 'newspack' ),
 			'section'     => 'newspack_header_options',
+		)
+	);
+
+		// Header - option for v. simplified header on subpages.
+	$wp_customize->add_setting(
+		'header_sub_simplified',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'header_sub_simplified',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Use simple header on subpages', 'newspack' ),
+			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
+			'section'     => 'newspack_header_options',
+		)
+	);
+
+	// Add option to upload logo specifically for the footer.
+	$wp_customize->add_setting(
+		'newspack_alternative_logo',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Cropped_Image_Control(
+			$wp_customize,
+			'newspack_alternative_logo',
+			array(
+				'label'       => esc_html__( 'Alternative Logo', 'newspack' ),
+				'description' => esc_html__( 'Upload a flipped "light" version of your logo if your logo is dark.', 'newspack' ),
+				'section'     => 'newspack_header_options',
+				'settings'    => 'newspack_alternative_logo',
+				'flex_width'  => false,
+				'flex_height' => true,
+				'width'       => 400,
+				'height'      => 300,
+			)
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -49,7 +49,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'header_section_appearance',
 		array(
-			'title' => esc_html__( 'Header Appearance', 'newspack' ),
+			'title' => esc_html__( 'Appearance', 'newspack' ),
 			'panel' => 'newspack_header_options',
 		)
 	);
@@ -114,7 +114,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'header_section_slideout',
 		array(
-			'title' => esc_html__( 'Slideout Sidebar', 'newspack' ),
+			'title' => esc_html__( 'Slide-out Sidebar', 'newspack' ),
 			'panel' => 'newspack_header_options',
 		)
 	);
@@ -183,7 +183,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_section(
 		'header_section_subpages',
 		array(
-			'title' => esc_html__( 'Subpage Options', 'newspack' ),
+			'title' => esc_html__( 'Subpage Header', 'newspack' ),
 			'panel' => 'newspack_header_options',
 		)
 	);
@@ -201,7 +201,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Use simple header on subpages', 'newspack' ),
-			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
+			'description' => esc_html__( 'On posts, pages, archive and search results, use a header that only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
 			'section'     => 'header_section_subpages',
 		)
 	);
@@ -221,7 +221,7 @@ function newspack_customize_register( $wp_customize ) {
 			'newspack_alternative_logo',
 			array(
 				'label'       => esc_html__( 'Alternative Logo', 'newspack' ),
-				'description' => esc_html__( 'Upload a flipped "light" version of your logo if your logo is dark.', 'newspack' ),
+				'description' => esc_html__( 'Upload an alternative logo to be used on posts with the featured image behind and featured image beside settings, where the logo will be overlapping.', 'newspack' ),
 				'section'     => 'header_section_subpages',
 				'settings'    => 'newspack_alternative_logo',
 				'flex_width'  => false,

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -110,6 +110,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'    => 'checkbox',
 			'label'   => esc_html__( 'Subpage Simple Header', 'newspack' ),
+			'description' => esc_html__( 'On subpages, the header only displays the site logo and search icon, with all menus hidden under a toggle.', 'newspack' ),
 			'section' => 'newspack_header_options',
 		)
 	);

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -87,7 +87,7 @@ function newspack_body_classes( $classes ) {
 
 	// Adds classes to reflect the header layout
 	$header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
-	if ( true === $header_sub_simplified ) {
+	if ( true === $header_sub_simplified && ! is_front_page() ) {
 		$classes[] = 'h-sub';
 	} else {
 		$classes[] = 'h-nsub';

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -86,6 +86,13 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Adds classes to reflect the header layout
+	$header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
+	if ( true === $header_sub_simplified ) {
+		$classes[] = 'h-sub';
+	} else {
+		$classes[] = 'h-nsub';
+	}
+
 	$header_solid_background = get_theme_mod( 'header_solid_background', false );
 	if ( true === $header_solid_background ) {
 		$classes[] = 'h-sb'; // header - solid background.

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -500,7 +500,7 @@ function newspack_the_custom_logo() {
 	endif;
 
 	if ( $use_alternative_logo ) : ?>
-		<a class="custom-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+		<a class="custom-logo-link alternative-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
 			<?php
 			echo wp_get_attachment_image(
 				get_theme_mod( 'newspack_alternative_logo', '' ),
@@ -511,10 +511,10 @@ function newspack_the_custom_logo() {
 			?>
 		</a>
 	<?php
-	else :
-		// Otherwise, return the regular logo:
-		if ( has_custom_logo() ) {
-			the_custom_logo();
-		}
 	endif;
+
+	// Otherwise, return the regular logo:
+	if ( has_custom_logo() ) {
+		the_custom_logo();
+	}
 }

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -482,3 +482,39 @@ function newspack_color_with_contrast( $color ) {
 	}
 	return $color;
 }
+
+/**
+ * Decides which logo to use, based on Customizer settings and current post.
+ */
+function newspack_the_custom_logo() {
+	// By default, don't use the alternative logo.
+	$use_alternative_logo = false;
+	// Check if the site is set to use the simplified header:
+	$simplified_header_subpages = get_theme_mod( 'header_sub_simplified', false );
+	// Check if an alternative logo has been set:
+	$has_alternative_logo = ( '' !== get_theme_mod( 'newspack_alternative_logo', '' ) && 0 !== get_theme_mod( 'newspack_alternative_logo', '' ) );
+
+	// Check if we're currently on a page where the alternative logo should be used in the short header, if set:
+	if ( $simplified_header_subpages && $has_alternative_logo && in_array( newspack_featured_image_position(), array( 'behind', 'beside' ) ) ) :
+		$use_alternative_logo = true;
+	endif;
+
+	if ( $use_alternative_logo ) : ?>
+		<a class="custom-logo-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+			<?php
+			echo wp_get_attachment_image(
+				get_theme_mod( 'newspack_alternative_logo', '' ),
+				'newspack-alternative-logo',
+				'',
+				array( 'class' => 'custom-logo' )
+			);
+			?>
+		</a>
+	<?php
+	else :
+		// Otherwise, return the regular logo:
+		if ( has_custom_logo() ) {
+			the_custom_logo();
+		}
+	endif;
+}

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -80,6 +80,28 @@
 		);
 	}
 
+	// 'Fullmenu' fallback.
+	const fullmenuToggle = document.getElementsByClassName( 'fullmenu-toggle' ),
+		fullmenuSidebar = document.getElementById( 'fullmenu-sidebar-fallback' ),
+		fullmenuOpenButton = headerContain.getElementsByClassName( 'fullmenu-toggle' )[ 0 ],
+		fullmenuCloseButton = fullmenuSidebar.getElementsByClassName( 'fullmenu-toggle' )[ 0 ];
+
+	for ( let i = 0; i < fullmenuToggle.length; i++ ) {
+		fullmenuToggle[ i ].addEventListener(
+			'click',
+			function() {
+				if ( body.classList.contains( 'fullmenu-opened' ) ) {
+					body.classList.remove( 'fullmenu-opened' );
+					fullmenuOpenButton.focus();
+				} else {
+					body.classList.add( 'fullmenu-opened' );
+					fullmenuCloseButton.focus();
+				}
+			},
+			false
+		);
+	}
+
 	// Comments toggle fallback.
 	const commentsToggle = document.getElementById( 'comments-toggle' );
 

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -80,24 +80,24 @@
 		);
 	}
 
-	// 'Fullmenu' fallback.
-	const fullmenuToggle = document.getElementsByClassName( 'fullmenu-toggle' );
+	// 'Sub page' menu fallback.
+	const subpageToggle = document.getElementsByClassName( 'subpage-toggle' );
 
-	if ( null !== fullmenuToggle ) {
-		const fullmenuSidebar = document.getElementById( 'fullmenu-sidebar-fallback' ),
-			fullmenuOpenButton = headerContain.getElementsByClassName( 'fullmenu-toggle' )[ 0 ],
-			fullmenuCloseButton = fullmenuSidebar.getElementsByClassName( 'fullmenu-toggle' )[ 0 ];
+	if ( null !== subpageToggle ) {
+		const subpageSidebar = document.getElementById( 'subpage-sidebar-fallback' ),
+			subpageOpenButton = headerContain.getElementsByClassName( 'subpage-toggle' )[ 0 ],
+			subpageCloseButton = subpageSidebar.getElementsByClassName( 'subpage-toggle' )[ 0 ];
 
-		for ( let i = 0; i < fullmenuToggle.length; i++ ) {
-			fullmenuToggle[ i ].addEventListener(
+		for ( let i = 0; i < subpageToggle.length; i++ ) {
+			subpageToggle[ i ].addEventListener(
 				'click',
 				function() {
-					if ( body.classList.contains( 'fullmenu-sidebar-opened' ) ) {
-						body.classList.remove( 'fullmenu-sidebar-opened' );
-						fullmenuOpenButton.focus();
+					if ( body.classList.contains( 'subpage-sidebar-opened' ) ) {
+						body.classList.remove( 'subpage-sidebar-opened' );
+						subpageOpenButton.focus();
 					} else {
-						body.classList.add( 'fullmenu-sidebar-opened' );
-						fullmenuCloseButton.focus();
+						body.classList.add( 'subpage-sidebar-opened' );
+						subpageCloseButton.focus();
 					}
 				},
 				false

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -81,25 +81,28 @@
 	}
 
 	// 'Fullmenu' fallback.
-	const fullmenuToggle = document.getElementsByClassName( 'fullmenu-toggle' ),
-		fullmenuSidebar = document.getElementById( 'fullmenu-sidebar-fallback' ),
-		fullmenuOpenButton = headerContain.getElementsByClassName( 'fullmenu-toggle' )[ 0 ],
-		fullmenuCloseButton = fullmenuSidebar.getElementsByClassName( 'fullmenu-toggle' )[ 0 ];
+	const fullmenuToggle = document.getElementsByClassName( 'fullmenu-toggle' );
 
-	for ( let i = 0; i < fullmenuToggle.length; i++ ) {
-		fullmenuToggle[ i ].addEventListener(
-			'click',
-			function() {
-				if ( body.classList.contains( 'fullmenu-opened' ) ) {
-					body.classList.remove( 'fullmenu-opened' );
-					fullmenuOpenButton.focus();
-				} else {
-					body.classList.add( 'fullmenu-opened' );
-					fullmenuCloseButton.focus();
-				}
-			},
-			false
-		);
+	if ( null !== fullmenuToggle ) {
+		const fullmenuSidebar = document.getElementById( 'fullmenu-sidebar-fallback' ),
+			fullmenuOpenButton = headerContain.getElementsByClassName( 'fullmenu-toggle' )[ 0 ],
+			fullmenuCloseButton = fullmenuSidebar.getElementsByClassName( 'fullmenu-toggle' )[ 0 ];
+
+		for ( let i = 0; i < fullmenuToggle.length; i++ ) {
+			fullmenuToggle[ i ].addEventListener(
+				'click',
+				function() {
+					if ( body.classList.contains( 'fullmenu-sidebar-opened' ) ) {
+						body.classList.remove( 'fullmenu-sidebar-opened' );
+						fullmenuOpenButton.focus();
+					} else {
+						body.classList.add( 'fullmenu-sidebar-opened' );
+						fullmenuCloseButton.focus();
+					}
+				},
+				false
+			);
+		}
 	}
 
 	// Comments toggle fallback.

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -162,6 +162,21 @@
 			} );
 		} );
 
+		// Only show Alternative Logo option if 'simple subpage header' is picked
+		wp.customize( 'header_sub_simplified', function( setting ) {
+			wp.customize.control( 'newspack_alternative_logo', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
 		// Only show Author Bio truncate options when enabled.
 		wp.customize( 'author_bio_truncate', function( setting ) {
 			wp.customize.control( 'author_bio_length', function( control ) {

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -95,7 +95,8 @@
 	}
 
 	.mobile-menu-toggle,
-	.desktop-menu-toggle {
+	.desktop-menu-toggle,
+	.fullmenu-toggle {
 		font-size: 1em;
 		float: right;
 		margin: 0 0 $size__spacing-unit;
@@ -235,6 +236,12 @@
 	.nav1 .sub-menu > li > a,
 	.nav1 .sub-menu > li > a:visited {
 		color: $color__text-main;
+	}
+
+	nav + nav,
+	nav + .widget,
+	.widget + .widget {
+		border-color: $color__border;
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -1,6 +1,7 @@
 // Menu Toggles
 .mobile-menu-toggle,
-.desktop-menu-toggle {
+.desktop-menu-toggle,
+.fullmenu-toggle {
 	align-items: center;
 	background-color: transparent;
 	color: inherit;
@@ -23,7 +24,8 @@
 }
 
 .site-header .mobile-menu-toggle,
-.site-header .desktop-menu-toggle {
+.site-header .desktop-menu-toggle,
+.site-header .fullmenu-toggle {
 	&:hover {
 		color: inherit;
 	}
@@ -81,7 +83,8 @@
 }
 
 .mobile-sidebar,
-.desktop-sidebar {
+.desktop-sidebar,
+.fullmenu-sidebar {
 	font-size: $font__size-sm;
 	padding: $size__spacing-unit;
 	width: 90vw;
@@ -123,7 +126,8 @@
 }
 
 // Desktop Sidebar and Widget styles
-.desktop-sidebar {
+.desktop-sidebar,
+.fullmenu-sidebar {
 	background-color: #fff;
 	max-width: 400px;
 
@@ -152,19 +156,10 @@
 	}
 }
 
-// Modile Sidebar and Menu styles
-.mobile-sidebar {
-	background-color: $color__primary;
-	color: #fff;
-
+.mobile-sidebar,
+.fullmenu-sidebar {
 	@include media( tablet ) {
 		width: 33vw;
-	}
-
-	a,
-	a:visited,
-	.nav1 .sub-menu > li > a {
-		color: #fff;
 	}
 
 	ul ul {
@@ -223,8 +218,29 @@
 	}
 }
 
+// Mobile Sidebar and Menu styles
+.mobile-sidebar {
+	background-color: $color__primary;
+	color: #fff;
+
+	a,
+	a:visited,
+	.nav1 .sub-menu > li > a {
+		color: #fff;
+	}
+}
+
+// "Full Menu" Sidebar styles
+.fullmenu-sidebar {
+	.nav1 .sub-menu > li > a,
+	.nav1 .sub-menu > li > a:visited {
+		color: $color__text-main;
+	}
+}
+
 #desktop-sidebar-fallback,
-#mobile-sidebar-fallback {
+#mobile-sidebar-fallback,
+#fullmenu-sidebar-fallback {
 	bottom: 0;
 	overflow: auto;
 	position: fixed;
@@ -236,11 +252,19 @@
 	}
 }
 
-#desktop-sidebar-fallback {
+// Fallback - open from the left
+#desktop-sidebar-fallback,
+#fullmenu-sidebar-fallback {
 	left: -100%;
 	transition: left 0.2s;
 }
 
+.desktop-menu-opened #desktop-sidebar-fallback,
+.fullmenu-sidebar-opened #fullmenu-sidebar-fallback {
+	left: 0;
+}
+
+// Fallback - open from the right
 #mobile-sidebar-fallback {
 	right: -100%;
 	transition: right 0.2s;
@@ -248,10 +272,6 @@
 
 .menu-opened #mobile-sidebar-fallback {
 	right: 0;
-}
-
-.desktop-menu-opened #desktop-sidebar-fallback {
-	left: 0;
 }
 
 .menu-opened #mobile-sidebar-fallback,

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -37,7 +37,8 @@
 }
 
 // Hide desktop menu toggle on smaller screens
-.site-header .desktop-menu-toggle {
+.site-header .desktop-menu-toggle,
+.fullmenu-toggle-contain {
 	display: none;
 	font-size: $font__size-xs;
 	font-weight: normal;
@@ -58,12 +59,14 @@
 	// Header default height
 
 	// Mobile Menu toggle
-	.h-dh .site-header .mobile-menu-toggle {
+	.h-dh .site-header .mobile-menu-toggle,
+	.h-sub .site-header .mobile-menu-toggle {
 		display: none;
 	}
 
 	// Desktop Menu toggle
-	.h-dh .site-header .desktop-menu-toggle {
+	.h-dh .site-header .desktop-menu-toggle,
+	.fullmenu-toggle-contain {
 		display: flex;
 	}
 }

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -1,7 +1,7 @@
 // Menu Toggles
 .mobile-menu-toggle,
 .desktop-menu-toggle,
-.fullmenu-toggle {
+.subpage-toggle {
 	align-items: center;
 	background-color: transparent;
 	color: inherit;
@@ -28,7 +28,7 @@
 
 .site-header .mobile-menu-toggle,
 .site-header .desktop-menu-toggle,
-.site-header .fullmenu-toggle {
+.site-header .subpage-toggle {
 	&:hover {
 		color: inherit;
 	}
@@ -41,7 +41,7 @@
 
 // Hide desktop menu toggle on smaller screens
 .site-header .desktop-menu-toggle,
-.fullmenu-toggle-contain {
+.subpage-toggle-contain {
 	display: none;
 	font-size: $font__size-xs;
 	font-weight: normal;
@@ -50,7 +50,7 @@
 }
 
 .site-header .desktop-menu-toggle,
-.h-ll .fullmenu-toggle-contain {
+.h-ll .subpage-toggle-contain {
 	margin-right: #{1.25 * $size__spacing-unit};
 }
 
@@ -73,7 +73,7 @@
 
 	// Desktop Menu toggle
 	.h-dh .site-header .desktop-menu-toggle,
-	.fullmenu-toggle-contain {
+	.subpage-toggle-contain {
 		display: flex;
 	}
 }
@@ -94,7 +94,7 @@
 
 .mobile-sidebar,
 .desktop-sidebar,
-.fullmenu-sidebar {
+.subpage-sidebar {
 	font-size: $font__size-sm;
 	padding: $size__spacing-unit;
 	width: 90vw;
@@ -106,7 +106,7 @@
 
 	.mobile-menu-toggle,
 	.desktop-menu-toggle,
-	.fullmenu-toggle {
+	.subpage-toggle {
 		font-size: 1em;
 		float: right;
 		margin: 0 0 $size__spacing-unit;
@@ -138,7 +138,7 @@
 
 // Desktop Sidebar and Widget styles
 .desktop-sidebar,
-.fullmenu-sidebar {
+.subpage-sidebar {
 	background-color: #fff;
 	max-width: 400px;
 
@@ -168,7 +168,7 @@
 }
 
 .mobile-sidebar,
-.fullmenu-sidebar {
+.subpage-sidebar {
 	@include media( tablet ) {
 		width: 33vw;
 	}
@@ -242,7 +242,7 @@
 }
 
 // "Full Menu" Sidebar styles
-.fullmenu-sidebar {
+.subpage-sidebar {
 	.nav1 .sub-menu > li > a,
 	.nav1 .sub-menu > li > a:visited {
 		color: $color__text-main;
@@ -257,7 +257,7 @@
 
 #desktop-sidebar-fallback,
 #mobile-sidebar-fallback,
-#fullmenu-sidebar-fallback {
+#subpage-sidebar-fallback {
 	bottom: 0;
 	overflow: auto;
 	position: fixed;
@@ -271,13 +271,13 @@
 
 // Fallback - open from the left
 #desktop-sidebar-fallback,
-#fullmenu-sidebar-fallback {
+#subpage-sidebar-fallback {
 	left: -100%;
 	transition: left 0.2s;
 }
 
 .desktop-menu-opened #desktop-sidebar-fallback,
-.fullmenu-sidebar-opened #fullmenu-sidebar-fallback {
+.subpage-sidebar-opened #subpage-sidebar-fallback {
 	left: 0;
 }
 
@@ -293,21 +293,21 @@
 
 .menu-opened #mobile-sidebar-fallback,
 .desktop-menu-opened #desktop-sidebar-fallback,
-.fullmenu-sidebar-opened #fullmenu-sidebar-fallback {
+.subpage-sidebar-opened #subpage-sidebar-fallback {
 	> * {
 		display: block;
 	}
 
 	> .desktop-menu-toggle,
 	> .mobile-menu-toggle,
-	> .fullmenu-toggle {
+	> .subpage-toggle {
 		display: flex;
 	}
 }
 
 .menu-opened::after,
 .desktop-menu-opened::after,
-.fullmenu-sidebar-opened::after {
+.subpage-sidebar-opened::after {
 	background-color: rgba( 0, 0, 0, 0.2 );
 	bottom: 0;
 	content: '';

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -17,7 +17,10 @@
 	&:focus {
 		outline-offset: 0;
 	}
+}
 
+.mobile-menu-toggle,
+.h-dh .desktop-menu-toggle {
 	svg {
 		margin-right: #{0.25 * $size__spacing-unit};
 	}
@@ -43,8 +46,12 @@
 	font-size: $font__size-xs;
 	font-weight: normal;
 	line-height: 2;
-	margin-right: #{1.5 * $size__spacing-unit};
 	padding: #{0.125 * $size__spacing-unit} 0;
+}
+
+.site-header .desktop-menu-toggle,
+.h-ll .fullmenu-toggle-contain {
+	margin-right: #{1.25 * $size__spacing-unit};
 }
 
 .middle-header-contain .desktop-menu-toggle {
@@ -285,19 +292,22 @@
 }
 
 .menu-opened #mobile-sidebar-fallback,
-.desktop-menu-opened #desktop-sidebar-fallback {
+.desktop-menu-opened #desktop-sidebar-fallback,
+.fullmenu-sidebar-opened #fullmenu-sidebar-fallback {
 	> * {
 		display: block;
 	}
 
 	> .desktop-menu-toggle,
-	> .mobile-menu-toggle {
+	> .mobile-menu-toggle,
+	> .fullmenu-toggle {
 		display: flex;
 	}
 }
 
 .menu-opened::after,
-.desktop-menu-opened::after {
+.desktop-menu-opened::after,
+.fullmenu-sidebar-opened::after {
 	background-color: rgba( 0, 0, 0, 0.2 );
 	bottom: 0;
 	content: '';

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -379,7 +379,7 @@
 		display: none;
 	}
 
-	.wrapper {
+	.middle-header-contain .wrapper {
 		padding-bottom: #{0.5 * $size__spacing-unit};
 		padding-top: #{0.5 * $size__spacing-unit};
 	}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -183,11 +183,19 @@
 .h-cl {
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
-			justify-content: center;
+			flex: 1;
 			width: 35%;
 
 			&.site-branding {
 				width: 30%;
+			}
+
+			&:first-of-type > * {
+				margin-right: auto;
+			}
+
+			&:last-of-type {
+				justify-content: flex-end;
 			}
 		}
 
@@ -200,13 +208,6 @@
 			flex-direction: column;
 		}
 
-		.site-header .custom-logo-link,
-		.site-title,
-		.site-description {
-			text-align: center;
-			width: 100%;
-		}
-
 		.site-description {
 			padding-top: #{0.25 * $size__spacing-unit};
 		}
@@ -214,29 +215,41 @@
 		.site-header .custom-logo-link {
 			margin-right: 0;
 		}
-	}
-
-	@include media( tablet ) {
-		.site-header .middle-header-contain .wrapper > div {
-			flex: 1;
-			display: flex;
-			width: auto;
-
-			&.site-branding {
-				width: auto;
-			}
-
-			&:first-of-type > * {
-				margin-right: auto;
-			}
-
-			&:last-of-type {
-				justify-content: flex-end;
-			}
-		}
 
 		.site-header .custom-logo-link img {
 			max-width: inherit;
+		}
+	}
+
+	&.h-dh {
+		@include media( tablet ) {
+			.site-header .middle-header-contain .wrapper > div {
+				display: flex;
+				justify-content: center;
+			}
+
+			.site-header .custom-logo-link,
+			.site-title,
+			.site-description {
+				text-align: center;
+				width: 100%;
+			}
+		}
+	}
+
+	&.h-sh {
+		@include media( desktopnarrow ) {
+			.site-header .middle-header-contain .wrapper > div {
+				display: flex;
+				justify-content: center;
+			}
+
+			.site-header .custom-logo-link,
+			.site-title,
+			.site-description {
+				text-align: center;
+				width: 100%;
+			}
 		}
 	}
 }
@@ -361,7 +374,12 @@
 
 // h-sub
 .h-sub {
-	.middle-header-contain .wrapper {
+	.site-title,
+	.site-description {
+		display: none;
+	}
+
+	.wrapper {
 		padding-bottom: #{0.5 * $size__spacing-unit};
 		padding-top: #{0.5 * $size__spacing-unit};
 	}
@@ -399,45 +417,49 @@
 		&.h-cl {
 			.site-header .middle-header-contain .wrapper > div {
 				flex: auto;
+				&:last-of-type {
+					text-align: right;
+				}
 			}
 		}
 
 		// Featured template settings
-		&.single-featured-image-beside {
-			@include media( tablet ) {
-				.site-header {
-					position: absolute;
-					z-index: 10;
-					width: 100%;
+		&.h-sh,
+		&.h-dh {
+			.featured-image-behind,
+			.featured-image-beside {
+				min-height: 100vh;
+			}
+		}
+
+		&.h-sb {
+			&.single-featured-image-beside,
+			&.single-featured-image-behind {
+				.middle-header-contain {
+					background: transparent;
 				}
 			}
+		}
 
+		&.single-featured-image-beside,
+		&.single-featured-image-behind {
+			.site-header {
+				position: absolute;
+				z-index: 10;
+				width: 100%;
+			}
+		}
+
+		&.single-featured-image-beside {
 			.middle-header-contain {
 				border: 0;
 				margin: auto;
 				max-width: 1200px;
+
 				.wrapper {
 					margin: 0;
 					width: 50%;
 				}
-			}
-		}
-
-		.h-sb {
-			@include media( tablet ) {
-				&.single-featured-image-beside,
-				&.single-featured-image-behind {
-					.middle-header-contain {
-						background: transparent;
-					}
-				}
-			}
-		}
-
-		@include media( tablet ) {
-			.featured-image-behind,
-			.featured-image-beside {
-				min-height: 100vh;
 			}
 		}
 	}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -417,6 +417,7 @@
 		&.h-cl {
 			.site-header .middle-header-contain .wrapper > div {
 				flex: auto;
+				width: auto;
 				&:last-of-type {
 					text-align: right;
 				}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -218,6 +218,7 @@
 
 		.site-header .custom-logo-link img {
 			max-width: inherit;
+			margin: auto;
 		}
 	}
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -365,8 +365,64 @@
 	justify-content: flex-start;
 }
 
-// Hide desktop menus at specific breakpoints.
+// h-sub
+.h-sub {
+	&.h-sb {
+		.nav1 .main-menu > li,
+		.nav1 .main-menu > li > a {
+			color: $color__text-main;
+		}
 
+		@include media( tablet ) {
+			&.single-featured-image-beside,
+			&.single-featured-image-behind {
+				.middle-header-contain {
+					background: transparent;
+				}
+			}
+		}
+	}
+
+	&.single-featured-image-beside,
+	&.single-featured-image-behind {
+		@include media( tablet ) {
+			.site-header {
+				position: absolute;
+				z-index: 10;
+				width: 100%;
+			}
+		}
+	}
+
+	@include media( tablet ) {
+		.featured-image-behind,
+		.featured-image-beside {
+			min-height: 100vh;
+		}
+	}
+
+	.middle-header-contain .wrapper {
+		padding: #{0.5 * $size__spacing-unit} 0;
+
+		@include media( tablet ) {
+			.site-branding {
+				flex-basis: auto;
+			}
+		}
+	}
+
+	&.single-featured-image-beside {
+		.middle-header-contain {
+			max-width: 1200px;
+			.wrapper {
+				margin: 0;
+				width: 50%;
+			}
+		}
+	}
+}
+
+// Hide desktop menus at specific breakpoints.
 .desktop-only {
 	display: none;
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -234,24 +234,6 @@
 			width: 100%;
 		}
 	}
-
-	/*
-	&.h-sh {
-		@include media( narrowdesktop ) {
-			.site-header .middle-header-contain .wrapper .site-branding {
-				display: flex;
-				justify-content: center;
-			}
-
-			.site-header .custom-logo-link,
-			.site-title,
-			.site-description {
-				text-align: center;
-				width: 100%;
-			}
-		}
-	}
-	*/
 }
 
 // Solid Background

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -221,22 +221,21 @@
 		}
 	}
 
-	&.h-dh {
-		@include media( tablet ) {
-			.site-header .middle-header-contain .wrapper .site-branding {
-				display: flex;
-				justify-content: center;
-			}
+	@include media( tablet ) {
+		.site-header .middle-header-contain .wrapper .site-branding {
+			display: flex;
+			justify-content: center;
+		}
 
-			.site-header .custom-logo-link,
-			.site-title,
-			.site-description {
-				text-align: center;
-				width: 100%;
-			}
+		.site-header .custom-logo-link,
+		.site-title,
+		.site-description {
+			text-align: center;
+			width: 100%;
 		}
 	}
 
+	/*
 	&.h-sh {
 		@include media( narrowdesktop ) {
 			.site-header .middle-header-contain .wrapper .site-branding {
@@ -252,6 +251,7 @@
 			}
 		}
 	}
+	*/
 }
 
 // Solid Background
@@ -375,7 +375,8 @@
 // h-sub
 .h-sub {
 	.site-title,
-	.site-description {
+	.site-description,
+	.alternative-logo {
 		display: none;
 	}
 
@@ -453,6 +454,13 @@
 				position: absolute;
 				z-index: 10;
 				width: 100%;
+			}
+			.alternative-logo {
+				display: inline-block;
+
+				~ .custom-logo-link {
+					display: none;
+				}
 			}
 		}
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -383,13 +383,22 @@
 		}
 	}
 
-	&.single-featured-image-beside,
-	&.single-featured-image-behind {
+	&.single-featured-image-beside {
 		@include media( tablet ) {
 			.site-header {
 				position: absolute;
 				z-index: 10;
 				width: 100%;
+			}
+		}
+
+		.middle-header-contain {
+			border: 0;
+			margin: auto;
+			max-width: 1200px;
+			.wrapper {
+				margin: 0;
+				width: 50%;
 			}
 		}
 	}
@@ -401,23 +410,34 @@
 		}
 	}
 
-	.middle-header-contain .wrapper {
-		padding: #{0.5 * $size__spacing-unit} 0;
+	.middle-header-contain {
+		border-bottom: 1px solid $color__border;
+		.wrapper {
+			justify-content: flex-start;
+			padding-bottom: #{0.5 * $size__spacing-unit};
+			padding-top: #{0.5 * $size__spacing-unit};
 
-		@include media( tablet ) {
-			.site-branding {
-				flex-basis: auto;
+			@include media( tablet ) {
+				.site-branding {
+					flex-basis: auto;
+				}
 			}
+		}
+
+		.custom-logo {
+			max-height: 50px;
+			max-width: 180px;
+		}
+
+		.header-search-contain {
+			margin-left: auto;
 		}
 	}
 
-	&.single-featured-image-beside {
-		.middle-header-contain {
-			max-width: 1200px;
-			.wrapper {
-				margin: 0;
-				width: 50%;
-			}
+	// Centered Logo
+	&.h-cl {
+		.site-header .middle-header-contain .wrapper > div {
+			flex: auto;
 		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -213,16 +213,10 @@
 
 		.site-header .custom-logo-link {
 			margin-right: 0;
-
-			img {
-				height: auto;
-				margin: auto;
-				max-width: 100%;
-			}
 		}
 	}
 
-	@include media( desktop ) {
+	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
 			flex: 1;
 			display: flex;
@@ -259,8 +253,8 @@
 	.site-title a:visited,
 	.site-description,
 	.middle-header-contain,
-	.nav1 .main-menu > li,
-	.nav1 .main-menu > li > a {
+	.middle-header-contain .nav1 .main-menu > li,
+	.middle-header-contain .nav1 .main-menu > li > a {
 		color: #fff;
 	}
 
@@ -367,77 +361,84 @@
 
 // h-sub
 .h-sub {
-	&.h-sb {
-		.nav1 .main-menu > li,
-		.nav1 .main-menu > li > a {
-			color: $color__text-main;
-		}
-
-		@include media( tablet ) {
-			&.single-featured-image-beside,
-			&.single-featured-image-behind {
-				.middle-header-contain {
-					background: transparent;
-				}
-			}
-		}
-	}
-
-	&.single-featured-image-beside {
-		@include media( tablet ) {
-			.site-header {
-				position: absolute;
-				z-index: 10;
-				width: 100%;
-			}
-		}
-
-		.middle-header-contain {
-			border: 0;
-			margin: auto;
-			max-width: 1200px;
-			.wrapper {
-				margin: 0;
-				width: 50%;
-			}
-		}
+	.middle-header-contain .wrapper {
+		padding-bottom: #{0.5 * $size__spacing-unit};
+		padding-top: #{0.5 * $size__spacing-unit};
 	}
 
 	@include media( tablet ) {
-		.featured-image-behind,
-		.featured-image-beside {
-			min-height: 100vh;
+		// Default header background colour
+		&.h-db .middle-header-contain {
+			border-bottom: 1px solid $color__border;
 		}
-	}
 
-	.middle-header-contain {
-		border-bottom: 1px solid $color__border;
-		.wrapper {
-			justify-content: flex-start;
-			padding-bottom: #{0.5 * $size__spacing-unit};
-			padding-top: #{0.5 * $size__spacing-unit};
+		.middle-header-contain {
+			.wrapper {
+				justify-content: flex-start;
 
+				@include media( tablet ) {
+					.site-branding {
+						flex-basis: auto;
+					}
+				}
+			}
+
+			.custom-logo {
+				height: auto;
+				max-height: 50px;
+				max-width: 180px;
+				width: auto;
+			}
+
+			.header-search-contain {
+				margin-left: auto;
+			}
+		}
+
+		// Centered Logo
+		&.h-cl {
+			.site-header .middle-header-contain .wrapper > div {
+				flex: auto;
+			}
+		}
+
+		// Featured template settings
+		&.single-featured-image-beside {
 			@include media( tablet ) {
-				.site-branding {
-					flex-basis: auto;
+				.site-header {
+					position: absolute;
+					z-index: 10;
+					width: 100%;
+				}
+			}
+
+			.middle-header-contain {
+				border: 0;
+				margin: auto;
+				max-width: 1200px;
+				.wrapper {
+					margin: 0;
+					width: 50%;
 				}
 			}
 		}
 
-		.custom-logo {
-			max-height: 50px;
-			max-width: 180px;
+		.h-sb {
+			@include media( tablet ) {
+				&.single-featured-image-beside,
+				&.single-featured-image-behind {
+					.middle-header-contain {
+						background: transparent;
+					}
+				}
+			}
 		}
 
-		.header-search-contain {
-			margin-left: auto;
-		}
-	}
-
-	// Centered Logo
-	&.h-cl {
-		.site-header .middle-header-contain .wrapper > div {
-			flex: auto;
+		@include media( tablet ) {
+			.featured-image-behind,
+			.featured-image-beside {
+				min-height: 100vh;
+			}
 		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -223,7 +223,7 @@
 
 	&.h-dh {
 		@include media( tablet ) {
-			.site-header .middle-header-contain .wrapper > div {
+			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;
 			}
@@ -238,8 +238,8 @@
 	}
 
 	&.h-sh {
-		@include media( desktopnarrow ) {
-			.site-header .middle-header-contain .wrapper > div {
+		@include media( narrowdesktop ) {
+			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;
 			}
@@ -423,7 +423,7 @@
 			}
 		}
 
-		// Featured template settings
+		// Featured template settings - featured imgae height
 		&.h-sh,
 		&.h-dh {
 			.featured-image-behind,
@@ -432,6 +432,7 @@
 			}
 		}
 
+		// Featured template settings - header backgrounds
 		&.h-sb {
 			&.single-featured-image-beside,
 			&.single-featured-image-behind {
@@ -443,6 +444,10 @@
 
 		&.single-featured-image-beside,
 		&.single-featured-image-behind {
+			.middle-header-contain {
+				border: 0;
+				color: #fff;
+			}
 			.site-header {
 				position: absolute;
 				z-index: 10;
@@ -450,15 +455,17 @@
 			}
 		}
 
+		// Featured image beside - header layout
 		&.single-featured-image-beside {
 			.middle-header-contain {
-				border: 0;
 				margin: auto;
-				max-width: 1200px;
+				max-width: 90%;
+				width: 1200px;
 
 				.wrapper {
 					margin: 0;
-					width: 50%;
+					max-width: 50%;
+					padding-right: $size__spacing-unit;
 				}
 			}
 		}

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -608,7 +608,7 @@ body.page {
 		.entry-header {
 			margin-left: auto;
 			max-width: 90%;
-			padding-right: #{0.5 * $size__spacing-unit};
+			padding: #{2 * $size__spacing-unit} #{0.5 * $size__spacing-unit} $size__spacing-unit 0;
 			width: 600px;
 
 			@include media( desktop ) {
@@ -687,6 +687,11 @@ body.page {
 				width: 100%;
 			}
 		}
+	}
+
+	// Header - subpage short
+	.h-sub .featured-image-beside .entry-header {
+		padding-top: #{4 * $size__spacing-unit};
 	}
 }
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -607,9 +607,12 @@ body.page {
 
 		.entry-header {
 			margin-left: auto;
-			max-width: 600px;
+			max-width: 90%;
+			padding-right: #{0.5 * $size__spacing-unit};
+			width: 600px;
+
 			@include media( desktop ) {
-				margin-left: 10%;
+				padding-right: $size__spacing-unit;
 			}
 
 			a,

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -593,7 +593,7 @@ body.page {
 		}
 
 		> .wrapper {
-			padding: 0 #{2 * $size__spacing-unit};
+			padding: 0;
 			margin: auto 0;
 		}
 
@@ -608,7 +608,9 @@ body.page {
 		.entry-header {
 			margin-left: auto;
 			max-width: 600px;
-			padding: #{2 * $size__spacing-unit} 0 $size__spacing-unit;
+			@include media( desktop ) {
+				margin-left: 10%;
+			}
 
 			a,
 			a:hover,

--- a/newspack-theme/template-parts/header/fullmenu-sidebar.php
+++ b/newspack-theme/template-parts/header/fullmenu-sidebar.php
@@ -12,7 +12,7 @@ if ( newspack_is_amp() ) : ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>
 		</button>
 <?php else : ?>
-	<aside id="fullmenu-fallback" class="fullmenu-sidebar">
+	<aside id="fullmenu-sidebar-fallback" class="fullmenu-sidebar">
 		<button class="fullmenu-toggle">
 			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>

--- a/newspack-theme/template-parts/header/fullmenu-sidebar.php
+++ b/newspack-theme/template-parts/header/fullmenu-sidebar.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template to display the mobile navigation, either AMP or fallback.
+ *
+ * @package Newspack
+ */
+
+if ( newspack_is_amp() ) : ?>
+	<amp-sidebar id="fullmenu-sidebar" layout="nodisplay" side="left" class="fullmenu-sidebar">
+		<button class="fullmenu-toggle" on='tap:fullmenu-sidebar.toggle'>
+			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
+			<?php esc_html_e( 'Close', 'newspack' ); ?>
+		</button>
+<?php else : ?>
+	<aside id="fullmenu-fallback" class="fullmenu-sidebar">
+		<button class="fullmenu-toggle">
+			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
+			<?php esc_html_e( 'Close', 'newspack' ); ?>
+		</button>
+<?php endif; ?>
+
+		<?php
+		newspack_tertiary_menu();
+
+		get_search_form();
+
+		newspack_primary_menu();
+
+		newspack_secondary_menu();
+
+		newspack_social_menu_header();
+
+		if ( is_active_sidebar( 'header-1' ) ) {
+			dynamic_sidebar( 'header-1' );
+		}
+		?>
+
+<?php if ( newspack_is_amp() ) : ?>
+	</amp-sidebar>
+<?php else : ?>
+	</aside>
+<?php endif; ?>

--- a/newspack-theme/template-parts/header/fullmenu-sidebar.php
+++ b/newspack-theme/template-parts/header/fullmenu-sidebar.php
@@ -22,8 +22,6 @@ if ( newspack_is_amp() ) : ?>
 		<?php
 		newspack_tertiary_menu();
 
-		get_search_form();
-
 		newspack_primary_menu();
 
 		newspack_secondary_menu();

--- a/newspack-theme/template-parts/header/site-branding.php
+++ b/newspack-theme/template-parts/header/site-branding.php
@@ -7,9 +7,7 @@
 ?>
 <div class="site-branding">
 
-	<?php if ( has_custom_logo() ) : ?>
-		<?php the_custom_logo(); ?>
-	<?php endif; ?>
+	<?php newspack_the_custom_logo(); ?>
 
 	<div class="site-identity">
 		<?php $blog_info = get_bloginfo( 'name' ); ?>

--- a/newspack-theme/template-parts/header/subpage-sidebar.php
+++ b/newspack-theme/template-parts/header/subpage-sidebar.php
@@ -6,14 +6,14 @@
  */
 
 if ( newspack_is_amp() ) : ?>
-	<amp-sidebar id="fullmenu-sidebar" layout="nodisplay" side="left" class="fullmenu-sidebar">
-		<button class="fullmenu-toggle" on='tap:fullmenu-sidebar.toggle'>
+	<amp-sidebar id="subpage-sidebar" layout="nodisplay" side="left" class="subpage-sidebar">
+		<button class="subpage-toggle" on='tap:subpage-sidebar.toggle'>
 			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>
 		</button>
 <?php else : ?>
-	<aside id="fullmenu-sidebar-fallback" class="fullmenu-sidebar">
-		<button class="fullmenu-toggle">
+	<aside id="subpage-sidebar-fallback" class="subpage-sidebar">
+		<button class="subpage-toggle">
 			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>
 		</button>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a theme option to use a very simple header on subpages. This header will only include the logo (no site title or tagline), a search toggle, and a menu toggle; the menu under the toggle includes all menus assigned, and any widgets assigned to the slide out widget area if populated and turned on.

Closes #877.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Header Settings; the Header Options should now be split into three panels, with the existing one split over Appearance and Slide-out Sidebar, and a new one called Subpage Header:

![image](https://user-images.githubusercontent.com/177561/81025953-6658f580-8e2d-11ea-9e02-b0b737b853b6.png)

![image](https://user-images.githubusercontent.com/177561/81025964-6bb64000-8e2d-11ea-8ce8-368052da94de.png)

3. Check the box labelled  "Use simple header on subpages"; it should open an option to upload an Alternative Logo, but ignore that for now:

![image](https://user-images.githubusercontent.com/177561/81026348-ac628900-8e2e-11ea-810c-e6dd46333731.png)

4. View the homepage, and confirm that your header is displaying as expected:

![image](https://user-images.githubusercontent.com/177561/80547954-598c5b80-896e-11ea-84ba-781109fc737c.png)

5. View a regular single post, and confirm that you now have a simplified header (shown below with the default, solid background, and centered settings):

![image](https://user-images.githubusercontent.com/177561/80547541-5775cd00-896d-11ea-9ad2-6fbe7016d1e3.png)

![image](https://user-images.githubusercontent.com/177561/80547826-087c6780-896e-11ea-95aa-4cc113d77096.png)

![image](https://user-images.githubusercontent.com/177561/80547866-1b8f3780-896e-11ea-8ede-11144e22e5c6.png)

6. Try opening the menu and confirm that it contains your menus: 

![image](https://user-images.githubusercontent.com/177561/80547614-8be98900-896d-11ea-9bcd-bce8d2e22e42.png)

7. Check out a post with the 'behind' featured image style; confirm the header sits on top of the image (default and centred logo options shown below; background colours will not be applied to the header, even if assigned): 

![image](https://user-images.githubusercontent.com/177561/80547684-af143880-896d-11ea-8486-c094fa9994dc.png)

![image](https://user-images.githubusercontent.com/177561/80548150-0bc42300-896f-11ea-9c64-ac494aa285fb.png)

8. Check out a post with the 'beside' featured image styles; confirm the header elements sit over the solid colour:

![image](https://user-images.githubusercontent.com/177561/80547718-cb17da00-896d-11ea-968b-be6d146eadb2.png)

![image](https://user-images.githubusercontent.com/177561/80548178-21394d00-896f-11ea-8603-7cbbd8c75047.png)

9. Try scaling down the browser window -- the mobile header should kick in as usual, with a solid background and logo aligned left, regardless what your header settings are:

![image](https://user-images.githubusercontent.com/177561/80548535-02878600-8970-11ea-9b06-0c47f940f681.png)

10. Navigate back to Customize > Header Settings > Subpage Header, and upload an Alternative Logo. The use case here is if you have a dark logo that doesn't show up very well on the Behind and Beside featured image styles, this option can be used to replace it in those cases. So ideally the alternative logo will be a 'flipped' version of your site's real logo:

![image](https://user-images.githubusercontent.com/177561/81026428-efbcf780-8e2e-11ea-8b3f-c5e756dd37d3.png)

11. View the Featured Image Behind and Featured Image beside posts again; confirm the flipped logo is used:

![image](https://user-images.githubusercontent.com/177561/81029098-9bb71080-8e38-11ea-97fa-3ea43159043c.png)

![image](https://user-images.githubusercontent.com/177561/81029142-bf7a5680-8e38-11ea-8c33-ef5c89a7f0c7.png)

12. Scale down the browser window and confirm that the other logo is switched to at the same point the header gets a solid background):

![image](https://user-images.githubusercontent.com/177561/81029171-cf923600-8e38-11ea-9937-f3f9685ab4e1.png)

![image](https://user-images.githubusercontent.com/177561/81029156-c6a16480-8e38-11ea-9ded-f1569f222296.png)

13. Navigate to Customize > Header Settings > Appearance, and turn on the "Short Header".
14. View the Homepage, and subpages, and confirm the two header types are displaying as expected.

### Know issues
Copied from the comments below:

Depending on your exact settings, the 'alternative' logo might be needed for the Featured Image behind style, but might not work with the colour you have for the featured image beside option. If we run into that, I think the smartest thing to do might be to add a second logo upload, so you can pick a specific logo that will work for that background, too. It's not ideal -- a bit clunky UI-wise -- but I think it will be easier (and more predictable!) than trying to make the code 'smart' to try to guess the brightness of your logo. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
