### PR TITLE
Featured image beside: add top and bottom padding to title

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -608,8 +608,7 @@ body.page {
 		.entry-header {
 			margin-left: auto;
 			max-width: 600px;
-			padding-left: 0;
-			padding-right: 0;
+			padding: #{2 * $size__spacing-unit} 0;
 
 			a,
 			a:hover,

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -608,7 +608,7 @@ body.page {
 		.entry-header {
 			margin-left: auto;
 			max-width: 600px;
-			padding: #{2 * $size__spacing-unit} 0;
+			padding: #{2 * $size__spacing-unit} 0 $size__spacing-unit;
 
 			a,
 			a:hover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a top and bottom padding to the entry title when using the featured-image-beside style, to make sure it can't "hit" the top and bottom of the container at certain screen sizes. 

Closes #900.

### How to test the changes in this Pull Request:

1. Set up a post using the 'featured image beside' style for the featured image.
2. Scale down the browser window to be between 800 and 1200px wide, and shorter -- you should be able to move it around and get the category to touch the header:

<img width="745" alt="image" src="https://user-images.githubusercontent.com/177561/80289824-2fc8ff80-86f6-11ea-8a57-e355280bb515.png">

3. Apply the PR and run `npm run build`.
4. Refresh the page; the post title should no longer be touching the header, and the spacing above and below it should be even:

<img width="525" alt="image" src="https://user-images.githubusercontent.com/177561/80289882-7c143f80-86f6-11ea-9e16-0e7c4f05caa1.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
