### PR TITLE
fix: make sure first floated element has top margin

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -14,7 +14,6 @@
 	&.alignleft {
 		/*rtl:ignore*/
 		float: left;
-		margin-top: 0;
 		margin-left: 0;
 		/*rtl:ignore*/
 		margin-right: $size__spacing-unit;
@@ -25,11 +24,17 @@
 	&.alignright {
 		/*rtl:ignore*/
 		float: right;
-		margin-top: 0;
 		margin-right: 0;
 		/*rtl:ignore*/
 		margin-left: $size__spacing-unit;
 		max-width: 50%;
+	}
+
+	&.wp-block-image:not( :first-child ) .alignleft,
+	&.wp-block-image:not( :first-child ) .alignright,
+	.alignleft:not( :first-child ),
+	.alignright:not( :first-child ) {
+		margin-top: 0;
 	}
 
 	&.aligncenter {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -30,8 +30,6 @@
 		max-width: 50%;
 	}
 
-	&.wp-block-image:not( :first-child ) .alignleft,
-	&.wp-block-image:not( :first-child ) .alignright,
 	.alignleft:not( :first-child ),
 	.alignright:not( :first-child ) {
 		margin-top: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now floated blocks don't have a top margin, so their placement seems more natural mid-page. But this also means all but the image block look wacky when they're the first thing in the content. 

This PR updates the styles that remove the top margin, so they're only applied when a floated block isn't the first thing in the content.

Closes #892.

### How to test the changes in this Pull Request:

1. Create a post, and add a group block to the top with a background colour, and float it left or right, along with some regular text content.
2. View the post on the front-end; note that the floated blocks stick up above the content:

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/177561/80290231-e9c16b00-86f8-11ea-95e0-b9887ab4dabf.png">

3. Apply the PR and run `npm run build`
4. Refresh the post; verify that the floated group block now has space above it:

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/177561/80290473-07430480-86fa-11ea-9e76-bc1dc3a07592.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
