### PR TITLE
Content Options: Make sure styles are enqueued, correct

### DIFF
--- a/newspack-joseph/functions.php
+++ b/newspack-joseph/functions.php
@@ -108,16 +108,14 @@ add_action( 'wp_head', 'newspack_joseph_typography_css_wrap' );
  * Enqueue scripts and styles.
  */
 function newspack_joseph_scripts() {
-	// Dequeue parent styles
-	wp_dequeue_style( 'newspack-style' );
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-joseph-fonts', newspack_joseph_fonts_url(), array(), null );
 	// Enqueue child styles
-	wp_enqueue_style( 'newspack-joseph-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-joseph-style', 'rtl', 'replace' );
+	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
-add_action( 'wp_enqueue_scripts', 'newspack_joseph_scripts', 99 );
+add_action( 'wp_enqueue_scripts', 'newspack_joseph_scripts' );
 
 
 /**

--- a/newspack-joseph/functions.php
+++ b/newspack-joseph/functions.php
@@ -110,10 +110,6 @@ add_action( 'wp_head', 'newspack_joseph_typography_css_wrap' );
 function newspack_joseph_scripts() {
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-joseph-fonts', newspack_joseph_fonts_url(), array(), null );
-	// Enqueue child styles
-	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
-	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_joseph_scripts' );
 

--- a/newspack-katharine/functions.php
+++ b/newspack-katharine/functions.php
@@ -94,12 +94,8 @@ add_action( 'wp_head', 'newspack_katharine_typography_css_wrap' );
 function newspack_katharine_scripts() {
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-katharine-fonts', newspack_katharine_fonts_url(), array(), null );
-	// Enqueue child styles
-	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
-	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
-add_action( 'wp_enqueue_scripts', 'newspack_katharine_scripts', 99 );
+add_action( 'wp_enqueue_scripts', 'newspack_katharine_scripts' );
 
 
 /**

--- a/newspack-katharine/functions.php
+++ b/newspack-katharine/functions.php
@@ -92,14 +92,12 @@ add_action( 'wp_head', 'newspack_katharine_typography_css_wrap' );
  * Enqueue scripts and styles.
  */
 function newspack_katharine_scripts() {
-	// Dequeue parent styles
-	wp_dequeue_style( 'newspack-style' );
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-katharine-fonts', newspack_katharine_fonts_url(), array(), null );
 	// Enqueue child styles
-	wp_enqueue_style( 'newspack-katharine-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-katharine-style', 'rtl', 'replace' );
+	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_katharine_scripts', 99 );
 

--- a/newspack-nelson/functions.php
+++ b/newspack-nelson/functions.php
@@ -92,14 +92,12 @@ add_action( 'wp_head', 'newspack_nelson_typography_css_wrap' );
  * Enqueue scripts and styles.
  */
 function newspack_nelson_scripts() {
-	// Dequeue parent styles
-	wp_dequeue_style( 'newspack-style' );
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-nelson-fonts', newspack_nelson_fonts_url(), array(), null );
 	// Enqueue child styles
-	wp_enqueue_style( 'newspack-nelson-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-nelson-style', 'rtl', 'replace' );
+	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_nelson_scripts', 99 );
 

--- a/newspack-nelson/functions.php
+++ b/newspack-nelson/functions.php
@@ -94,12 +94,8 @@ add_action( 'wp_head', 'newspack_nelson_typography_css_wrap' );
 function newspack_nelson_scripts() {
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-nelson-fonts', newspack_nelson_fonts_url(), array(), null );
-	// Enqueue child styles
-	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
-	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
-add_action( 'wp_enqueue_scripts', 'newspack_nelson_scripts', 99 );
+add_action( 'wp_enqueue_scripts', 'newspack_nelson_scripts' );
 
 
 /**

--- a/newspack-sacha/functions.php
+++ b/newspack-sacha/functions.php
@@ -94,12 +94,8 @@ add_action( 'wp_head', 'newspack_sacha_typography_css_wrap' );
 function newspack_sacha_scripts() {
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-sacha-fonts', newspack_sacha_fonts_url(), array(), null );
-	// Enqueue child styles
-	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
-	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
-add_action( 'wp_enqueue_scripts', 'newspack_sacha_scripts', 99 );
+add_action( 'wp_enqueue_scripts', 'newspack_sacha_scripts' );
 
 
 /**

--- a/newspack-sacha/functions.php
+++ b/newspack-sacha/functions.php
@@ -92,14 +92,12 @@ add_action( 'wp_head', 'newspack_sacha_typography_css_wrap' );
  * Enqueue scripts and styles.
  */
 function newspack_sacha_scripts() {
-	// Dequeue parent styles
-	wp_dequeue_style( 'newspack-style' );
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-sacha-fonts', newspack_sacha_fonts_url(), array(), null );
 	// Enqueue child styles
-	wp_enqueue_style( 'newspack-sacha-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-sacha-style', 'rtl', 'replace' );
+	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_sacha_scripts', 99 );
 

--- a/newspack-scott/functions.php
+++ b/newspack-scott/functions.php
@@ -94,12 +94,8 @@ add_action( 'wp_head', 'newspack_scott_typography_css_wrap' );
 function newspack_scott_scripts() {
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-scott-fonts', newspack_scott_fonts_url(), array(), null );
-	// Enqueue child styles
-	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
-	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
-add_action( 'wp_enqueue_scripts', 'newspack_scott_scripts', 99 );
+add_action( 'wp_enqueue_scripts', 'newspack_scott_scripts' );
 
 
 /**

--- a/newspack-scott/functions.php
+++ b/newspack-scott/functions.php
@@ -92,14 +92,12 @@ add_action( 'wp_head', 'newspack_scott_typography_css_wrap' );
  * Enqueue scripts and styles.
  */
 function newspack_scott_scripts() {
-	// Dequeue parent styles
-	wp_dequeue_style( 'newspack-style' );
 	// Enqueue Google fonts.
 	wp_enqueue_style( 'newspack-scott-fonts', newspack_scott_fonts_url(), array(), null );
 	// Enqueue child styles
-	wp_enqueue_style( 'newspack-scott-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
+	wp_enqueue_style( 'newspack-style', get_stylesheet_uri(), array(), wp_get_theme()->get( 'Version' ) );
 	// Enqueue child RTL styles
-	wp_style_add_data( 'newspack-scott-style', 'rtl', 'replace' );
+	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scott_scripts', 99 );
 

--- a/newspack-theme/inc/jetpack.php
+++ b/newspack-theme/inc/jetpack.php
@@ -48,7 +48,7 @@ function newspack_jetpack_setup() {
 				'date'       => '.posted-on',
 				'categories' => '.cat-links',
 				'tags'       => '.tags-links',
-				'author'     => '.byline',
+				'author'     => '.byline, .author-avatar',
 				'comment'    => '.comments-link',
 			),
 			'featured-images' => array(

--- a/newspack-theme/inc/jetpack.php
+++ b/newspack-theme/inc/jetpack.php
@@ -49,7 +49,6 @@ function newspack_jetpack_setup() {
 				'categories' => '.cat-links',
 				'tags'       => '.tags-links',
 				'author'     => '.byline, .author-avatar',
-				'comment'    => '.comments-link',
 			),
 			'featured-images' => array(
 				'archive' => true,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -150,6 +150,18 @@
 	figcaption {
 		max-width: 100%;
 	}
+
+	// Make sure Jetpack Content Options don't override
+	.posted-on,
+	.cat-links,
+	.tags-links,
+	.byline,
+	.author-avatar {
+		clip: auto;
+		height: auto;
+		position: relative;
+		width: auto;
+	}
 }
 
 //! Newspack Carousel Block


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The original child theme set up was unnecessarily heavy handed in assigning style sheets -- one odd fallout from that is that it caused the Content Options to not work, because the CSS was not being enqueued properly. 

This PR updates how the child themes assign stylesheets, falling back to WordPress's automatic behaviour of enqueuing the child theme's CSS and ignoring the parent theme's CSS automatically.

It also makes a couple small updates to the Content Options - it removes the option to hide the comments link (which is not used in the Newspack Theme), and adds some CSS to make sure the content options don't affect the Homepage Posts block, since it has its own controls to hide author, date, categories, etc. 

Closes #749.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Install and activate the [RTL Tester](https://wordpress.org/plugins/rtl-tester/) plugin, to help confirm everything in the child theme is still being loaded as expected.
3. Activate Newspack Joseph, and confirm it looks correct.
4. Click on 'Switch to LTR' in the Admin Toolbar, and confirm it looks correct.
5. Repeat steps 3 and 4 for Newspacks Katharine, Nelson, Sacha and Scott. 
6. Once it's confirmed the child theme changes didn't break anything new and fun, navigate to Customize > Content Options, and uncheck everything under 'Post Details': Display date, Display categories, Display tags and Display author:

![image](https://user-images.githubusercontent.com/177561/80408330-e30f3100-887b-11ea-9b76-fc4a495d3be1.png)

7. View a single post, and confirm that the author, date, category and tags are not displaying:

Before:

![image](https://user-images.githubusercontent.com/177561/80408548-2ec1da80-887c-11ea-92e4-28b061d02b04.png)

![image](https://user-images.githubusercontent.com/177561/80408538-29649000-887c-11ea-93fc-481daa0b0b12.png)

After: 

![image](https://user-images.githubusercontent.com/177561/80408416-0043ff80-887c-11ea-8f50-e913d2508391.png)

![image](https://user-images.githubusercontent.com/177561/80408455-0e921b80-887c-11ea-9292-15656dec12d1.png)

8. View an archive page, and confirm that the author date and name are not displaying:

Before:

![image](https://user-images.githubusercontent.com/177561/80408596-44cf9b00-887c-11ea-809e-1a4cbbe5a23c.png)

After:

![image](https://user-images.githubusercontent.com/177561/80408616-52852080-887c-11ea-86bd-8eb7c2d977ec.png)

9. View a search result page, and confirm that the author, date and category are not displaying:

Before:

![image](https://user-images.githubusercontent.com/177561/80408662-6e88c200-887c-11ea-8bd2-2be00a8274a7.png)

After:

![image](https://user-images.githubusercontent.com/177561/80408704-7cd6de00-887c-11ea-8d2a-5ec780b3a578.png)

10. Lastly, set up a Homepage Posts block with everything set to display (author, date and category); confirm that the author, date and category _are_ showing, as the block has its own controls for these options:

![image](https://user-images.githubusercontent.com/177561/80408838-aabc2280-887c-11ea-83a4-f98623719743.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
