### PR TITLE
Button Block: Add temporary fix for doubled-button outline

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1199,3 +1199,9 @@
 		color: currentColor;
 	}
 }
+
+//! Temporary fix for a block button issue
+// See: https://github.com/WordPress/gutenberg/issues/21747
+.wp-block-button.is-style-outline:not( .wp-block-button__link ) {
+	border: 0;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a temporary fix to a doubled-border issue in Gutenberg, and can be removed once the fix baked into Gutenberg in 8.0.

Closes #906.

### How to test the changes in this Pull Request:

1. Turn off the Gutenberg plugin.
2. Add a button block with a few buttons and them the outline button style.
3. View on the front end:

![image](https://user-images.githubusercontent.com/177561/80528341-a1998700-894a-11ea-8f06-79ac10b9deb5.png)

4. Turn back on the Gutenberg plugin, and confirm it's at least version 7.9. 
5. Refresh the page with the buttons: 

![image](https://user-images.githubusercontent.com/177561/80528441-c8f05400-894a-11ea-8d90-938e8b133936.png)

6. Apply the PR and run `npm run build`.
7. Confirm the buttons no longer have the doubled border.
8. Turn back off the Gutenberg plugin.
9. View the buttons again; confirm that the change won't have a negative impact on the buttons when not running 7.9.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
