### PR TITLE
Allow html in title when filtering in WooCommerce code

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -175,7 +175,7 @@ function newspack_thankyou_page_title( $title, $id ) {
 		is_order_received_page() && get_the_ID() === $id ) {
 		$title = get_theme_mod( 'woocommerce_thank_you_title', esc_html__( 'Order received', 'newspack' ) );
 	}
-	return esc_html( $title );
+	return wp_kses_post( $title );
 }
 add_filter( 'the_title', 'newspack_thankyou_page_title', 10, 2 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The escaping used for the thank you page customization is causing issues with HTML used in titles elsewhere on the site. 

This PR switches it from `esc_html()` to `wp_kses_post()` to allow HTML.

### How to test the changes in this Pull Request:

1. Install and activate WooCommerce if it's not already.
2. Edit a post and add some simple HTML (`strong`, `em` or `span` tags).
3. View the post on the front end, and in a block; note that your HTML is escaped:

![image](https://user-images.githubusercontent.com/177561/80734073-771f0980-8ac3-11ea-8531-3437e7e8ca7c.png)

![image](https://user-images.githubusercontent.com/177561/80734099-800fdb00-8ac3-11ea-852f-759b788a6ce3.png)

4. Apply the PR.
5. Confirm your HTML is now being applied:

![image](https://user-images.githubusercontent.com/177561/80734475-147a3d80-8ac4-11ea-93a4-8fe46a41bd81.png)

![image](https://user-images.githubusercontent.com/177561/80734451-0c220280-8ac4-11ea-902e-8173467de19e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
