### PR TITLE
Bump woocommerce thank you page version

### DIFF
--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.2.0
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, the thank you page version in the theme is 3.2, but [the current version is 3.7](https://github.com/woocommerce/woocommerce/blob/master/templates/checkout/thankyou.php), so a warning shows in the WordPress Dashboard:

![image](https://user-images.githubusercontent.com/177561/80741392-6922b600-8ace-11ea-91f6-f99741a7a3dd.png)

Reviewing the WooCommerce repo, I think I managed to mangle the template version while working on theme development -- in the plugin, the thankyou.php page has been at version 3.7 since July 2019. So to fix, I just bumped the version number.

### How to test the changes in this Pull Request:

1. Activate WooCommerce. 
2. View your site's WP Dashboard and note the above WooCommerce notice. 
3. Apply the PR.
4. Confirm that the notice is now gone. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
