### PR TITLE
Button Block: Make sure editor colours are correct

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -638,7 +638,8 @@ function newspack_custom_colors_css() {
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block a,
-		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link:not(.has-text-color), /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link:not(.has-text-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink {
 			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 		}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -600,19 +600,27 @@ function newspack_custom_colors_css() {
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-color {
 			color: ' . esc_html( $primary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-color {
 			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-background-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-background-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-background-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-background-color {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-background-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-background-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-background-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-background-color {
 			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 		}
 
@@ -655,19 +663,27 @@ function newspack_custom_colors_css() {
 			color: inherit;
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-color {
 			color: ' . esc_html( $secondary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-color {
 			color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-background-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-background-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-background-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-background-color {
 			background-color: ' . esc_html( $secondary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-background-color {
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-background-color,
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-background-color, /* legacy selector */
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-background-color {
 			background-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
 		}
 		';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -619,19 +619,13 @@ function newspack_custom_colors_css() {
 		/* Secondary color */
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-background),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			background-color: ' . esc_html( $secondary_color ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:active,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:focus,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button:not(.is-style-outline) .wp-block-button__link:hover,
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-text-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
 			color: ' . esc_html( $secondary_color_contrast ) . '; /* base: #0073a8; */
 		}
@@ -644,10 +638,7 @@ function newspack_custom_colors_css() {
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block a,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline .wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:hover .wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:focus .wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button.is-style-outline:active .wp-block-button__link:not(.has-text-color),
+		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link:not(.has-text-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink {
 			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 		}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -963,7 +963,7 @@
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
 	.wp-block-button.has-white-color,
-	.is-style-outline .wp-block-button__link.has-white-colo:not( :hover ), // legacy selector
+	.is-style-outline .wp-block-button__link.has-white-color:not( :hover ), // legacy selector
 	.wp-block-button__link.is-style-outline.has-white-color:not( :hover ) {
 		color: #fff;
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -939,6 +939,7 @@
 	.has-dark-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
 	.wp-block-button.has-dark-gray-color,
+	.is-style-outline .wp-block-button__link.has-dark-gray-color, // legacy selector
 	.wp-block-button__link.is-style-outline.has-dark-gray-color {
 		color: #111;
 	}
@@ -946,6 +947,7 @@
 	.has-medium-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color,
 	.wp-block-button.has-medium-gray-color,
+	.is-style-outline .wp-block-button__link.has-medium-gray-color, // legacy selector
 	.wp-block-button__link.is-style-outline.has-medium-gray-color {
 		color: #767676;
 	}
@@ -953,6 +955,7 @@
 	.has-light-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
 	.wp-block-button.has-light-gray-color,
+	.is-style-outline .wp-block-button__link.has-light-gray-color, // legacy selector
 	.wp-block-button__link.is-style-outline.has-light-gray-color {
 		color: #eee;
 	}
@@ -960,6 +963,7 @@
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
 	.wp-block-button.has-white-color,
+	.is-style-outline .wp-block-button__link.has-white-color, // legacy selector
 	.wp-block-button__link.is-style-outline.has-white-color {
 		color: #fff;
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -911,28 +911,36 @@
 	.has-primary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p,
-	.wp-block-button.has-primary-color {
+	.wp-block-button.has-primary-color,
+	.is-style-outline .wp-block-button__link.has-primary-color:not( :hover ), //legacy selector
+	.wp-block-button__link.is-style-outline.has-primary-color:not( :hover ) {
 		color: $color__primary;
 	}
 
 	.has-primary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p,
-	.wp-block-button.has-primary-variation-color {
+	.wp-block-button.has-primary-variation-color,
+	.is-style-outline .wp-block-button__link.has-primary-variation-color:not( :hover ), //legacy selector
+	.wp-block-button__link.is-style-outline.has-primary-variation-color:not( :hover ) {
 		color: $color__primary-variation;
 	}
 
 	.has-secondary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p,
-	.wp-block-button.has-secondary-color {
+	.wp-block-button.has-secondary-color,
+	.is-style-outline .wp-block-button__link.has-secondary-color:not( :hover ), //legacy selector
+	.wp-block-button__link.is-style-outline.has-secondary-color:not( :hover ) {
 		color: $color__secondary;
 	}
 
 	.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p,
-	.wp-block-button.has-secondary-variation-color {
+	.wp-block-button.has-secondary-variation-color,
+	.is-style-outline .wp-block-button__link.has-secondary-variation-color:not( :hover ), //legacy selector
+	.wp-block-button__link.is-style-outline.has-secondary-variation-color:not( :hover ) {
 		color: $color__secondary-variation;
 	}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -939,32 +939,32 @@
 	.has-dark-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
 	.wp-block-button.has-dark-gray-color,
-	.is-style-outline .wp-block-button__link.has-dark-gray-color, // legacy selector
-	.wp-block-button__link.is-style-outline.has-dark-gray-color {
+	.is-style-outline .wp-block-button__link.has-dark-gray-color:not( :hover ), // legacy selector
+	.wp-block-button__link.is-style-outline.has-dark-gray-color:not( :hover ) {
 		color: #111;
 	}
 
 	.has-medium-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color,
 	.wp-block-button.has-medium-gray-color,
-	.is-style-outline .wp-block-button__link.has-medium-gray-color, // legacy selector
-	.wp-block-button__link.is-style-outline.has-medium-gray-color {
+	.is-style-outline .wp-block-button__link.has-medium-gray-color:not( :hover ), // legacy selector
+	.wp-block-button__link.is-style-outline.has-medium-gray-color:not( :hover ) {
 		color: #767676;
 	}
 
 	.has-light-gray-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
 	.wp-block-button.has-light-gray-color,
-	.is-style-outline .wp-block-button__link.has-light-gray-color, // legacy selector
-	.wp-block-button__link.is-style-outline.has-light-gray-color {
+	.is-style-outline .wp-block-button__link.has-light-gray-color:not( :hover ), // legacy selector
+	.wp-block-button__link.is-style-outline.has-light-gray-color:not( :hover ) {
 		color: #eee;
 	}
 
 	.has-white-color,
 	.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
 	.wp-block-button.has-white-color,
-	.is-style-outline .wp-block-button__link.has-white-color, // legacy selector
-	.wp-block-button__link.is-style-outline.has-white-color {
+	.is-style-outline .wp-block-button__link.has-white-colo:not( :hover ), // legacy selector
+	.wp-block-button__link.is-style-outline.has-white-color:not( :hover ) {
 		color: #fff;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -332,18 +332,26 @@ figcaption,
 /** === Button === */
 
 .wp-block-button__link {
-	background: $color__background-button;
 	border-radius: 5px;
 	line-height: 1.8;
 	font-family: $font__heading;
 	font-size: $font__size-sm;
 	font-weight: bold;
+
+	&:not( .has-background ) {
+		background: $color__background-button;
+	}
+
+	&:not( .has-text-color ) {
+		color: #fff;
+	}
 }
 
 .is-style-outline .wp-block-button__link, // legacy selector
 .wp-block-button__link.is-style-outline {
-	background: transparent;
-	color: $color__background-button;
+	&:not( .has-background ) {
+		background: transparent;
+	}
 
 	&:not( .has-text-color ) {
 		color: $color__background-button;
@@ -832,19 +840,23 @@ ul.wp-block-archives,
 	background-color: $color__secondary-variation;
 }
 
-.has-dark-gray-background-color {
+.has-dark-gray-background-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-background-color {
 	background-color: #111;
 }
 
-.has-medium-gray-background-color {
+.has-medium-gray-background-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-background-color {
 	background-color: #767676;
 }
 
-.has-light-gray-background-color {
+.has-light-gray-background-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-background-color {
 	background-color: #eee;
 }
 
-.has-white-background-color {
+.has-white-background-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-white-background-color {
 	background-color: #fff;
 }
 
@@ -864,18 +876,22 @@ ul.wp-block-archives,
 	color: $color__secondary-variation;
 }
 
-.has-dark-gray-color {
+.has-dark-gray-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-color {
 	color: #111;
 }
 
-.has-medium-gray-color {
+.has-medium-gray-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-color {
 	color: #767676;
 }
 
-.has-light-gray-color {
+.has-light-gray-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-color {
 	color: #eee;
 }
 
-.has-white-color {
+.has-white-color,
+.wp-block-button.is-style-outline .wp-block-button__link.has-white-color {
 	color: #fff;
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -824,78 +824,98 @@ ul.wp-block-archives,
 
 /** === Custom Colors === */
 
-.has-primary-background-color {
+.has-primary-background-color,
+.is-style-outline .wp-block-button__link.has-primary-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-primary-background-color {
 	background-color: $color__primary;
 }
 
-.has-primary-variation-background-color {
+.has-primary-variation-background-color,
+.is-style-outline .wp-block-button__link.has-primary-variation-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-primary-variation-background-color {
 	background-color: $color__primary-variation;
 }
 
-.has-secondary-background-color {
+.has-secondary-background-color,
+.is-style-outline .wp-block-button__link.has-secondary-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-secondary-background-color {
 	background-color: $color__secondary;
 }
 
-.has-secondary-variation-background-color {
+.has-secondary-variation-background-color,
+.is-style-outline .wp-block-button__link.has-secondary-variation-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-secondary-variation-background-color {
 	background-color: $color__secondary-variation;
 }
 
 .has-dark-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-background-color, // legacy selector
+.is-style-outline .wp-block-button__link.has-dark-gray-background-color, // legacy selector
 .wp-block-button__link.is-style-outline.has-dark-gray-background-color {
 	background-color: #111;
 }
 
 .has-medium-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-background-color, // legacy selector
+.is-style-outline .wp-block-button__link.has-medium-gray-background-color, // legacy selector
 .wp-block-button__link.is-style-outline.has-medium-gray-background-color {
 	background-color: #767676;
 }
 
 .has-light-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-background-color, // legacy selector
+.is-style-outline .wp-block-button__link.has-light-gray-background-color, // legacy selector
 .wp-block-button__link.is-style-outline.has-light-gray-background-color {
 	background-color: #eee;
 }
 
 .has-white-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-white-background-color, // legacy selector
+.is-style-outline .wp-block-button__link.has-white-background-color, // legacy selector
 .wp-block-button__link.is-style-outline.has-white-background-color {
 	background-color: #fff;
 }
 
-.has-primary-color {
+.has-primary-color,
+.is-style-outline .wp-block-button__link.has-primary-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-primary-color {
 	color: $color__primary;
 }
 
-.has-primary-variation-color {
+.has-primary-variation-color,
+.is-style-outline .wp-block-button__link.has-primary-variation-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-primary-variation-color {
 	color: $color__primary-variation;
 }
 
-.has-secondary-color {
+.has-secondary-color,
+.is-style-outline .wp-block-button__link.has-secondary-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-secondary-color {
 	color: $color__secondary;
 }
 
-.has-secondary-variation-color {
+.has-secondary-variation-color,
+.is-style-outline .wp-block-button__link.has-secondary-variation-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-secondary-variation-color {
 	color: $color__secondary-variation;
 }
 
 .has-dark-gray-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-color {
+.is-style-outline .wp-block-button__link.has-dark-gray-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-dark-gray-color {
 	color: #111;
 }
 
 .has-medium-gray-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-color {
+.is-style-outline .wp-block-button__link.has-medium-gray-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-medium-gray-color {
 	color: #767676;
 }
 
 .has-light-gray-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-color {
+.is-style-outline .wp-block-button__link.has-light-gray-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-light-gray-color {
 	color: #eee;
 }
 
 .has-white-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-white-color {
+.is-style-outline .wp-block-button__link.has-white-color, //legacy selector
+.wp-block-button__link.is-style-outline.has-white-color {
 	color: #fff;
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -841,22 +841,26 @@ ul.wp-block-archives,
 }
 
 .has-dark-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-background-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-dark-gray-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-dark-gray-background-color {
 	background-color: #111;
 }
 
 .has-medium-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-background-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-medium-gray-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-medium-gray-background-color {
 	background-color: #767676;
 }
 
 .has-light-gray-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-background-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-light-gray-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-light-gray-background-color {
 	background-color: #eee;
 }
 
 .has-white-background-color,
-.wp-block-button.is-style-outline .wp-block-button__link.has-white-background-color {
+.wp-block-button.is-style-outline .wp-block-button__link.has-white-background-color, // legacy selector
+.wp-block-button__link.is-style-outline.has-white-background-color {
 	background-color: #fff;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the button blocks pick up the custom colours in the editor.

It also fixes an issue with the button outline styles on the front end; the button block markup was rolled back in 8.0, so the "fixed" styles were no longer as fixed as they could be 😅 

Closes #905.

### How to test the changes in this Pull Request:

This PR should be tested with both Gutenberg 7.9.1 and Gutenberg 8.0; though the markup changes were rolled back in 8.0, they will be re-added down the road with more lead time so themes have a chance to fix the breaking changes before they're changed.

1. Apply the PR and run `npm run build`
2. Download and roll back to a copy of [Gutenberg 7.9.1](https://downloads.wordpress.org/plugin/gutenberg.7.9.1.zip), if your site isn't running it already.
3. Add a combination of buttons (solid and outline), using the different custom colours.
4. View in the editor and on the front-end, and confirm your buttons are using the colours you applied:

![image](https://user-images.githubusercontent.com/177561/80769559-6f328a00-8b02-11ea-9960-73349c251aea.png)

![image](https://user-images.githubusercontent.com/177561/80769569-79ed1f00-8b02-11ea-9f8e-7e6c465ac64b.png)

5. Upgrade to Gutenberg 8.0:
6. In the editor, re-add the same types of buttons with the same settings; the original set may now be throwing errors in the editor, but it will display correctly on the front-end.
7. Confirm that the second set uses the correct colours in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/80769718-fed83880-8b02-11ea-93e4-ded5d132f9df.png)

![image](https://user-images.githubusercontent.com/177561/80769732-0bf52780-8b03-11ea-8b14-29eea5d0187e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
