### PR TITLE
Header: Correct alignment with centered logo

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -189,6 +189,14 @@
 			&.site-branding {
 				width: 30%;
 			}
+
+			&:first-of-type > * {
+				margin-right: auto;
+			}
+
+			&:last-of-type {
+				justify-content: flex-end;
+			}
 		}
 
 		.site-branding {
@@ -230,14 +238,6 @@
 
 			&.site-branding {
 				width: auto;
-			}
-
-			&:first-of-type > * {
-				margin-right: auto;
-			}
-
-			&:last-of-type {
-				justify-content: flex-end;
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the logo is centered, at certain breakpoints, the elements to the left and right of the logo are centered in their spaces, too. This PR fixes that.

### How to test the changes in this Pull Request:

1. Under Customizer > Header Settings, check 'Center Logo' and uncheck 'Short Header'.
2. View on the front end, and shrink down the browser window, so it's narrower than the site's width (1200px), but not so narrow that the mobile menu kicks in. 
3. Note that the social links and tertiary menu/search are kind of floating in their spaces, instead of being fully right or left:

![image](https://user-images.githubusercontent.com/177561/81117609-3a487d80-8edc-11ea-9ed7-feba37e8b149.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the social links and tertiary menu/search fully stay on their sides on all screen sizes, until the mobile header is triggered:

![image](https://user-images.githubusercontent.com/177561/81117696-5fd58700-8edc-11ea-9f65-8d9827800156.png)

6. Navigate to Customizer > Header Settings and check 'Short Header'.
7. Confirm that the primary menu and tertiary menu/search are flush to the left/right on all screen sizes that use the desktop header:

![image](https://user-images.githubusercontent.com/177561/81117779-914e5280-8edc-11ea-9afa-eebc24b5010c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
