### PR TITLE
Default Template: Make sure full width blocks preview centered in editor

### DIFF
--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -12,10 +12,11 @@
 /** === Default Template === */
 
 @include media( mobile ) {
-	body.newspack-default-template .wp-block[data-align='full'] {
+	body.newspack-default-template
+		.block-editor-block-list__layout.is-root-container
+		> .wp-block[data-align='full'] {
 		margin-left: auto;
 		margin-right: auto;
-		max-width: 780px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a post or page is using the default template, blocks that are aligned wide and full display the same width as the rest of the posts. In the editor right now, full-width blocks are previewing at the correct width, but have the incorrect alignment. 

Closes #912.

### How to test the changes in this Pull Request:

1. Create a post using the default template.
2. Add a full-width group block and give it a background colour.
3. Note how it looks in the editor:

![image](https://user-images.githubusercontent.com/177561/81121383-759a7a80-8ee3-11ea-8ef2-3f8336aa38b9.png)

4. Apply the PR and run `npm run build`.
5. Refresh the editor, and confirm that the full-width block is centred:

![image](https://user-images.githubusercontent.com/177561/81121435-9e227480-8ee3-11ea-8c3d-f346c8168b68.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
