### PR TITLE
Cover Block: Make sure the gradient overlay isn't cut off on wide and full blocks

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -130,7 +130,7 @@
 		.wp-block-group {
 			&.alignfull,
 			&.alignwide {
-				> *:not( .alignfull ):not( .alignwide ) {
+				> *:not( .alignfull ):not( .alignwide ):not( .wp-block-cover__gradient-background ) {
 					margin-left: auto;
 					margin-right: auto;
 					max-width: 1200px;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -130,7 +130,7 @@
 		.wp-block-group {
 			&.alignfull,
 			&.alignwide {
-				> *:not( .alignfull ):not( .alignwide ):not( .wp-block-cover__gradient-background ) {
+				> div > *:not( .alignfull ):not( .alignwide ) {
 					margin-left: auto;
 					margin-right: auto;
 					max-width: 1200px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There are styles to make sure the contents of the full and wide width blocks respected the width of the content area, unless they, too, were wide or full align blocks. This was accidentally getting picked up by the cover block's gradient style, though, on the 'wide' templates -- this PR fixes that.

Closes #854.

### How to test the changes in this Pull Request:

1. Add two cover blocks to the home page (which uses the wide template). Make one wide and one full width, and add gradients to both.
2. View on the front end and note the gradient doesn't fill the available space:

![image](https://user-images.githubusercontent.com/177561/81125871-64a33680-8eee-11ea-87dd-b3ece6f26b50.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the gradient now fills the available space:

![image](https://user-images.githubusercontent.com/177561/81125911-88ff1300-8eee-11ea-8e75-779fef93cb69.png)

5. Use the element inspector or align a nested block to the left to confirm that the nested block is only 1200px wide:

![image](https://user-images.githubusercontent.com/177561/81125964-af24b300-8eee-11ea-8f04-981358b171ed.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
