### PR TITLE
Group Block: Make sure preview width is correct 

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -329,6 +329,12 @@ figcaption,
 	text-align: left;
 }
 
+/** === Group === */
+.wp-block[data-align='left'] .wp-block-group,
+.wp-block[data-align='right'] .wp-block-group {
+	max-width: 50%;
+}
+
 /** === Button === */
 
 .wp-block-button__link {

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -70,6 +70,8 @@ body.newspack-single-column-template {
 	}
 
 	.wp-block[data-align='left'] {
+		position: relative;
+
 		@include media( desktop ) {
 			left: #{-2 * $size__spacing-unit};
 		}
@@ -83,6 +85,8 @@ body.newspack-single-column-template {
 	}
 
 	.wp-block[data-align='right'] {
+		position: relative;
+
 		@include media( desktop ) {
 			right: #{-2 * $size__spacing-unit};
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the Group block is aligned left or right, it should have a max width of 50%.

This closes https://github.com/Automattic/newspack-blocks/issues/433; it was originally filed in the block repo, but since the theme is what is making other aligned blocks a maximum of 50%, it makes more sense to fix this in the theme, too.

### How to test the changes in this Pull Request:

1. Add a group block to a page; give it  a background colour and a long string of text in a paragraph block inside. 
2. View in the editor and note the appearance:

![image](https://user-images.githubusercontent.com/177561/81215450-3bd27e00-8f8e-11ea-9683-5cafdd977567.png)

3. Apply the PR and run `npm run build`.
4. Refresh the editor and confirm the group block is no more than 50% of the content area width. If you're using the One Column template, it should also stick out a bit to the right or the left:

![image](https://user-images.githubusercontent.com/177561/81215549-5efd2d80-8f8e-11ea-95de-b2eef0dbfacd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
