### PR TITLE
Group Block: adjust border styles

### DIFF
--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -26,6 +26,10 @@ Newspack Sacha Editor Styles
 	}
 }
 
+.wp-block-group.is-style-border {
+	border: 3px double currentColor;
+}
+
 /* Separator */
 .wp-block-separator {
 	&:not( .is-style-dots ) {

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -318,6 +318,10 @@ textarea {
 	}
 }
 
+.wp-block-group.is-style-border {
+	border: 3px double currentColor;
+}
+
 //! Pullquote
 .wp-block-pullquote {
 	border: 0;

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -207,3 +207,8 @@ hr {
 		}
 	}
 }
+
+.wp-block-group.is-style-border {
+	border-style: dotted;
+	border-color: $color__text-main;
+}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -244,7 +244,8 @@ figcaption,
 }
 
 //! Columns Block
-.wp-block-columns.is-style-borders .wp-block-column::after {
+.wp-block-columns.is-style-borders .wp-block-column::after,
+.wp-block-group.is-style-border {
 	border-style: dotted;
 	border-color: $color__text-main;
 }

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -66,6 +66,10 @@ blockquote {
 	font-weight: 800;
 }
 
+.wp-block-group.is-style-border {
+	border-color: $color__text-main;
+}
+
 .wp-block[data-type='core/pullquote'] {
 	.wp-block-pullquote {
 		border-width: 16px 0 4px;

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -67,7 +67,7 @@ blockquote {
 }
 
 .wp-block-group.is-style-border {
-	border-color: $color__text-main;
+	border-color: currentColor;
 }
 
 .wp-block[data-type='core/pullquote'] {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -309,7 +309,7 @@ blockquote {
 
 //! Group Block
 .wp-block-group.is-style-border {
-	border-color: $color__text-main;
+	border-color: currentColor;
 }
 
 //! Newspack Article Block

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -307,6 +307,11 @@ blockquote {
 	font-weight: 800;
 }
 
+//! Group Block
+.wp-block-group.is-style-border {
+	border-color: $color__text-main;
+}
+
 //! Newspack Article Block
 .wpnbha {
 	article .entry-meta {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR goes with https://github.com/Automattic/newspack-blocks/pull/463. It updates the Group Block border styles for Newspack Nelson, Katharine and Joseph to better match their border styles.

### How to test the changes in this Pull Request:

1. Apply https://github.com/Automattic/newspack-blocks/pull/463 to the block plugin, and run `npm run build`.
2. Apply this PR to the theme repo, and run `npm run build`. 
3. Edit a post or page, and add a group block, and apply the border style. By default, it will use the light grey border colour:

4. Switch to Newspack Nelson, and confirm the border is very dark gray, on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/81223723-4f381600-8f9b-11ea-8e75-898c9c4ed293.png)

5. Switch to Newspack Katharine, and confirm that the border is dotted on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/81224314-5f9cc080-8f9c-11ea-8ee3-ec935cff099c.png)

6. Switch to Newspack Joseph and confirm the border is black and doubled, on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/81223682-3d567300-8f9b-11ea-8288-7f234a0dc3e0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
