### PR TITLE
Homepage Posts: Move content option fixes to block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -153,18 +153,6 @@
 	figcaption {
 		max-width: 100%;
 	}
-
-	// Make sure Jetpack Content Options don't override
-	.posted-on,
-	.cat-links,
-	.tags-links,
-	.byline,
-	.author-avatar {
-		clip: auto;
-		height: auto;
-		position: relative;
-		width: auto;
-	}
 }
 
 //! Newspack Carousel Block


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes some Homepage Posts block fixes that made sure Jetpack Content Options were not affecting the block. These fixes have been added to the block here, since Content Options exist in other themes: https://github.com/Automattic/newspack-blocks/pull/467

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`; make sure there are no errrors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
