### PR TITLE
Improved styling for shop and products

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -63,6 +63,10 @@ a.button {
 		}
 	}
 
+	.page-description {
+		font-size: 1em;
+	}
+
 	form .form-row {
 		.required {
 			color: firebrick;
@@ -252,6 +256,7 @@ ul.products {
 
 	li.product {
 		list-style: none;
+		display: block;
 
 		.woocommerce-loop-product__link {
 			display: block;
@@ -292,6 +297,7 @@ ul.products {
 
 		.button {
 			vertical-align: middle;
+			word-break: normal;
 
 			&.loading {
 				opacity: 0.5;
@@ -407,6 +413,7 @@ dl.variation,
 	.entry {
 		.entry-title {
 			margin-top: 0;
+			font-size: 2em;
 
 			&::before {
 				margin-top: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes a handful of improvements to the shop and product pages. This is mostly useful for sites sell products as opposed to memberships or subscriptions.

### Testing instructions

#### Add some content to the Shop page

Before:
<img width="985" alt="Screen Shot 2020-05-08 at 10 11 49 AM" src="https://user-images.githubusercontent.com/7317227/81433299-30f82480-9119-11ea-8a49-cc368e40bb41.png">

After:
<img width="659" alt="Screen Shot 2020-05-08 at 10 15 45 AM" src="https://user-images.githubusercontent.com/7317227/81433309-348bab80-9119-11ea-97f9-832164bb2ef4.png">

### Add some products and observe products listed on the Shop page

Before:
<img width="362" alt="Screen Shot 2020-05-08 at 10 16 56 AM" src="https://user-images.githubusercontent.com/7317227/81433424-6270f000-9119-11ea-9ae3-e6cda5bd0cae.png">

After:
<img width="228" alt="Screen Shot 2020-05-08 at 10 17 04 AM" src="https://user-images.githubusercontent.com/7317227/81433438-6866d100-9119-11ea-8450-5d192de3cf69.png">

Before:
<img width="167" alt="Screen Shot 2020-05-08 at 10 18 26 AM" src="https://user-images.githubusercontent.com/7317227/81433465-73216600-9119-11ea-9072-35b9b71925f0.png">

After:
<img width="154" alt="Screen Shot 2020-05-08 at 10 18 53 AM" src="https://user-images.githubusercontent.com/7317227/81433475-774d8380-9119-11ea-986e-fbb5ff81eb6c.png">

#### View a single product

Before:
<img width="683" alt="Screen Shot 2020-05-08 at 10 40 19 AM" src="https://user-images.githubusercontent.com/7317227/81433509-86343600-9119-11ea-92e8-04d06cb5f005.png">

After:
<img width="606" alt="Screen Shot 2020-05-08 at 10 41 38 AM" src="https://user-images.githubusercontent.com/7317227/81433530-8b918080-9119-11ea-865a-a2fe64ab0405.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
