### PR TITLE
Footer: Add option to customize copyright text

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -25,9 +25,15 @@
 			<?php get_template_part( 'template-parts/footer/below-footer', 'widgets' ); ?>
 
 			<div class="wrapper site-info-contain">
-				<?php $blog_info = get_bloginfo( 'name' ); ?>
-				<?php if ( ! empty( $blog_info ) ) : ?>
-					<span class="copyright">&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>.</span>
+				<?php
+					$copyright_info   = get_bloginfo( 'name' );
+					$custom_copyright = get_theme_mod( 'footer_copyright', '' );
+					if ( ! empty( $custom_copyright ) ) {
+						$copyright_info = $custom_copyright;
+					}
+				?>
+				<?php if ( ! empty( $copyright_info ) ) : ?>
+					<span class="copyright">&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php echo esc_html( $copyright_info ); ?>.</span>
 				<?php endif; ?>
 
 				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'newspack' ) ); ?>" class="imprint">

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -478,6 +478,34 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	/**
+	 * Footer settings
+	 */
+	$wp_customize->add_section(
+		'footer_options',
+		array(
+			'title' => esc_html__( 'Footer Settings', 'newspack' ),
+		)
+	);
+
+	// Add option to collapse the comments.
+	$wp_customize->add_setting(
+		'footer_copyright',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+	$wp_customize->add_control(
+		'footer_copyright',
+		array(
+			'type'        => 'text',
+			'label'       => esc_html__( 'Copyright Information', 'newspack' ),
+			'description' => esc_html__( 'Add custom text to be displayed next to a copyright symbol and current year in the footer. By default, it will display your site title.', 'newspack' ),
+			'section'     => 'footer_options',
+		)
+	);
+
+	/**
 	 * WooCommerce Order Details settings
 	 */
 	$wp_customize->add_section(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to the Customizer to change the text that appears next to the copyright symbol and current year in the footer.

By default, if nothing is added to the field, the site title will display.

Closes #921.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm that your copyright is still displaying your Site Title.
3. Navigate to Customize > Footer Settings. Add some text to the Copyright Information field:

![image](https://user-images.githubusercontent.com/177561/81448793-d7512380-9133-11ea-9867-ba458a8db318.png)

4. Click 'Publish'.
5. Confirm that your custom text is now appearing in the footer:

![image](https://user-images.githubusercontent.com/177561/81448853-ef28a780-9133-11ea-9523-1a34184ab6d0.png)

6. Navigate back to Customize > Footer Settings, remove the custom text, and click 'Publish' again.
7. Confirm that the footer is displaying your site title again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
