### PR TITLE
Header: correct alignment issue with simplified header and centered logo

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -223,16 +223,35 @@
 	}
 
 	@include media( tablet ) {
-		.site-header .middle-header-contain .wrapper .site-branding {
-			display: flex;
-			justify-content: center;
-		}
+		&.h-dh,
+		&.h-sub {
+			.site-header .middle-header-contain .wrapper .site-branding {
+				display: flex;
+				justify-content: center;
+			}
 
-		.site-header .custom-logo-link,
-		.site-title,
-		.site-description {
-			text-align: center;
-			width: 100%;
+			.site-header .custom-logo-link,
+			.site-title,
+			.site-description {
+				text-align: center;
+				width: 100%;
+			}
+		}
+	}
+
+	@include media( narrowdesktop ) {
+		&.h-sh {
+			.site-header .middle-header-contain .wrapper .site-branding {
+				display: flex;
+				justify-content: center;
+			}
+
+			.site-header .custom-logo-link,
+			.site-title,
+			.site-description {
+				text-align: center;
+				width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I think this was introduced in changes in #901.

When you have a simplified header the header switches to the mobile view "sooner" since there is less space for links.

This is working as expected, but when the logo is centered, is stays centered after the menus switch to mobile view, until the browser window is shrunk down to tablet size.

### How to test the changes in this Pull Request:
o
1. Navigate to Customizer > Header Settings > Appearance, and select both 'Short Header' and 'Center Logo'.
2. View on front-end and shrink down the browser window. When the header switches to mobile view, note that the logo is still centered for tablet-sized screens, then corrects as the window gets smaller:

![image](https://user-images.githubusercontent.com/177561/81604762-41acd280-9385-11ea-93ec-70ac9d575dc5.png)

![image](https://user-images.githubusercontent.com/177561/81604772-46718680-9385-11ea-8a8c-9ca7b14ac09d.png)

![image](https://user-images.githubusercontent.com/177561/81604784-4b363a80-9385-11ea-9d8f-b5cd393463af.png)

3. Apply the PR and run `npm run build`.
4. Confirm that tablet-sized screens now display as expected with the above:

![image](https://user-images.githubusercontent.com/177561/81604905-80db2380-9385-11ea-9f84-708ed1bbdbd5.png)

5. Navigate to Customizer > Header Settings > Appearance and uncheck 'Short Header', and confirm everything displays as expected on different screen sizes:

![image](https://user-images.githubusercontent.com/177561/81604921-89335e80-9385-11ea-9605-071c20539e7f.png)

![image](https://user-images.githubusercontent.com/177561/81604958-93555d00-9385-11ea-8eed-1bf6ec02108f.png)

6. Navigate to Customizer > Header Settings > Subpage Header, and check 'Use simple header on subpages'.
7. View a post with normal featured image settings on different screen sizes:

![image](https://user-images.githubusercontent.com/177561/81605179-ee874f80-9385-11ea-8473-e49f5ef947ec.png)

![image](https://user-images.githubusercontent.com/177561/81605191-f3e49a00-9385-11ea-9f8d-9dc14ff9e1fe.png)

![image](https://user-images.githubusercontent.com/177561/81605205-f941e480-9385-11ea-8024-9125b67d4486.png)

8. View a post with featured image behind set on different screen sizes:

![image](https://user-images.githubusercontent.com/177561/81605120-d9aabc00-9385-11ea-8491-8edd74685ab8.png)

![image](https://user-images.githubusercontent.com/177561/81605130-dfa09d00-9385-11ea-9ddd-d650df7c69ec.png)

![image](https://user-images.githubusercontent.com/177561/81605148-e4655100-9385-11ea-8612-4c9f6646ff70.png)

9. View a post with featured image beside set on different screen sizes.

![image](https://user-images.githubusercontent.com/177561/81605229-0232b600-9386-11ea-99b1-3f944960e413.png)

![image](https://user-images.githubusercontent.com/177561/81605243-08c12d80-9386-11ea-9e0c-82856c9318d6.png)

![image](https://user-images.githubusercontent.com/177561/81605259-0d85e180-9386-11ea-8d7d-77d7259e879e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
