### PR TITLE
Featured Images: Make sure special featured image styles show credits

### DIFF
--- a/newspack-theme/template-parts/post/large-featured-image.php
+++ b/newspack-theme/template-parts/post/large-featured-image.php
@@ -5,7 +5,10 @@
  * @package Newspack
  */
 
-$caption                 = get_post( get_post_thumbnail_id() )->post_excerpt;
+$caption = get_the_excerpt( get_post_thumbnail_id() );
+// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
+$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
+
 
 if ( 'behind' === newspack_featured_image_position() ) :
 ?>
@@ -19,7 +22,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 		</div><!-- .wrapper -->
 	</div><!-- .featured-image-behind -->
 
-	<?php if ( $caption ) : ?>
+	<?php if ( $caption_exists ) : ?>
 		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
 	<?php endif; ?>
 
@@ -34,7 +37,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 
 		<?php newspack_post_thumbnail(); ?>
 
-		<?php if ( $caption ) : ?>
+		<?php if ( $caption_exists ) : ?>
 			<figcaption><span><?php echo wp_kses_post( $caption ); ?></span></figcaption>
 		<?php endif; ?>
 	</div><!-- .featured-image-behind -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the 'special' featured image settings for single posts (Featured Image Behind Title and Featured Image Beside Title) aren't showing the photo credits. This update makes sure they're getting filtered correctly.

### How to test the changes in this Pull Request:

1. If not already, install and activate the Newspack Image Credits plugin.
2. Set up a post with the featured image set to display behind, and give it a caption and a credit.
3. Set up a post with the featured image set to display beside, and give it a caption and a credit.
4. View both on the front-end; note that while the caption shows, the credit does not:

_Behind:_

![image](https://user-images.githubusercontent.com/177561/81731834-6025d300-9444-11ea-8eb9-3d3aa6988230.png)

_Beside:_

![image](https://user-images.githubusercontent.com/177561/81731816-5603d480-9444-11ea-8c66-320b9d3b6075.png)

5. Apply the PR.
6. Confirm that the captions are now showing:

_Behind:_

![image](https://user-images.githubusercontent.com/177561/81731920-83e91900-9444-11ea-8fdb-24b10b5a48f9.png)

_Beside:_

![image](https://user-images.githubusercontent.com/177561/81731897-7a5fb100-9444-11ea-9ad3-e095fec872e5.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
