### PR TITLE
Header: Correct centered logo sizing

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -183,7 +183,6 @@
 .h-cl {
 	@include media( tablet ) {
 		.site-header .middle-header-contain .wrapper > div {
-			flex: 1;
 			width: 35%;
 
 			&.site-branding {
@@ -217,12 +216,11 @@
 		}
 
 		.site-header .custom-logo-link img {
-			max-width: inherit;
+			height: auto;
+			max-width: 100%;
 			margin: auto;
 		}
-	}
 
-	@include media( tablet ) {
 		&.h-dh,
 		&.h-sub {
 			.site-header .middle-header-contain .wrapper .site-branding {
@@ -252,6 +250,21 @@
 				text-align: center;
 				width: 100%;
 			}
+		}
+	}
+
+	@include media( desktop ) {
+		.site-header .middle-header-contain .wrapper > div {
+			flex: 1;
+			width: auto;
+
+			&.site-branding {
+				width: auto;
+			}
+		}
+
+		.site-header .custom-logo-link img {
+			max-width: inherit;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

#901 introduced an issue with the centered logo scaling down on tablet-sized screens; it would stay at its full size, rather than going down to a reduced size for mid-sized screens, before scaling down again for mobile-sized screens.

### How to test the changes in this Pull Request:

**Note:** I recommend testing against a live site with a centered logo, using the same logo graphic (like Rivard or OK Watch; Technode too, though there is custom CSS in place to make the logo smaller than default on mobile). This way, it's easy to confirm that the behaviour pre-901 (on the customer site), and with this PR is the same. 

1. Set up a test site header with a centered logo, and other settings to roughly line up with the site you're comparing against (menus, logo size). 
2. View on the front end.
3. Scale down the browser window to roughly tablet-sized (before the mobile menu kicks in). 
4. Contrast against the site you're comparing against; the logo on that site should be shrunk down, but the logo on your test site will be maintaining the same size.
5. Apply the PR and run `npm run build`. 
6. Refresh the test site; confirm the logos are the same size.
7. Try different screen sizes and confirm the logo matches the site it's being compared against.
8. Try both AMP and non-AMP, and make sure the logo is sizing similarly for both. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
