### PR TITLE
Header: Keep centred logo from getting cut off in IE11

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -268,7 +268,7 @@
 	}
 
 	// IE 11-specific logo fix
-	@media screen and ( -ms-high-contrast: none ), ( min-width: $desktop_width ) {
+	@media screen and ( -ms-high-contrast: none ) and ( min-width: $desktop_width ) {
 		.site-header .custom-logo-link img {
 			height: auto;
 			max-width: 100%;

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -266,6 +266,14 @@
 			max-width: inherit;
 		}
 	}
+
+	// IE 11-specific logo fix
+	@media screen and ( -ms-high-contrast: none ), ( min-width: $desktop_width ) {
+		.site-header .custom-logo-link img {
+			height: auto;
+			max-width: 100%;
+		}
+	}
 }
 
 // Solid Background


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now in IE11, if you centre a wider logo, it will get cut off on the right. This PR adds an IE-specific fix for that issue. Best tested after #930 lands to confirm logo scaling down still behaves as expected, as it also can cause the logo to get cut off.

Note: In my testing, most images were distorted when AMP was enabled in IE11; I filed a separate issue for that here: https://github.com/ampproject/amphtml/issues/28398

Closes #931.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Header Settings > Appearance, and select Centered Logo.
2. Add a logo with a horizontal orientation, and make it rather wide -- roughly 600px wide on desktop (half the header width).
3. View in a modern browser (Firefox, Chrome, etc), and note the appearance:

![image](https://user-images.githubusercontent.com/177561/81876677-174f4680-9538-11ea-8a26-710cf13bc9ec.png)

4. View in IE11: 

![image](https://user-images.githubusercontent.com/177561/81876781-55e50100-9538-11ea-9998-e1fb5d05f0dd.png)

5. Apply the PR and run `npm run build`.
6. Confirm the logo still displays at the larger size in modern browsers:

![image](https://user-images.githubusercontent.com/177561/81876881-8dec4400-9538-11ea-8947-dcadcb763fc3.png)

7. Confirm that the logo is now smaller in IE11, but no longer cut off:

![image](https://user-images.githubusercontent.com/177561/81876869-862c9f80-9538-11ea-84fa-75ebe41fb5a4.png)

8. Confirm that things look good in modern version of Edge.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
