### PR TITLE
Header: Fix JS error in simplified subpage header non-AMP fallback

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -83,7 +83,7 @@
 	// 'Sub page' menu fallback.
 	const subpageToggle = document.getElementsByClassName( 'subpage-toggle' );
 
-	if ( null !== subpageToggle ) {
+	if ( 0 < subpageToggle.length ) {
 		const subpageSidebar = document.getElementById( 'subpage-sidebar-fallback' ),
 			subpageOpenButton = headerContain.getElementsByClassName( 'subpage-toggle' )[ 0 ],
 			subpageCloseButton = subpageSidebar.getElementsByClassName( 'subpage-toggle' )[ 0 ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR prevents a JS error being thrown on the homepage when the simplified subpage header is enabled.  

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Header Settings > Subpage Header, and check 'Use simple header on subpages'
2. Turn off AMP.
3. View the Homepage and open the Console; note the following JS error:

`TypeError: subpageSidebar is null`

4. Apply the PR and run `npm run build`
5. Refresh the homepage and confirm the error is gone.
6. Navigate to a subpage and confirm that the menu toggle still opens/closes the menu.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
