### PR TITLE
Header: correct logo size display issues with AMP

### DIFF
--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -98,7 +98,7 @@ function newspack_customize_logo_resize( $html ) {
 		$mobile_max_height = 65;
 
 		$subhead_max_width  = 200;
-		$subhead_max_height = 50;
+		$subhead_max_height = 60;
 
 		$mobile  = newspack_logo_small_sizes( $img['width'], $img['height'], $mobile_max_width, $mobile_max_height );
 		$subhead = newspack_logo_small_sizes( $img['width'], $img['height'], $subhead_max_width, $subhead_max_height );

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -152,7 +152,7 @@ function newspack_logo_resize_min_max( $short, $long, $short_max, $long_max, $pe
 }
 
 /**
- * Helper function to return smaller versionf of the logo size
+ * Helper function to return smaller version of the logo size
  */
 function newspack_logo_small_sizes( $width, $height, $maxwidth, $maxheight ) {
 	$smallsize['width']  = round( $maxheight * ( $width / $height ) );

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -154,16 +154,18 @@ function newspack_logo_resize_min_max( $short, $long, $short_max, $long_max, $pe
 /**
  * Helper function to return smaller version of the logo size
  */
-function newspack_logo_small_sizes( $width, $height, $maxwidth, $maxheight ) {
-	$smallsize['width']  = round( $maxheight * ( $width / $height ) );
-	$smallsize['height'] = $maxheight;
+function newspack_logo_small_sizes( $width, $height, $max_width, $max_height ) {
+	$size = array(
+		'width'  => round( $max_height * ( $width / $height ) ),
+		'height' => $max_height,
+	);
 
-	if ( $smallsize['width'] > $maxwidth ) {
-		$smallsize['height'] = round( $maxwidth * ( $height / $width ) );
-		$smallsize['width']  = $maxwidth;
+	if ( $size['width'] > $max_width ) {
+		$size['height'] = round( $max_width * ( $height / $width ) );
+		$size['width']  = $max_width;
 	}
 
-	return $smallsize;
+	return $size;
 }
 
 /**

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -94,6 +94,15 @@ function newspack_customize_logo_resize( $html ) {
 			);
 		}
 
+		$mobile_max_width  = 175;
+		$mobile_max_height = 65;
+
+		$subhead_max_width  = 200;
+		$subhead_max_height = 50;
+
+		$mobile  = newspack_logo_small_sizes( $img['width'], $img['height'], $mobile_max_width, $mobile_max_height );
+		$subhead = newspack_logo_small_sizes( $img['width'], $img['height'], $subhead_max_width, $subhead_max_height );
+
 		// add the CSS
 		$css = '
 		<style>
@@ -102,6 +111,20 @@ function newspack_customize_logo_resize( $html ) {
 			max-height: ' . $max['height'] . 'px;
 			max-width: ' . $max['width'] . 'px;
 			width: ' . $img['width'] . 'px;
+		}
+
+		@media (max-width: 781px) {
+			.site-header .custom-logo {
+				max-width: ' . $mobile['width'] . 'px;
+				max-height: ' . $mobile['height'] . 'px;
+			}
+		}
+
+		@media (min-width: 782px) {
+			.h-sub .site-header .custom-logo {
+				max-width: ' . $subhead['width'] . 'px;
+				max-height: ' . $subhead['height'] . 'px;
+			}
 		}
 		</style>';
 
@@ -126,6 +149,21 @@ function newspack_logo_resize_min_max( $short, $long, $short_max, $long_max, $pe
 	$size['long']  = round( $size['short'] / ( $short / $long ) );
 
 	return $size;
+}
+
+/**
+ * Helper function to return smaller versionf of the logo size
+ */
+function newspack_logo_small_sizes( $width, $height, $maxwidth, $maxheight ) {
+	$smallsize['width']  = round( $maxheight * ( $width / $height ) );
+	$smallsize['height'] = $maxheight;
+
+	if ( $smallsize['width'] > $maxwidth ) {
+		$smallsize['height'] = round( $maxwidth * ( $height / $width ) );
+		$smallsize['width']  = $maxwidth;
+	}
+
+	return $smallsize;
 }
 
 /**

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -22,8 +22,7 @@
 .site-header .custom-logo-link .custom-logo {
 	@include media( tabletonly ) {
 		height: auto;
-		max-height: 75px;
-		max-width: 175px;
+		min-height: 45px;
 		width: auto;
 	}
 }
@@ -401,6 +400,11 @@
 	}
 
 	@include media( tablet ) {
+		.site-header .custom-logo {
+			width: auto;
+			height: auto;
+		}
+
 		// Default header background colour
 		&.h-db .middle-header-contain {
 			border-bottom: 1px solid $color__border;
@@ -417,13 +421,6 @@
 				}
 			}
 
-			.custom-logo {
-				height: auto;
-				max-height: 50px;
-				max-width: 180px;
-				width: auto;
-			}
-
 			.header-search-contain {
 				margin-left: auto;
 			}
@@ -438,6 +435,15 @@
 					text-align: right;
 				}
 			}
+		}
+
+		&.h-ll {
+			// Make sure the alt logo still sits to the left if smaller than the main logo.
+			/* stylelint-disable selector-type-no-unknown  */
+			.site-header .custom-logo-link amp-img.amp-wp-enforced-sizes[layout='intrinsic'] > img {
+				object-position: left center;
+			}
+			/* stylelint-enable */
 		}
 
 		// Featured template settings - featured imgae height

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -96,7 +96,7 @@
 .middle-header-contain .wrapper {
 	align-items: center;
 	padding: $size__spacing-unit 0;
-	@include media( mobile ) {
+	@include media( tablet ) {
 		padding: #{1.5 * $size__spacing-unit} 0;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When scaling down images, AMP will size an image using `object-fit: contain`; if the image's size or max-size isn't the same aspect ratio, this will cause the image to appear centered inside of the max-width space, causing a gap on both sides. This happens when the image is scaled down for mobile, or for the subpage header. 

This PR should fix most cases; the only odd case is when a site is using the subpage header option, and have uploaded an alternative logo for the featured image beside and featured image behind posts that is not the same aspect ratio as the original logo (this is the case with MTFP). The logo won't be sized quite right -- for example, if the original is wider than the alternative version, the alternative version may be scaled down more than it needs to be. This is an odd case, and not the actual use case for that logo, so I think it's safe to fix this on a one-off basis with Custom CSS, but we can revisit and calculate a separate size for that logo if it turns into a bigger thing. 

Closes #838 

### How to test the changes in this Pull Request:

1. Set up a header with a left-aligned square logo, and turn on AMP to Transitional mode for easier testing. 
2. Under Customizer > Header Settings > Subpage Header, check 'Use simple header on subpages'.
3. View the AMP version of a page, and scale down the browser window to mobile size -- note the gap that appears on either side:

![image](https://user-images.githubusercontent.com/177561/81989323-e895a680-95f1-11ea-9419-3346f5bfa19c.png)

![image](https://user-images.githubusercontent.com/177561/81989360-f8ad8600-95f1-11ea-9c10-ffed9393a0f1.png)

![image](https://user-images.githubusercontent.com/177561/81989389-0105c100-95f2-11ea-993a-419bcb382125.png)

4. Navigate to a subpage, and note a similar issue in the scaled-down subpage header:

![image](https://user-images.githubusercontent.com/177561/81990448-111ea000-95f4-11ea-8e9f-9b2b299e09bf.png)

5. Apply the PR and run `npm run build`.
6. Revisit both pages, and confirm the logo spacing looks better; also confirm it's the same without AMP:

![image](https://user-images.githubusercontent.com/177561/81989995-1e875a80-95f3-11ea-8540-f98a009055ff.png)

![image](https://user-images.githubusercontent.com/177561/81990561-41fed500-95f4-11ea-928b-eac00969c11e.png)

7. Test on a subpage with the featured image behind and featured image beside setting, and confirm it's displaying as expected, with and without AMP:

![image](https://user-images.githubusercontent.com/177561/81991430-0fee7280-95f6-11ea-89bb-c44beee9b0aa.png)

![image](https://user-images.githubusercontent.com/177561/81991460-1e3c8e80-95f6-11ea-9911-099af58116bb.png)

8. Try some other logo shapes -- horizontal and vertical -- and confirm they all display well with and without AMP:

![image](https://user-images.githubusercontent.com/177561/81991574-71164600-95f6-11ea-9749-910caf45f9e1.png)

![image](https://user-images.githubusercontent.com/177561/81991588-7b384480-95f6-11ea-8ea7-0c876b7918bd.png)

![image](https://user-images.githubusercontent.com/177561/81992132-ab341780-95f7-11ea-8adc-b316afeb7429.png)

![image](https://user-images.githubusercontent.com/177561/81992150-b129f880-95f7-11ea-88b1-d5e2f1f31c38.png)

![image](https://user-images.githubusercontent.com/177561/81992161-b5eeac80-95f7-11ea-8ed9-3850d2bcacb7.png)

![image](https://user-images.githubusercontent.com/177561/81994400-9f971f80-95fc-11ea-9be4-bc7bf6446fe9.png)

![image](https://user-images.githubusercontent.com/177561/81994515-e7b64200-95fc-11ea-81c3-f2a07da5ceff.png)

![image](https://user-images.githubusercontent.com/177561/81994548-f69cf480-95fc-11ea-8896-3b8646ba9758.png)

![image](https://user-images.githubusercontent.com/177561/81994565-fef52f80-95fc-11ea-9aa0-43dbe2d5dab9.png)

![image](https://user-images.githubusercontent.com/177561/81994586-0583a700-95fd-11ea-8d1a-0ab9dfb1f5fd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
