### PR TITLE
Header: improve subpage header code to remove AMP errors

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -346,8 +346,14 @@ function newspack_primary_menu() {
 	if ( ! has_nav_menu( 'primary-menu' ) ) {
 		return;
 	}
+
+	// Only set a toolbar-target attributes if the primary menu container exists in the header - if not subpage header.
+	$toolbar_attributes = '';
+	if ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) {
+		$toolbar_attributes = 'toolbar-target="site-navigation" toolbar="(min-width: 767px)"';
+	}
 	?>
-	<nav toolbar="(min-width: 767px)" toolbar-target="site-navigation" class="main-navigation nav1" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>">
+	<nav class="main-navigation nav1" aria-label="<?php esc_attr_e( 'Top Menu', 'newspack' ); ?>" <?php echo $toolbar_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
 		wp_nav_menu(
 			array(
@@ -370,9 +376,9 @@ function newspack_secondary_menu() {
 		return;
 	}
 
-	// Only set the AMP toolbar attributes if the secondary menu container exists in the header.
+	// Only set a toolbar-target attributes if the secondary menu container exists in the header - if not short or subpage header.
 	$toolbar_attributes = '';
-	if ( false === get_theme_mod( 'header_simplified', false ) ) {
+	if ( false === get_theme_mod( 'header_simplified', false ) && ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) ) {
 		$toolbar_attributes = 'toolbar-target="secondary-nav-contain" toolbar="(min-width: 767px)"';
 	}
 
@@ -400,8 +406,14 @@ function newspack_tertiary_menu() {
 	if ( ! has_nav_menu( 'tertiary-menu' ) ) {
 		return;
 	}
+
+	// Only set a toolbar-target attributes if the tertiary menu container exists in the header - if not subpage header.
+	$toolbar_attributes = '';
+	if ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) {
+		$toolbar_attributes = 'toolbar-target="tertiary-nav-contain" toolbar="(min-width: 767px)"';
+	}
 	?>
-		<nav toolbar="(min-width: 767px)" toolbar-target="tertiary-nav-contain" class="tertiary-menu nav3" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>">
+		<nav class="tertiary-menu nav3" aria-label="<?php esc_attr_e( 'Tertiary Menu', 'newspack' ); ?>" <?php echo $toolbar_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php
 			wp_nav_menu(
 				array(
@@ -440,9 +452,9 @@ function newspack_social_menu_header() {
 		return;
 	}
 
-	// Only set a toolbar-target attributes if the social menu container exists in the header.
+	// Only set a toolbar-target attributes if the social menu container exists in the header - if not short or subpage header.
 	$toolbar_attributes = '';
-	if ( false === get_theme_mod( 'header_simplified', false ) ) {
+	if ( false === get_theme_mod( 'header_simplified', false ) && ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) ) {
 		$toolbar_attributes = 'toolbar="(min-width: 767px)" toolbar-target="social-nav-contain"';
 	}
 	?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `amp-sidebar` code used for the mobile menu, desktop slideout sidebar and now the simplified subpage header uses two attributes to "move" content placed inside of it to the desktop view of the page: `toolbar="(min-width: 767px)"` to determine the page width when to move, and `toolbar-target="social-nav-contain"` to set the ID of the target where the content should be moved.

When the `toolbar-target` doesn't exist on the page, AMP will throw an error.

In the theme we're sharing the same menu markup for the different header menus across the different settings, but in some cases -- like with the simplified subpage header -- we don't need the toolbar attributes because we don't actually want the to try to move and throw errors.

This PR adds a check for the simplified subpage header before outputting the toolbar attributes.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Header Settings > Subpage Header, and check "Use simple header on subpages". 
2. Under Customizer > Header Settings > Appearance, uncheck 'Short Header'. 
3. Under Customizer > Menus, set up menus in the Primary, Secondary, Social and Tertiary locations.
4. Make sure AMP is set to Standard mode, or that you're viewing the AMP version of the following pages when testing.
5. View the front end of the site , and navigate to a subpage. Open the Console and note the errors:

![image](https://user-images.githubusercontent.com/177561/82074726-0ade0180-9690-11ea-9f75-d2163b254cc7.png)

6. Apply the PR.
7. Refresh the same page and confirm that errrors aren't displaying.
8. Navigate to the homepage and confirm you're setting all of your assigned menus on desktop view (making sure the toolbar attributes are still being added when needed).
9. Navigate to Customizer > Header Settings > Appearance, and check 'Short Header'.
10. Re-check the homepage and subpages, and confirm the menus are displaying without errors.
11. Navigate to Customizer > Header Settings > Subpage Header, and uncheck "Use simple header on subpages". 
12. Repeat step 10.
13. Navigate to Customizer > Header Settings > Appearance, and uncheck "Short Header" again. 14. Repeat step 10 a final time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
