### PR TITLE
Header: Add `object-fit` for logos when AMP isn't active

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -22,6 +22,8 @@
 .site-header .custom-logo-link .custom-logo {
 	@include media( tabletonly ) {
 		height: auto;
+		min-height: 45px;
+		object-fit: contain;
 		width: auto;
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -22,7 +22,6 @@
 .site-header .custom-logo-link .custom-logo {
 	@include media( tabletonly ) {
 		height: auto;
-		min-height: 45px;
 		width: auto;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Recent header changes have included a minimum height for the logo, to preserve the mobile header height, but in extreme cases (with wide, short logos), it can cause distortion when AMP is not enabled.

This PR adds `object-fit: contain` (already added by AMP) to account for those cases. 

### How to test the changes in this Pull Request:

1. Add a short, wide logo.
2. Turn off AMP, or switch it to Transitioal mode so you can toggle between AMP and non-AMP versions of the pages. 
3. View the page in non-AMP mode; shrink the browser window down to mobile size -- note the logo shape: 

![image](https://user-images.githubusercontent.com/177561/82268163-2dd41400-9923-11ea-8d0d-c18eb2685e45.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the logo is no longer distorted:

![image](https://user-images.githubusercontent.com/177561/82268021-d6ce3f00-9922-11ea-881a-a3eaf470c910.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
