### PR TITLE
Archives: add extra HTML to the_archive_title for easier styling

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -807,6 +807,28 @@ add_filter( 'the_excerpt_rss', 'newspack_thumbnails_in_rss' );
 add_filter( 'the_content_feed', 'newspack_thumbnails_in_rss' );
 
 /**
+ * Add a extra span and class to the_archive_title, for easier styling.
+ */
+function newspack_update_the_archive_title( $title ) {
+	// Split the title into parts so we can wrap them with spans:
+	$title_parts = explode( '<span class="page-description">', $title, 2 );
+	// Glue it back together again.
+	if ( ! empty( $title_parts[1] ) ) {
+		$title = wp_kses(
+			$title_parts[1],
+			array(
+				'span' => array(
+					'class' => array(),
+				),
+			)
+		);
+		$title = '<span class="page-subtitle">' . esc_html( $title_parts[0] ) . '</span><span class="page-description">' . $title;
+	}
+	return $title;
+}
+add_filter( 'get_the_archive_title', 'newspack_update_the_archive_title', 11, 1 );
+
+/**
  * Notify about child theme deprecation.
  * TODO: Remove after child theme code is removed.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR filters the output of `the_archive_title()` to add an extra span; originally, only the 'description' (the actual category/tag/author name) is wrapped in a tag, which makes it more difficult to target the first part ('category', 'tag', 'author') with styles, especially to hide. 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Inspect archive pages, and confirm they now contain two spans -- the original one, wrapping the archive name in a span with the class `page-description`, and a new one, wrapping the type of archive in a span with the class `page-subtitle`:

![image](https://user-images.githubusercontent.com/177561/82374896-93cca400-99d4-11ea-965c-f26002033248.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
