### PR TITLE
Block Editor: Add a line height to the post title

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -122,6 +122,7 @@ figcaption,
 		font-family: $font__heading;
 		font-size: $font__size-xxl;
 		font-weight: 700;
+		line-height: 1.2;
 
 		@include media( desktop ) {
 			font-size: $font__size-xxxl;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a line height to the post titles in the editor, so they're not too tall.

Closes #926

### How to test the changes in this Pull Request:

1. Edit a post with a longer title (wrapping at least one line); note the line height:

![image](https://user-images.githubusercontent.com/177561/82376275-afd14500-99d6-11ea-84d1-0cd07990a6cb.png)

2. Apply the PR and run `npm run build`
3. Confirm that the line height is tightened up, closer to how it appears on the front-end:

![image](https://user-images.githubusercontent.com/177561/82376365-d7281200-99d6-11ea-94c2-3dc925a33cda.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
