### PR TITLE
Nelson: Move style pack-specific ad styles to the child theme

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -65,6 +65,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 .site-content,
 .newspack-front-page.hide-homepage-title .site-content,
+body:not( .newspack-front-page ) .newspack_global_ad.global_below_header + .site-content,
 .site-breadcrumb {
 	@include media( tablet ) {
 		margin-top: #{-3.5 * $size__spacing-unit};
@@ -582,4 +583,9 @@ blockquote {
 
 .entry-meta .trust-label {
 	margin-top: #{0.5 * $size__spacing-unit};
+}
+
+// Ads
+.newspack_global_ad.global_below_header {
+	display: none;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

While putting together #948, I ran across some styles using the style pack CSS class to make sure below header ads were not displayed in Newspack Nelson, since the theme doesn't really have the space for it. 

This PR moves those styles to Newspack Nelson; they also rely on #948 being merged, since prior to that the styles use `:not( .style-pack-style-2 )` as part of the selector. That class will no longer exist after that PR is merged, but with it in place, this CSS is not specific enough to override it. 

Closes #949.

### How to test the changes in this Pull Request:

1. Start with a test site where you can apply ads with Google Ad Manager (I did not have this fully set up on my test site, but enough that I could assign empty ads to spaces).
2. Switch to Newspack Nelson. 
3. Add an ad to the 'Global: Below Header' location.
4. View on the front-end; note how the content area is pushed very far down, and the ad (in this case, my invisible ad), is sitting at the top of the content area:

![image](https://user-images.githubusercontent.com/177561/82844265-c07d3180-9e94-11ea-82ac-9570e5e9f7fb.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the content area is not pushed down, and that the ad location is hidden via CSS:

![image](https://user-images.githubusercontent.com/177561/82844238-a3e0f980-9e94-11ea-9bbb-32719311856f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
