### PR TITLE
Newspack Sacha: Correct post title alignment preview in editor

### DIFF
--- a/newspack-sacha/functions.php
+++ b/newspack-sacha/functions.php
@@ -126,6 +126,10 @@ function newspack_sacha_editor_customizer_styles() {
 		// Add inline styles:
 		wp_add_inline_style( 'newspack-sacha-editor-inline-styles', $theme_customizations );
 	}
+
+	// Enqueue CSS styles for the editor that use the <body> tag.
+	wp_enqueue_style( 'newspack-sacha-editor-overrides', get_theme_file_uri( '/styles/child-style-editor-overrides.css' ), array(), null, 'all' );
+
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_sacha_editor_customizer_styles' );
 

--- a/newspack-sacha/sass/child-style-editor-overrides.scss
+++ b/newspack-sacha/sass/child-style-editor-overrides.scss
@@ -1,0 +1,16 @@
+/*!
+ * Newspack Sacha Editor Overrides
+ *
+ * This CSS files contains Gutenberg editor styles that need to reference classes on the body tag.
+ */
+
+/** === Single Posts === */
+
+body.post-type-post {
+	.editor-post-title__block {
+		max-width: 1020px; // 85% of 1200px.
+		.editor-post-title__input {
+			text-align: center;
+		}
+	}
+}

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -159,6 +159,10 @@ const SASS_STYLESHEETS = [
 		inFile: 'newspack-sacha/sass/style-editor.scss',
 		outFile: 'newspack-sacha/styles/style-editor.css',
 	},
+	{
+		inFile: 'newspack-sacha/sass/child-style-editor-overrides.scss',
+		outFile: 'newspack-sacha/styles/child-style-editor-overrides.css',
+	},
 	// Newspack Scott Child theme
 	{
 		inFile: 'newspack-scott/sass/style.scss',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Discovered as part of #948, this PR moves some stylepack specific styles for Style 4 into the Sacha child theme.

It loads styles in the editor to centre the post title, to match the front-end.

Closes #950 

### How to test the changes in this Pull Request:

1. Switch to Newspack Sacha.
2. View both a post and a page in the editor; note that the titles for both are aligned left:

Post: 
![image](https://user-images.githubusercontent.com/177561/82848290-c3355200-9ea7-11ea-8526-691f8b3b1659.png)

Page: 
![image](https://user-images.githubusercontent.com/177561/82848320-dea05d00-9ea7-11ea-879c-4772c35ca32e.png)

3. Apply the PR and run `npm run build`.
4. View both a post and a page in the editor; confirm that the post's title is now centred, but the page is still aligned left, matching what's happening on the front-end:

Post: 
![image](https://user-images.githubusercontent.com/177561/82848241-89644b80-9ea7-11ea-92ed-e24a8ee90906.png)

Page: 
![image](https://user-images.githubusercontent.com/177561/82848248-8e28ff80-9ea7-11ea-84e2-dc5d3f797507.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
