### PR TITLE
fix: WooCommerce shop description markup

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -195,3 +195,21 @@ function newspack_subscription_thank_you() {
 	return '';
 }
 add_filter( 'woocommerce_subscriptions_thank_you_message', 'newspack_subscription_thank_you' );
+
+
+/**
+ * Override the Woo function that prints the shop page content.
+ */
+function woocommerce_product_archive_description() {
+	// Don't display the description on search results page.
+	if ( is_search() ) {
+		return;
+	}
+
+	if ( is_post_type_archive( 'product' ) && in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true ) ) {
+		$shop_page = get_post( wc_get_page_id( 'shop' ) );
+		if ( $shop_page ) {
+			echo $shop_page->post_content;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce adds some extra markup around any content added through the editor on the shop page. This extra markup, and accompanying CSS, messes with the theme's built-in styling and can result in normal paragraphs having a huge font size, bold and other unpleasantness. This is not great for those publishers using Woo for purposes other than the Newspack donations system, and who need a functioning Shop page.

This change overrides the relevant Woo function to echo the content as-is without any extra markup.

### How to test the changes in this Pull Request:

1. Set up WooCommerce with a Shop page
2. Add some content to the shop page using the normal WP editor
3. View the page and observe that your content appears above the products list, is likely bold, and maybe large, and is enclosed in a `div` tag with a class of `page-description`.
4. Apply this PR and refresh the page
5. Observe that the `div` is removed and there is no longer any styling differences between a normal page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

