### PR TITLE
Correct path to WooCommerce fonts in theme

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -17,21 +17,24 @@ $highlights-color: #36f;
  */
 @font-face {
 	font-family: star;
-	src: url( '../fonts/star.eot' );
-	src: url( '../fonts/star.eot?#iefix' ) format( 'embedded-opentype' ),
-		url( '../fonts/star.woff' ) format( 'woff' ), url( '../fonts/star.ttf' ) format( 'truetype' ),
-		url( '../fonts/star.svg#star' ) format( 'svg' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/star.eot' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/star.eot?#iefix' )
+			format( 'embedded-opentype' ),
+		url( '../../../plugins/woocommerce/assets/fonts/star.woff' ) format( 'woff' ),
+		url( '../../../plugins/woocommerce/assets/fonts/star.ttf' ) format( 'truetype' ),
+		url( '../../../plugins/woocommerce/assets/fonts/star.svg#star' ) format( 'svg' );
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: WooCommerce;
-	src: url( '../fonts/WooCommerce.eot' );
-	src: url( '../fonts/WooCommerce.eot?#iefix' ) format( 'embedded-opentype' ),
-		url( '../fonts/WooCommerce.woff' ) format( 'woff' ),
-		url( '../fonts/WooCommerce.ttf' ) format( 'truetype' ),
-		url( '../fonts/WooCommerce.svg#WooCommerce' ) format( 'svg' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.eot' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix' )
+			format( 'embedded-opentype' ),
+		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.woff' ) format( 'woff' ),
+		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf' ) format( 'truetype' ),
+		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce' ) format( 'svg' );
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a path to two font files included in the theme's WooCommerce styles, to make sure they're pointing to the files in the plugin.

### How to test the changes in this Pull Request:

1. View your site's WooCommerce shop page; edit in the element inspector and add `<div class="star-rating"></div>` to the content area. This should load the 'star' font.
2. Note it appears as five s's, not stars, because it's falling back to the page font:

![image](https://user-images.githubusercontent.com/177561/83660484-be446280-a579-11ea-8b5f-31918f03996b.png)

3. Apply the PR and run `npm run build`.
4. Repeat step one; confirm that the div actually displays stars:

![image](https://user-images.githubusercontent.com/177561/83660359-96ed9580-a579-11ea-89ba-e622cb26dbf8.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
