### PR TITLE
Subpage Header: Hide below header ad in certain cases

### DIFF
--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -31,3 +31,17 @@ body {
 		}
 	}
 }
+
+// The Subpage header + special featured image placements also can't really support an ad in this spot.
+.h-sub {
+	&.single-featured-image-beside,
+	&.single-featured-image-behind {
+		.global_below_header {
+			display: none;
+		}
+
+		&:not( .newspack-front-page ):not( .style-pack-style-2 ) .global_below_header + .site-content {
+			margin-top: 0;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you combine the Subpage Header with the behind or beside featured image styles, the ad space below the header kind of blows things up. This PR hides that space in that case.

Closes #960.

### How to test the changes in this Pull Request:

1. On a test site, add an ad below the header. 
2. Navigate to the Customizer > Header Settings > Subpage Header, and turn on the subpage header.
3. Set up two posts, one with the featured image behind setting, and one with the featured image beside setting. 
4. View the posts and note the display issues: 

![image](https://user-images.githubusercontent.com/177561/83665342-2433e880-a580-11ea-920b-787f97a4781c.png)

![image](https://user-images.githubusercontent.com/177561/83665389-357cf500-a580-11ea-9f03-955ecbab53a3.png)

5. Apply the PR and run `npm run build`
6. Confirm the ad space no longer appears on those two posts, but does appear on posts without those featured image settings:

![image](https://user-images.githubusercontent.com/177561/83665617-82f96200-a580-11ea-8577-a8d0ecae0e3a.png)

![image](https://user-images.githubusercontent.com/177561/83665573-737a1900-a580-11ea-94c1-b4a9e279dded.png)

![image](https://user-images.githubusercontent.com/177561/83665654-90aee780-a580-11ea-844a-976747c93e1e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
