### PR TITLE
Subpage Header: Make sure subpage menu toggle is not there when empty

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -45,12 +45,14 @@ endif;
 		<?php if ( true === $header_sub_simplified && ! is_front_page() ) : ?>
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<div class="subpage-toggle-contain">
-						<button class="subpage-toggle" on="tap:subpage-sidebar.toggle">
-							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-							<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
-						</button>
-					</div>
+					<?php if ( newspack_has_menus() || ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) ) : ?>
+						<div class="subpage-toggle-contain">
+							<button class="subpage-toggle" on="tap:subpage-sidebar.toggle">
+								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+								<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
+							</button>
+						</div>
+					<?php endif; ?>
 
 					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the simplied subpage header's menu toggle doesn't show if you don't have at least one of the primary, secondary or tertiary menu locations populated, or you don't have the slideout subpage on and populated.

Closes #961.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Menus, and unassign all menus. 
2. Navigate to Customize > Header Settings > Slideout sidebar, and turn it off. 
3. Navigate to Customize > Header Settings > Subpage Header, and enable the subpage header.
4. View a subpage; note the menu toggle is still there, and the menu it opens is empty:

![image](https://user-images.githubusercontent.com/177561/83670876-b04a0e00-a588-11ea-97a4-79078634bb48.png)

![image](https://user-images.githubusercontent.com/177561/83670898-b63fef00-a588-11ea-80ff-b7e1a02b4828.png)

5. Apply the PR.
6. Confirm that the menu toggle is now not showing:

![image](https://user-images.githubusercontent.com/177561/83671043-e7b8ba80-a588-11ea-8d2f-095da5be1921.png)

7. Try adding a menu to the primary, secondary, or tertiary location, and confirm the toggle shows up.
8. Remove the menu; try enabling and populating the slideout sidebar, and confirm the toggle shows up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
