### PR TITLE
Fix $content_width setting in theme

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -324,7 +324,7 @@ function newspack_content_width() {
 	// This variable is intended to be overruled from themes.
 	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', 960 );
+	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', 1200 );
 }
 add_action( 'after_setup_theme', 'newspack_content_width', 0 );
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -321,12 +321,18 @@ add_action( 'widgets_init', 'newspack_widgets_init' );
  * @global int $content_width Content width.
  */
 function newspack_content_width() {
+	$content_width = 780;
+
+	// Check if front page or using One-Column Wide template
+	if ( ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) || is_page_template( 'single-wide.php' ) ) {
+		$content_width = 1200;
+	}
 	// This variable is intended to be overruled from themes.
 	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', 1200 );
+	$GLOBALS['content_width'] = apply_filters( 'newspack_content_width', $content_width );
 }
-add_action( 'after_setup_theme', 'newspack_content_width', 0 );
+add_action( 'template_redirect', 'newspack_content_width', 0 );
 
 /**
  * Enqueue scripts and styles.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As part of the work for https://github.com/Automattic/newspack-blocks/pull/503, I realized the theme has the incorrect `$content_width`. It's currently set to 960; for the homepage and one-column wide templates, it should be set to 1200; for regular templates it should be set to 780.

$content_width isn't really used with Gutenberg, but I noticed when switching the Newspack Block to not include image sizes, and when Photon was disabled, the 'Large' image size fallback was only up to 960px wide. So this update should fix that.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Confirm that the homepage, regular posts, and a post with the one-column wide template don't throw templates.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
