### PR TITLE
Fallback to author if coauthors fails

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -12,7 +12,7 @@ if ( false === get_theme_mod( 'show_author_bio', true ) ) {
 
 $author_bio_length = get_theme_mod( 'author_bio_length', 200 );
 
-if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
+if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_coauthors() ) ) : // phpcs:ignore PHPCompatibility.LanguageConstructs.NewEmptyNonVariable.Found
 
 	$authors      = get_coauthors();
 	$author_count = count( $authors );

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -60,7 +60,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 	 */
 	function newspack_posted_by() {
 
-		if ( function_exists( 'coauthors_posts_links' ) ) :
+		if ( function_exists( 'coauthors_posts_links' ) && ! empty( get_coauthors() ) ) : // phpcs:ignore PHPCompatibility.LanguageConstructs.NewEmptyNonVariable.Found
 
 			$authors      = get_coauthors();
 			$author_count = count( $authors );

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -13,7 +13,7 @@ if ( false === get_theme_mod( 'show_author_bio', true ) ) {
 
 $author_bio_length = get_theme_mod( 'author_bio_length', 200 );
 
-if ( function_exists( 'coauthors_posts_links' ) && is_single() ) :
+if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_coauthors() ) ) : // phpcs:ignore PHPCompatibility.LanguageConstructs.NewEmptyNonVariable.Found
 
 	$authors      = get_coauthors();
 	$author_count = count( $authors );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue I noticed on BDN. On some historic posts, `get_coauthors()` would return an empty array. I haven't figured out the exact cause why, but it's likely old metadata with the same key or something like that.

This PR adds a fall back to display the regular post author if `get_coauthors()` doesn't return anything.

The `phpcs:ignore` statements are there because the linter was complaining about PHP <5.5, but that's below the WP minimum version at this point.

### How to test the changes in this Pull Request:

1. Add the following somewhere: `add_filter( 'get_coauthors', '__return_empty_array' );`
2. Visit a post, observe there is "By {nobody}" displayed:
<img width="454" alt="Screen Shot 2020-06-15 at 6 38 49 PM" src="https://user-images.githubusercontent.com/7317227/84722711-d6808e00-af38-11ea-9873-64a48d8072fe.png">

3. Apply this patch, observe the post author is displayed:
<img width="487" alt="Screen Shot 2020-06-15 at 6 39 08 PM" src="https://user-images.githubusercontent.com/7317227/84722744-eb5d2180-af38-11ea-8745-1dfa4f5fba5a.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
