### PR TITLE
Allow other post types to register featured image settings support

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -373,8 +373,20 @@ add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
  * - Article Subtitle
  */
 function newspack_enqueue_scripts() {
-	wp_enqueue_script( 'newspack-extend-featured-image-script', get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ), array( 'wp-blocks', 'wp-components' ), wp_get_theme()->get( 'Version' ) );
+	wp_register_script( 
+		'newspack-extend-featured-image-script',
+		get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ),
+		array( 'wp-blocks', 'wp-components' ),
+		rand().wp_get_theme()->get( 'Version' )
+	);
 	wp_set_script_translations( 'newspack-extend-featured-image-script', 'newspack', get_parent_theme_file_path( '/languages' ) );
+	wp_localize_script(
+		'newspack-extend-featured-image-script',
+		'newspack_theme_featured_image_post_types',
+		newspack_get_featured_image_post_types()
+	);
+
+	wp_enqueue_script( 'newspack-extend-featured-image-script' );
 
 	if ( 'post' === get_current_screen()->post_type ) {
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
@@ -556,15 +568,19 @@ add_filter( 'jetpack_photon_override_image_downsize', 'newspack_override_avatar_
  * - Article Subtitle
  */
 function newspack_register_meta() {
-	register_meta(
-		'post',
-		'newspack_featured_image_position',
-		array(
-			'show_in_rest' => true,
-			'single'       => true,
-			'type'         => 'string',
-		)
-	);
+	$featured_image_post_types = newspack_get_featured_image_post_types();
+
+	foreach ( $featured_image_post_types as $post_type ) {
+		register_post_meta(
+			$post_type,
+			'newspack_featured_image_position',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+			)
+		);
+	}
 
 	register_post_meta(
 		'post',
@@ -704,6 +720,15 @@ function newspack_sanitize_avatars() {
 	);
 
 	return $avatar_args;
+}
+
+/**
+ * Get post types that support featured image settings.
+ *
+ * @return array Array of post type slugs.
+ */
+function newspack_get_featured_image_post_types() {
+	return apply_filters( 'newspack_theme_featured_image_post_types', [ 'post' ] );
 }
 
 /**

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -377,7 +377,7 @@ function newspack_enqueue_scripts() {
 		'newspack-extend-featured-image-script',
 		get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ),
 		array( 'wp-blocks', 'wp-components' ),
-		rand().wp_get_theme()->get( 'Version' )
+		wp_get_theme()->get( 'Version' )
 	);
 	wp_set_script_translations( 'newspack-extend-featured-image-script', 'newspack', get_parent_theme_file_path( '/languages' ) );
 	wp_localize_script(
@@ -385,7 +385,6 @@ function newspack_enqueue_scripts() {
 		'newspack_theme_featured_image_post_types',
 		newspack_get_featured_image_post_types()
 	);
-
 	wp_enqueue_script( 'newspack-extend-featured-image-script' );
 
 	if ( 'post' === get_current_screen()->post_type ) {

--- a/newspack-theme/js/src/extend-featured-image-editor.js
+++ b/newspack-theme/js/src/extend-featured-image-editor.js
@@ -55,7 +55,8 @@ const wrapPostFeaturedImage = OriginalComponent => {
 	return props => {
 		const post_type = select( 'core/editor' ).getCurrentPostType();
 
-		if ( 'post' !== post_type ) {
+		// eslint-disable-next-line no-undef
+		if ( ! newspack_theme_featured_image_post_types.includes( post_type ) ) {
 			return <OriginalComponent { ...props } />;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This feature is related to my work with CalMatters, which has a couple custom post types. This PR adds a filter which lets people add other post types to the featured image setting options. With the exception of the 'page' post type, this works nicely because they just use the single template. After this PR we will be much closer to having those featured image settings available for Pages, though.

### How to test the changes in this Pull Request:

1. Add the following snippet somewhere: 
```
add_filter( 'newspack_theme_featured_image_post_types', function( $post_types ) {
	$post_types[] = 'page';
	return $post_types;
} );
```
2. Edit a Page. Observe the featured image settings are available. (The frontend template for Pages needs to handle the setting, though, so it won't be reflected on the frontend)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
