### PR TITLE
Menus: Close slide out menus when clicking overlays (non-AMP fallback)

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -96,7 +96,7 @@
 		mobileToggle[ i ].addEventListener(
 			'click',
 			function() {
-				if ( body.classList.contains( 'menu-opened' ) ) {
+				if ( body.classList.contains( 'mobile-menu-opened' ) ) {
 					closeMenu( 'mobile-menu-opened', mobileOpenButton, 'mask-mobile' );
 				} else {
 					openMenu( 'mobile-menu-opened', mobileCloseButton, 'mask-mobile' );

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -35,54 +35,93 @@
 		false
 	);
 
-	// Mobile menu fallback.
-	const menuToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
+	// Menu toggle variables.
+	const mobileToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
 		body = document.getElementsByTagName( 'body' )[ 0 ],
 		mobileSidebar = document.getElementById( 'mobile-sidebar-fallback' ),
-		menuOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
-		menuCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ];
+		mobileOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
+		mobileCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
+		desktopToggle = document.getElementsByClassName( 'desktop-menu-toggle' ),
+		desktopSidebar = document.getElementById( 'desktop-sidebar-fallback' ),
+		desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
+		desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
+		subpageToggle = document.getElementsByClassName( 'subpage-toggle' );
 
-	for ( let i = 0; i < menuToggle.length; i++ ) {
-		menuToggle[ i ].addEventListener(
+	/**
+	 * @description Creates semi-transparent overlay behind menus.
+	 * @param {string} maskId The ID to add to the div.
+	 */
+	function createOverlay( maskId ) {
+		const mask = document.createElement( 'div' );
+		mask.setAttribute( 'class', 'overlay-mask' );
+		mask.setAttribute( 'id', maskId );
+		document.body.appendChild( mask );
+	}
+
+	/**
+	 * @description Removes semi-transparent overlay behind menus.
+	 * @param {string} maskId The ID to use for the overlay.
+	 */
+	function removeOverlay( maskId ) {
+		const mask = document.getElementById( maskId );
+		mask.parentNode.removeChild( mask );
+	}
+
+	/**
+	 * @description Opens specifed slide-out menu.
+	 * @param {string} menuClass  The class to add to the body to toggle menu visibility.
+	 * @param {string} openButton The button used to open the menu.
+	 * @param {string} maskId     The ID to use for the overlay.
+	 */
+	function openMenu( menuClass, openButton, maskId ) {
+		body.classList.add( menuClass );
+		openButton.focus();
+		createOverlay( maskId );
+	}
+
+	/**
+	 * @description Closes specifed slide-out menu.
+	 * @param {string} menuClass  The class to remove from the body to toggle menu visibility.
+	 * @param {string} openButton The button used to open the menu.
+	 * @param {string} maskId The ID to use for the overlay.
+	 */
+	function closeMenu( menuClass, openButton, maskId ) {
+		body.classList.remove( menuClass );
+		openButton.focus();
+		removeOverlay( maskId );
+	}
+
+	// Mobile menu fallback.
+	for ( let i = 0; i < mobileToggle.length; i++ ) {
+		mobileToggle[ i ].addEventListener(
 			'click',
 			function() {
 				if ( body.classList.contains( 'menu-opened' ) ) {
-					body.classList.remove( 'menu-opened' );
-					menuOpenButton.focus();
+					closeMenu( 'mobile-menu-opened', mobileOpenButton, 'mask-mobile' );
 				} else {
-					body.classList.add( 'menu-opened' );
-					menuCloseButton.focus();
+					openMenu( 'mobile-menu-opened', mobileCloseButton, 'mask-mobile' );
 				}
 			},
 			false
 		);
 	}
 
-	// Desktop menu fallback.
-	const desktopToggle = document.getElementsByClassName( 'desktop-menu-toggle' ),
-		desktopSidebar = document.getElementById( 'desktop-sidebar-fallback' ),
-		desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
-		desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ];
-
+	// Desktop menu (AKA slide-out sidebar) fallback.
 	for ( let i = 0; i < desktopToggle.length; i++ ) {
 		desktopToggle[ i ].addEventListener(
 			'click',
 			function() {
 				if ( body.classList.contains( 'desktop-menu-opened' ) ) {
-					body.classList.remove( 'desktop-menu-opened' );
-					desktopOpenButton.focus();
+					closeMenu( 'desktop-menu-opened', desktopOpenButton, 'mask-desktop' );
 				} else {
-					body.classList.add( 'desktop-menu-opened' );
-					desktopCloseButton.focus();
+					openMenu( 'desktop-menu-opened', desktopCloseButton, 'mask-desktop' );
 				}
 			},
 			false
 		);
 	}
 
-	// 'Sub page' menu fallback.
-	const subpageToggle = document.getElementsByClassName( 'subpage-toggle' );
-
+	// 'Subpage' menu fallback.
 	if ( 0 < subpageToggle.length ) {
 		const subpageSidebar = document.getElementById( 'subpage-sidebar-fallback' ),
 			subpageOpenButton = headerContain.getElementsByClassName( 'subpage-toggle' )[ 0 ],
@@ -92,18 +131,27 @@
 			subpageToggle[ i ].addEventListener(
 				'click',
 				function() {
-					if ( body.classList.contains( 'subpage-sidebar-opened' ) ) {
-						body.classList.remove( 'subpage-sidebar-opened' );
-						subpageOpenButton.focus();
+					if ( body.classList.contains( 'subpage-menu-opened' ) ) {
+						closeMenu( 'subpage-menu-opened', subpageOpenButton, 'mask-subpage' );
 					} else {
-						body.classList.add( 'subpage-sidebar-opened' );
-						subpageCloseButton.focus();
+						openMenu( 'subpage-menu-opened', subpageCloseButton, 'mask-subpage' );
 					}
 				},
 				false
 			);
 		}
 	}
+
+	// Add listener to the menu overlays, so they can be closed on click.
+	document.addEventListener( 'click', function( e ) {
+		if ( e.target && e.target.className === 'overlay-mask' ) {
+			const maskId = e.target.id;
+			const menu = maskId.split( '-' );
+
+			body.classList.remove( menu[ 1 ] + '-menu-opened' );
+			removeOverlay( maskId );
+		}
+	} );
 
 	// Comments toggle fallback.
 	const commentsToggle = document.getElementById( 'comments-toggle' );

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -277,7 +277,7 @@
 }
 
 .desktop-menu-opened #desktop-sidebar-fallback,
-.subpage-sidebar-opened #subpage-sidebar-fallback {
+.subpage-menu-opened #subpage-sidebar-fallback {
 	left: 0;
 }
 
@@ -287,13 +287,13 @@
 	transition: right 0.2s;
 }
 
-.menu-opened #mobile-sidebar-fallback {
+.mobile-menu-opened #mobile-sidebar-fallback {
 	right: 0;
 }
 
-.menu-opened #mobile-sidebar-fallback,
+.mobile-menu-opened #mobile-sidebar-fallback,
 .desktop-menu-opened #desktop-sidebar-fallback,
-.subpage-sidebar-opened #subpage-sidebar-fallback {
+.subpage-menu-opened #subpage-sidebar-fallback {
 	> * {
 		display: block;
 	}
@@ -305,10 +305,8 @@
 	}
 }
 
-.menu-opened::after,
-.desktop-menu-opened::after,
-.subpage-sidebar-opened::after {
-	background-color: rgba( 0, 0, 0, 0.2 );
+.overlay-mask {
+	background-color: rgba( 0, 0, 0, 0.5 );
 	bottom: 0;
 	content: '';
 	left: 0;

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -313,5 +313,5 @@
 	position: fixed;
 	right: 0;
 	top: 0;
-	z-index: 99;
+	z-index: 999998;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now if you click on the overlay for the mobile menu, subpage menu or slideout sidebar, the menu will close, but only when you're using AMP. This PR adds the same functionality to the AMP fallback version of the menu.

It also reworks the JS a bit to reduce duplication, and darkens the overlay used for the non-AMP version, to match the opacity of the AMP version. 

Closes #973.

### How to test the changes in this Pull Request:

1. Navigate to Customize > Header Settings, and turn on Slide-out Sidebar and the Subpage Header, and make sure both -- plus the primary menu -- are populated. 
2. Turn off AMP or switch it to transitional, so you can view the non-AMP version of the site. 
3. Apply the PR and run `npm run build`.
4. Test each of the menus; make sure you can open and close them as usual using the Menu/Close toggles.
5. Open each menu, and click on the overlay; verify that this now also closes the menus. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
