### PR TITLE
Group Block: remove space between group blocks with backgrounds

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -842,6 +842,10 @@
 				margin-bottom: 0;
 			}
 		}
+
+		&.has-background + .wp-block-group.has-background {
+			margin-top: -32px;
+		}
 	}
 
 	//! Font Sizes


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes space between two stack group blocks with background colours, to match what happens in the editor and to allow for more interesting layouts. 

Closes #983.

### How to test the changes in this Pull Request:

1. Add two group blocks to a page or post, and give them background colours.
2. View on the front-end and note they're spaced out:

![image](https://user-images.githubusercontent.com/177561/85455786-21129380-b553-11ea-9f82-ce70b3bcda66.png)

3. Apply PR and run `npm run build`.
4. Confirm that the group blocks now don't have space between them, like in the editor:

![image](https://user-images.githubusercontent.com/177561/85455624-f1fc2200-b552-11ea-8377-d2040357f1f0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
