### PR TITLE
feat: default post template selection

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -373,7 +373,7 @@ add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
  * - Article Subtitle
  */
 function newspack_enqueue_scripts() {
-	wp_register_script( 
+	wp_register_script(
 		'newspack-extend-featured-image-script',
 		get_theme_file_uri( '/js/dist/extend-featured-image-editor.js' ),
 		array( 'wp-blocks', 'wp-components' ),
@@ -891,6 +891,23 @@ function newspack_child_theme_deprecation_notification() {
 	<?php
 }
 add_action( 'admin_notices', 'newspack_child_theme_deprecation_notification' );
+
+/**
+ * When new post is created, maybe set the post template.
+ *
+ * @param integer $post_ID The post ID.
+ * @param WP_Post $post Post object.
+ * @param boolean $update Whether this is an existing post being updated or not.
+ */
+function newspack_maybe_set_default_post_template( $post_ID, $post, $update ) {
+	if ( ! $update && 'post' === $post->post_type ) {
+		$post_template_default = get_theme_mod( 'post_template_default' );
+		if ( 'default' !== $post_template_default ) {
+			update_post_meta( $post_ID, '_wp_page_template', $post_template_default );
+		}
+	}
+}
+add_action( 'wp_insert_post', 'newspack_maybe_set_default_post_template', 10, 3 );
 
 /**
  * SVG Icons class.

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -509,12 +509,12 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	/**
-	 * Featured Image settings
+	 * Default Post Settings
 	 */
 	$wp_customize->add_section(
-		'featured_image_options',
+		'post_default_settings',
 		array(
-			'title' => esc_html__( 'Featured Image Settings', 'newspack' ),
+			'title' => esc_html__( 'Post Defaults', 'newspack' ),
 		)
 	);
 
@@ -538,7 +538,29 @@ function newspack_customize_register( $wp_customize ) {
 				'beside' => esc_html__( 'Beside article title', 'newspack' ),
 				'hidden' => esc_html__( 'Hidden', 'newspack' ),
 			),
-			'section' => 'featured_image_options',
+			'section' => 'post_default_settings',
+		)
+	);
+
+	// Add option to select the default post template
+	$wp_customize->add_setting(
+		'post_template_default',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_post_template',
+		)
+	);
+	$wp_customize->add_control(
+		'post_template_default',
+		array(
+			'type'    => 'select',
+			'label'   => __( 'Default Post Template', 'newspack' ),
+			'choices' => array(
+				'default'            => esc_html__( 'Default Template', 'newspack' ),
+				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
+				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
+			),
+			'section' => 'post_default_settings',
 		)
 	);
 
@@ -920,6 +942,26 @@ function newspack_sanitize_feature_image_position( $choice ) {
 	}
 
 	return 'large';
+}
+
+/**
+ * Sanitize post template.
+ *
+ * @param string $choice Post template file name.
+ *
+ * @return string
+ */
+function newspack_sanitize_post_template( $choice ) {
+	$valid = array(
+		'single-feature.php',
+		'single-wide.php',
+	);
+
+	if ( in_array( $choice, $valid, true ) ) {
+		return $choice;
+	}
+
+	return 'default';
 }
 
 /**

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -509,12 +509,12 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	/**
-	 * Default Post Settings
+	 * Template Settings
 	 */
 	$wp_customize->add_section(
 		'post_default_settings',
 		array(
-			'title' => esc_html__( 'Post Defaults', 'newspack' ),
+			'title' => esc_html__( 'Template Settings', 'newspack' ),
 		)
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a setting to the Customizer to select the default Post template. The selected template will be set whenever a new Post is created. The change will have no impact on existing Posts. The new option is in the same section as Featured Image Default Position, and the section has been renamed to Post Defaults. Even though Featured Image Default Position uses radio buttons, I opted for a Select to match the UI in the Post editor. 

Closes https://github.com/Automattic/newspack-theme/issues/624

### How to test the changes in this Pull Request:

1. Navigate to Customizer->Post Defaults, select One Column or One Column Wide Default Post Template.
2. Create a new Post. Observe the Post template is set to the selected default. Verify the styling in the editor is correct for that template.
3. Edit an older post, observe the template has not changed to the new selection.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
