### PR TITLE
Header: Add mobile CTA button

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -68,6 +68,11 @@ body {
 	}
 }
 
+// Mobile CTA
+.button.mb-cta {
+	border-radius: 0;
+}
+
 // Yoast Breadcrumbs
 .site-breadcrumb {
 	border-bottom: 1px solid;

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -58,6 +58,11 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
+// Mobile CTA
+.button.mb-cta {
+	border-radius: 0;
+}
+
 // Accent headers
 
 .accent-header,

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -90,6 +90,11 @@ body:not( .h-sb ) .site-header {
 	border-bottom: 0;
 }
 
+// Mobile CTA
+.button.mb-cta {
+	border-radius: 0;
+}
+
 // Featured templates - Short header on subpages
 .single-featured-image-beside,
 .single-featured-image-behind {

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -74,6 +74,11 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
+// Mobile CTA
+.button.mb-cta {
+	border-radius: 0;
+}
+
 // Accent headers
 .accent-header,
 .article-section-title,

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -41,6 +41,11 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
+// Mobile CTA
+.button.mb-cta {
+	border-radius: 0;
+}
+
 .accent-header,
 .wp-block-columns .wp-block-column > .accent-header,
 .entry .wpnbha .article-section-title {

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -426,7 +426,7 @@ function newspack_editor_customizer_styles() {
 
 	// Check for color or font customizations.
 	$theme_customizations = '';
-	if ( 'custom' === get_theme_mod( 'theme_colors' ) ) {
+	if ( 'custom' === get_theme_mod( 'theme_colors' ) || newspack_get_mobile_cta_color() !== get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 		$theme_customizations .= newspack_custom_colors_css();

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -597,7 +597,7 @@ add_action( 'after_switch_theme', 'newspack_migrate_settings', 10, 2 );
 function newspack_colors_css_wrap() {
 
 	// Only bother if we haven't customized the color.
-	if ( ( ! is_customize_preview() && 'default' === get_theme_mod( 'theme_colors', 'default' ) ) || is_admin() ) {
+	if ( ( ! is_customize_preview() && ( 'default' === get_theme_mod( 'theme_colors', 'default' ) || newspack_get_mobile_cta_color() === get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() ) ) ) || is_admin() ) {
 		return;
 	}
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -426,7 +426,7 @@ function newspack_editor_customizer_styles() {
 
 	// Check for color or font customizations.
 	$theme_customizations = '';
-	if ( 'custom' === get_theme_mod( 'theme_colors' ) || newspack_get_mobile_cta_color() !== get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() ) ) {
+	if ( 'custom' === get_theme_mod( 'theme_colors' ) || newspack_get_mobile_cta_color() !== get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 		$theme_customizations .= newspack_custom_colors_css();
@@ -597,7 +597,7 @@ add_action( 'after_switch_theme', 'newspack_migrate_settings', 10, 2 );
 function newspack_colors_css_wrap() {
 
 	// Only bother if we haven't customized the color.
-	if ( ( ! is_customize_preview() && ( 'default' === get_theme_mod( 'theme_colors', 'default' ) || newspack_get_mobile_cta_color() === get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() ) ) ) || is_admin() ) {
+	if ( ( ! is_customize_preview() && ( 'default' === get_theme_mod( 'theme_colors', 'default' ) && newspack_get_mobile_cta_color() === get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() ) ) ) || is_admin() ) {
 		return;
 	}
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -426,7 +426,7 @@ function newspack_editor_customizer_styles() {
 
 	// Check for color or font customizations.
 	$theme_customizations = '';
-	if ( 'custom' === get_theme_mod( 'theme_colors' ) || newspack_get_mobile_cta_color() !== get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() ) ) {
+	if ( 'custom' === get_theme_mod( 'theme_colors' ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
 		$theme_customizations .= newspack_custom_colors_css();

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -61,7 +61,7 @@ endif;
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+							<span><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
 						</button>
 					<?php endif; ?>
 
@@ -195,7 +195,7 @@ endif;
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-							<?php esc_html_e( 'Menu', 'newspack' ); ?>
+							<span><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
 						</button>
 					<?php endif; ?>
 

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -56,6 +56,8 @@ endif;
 
 					<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 
+					<?php newspack_mobile_cta(); ?>
+
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
@@ -187,6 +189,8 @@ endif;
 							endif;
 						?>
 					</div><!-- .nav-wrapper -->
+
+					<?php newspack_mobile_cta(); ?>
 
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -34,6 +34,7 @@ function newspack_custom_colors_css() {
 
 	$theme_css = '';
 
+	// Front-end colors that require the theme_colors to be set to 'custom':
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$theme_css .= '
 			/* Set primary background color */
@@ -318,7 +319,7 @@ function newspack_custom_colors_css() {
 		}
 	}
 
-	/* Set Mobile CTA Colors */
+	// Front-end colors that don't require the theme_colors to be set to 'custom':
 	if ( newspack_get_mobile_cta_color() !== $cta_color ) {
 		$theme_css .= '
 			.button.mb-cta,

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -10,16 +10,21 @@
  */
 function newspack_custom_colors_css() {
 
-	$primary_color   = get_theme_mod( 'primary_color_hex', newspack_get_primary_color() );
-	$secondary_color = get_theme_mod( 'secondary_color_hex', newspack_get_secondary_color() );
-	$cta_color       = get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() );
+	$primary_color   = newspack_get_primary_color();
+	$secondary_color = newspack_get_secondary_color();
+	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
 
-	if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-		$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-		$header_color_contrast = newspack_get_color_contrast( $header_color );
-	} else {
-		$header_color          = $primary_color;
-		$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
+		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
+		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color          = $primary_color;
+			$header_color_contrast = newspack_get_color_contrast( $primary_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -29,7 +34,6 @@ function newspack_custom_colors_css() {
 
 	$theme_css = '
 		/* Set primary background color */
-
 		.mobile-sidebar,
 		/* Header default background; header default height */
 		body.h-db.h-dh .site-header .nav3 .menu-highlight a,

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -12,10 +12,12 @@ function newspack_custom_colors_css() {
 
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
+	$cta_color       = newspack_get_mobile_cta_color();
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+		$cta_color       = get_theme_mod( 'mobile_cta_hex', $cta_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
@@ -29,6 +31,7 @@ function newspack_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$cta_color_contrast       = newspack_get_color_contrast( $cta_color );
 
 	$theme_css = '
 		/* Set primary background color */
@@ -215,6 +218,12 @@ function newspack_custom_colors_css() {
 		.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
 		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
 			color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+		}
+
+		/* Set Mobile CTA Colors */
+		.button.mb-cta {
+			background-color: ' . esc_html( $cta_color ) . ';
+			color: ' . esc_html( $cta_color_contrast ) . ';
 		}
 		';
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -32,204 +32,53 @@ function newspack_custom_colors_css() {
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$cta_color_contrast       = newspack_get_color_contrast( $cta_color );
 
-	$theme_css = '
-		/* Set primary background color */
-		.mobile-sidebar,
-		/* Header default background; header default height */
-		body.h-db.h-dh .site-header .nav3 .menu-highlight a,
-		.entry .entry-content .has-primary-background-color,
-		.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
-		.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
-		.entry .entry-content .wp-block-file .wp-block-file__button,
-		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
-		.comment .comment-author .post-author-badge {
-			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
-		}
+	$theme_css = '';
 
-		@media only screen and (min-width: 782px) {
-			/* Header default background */
-			.h-db .featured-image-beside {
-				background-color: ' . esc_html( $primary_color ) . ';
-			}
-		}
-
-		/* Set primary color that contrasts against white */
-		.entry .entry-content .more-link:hover,
-		.nav1 .main-menu > li > a + svg,
-		.search-form button:active, .search-form button:hover, .search-form button:focus,
-		.entry-footer a,
-		.comment .comment-metadata > a:hover,
-		.comment .comment-metadata .comment-edit-link:hover,
-		.site-info a:hover,
-		.comments-toggle:hover, .comments-toggle:focus {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-		}
-
-		/* Set primary color */
-
-		.entry .entry-content .has-primary-color,
-		.entry .entry-content *[class^="wp-block-"] .has-primary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
-		.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-color:not(:hover), /* legacy styles */
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
-			color: ' . esc_html( $primary_color ) . ';
-		}
-
-		.mobile-sidebar,
-		.mobile-sidebar button:hover,
-		.mobile-sidebar a,
-		.mobile-sidebar a:visited,
-		.mobile-sidebar .nav1 .sub-menu > li > a,
-		.mobile-sidebar .nav1 ul.main-menu > li > a,
-		.site-header .nav1 .sub-menu a:hover,
-		.site-header .nav1 .sub-menu a:focus,
-		.site-header .nav1 .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
-		.site-header .nav1 .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
-		.highlight-menu .menu-label,
-		/* Header default background; default height */
-		body.h-db.h-dh .site-header .nav3 .menu-highlight a,
-		.comment .comment-author .post-author-badge,
-		.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
-			color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-
-		@media only screen and (min-width: 782px) {
-			/* Header default background */
-			.h-db .featured-image-beside .entry-header,
-			.h-db.h-sub.single-featured-image-beside .middle-header-contain {
-				color: ' . esc_html( $primary_color_contrast ) . ';
-			}
-		}
-
-		/* Set primary border color */
-
-		blockquote,
-		.entry .entry-content blockquote,
-		.entry .entry-content .wp-block-quote:not(.is-large),
-		.entry .entry-content .wp-block-quote:not(.is-style-large) {
-			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
-		}
-
-		.mobile-sidebar nav + nav,
-		.mobile-sidebar nav + .widget,
-		.mobile-sidebar .widget + .widget {
-			border-color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-
-		.gallery-item > div > a:focus {
-			box-shadow: 0 0 0 2px ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
-		}
-
-		/* Set secondary background color */
-
-		.entry .entry-content .wp-block-button__link:not(.has-background),
-		.button, button, input[type="button"], input[type="reset"], input[type="submit"],
-		.entry .entry-content .has-secondary-background-color,
-		.entry .entry-content *[class^="wp-block-"].has-secondary-background-color,
-		.entry .entry-content *[class^="wp-block-"] .has-secondary-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
-			background-color:' . esc_html( $secondary_color ) . '; /* base: #666 */
-		}
-
-		/* Set colour that contrasts against the secondary background */
-		.entry .entry-content .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background),
-		.button, .button:visited, .entry .entry-content .button, .entry .entry-content .button:visited, button, input[type="button"], input[type="reset"], input[type="submit"] {
-			color: ' . esc_html( $secondary_color_contrast ) . ';
-		}
-
-		/* Set secondary color */
-
-		.entry .entry-content .has-secondary-color,
-		.entry .entry-content *[class^="wp-block-"] .has-secondary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
-		.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-color:not(:hover), /* legacy styles */
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
-			color:' . esc_html( $secondary_color ) . '; /* base: #666 */
-		}
-
-		/* Set secondary color with contrast */
-		.site-header .highlight-menu .menu-label,
-		.entry-content a,
-		.author-bio .author-link,
-		.entry .entry-content .is-style-outline .wp-block-button__link, /* legacy selector */
-		.entry .entry-content .wp-block-button__link.is-style-outline {
-			color:' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
-		}
-
-		/* Set primary variation background color */
-
-		.site-header .nav1 .sub-menu > li > a:hover,
-		.site-header .nav1 .sub-menu > li > a:focus,
-		.site-header .nav1 .sub-menu > li > a:hover:after,
-		.site-header .nav1 .sub-menu > li > a:focus:after,
-		.site-header .nav1 .sub-menu > li > .menu-item-link-return:hover,
-		.site-header .nav1 .sub-menu > li > .menu-item-link-return:focus,
-		.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):hover,
-		.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):focus,
-		.entry .entry-content .has-primary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color  {
-			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . '; /* base: #005177; */
-		}
-
-		/* Set primary variation color */
-
-		.author-bio .author-description .author-link:hover,
-		.entry .entry-content .has-primary-variation-color,
-		.entry .entry-content *[class^="wp-block-"] .has-primary-variation-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color p,
-		.comment .comment-author .fn a:hover,
-		.comment-reply-link:hover,
-		.comment-reply-login:hover,
-		.comment-navigation .nav-previous a:hover,
-		.comment-navigation .nav-next a:hover,
-		#cancel-comment-reply-link:hover,
-		.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-variation-color:not(:hover), /* legacy styles */
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-variation-color:not(:hover) {
-			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
-		}
-
-		/* Set secondary variation background color */
-
-		.entry .entry-content .has-secondary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].has-secondary-variation-ackground-color,
-		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-background-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color {
-			background-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
-		}
-
-		/* Set secondary variation color */
-
-		.entry-content a:hover,
-		.widget a:hover,
-		.author-bio .author-link:hover,
-		.entry .entry-content .has-secondary-variation-color,
-		.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
-		.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p,
-		.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
-		.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
-			color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
-		}
-
-		/* Set Mobile CTA Colors */
-		.button.mb-cta,
-		.button.mb-cta:not(:hover):visited {
-			background-color: ' . esc_html( $cta_color ) . ';
-			color: ' . esc_html( $cta_color_contrast ) . ';
-		}
-		';
-
-	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$theme_css .= '
-			.mobile-sidebar {
-				background: ' . esc_html( $header_color ) . ';
+			/* Set primary background color */
+			.mobile-sidebar,
+			/* Header default background; header default height */
+			body.h-db.h-dh .site-header .nav3 .menu-highlight a,
+			.entry .entry-content .has-primary-background-color,
+			.entry .entry-content *[class^="wp-block-"].has-primary-background-color,
+			.entry .entry-content *[class^="wp-block-"] .has-primary-background-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
+			.entry .entry-content .wp-block-file .wp-block-file__button,
+			.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
+			.comment .comment-author .post-author-badge {
+				background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+			}
+
+			@media only screen and (min-width: 782px) {
+				/* Header default background */
+				.h-db .featured-image-beside {
+					background-color: ' . esc_html( $primary_color ) . ';
+				}
+			}
+
+			/* Set primary color that contrasts against white */
+			.entry .entry-content .more-link:hover,
+			.nav1 .main-menu > li > a + svg,
+			.search-form button:active, .search-form button:hover, .search-form button:focus,
+			.entry-footer a,
+			.comment .comment-metadata > a:hover,
+			.comment .comment-metadata .comment-edit-link:hover,
+			.site-info a:hover,
+			.comments-toggle:hover, .comments-toggle:focus {
+				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+			}
+
+			/* Set primary color */
+
+			.entry .entry-content .has-primary-color,
+			.entry .entry-content *[class^="wp-block-"] .has-primary-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
+			.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-color:not(:hover), /* legacy styles */
+			.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
+				color: ' . esc_html( $primary_color ) . ';
 			}
 
 			.mobile-sidebar,
@@ -237,89 +86,249 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar a,
 			.mobile-sidebar a:visited,
 			.mobile-sidebar .nav1 .sub-menu > li > a,
-			.mobile-sidebar .nav1 ul.main-menu > li > a {
-				color: ' . esc_html( $header_color_contrast ) . ';
+			.mobile-sidebar .nav1 ul.main-menu > li > a,
+			.site-header .nav1 .sub-menu a:hover,
+			.site-header .nav1 .sub-menu a:focus,
+			.site-header .nav1 .sub-menu > li.menu-item-has-children a:hover + .submenu-expand,
+			.site-header .nav1 .sub-menu > li.menu-item-has-children a:focus + .submenu-expand,
+			.highlight-menu .menu-label,
+			/* Header default background; default height */
+			body.h-db.h-dh .site-header .nav3 .menu-highlight a,
+			.comment .comment-author .post-author-badge,
+			.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
+				color: ' . esc_html( $primary_color_contrast ) . ';
 			}
-		';
-	}
 
-	if ( ! is_child_theme() ) {
-		$theme_css .= '
-			.mobile-sidebar .nav3 a {
-				background: transparent;
+			@media only screen and (min-width: 782px) {
+				/* Header default background */
+				.h-db .featured-image-beside .entry-header,
+				.h-db.h-sub.single-featured-image-beside .middle-header-contain {
+					color: ' . esc_html( $primary_color_contrast ) . ';
+				}
 			}
-			.mobile-sidebar .nav3 .menu-highlight a {
-				background: ' . esc_html( newspack_adjust_brightness( $primary_color, -20 ) ) . ';
+
+			/* Set primary border color */
+
+			blockquote,
+			.entry .entry-content blockquote,
+			.entry .entry-content .wp-block-quote:not(.is-large),
+			.entry .entry-content .wp-block-quote:not(.is-style-large) {
+				border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 			}
-			.cat-links a,
-			.cat-links a:visited,
-			.site-header .nav3 .menu-highlight a {
-				background-color: ' . esc_html( $primary_color ) . ';
-				color: ' . esc_html( $primary_color_contrast ) . ';
+
+			.mobile-sidebar nav + nav,
+			.mobile-sidebar nav + .widget,
+			.mobile-sidebar .widget + .widget {
+				border-color: ' . esc_html( $primary_color_contrast ) . ';
 			}
-			.cat-links a:hover {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-				color: ' . esc_html( $primary_color_contrast ) . ';
+
+			.gallery-item > div > a:focus {
+				box-shadow: 0 0 0 2px ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 			}
-			.accent-header, .article-section-title,
-			.entry .entry-footer a:hover {
-				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+
+			/* Set secondary background color */
+
+			.entry .entry-content .wp-block-button__link:not(.has-background),
+			.button, button, input[type="button"], input[type="reset"], input[type="submit"],
+			.entry .entry-content .has-secondary-background-color,
+			.entry .entry-content *[class^="wp-block-"].has-secondary-background-color,
+			.entry .entry-content *[class^="wp-block-"] .has-secondary-background-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-background-color {
+				background-color:' . esc_html( $secondary_color ) . '; /* base: #666 */
 			}
-		';
+
+			/* Set colour that contrasts against the secondary background */
+			.entry .entry-content .wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-background),
+			.button, .button:visited, .entry .entry-content .button, .entry .entry-content .button:visited, button, input[type="button"], input[type="reset"], input[type="submit"] {
+				color: ' . esc_html( $secondary_color_contrast ) . ';
+			}
+
+			/* Set secondary color */
+
+			.entry .entry-content .has-secondary-color,
+			.entry .entry-content *[class^="wp-block-"] .has-secondary-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
+			.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-color:not(:hover), /* legacy styles */
+			.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
+				color:' . esc_html( $secondary_color ) . '; /* base: #666 */
+			}
+
+			/* Set secondary color with contrast */
+			.site-header .highlight-menu .menu-label,
+			.entry-content a,
+			.author-bio .author-link,
+			.entry .entry-content .is-style-outline .wp-block-button__link, /* legacy selector */
+			.entry .entry-content .wp-block-button__link.is-style-outline {
+				color:' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
+			}
+
+			/* Set primary variation background color */
+
+			.site-header .nav1 .sub-menu > li > a:hover,
+			.site-header .nav1 .sub-menu > li > a:focus,
+			.site-header .nav1 .sub-menu > li > a:hover:after,
+			.site-header .nav1 .sub-menu > li > a:focus:after,
+			.site-header .nav1 .sub-menu > li > .menu-item-link-return:hover,
+			.site-header .nav1 .sub-menu > li > .menu-item-link-return:focus,
+			.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):hover,
+			.site-header .nav1 .sub-menu > li > a:not(.submenu-expand):focus,
+			.entry .entry-content .has-primary-variation-background-color,
+			.entry .entry-content *[class^="wp-block-"].has-primary-variation-background-color,
+			.entry .entry-content *[class^="wp-block-"] .has-primary-variation-background-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color  {
+				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . '; /* base: #005177; */
+			}
+
+			/* Set primary variation color */
+
+			.author-bio .author-description .author-link:hover,
+			.entry .entry-content .has-primary-variation-color,
+			.entry .entry-content *[class^="wp-block-"] .has-primary-variation-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-primary-variation-color p,
+			.comment .comment-author .fn a:hover,
+			.comment-reply-link:hover,
+			.comment-reply-login:hover,
+			.comment-navigation .nav-previous a:hover,
+			.comment-navigation .nav-next a:hover,
+			#cancel-comment-reply-link:hover,
+			.entry .entry-content .is-style-outline .wp-block-button__link.has-primary-variation-color:not(:hover), /* legacy styles */
+			.entry .entry-content .wp-block-button__link.is-style-outline.has-primary-variation-color:not(:hover) {
+				color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
+			}
+
+			/* Set secondary variation background color */
+
+			.entry .entry-content .has-secondary-variation-background-color,
+			.entry .entry-content *[class^="wp-block-"].has-secondary-variation-ackground-color,
+			.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-background-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color {
+				background-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+			}
+
+			/* Set secondary variation color */
+
+			.entry-content a:hover,
+			.widget a:hover,
+			.author-bio .author-link:hover,
+			.entry .entry-content .has-secondary-variation-color,
+			.entry .entry-content *[class^="wp-block-"] .has-secondary-variation-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color,
+			.entry .entry-content *[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p,
+			.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
+			.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
+				color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+			}
+			';
 
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
+				.mobile-sidebar {
+					background: ' . esc_html( $header_color ) . ';
+				}
+
+				.mobile-sidebar,
+				.mobile-sidebar button:hover,
+				.mobile-sidebar a,
+				.mobile-sidebar a:visited,
+				.mobile-sidebar .nav1 .sub-menu > li > a,
+				.mobile-sidebar .nav1 ul.main-menu > li > a {
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+			';
+		}
+
+		if ( ! is_child_theme() ) {
+			$theme_css .= '
+				.mobile-sidebar .nav3 a {
+					background: transparent;
+				}
 				.mobile-sidebar .nav3 .menu-highlight a {
-					background: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+					background: ' . esc_html( newspack_adjust_brightness( $primary_color, -20 ) ) . ';
 				}
-				.h-sb .site-header .nav3 a {
-					background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';
-					color: ' . esc_html( $header_color_contrast ) . ';
+				.cat-links a,
+				.cat-links a:visited,
+				.site-header .nav3 .menu-highlight a {
+					background-color: ' . esc_html( $primary_color ) . ';
+					color: ' . esc_html( $primary_color_contrast ) . ';
 				}
-				.h-sb .site-header .nav3 .menu-highlight a {
-					background-color: ' . $secondary_color . ';
-					color: ' . esc_html( $secondary_color_contrast ) . ';
+				.cat-links a:hover {
+					background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
+					color: ' . esc_html( $primary_color_contrast ) . ';
+				}
+				.accent-header, .article-section-title,
+				.entry .entry-footer a:hover {
+					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 				}
 			';
+
+			if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+				$theme_css .= '
+					.mobile-sidebar .nav3 .menu-highlight a {
+						background: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+					}
+					.h-sb .site-header .nav3 a {
+						background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';
+						color: ' . esc_html( $header_color_contrast ) . ';
+					}
+					.h-sb .site-header .nav3 .menu-highlight a {
+						background-color: ' . $secondary_color . ';
+						color: ' . esc_html( $secondary_color_contrast ) . ';
+					}
+				';
+			}
+		}
+
+		if ( ! is_child_theme() ) {
+			$theme_css .= '
+				.archive .page-title,
+				.entry-meta .byline a, .entry-meta .byline a:visited,
+				.entry .entry-content .entry-meta .byline a, .entry .entry-content .entry-meta .byline a:visited,
+				.entry .entry-meta a:hover {
+					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+				}
+			';
+
+			if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+				$theme_css .= '
+					/* Header solid background */
+					.h-sb .middle-header-contain {
+						background-color: ' . esc_html( $header_color ) . ';
+					}
+					.h-sb .top-header-contain {
+						background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
+						border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+					}
+					.h-sb .site-header,
+					.h-sb .site-title,
+					.h-sb .site-title a:link,
+					.h-sb .site-title a:visited,
+					.h-sb .site-description,
+					/* Header solid background; short height */
+					.h-sb.h-sh .site-header .nav1 .main-menu > li,
+					.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a,
+					.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a:hover,
+					.h-sb .top-header-contain,
+					.h-sb .middle-header-contain {
+						color: ' . esc_html( $header_color_contrast ) . ';
+					}
+				';
+			}
 		}
 	}
 
-	if ( ! is_child_theme() ) {
+	/* Set Mobile CTA Colors */
+	if ( newspack_get_mobile_cta_color() !== $cta_color ) {
 		$theme_css .= '
-			.archive .page-title,
-			.entry-meta .byline a, .entry-meta .byline a:visited,
-			.entry .entry-content .entry-meta .byline a, .entry .entry-content .entry-meta .byline a:visited,
-			.entry .entry-meta a:hover {
-				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+			.button.mb-cta,
+			.button.mb-cta:not(:hover):visited {
+				background-color: ' . esc_html( $cta_color ) . ';
+				color: ' . esc_html( $cta_color_contrast ) . ';
 			}
 		';
-
-		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
-			$theme_css .= '
-				/* Header solid background */
-				.h-sb .middle-header-contain {
-					background-color: ' . esc_html( $header_color ) . ';
-				}
-				.h-sb .top-header-contain {
-					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
-					border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
-				}
-				.h-sb .site-header,
-				.h-sb .site-title,
-				.h-sb .site-title a:link,
-				.h-sb .site-title a:visited,
-				.h-sb .site-description,
-				/* Header solid background; short height */
-				.h-sb.h-sh .site-header .nav1 .main-menu > li,
-				.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a,
-				.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a:hover,
-				.h-sb .top-header-contain,
-				.h-sb .middle-header-contain {
-					color: ' . esc_html( $header_color_contrast ) . ';
-				}
-			';
-		}
 	}
+
 
 	$editor_css = '
 		/*

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -10,22 +10,16 @@
  */
 function newspack_custom_colors_css() {
 
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
-	$cta_color       = newspack_get_mobile_cta_color();
+	$primary_color   = get_theme_mod( 'primary_color_hex', newspack_get_primary_color() );
+	$secondary_color = get_theme_mod( 'secondary_color_hex', newspack_get_secondary_color() );
+	$cta_color       = get_theme_mod( 'mobile_cta_hex', newspack_get_mobile_cta_color() );
 
-	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
-		$cta_color       = get_theme_mod( 'mobile_cta_hex', $cta_color );
-
-		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
-		} else {
-			$header_color          = $primary_color;
-			$header_color_contrast = newspack_get_color_contrast( $primary_color );
-		}
+	if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+		$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
+		$header_color_contrast = newspack_get_color_contrast( $header_color );
+	} else {
+		$header_color          = $primary_color;
+		$header_color_contrast = newspack_get_color_contrast( $primary_color );
 	}
 
 	// Set colour contrasts.
@@ -221,7 +215,8 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Set Mobile CTA Colors */
-		.button.mb-cta {
+		.button.mb-cta,
+		.button.mb-cta:not(:hover):visited {
 			background-color: ' . esc_html( $cta_color ) . ';
 			color: ' . esc_html( $cta_color_contrast ) . ';
 		}

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -247,7 +247,7 @@ function newspack_customize_register( $wp_customize ) {
 		'mobile_cta_text',
 		array(
 			'type'        => 'text',
-			'label'       => esc_html__( 'Mobile CTA Text', 'newspack' ),
+			'label'       => esc_html__( 'Button Text', 'newspack' ),
 			'description' => esc_html__( 'Text to use for the mobile call-to-action button.', 'newspack' ),
 			'section'     => 'header_section_donate',
 		)
@@ -265,8 +265,8 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'mobile_cta_page',
 		array(
-			'label'       => esc_html__( 'Mobile CTA Link', 'newspack' ),
-			'description' => esc_html__( 'Page the Donate CTA should link to.', 'newspack' ),
+			'label'       => esc_html__( 'Button Link', 'newspack' ),
+			'description' => esc_html__( 'Pick a page that the call-to-action button should link to.', 'newspack' ),
 			'type'        => 'dropdown-pages',
 			'section'     => 'header_section_donate',
 		)
@@ -286,7 +286,8 @@ function newspack_customize_register( $wp_customize ) {
 			$wp_customize,
 			'mobile_cta_hex',
 			array(
-				'description' => __( 'Apply a primary custom color.', 'newspack' ),
+				'label'       => esc_html__( 'Background Color', 'newspack' ),
+				'description' => __( 'Apply a custom background color to the Mobile CTA. Picking something different than your site\'s color palette will help it stand out more.', 'newspack' ),
 				'section'     => 'header_section_donate',
 			)
 		)

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -274,9 +274,9 @@ function newspack_customize_register( $wp_customize ) {
 
 	// Mobile CTA - button color.
 	$wp_customize->add_setting(
-		'mobile_cta_color',
+		'mobile_cta_hex',
 		array(
-			'default'           => '#dd3333',
+			'default'           => newspack_get_mobile_cta_color(),
 			'sanitize_callback' => 'sanitize_hex_color',
 		)
 	);
@@ -284,7 +284,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		new WP_Customize_Color_Control(
 			$wp_customize,
-			'mobile_cta_color',
+			'mobile_cta_hex',
 			array(
 				'description' => __( 'Apply a primary custom color.', 'newspack' ),
 				'section'     => 'header_section_donate',

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -230,7 +230,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Show Mobile CTA', 'newspack' ),
-			'description' => esc_html__( 'Show a call-to-action button in the mobile header that can be used to link to an important page, like for donations.', 'newspack' ),
+			'description' => esc_html__( 'Show an essential call-to-action button in the mobile header, that is always visible.', 'newspack' ),
 			'section'     => 'header_section_cta',
 		)
 	);
@@ -246,10 +246,9 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'header_cta_text',
 		array(
-			'type'        => 'text',
-			'label'       => esc_html__( 'Button Text', 'newspack' ),
-			'description' => esc_html__( 'Text to use for the mobile call-to-action button.', 'newspack' ),
-			'section'     => 'header_section_cta',
+			'type'    => 'text',
+			'label'   => esc_html__( 'Button Text', 'newspack' ),
+			'section' => 'header_section_cta',
 		)
 	);
 
@@ -265,10 +264,9 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'header_cta_url',
 		array(
-			'label'       => esc_html__( 'Button URL', 'newspack' ),
-			'description' => esc_html__( 'Add a webpage URL that the call-to-action button should link to.', 'newspack' ),
-			'type'        => 'text',
-			'section'     => 'header_section_cta',
+			'label'   => esc_html__( 'Button URL', 'newspack' ),
+			'type'    => 'text',
+			'section' => 'header_section_cta',
 		)
 	);
 
@@ -306,7 +304,7 @@ function newspack_customize_register( $wp_customize ) {
 			'header_cta_hex',
 			array(
 				'label'       => esc_html__( 'Background Color', 'newspack' ),
-				'description' => __( 'Apply a custom background color to the Mobile CTA. Picking something different than your site\'s color palette will help it stand out more.', 'newspack' ),
+				'description' => __( 'Selecting a strong, non-palette color is recommended to ensure the CTA stands out.', 'newspack' ),
 				'section'     => 'header_section_cta',
 			)
 		)

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -210,7 +210,7 @@ function newspack_customize_register( $wp_customize ) {
 	 * Header - Mobile Donate CTA
 	 */
 	$wp_customize->add_section(
-		'header_section_donate',
+		'header_section_cta',
 		array(
 			'title' => esc_html__( 'Mobile Call-to-Action', 'newspack' ),
 			'panel' => 'newspack_header_options',
@@ -219,43 +219,43 @@ function newspack_customize_register( $wp_customize ) {
 
 	// Mobile CTA - toggle on and off.
 	$wp_customize->add_setting(
-		'show_mobile_cta',
+		'show_header_cta',
 		array(
 			'default'           => false,
 			'sanitize_callback' => 'newspack_sanitize_checkbox',
 		)
 	);
 	$wp_customize->add_control(
-		'show_mobile_cta',
+		'show_header_cta',
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Show Mobile CTA', 'newspack' ),
 			'description' => esc_html__( 'Show a call-to-action button in the mobile header that can be used to link to an important page, like for donations.', 'newspack' ),
-			'section'     => 'header_section_donate',
+			'section'     => 'header_section_cta',
 		)
 	);
 
 	// Mobile CTA - button text.
 	$wp_customize->add_setting(
-		'mobile_cta_text',
+		'header_cta_text',
 		array(
 			'default'           => esc_html__( 'Donate', 'newspack' ),
 			'sanitize_callback' => 'sanitize_text_field',
 		)
 	);
 	$wp_customize->add_control(
-		'mobile_cta_text',
+		'header_cta_text',
 		array(
 			'type'        => 'text',
 			'label'       => esc_html__( 'Button Text', 'newspack' ),
 			'description' => esc_html__( 'Text to use for the mobile call-to-action button.', 'newspack' ),
-			'section'     => 'header_section_donate',
+			'section'     => 'header_section_cta',
 		)
 	);
 
 	// Mobile CTA - URL.
 	$wp_customize->add_setting(
-		'mobile_cta_page',
+		'header_cta_page',
 		array(
 			'default'           => 0,
 			'sanitize_callback' => 'newspack_sanitize_numeric_value',
@@ -263,18 +263,18 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	$wp_customize->add_control(
-		'mobile_cta_page',
+		'header_cta_page',
 		array(
 			'label'       => esc_html__( 'Button Link', 'newspack' ),
 			'description' => esc_html__( 'Pick a page that the call-to-action button should link to.', 'newspack' ),
 			'type'        => 'dropdown-pages',
-			'section'     => 'header_section_donate',
+			'section'     => 'header_section_cta',
 		)
 	);
 
 	// Mobile CTA - button color.
 	$wp_customize->add_setting(
-		'mobile_cta_hex',
+		'header_cta_hex',
 		array(
 			'default'           => newspack_get_mobile_cta_color(),
 			'sanitize_callback' => 'sanitize_hex_color',
@@ -284,11 +284,11 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		new WP_Customize_Color_Control(
 			$wp_customize,
-			'mobile_cta_hex',
+			'header_cta_hex',
 			array(
 				'label'       => esc_html__( 'Background Color', 'newspack' ),
 				'description' => __( 'Apply a custom background color to the Mobile CTA. Picking something different than your site\'s color palette will help it stand out more.', 'newspack' ),
-				'section'     => 'header_section_donate',
+				'section'     => 'header_section_cta',
 			)
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -272,6 +272,25 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Mobile CTA - link target.
+	$wp_customize->add_setting(
+		'header_cta_target',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+
+	$wp_customize->add_control(
+		'header_cta_target',
+		array(
+			'label'   => esc_html__( 'Open link in new window', 'newspack' ),
+			'type'    => 'checkbox',
+			'section' => 'header_section_cta',
+		)
+	);
+
+
 	// Mobile CTA - button color.
 	$wp_customize->add_setting(
 		'header_cta_hex',

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -255,19 +255,19 @@ function newspack_customize_register( $wp_customize ) {
 
 	// Mobile CTA - URL.
 	$wp_customize->add_setting(
-		'header_cta_page',
+		'header_cta_url',
 		array(
-			'default'           => 0,
-			'sanitize_callback' => 'newspack_sanitize_numeric_value',
+			'default'           => '',
+			'sanitize_callback' => 'esc_url_raw',
 		)
 	);
 
 	$wp_customize->add_control(
-		'header_cta_page',
+		'header_cta_url',
 		array(
-			'label'       => esc_html__( 'Button Link', 'newspack' ),
-			'description' => esc_html__( 'Pick a page that the call-to-action button should link to.', 'newspack' ),
-			'type'        => 'dropdown-pages',
+			'label'       => esc_html__( 'Button URL', 'newspack' ),
+			'description' => esc_html__( 'Add a webpage URL that the call-to-action button should link to.', 'newspack' ),
+			'type'        => 'text',
 			'section'     => 'header_section_cta',
 		)
 	);
@@ -1063,21 +1063,6 @@ function newspack_sanitize_checkbox( $input ) {
 		return true;
 	} else {
 		return false;
-	}
-}
-
-/**
- * Sanitize a numeric value.
- *
- * @param number $input Value of dropdown.
- *
- * @return number A valid number, or returns 0.
- */
-function newspack_sanitize_numeric_value( $input ) {
-	if ( is_numeric( $input ) ) {
-		return intval( $input );
-	} else {
-		return 0;
 	}
 }
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -230,7 +230,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Show Mobile CTA', 'newspack' ),
-			'description' => esc_html__( 'Show a call-to-action button in the mobile header that can be used to link to a donate or subscription page.', 'newspack' ),
+			'description' => esc_html__( 'Show a call-to-action button in the mobile header that can be used to link to an important page, like for donations.', 'newspack' ),
 			'section'     => 'header_section_donate',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -206,6 +206,92 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	/**
+	 * Header - Mobile Donate CTA
+	 */
+	$wp_customize->add_section(
+		'header_section_donate',
+		array(
+			'title' => esc_html__( 'Mobile Call-to-Action', 'newspack' ),
+			'panel' => 'newspack_header_options',
+		)
+	);
+
+	// Mobile CTA - toggle on and off.
+	$wp_customize->add_setting(
+		'show_mobile_cta',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'show_mobile_cta',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Show Mobile CTA', 'newspack' ),
+			'description' => esc_html__( 'Show a call-to-action button in the mobile header that can be used to link to a donate or subscription page.', 'newspack' ),
+			'section'     => 'header_section_donate',
+		)
+	);
+
+	// Mobile CTA - button text.
+	$wp_customize->add_setting(
+		'mobile_cta_text',
+		array(
+			'default'           => esc_html__( 'Donate', 'newspack' ),
+			'sanitize_callback' => 'sanitize_text_field',
+		)
+	);
+	$wp_customize->add_control(
+		'mobile_cta_text',
+		array(
+			'type'        => 'text',
+			'label'       => esc_html__( 'Mobile CTA Text', 'newspack' ),
+			'description' => esc_html__( 'Text to use for the mobile call-to-action button.', 'newspack' ),
+			'section'     => 'header_section_donate',
+		)
+	);
+
+	// Mobile CTA - URL.
+	$wp_customize->add_setting(
+		'mobile_cta_page',
+		array(
+			'default'           => 0,
+			'sanitize_callback' => 'newspack_sanitize_numeric_value',
+		)
+	);
+
+	$wp_customize->add_control(
+		'mobile_cta_page',
+		array(
+			'label'       => esc_html__( 'Mobile CTA Link', 'newspack' ),
+			'description' => esc_html__( 'Page the Donate CTA should link to.', 'newspack' ),
+			'type'        => 'dropdown-pages',
+			'section'     => 'header_section_donate',
+		)
+	);
+
+	// Mobile CTA - button color.
+	$wp_customize->add_setting(
+		'mobile_cta_color',
+		array(
+			'default'           => '#dd3333',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'mobile_cta_color',
+			array(
+				'description' => __( 'Apply a primary custom color.', 'newspack' ),
+				'section'     => 'header_section_donate',
+			)
+		)
+	);
+
 	// Add option to upload logo specifically for the footer.
 	$wp_customize->add_setting(
 		'newspack_alternative_logo',
@@ -976,6 +1062,21 @@ function newspack_sanitize_checkbox( $input ) {
 		return true;
 	} else {
 		return false;
+	}
+}
+
+/**
+ * Sanitize a numeric value.
+ *
+ * @param number $input Value of dropdown.
+ *
+ * @return number A valid number, or returns 0.
+ */
+function newspack_sanitize_numeric_value( $input ) {
+	if ( is_numeric( $input ) ) {
+		return intval( $input );
+	} else {
+		return 0;
 	}
 }
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -393,6 +393,15 @@ function newspack_get_secondary_color() {
 }
 
 /**
+ * The default color used for the mobile cta in the header.
+ *
+ * @return string the default hexidecimal color.
+ */
+function newspack_get_mobile_cta_color() {
+	return '#dd3333';
+}
+
+/**
  * Adjust a hexidecimal colour value to lighten or darken it.
  *
  * @param  string $hex Hexidecimal value of the color to adjust.

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -378,6 +378,21 @@ if ( ! function_exists( 'newspack_the_posts_navigation' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'newspack_mobile_cta' ) ) :
+	/**
+	 * Echo a CTA link in the mobile header.
+	 */
+	function newspack_mobile_cta() {
+		$cta_show    = get_theme_mod( 'show_mobile_cta', false );
+		$cta_text    = get_theme_mod( 'mobile_cta_text', esc_html__( 'Donate', 'newspack' ) );
+		$cta_page_id = get_theme_mod( 'mobile_cta_page', 0 );
+
+		if ( true === $cta_show && 0 !== $cta_page_id ) {
+			echo '<a class="mobile-cta" href="' . esc_url( get_permalink( $cta_page_id ) ) . '">' . esc_html( $cta_text ) . '</a>';
+		}
+	}
+endif;
+
 /**
  * Check if any header menus are applied; used to show menu toggle on smaller screens.
  */

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -383,12 +383,12 @@ if ( ! function_exists( 'newspack_mobile_cta' ) ) :
 	 * Echo a CTA link in the mobile header.
 	 */
 	function newspack_mobile_cta() {
-		$cta_show    = get_theme_mod( 'show_header_cta', false );
-		$cta_text    = get_theme_mod( 'header_cta_text', esc_html__( 'Donate', 'newspack' ) );
-		$cta_page_id = get_theme_mod( 'header_cta_page', 0 );
+		$cta_show = get_theme_mod( 'show_header_cta', false );
+		$cta_text = get_theme_mod( 'header_cta_text', esc_html__( 'Donate', 'newspack' ) );
+		$cta_url  = get_theme_mod( 'header_cta_url', '' );
 
-		if ( true === $cta_show && 0 !== $cta_page_id ) {
-			echo '<a class="button mb-cta" href="' . esc_url( get_permalink( $cta_page_id ) ) . '">' . esc_html( $cta_text ) . '</a>';
+		if ( true === $cta_show && '' !== $cta_url ) {
+			echo '<a class="button mb-cta" href="' . esc_url( $cta_url ) . '">' . esc_html( $cta_text ) . '</a>';
 		}
 	}
 endif;

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -388,7 +388,7 @@ if ( ! function_exists( 'newspack_mobile_cta' ) ) :
 		$cta_page_id = get_theme_mod( 'mobile_cta_page', 0 );
 
 		if ( true === $cta_show && 0 !== $cta_page_id ) {
-			echo '<a class="mobile-cta" href="' . esc_url( get_permalink( $cta_page_id ) ) . '">' . esc_html( $cta_text ) . '</a>';
+			echo '<a class="button mb-cta" href="' . esc_url( get_permalink( $cta_page_id ) ) . '">' . esc_html( $cta_text ) . '</a>';
 		}
 	}
 endif;

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -383,12 +383,17 @@ if ( ! function_exists( 'newspack_mobile_cta' ) ) :
 	 * Echo a CTA link in the mobile header.
 	 */
 	function newspack_mobile_cta() {
-		$cta_show = get_theme_mod( 'show_header_cta', false );
-		$cta_text = get_theme_mod( 'header_cta_text', esc_html__( 'Donate', 'newspack' ) );
-		$cta_url  = get_theme_mod( 'header_cta_url', '' );
+		$cta_show   = get_theme_mod( 'show_header_cta', false );
+		$cta_text   = get_theme_mod( 'header_cta_text', esc_html__( 'Donate', 'newspack' ) );
+		$cta_url    = get_theme_mod( 'header_cta_url', '' );
+		$cta_target = get_theme_mod( 'header_cta_target', false );
 
 		if ( true === $cta_show && '' !== $cta_url ) {
-			echo '<a class="button mb-cta" href="' . esc_url( $cta_url ) . '">' . esc_html( $cta_text ) . '</a>';
+			echo '<a class="button mb-cta" href="' . esc_url( $cta_url ) . '"';
+			if ( true === $cta_target ) {
+				echo ' target="_blank"';
+			}
+			echo '>' . esc_html( $cta_text ) . '</a>';
 		}
 	}
 endif;

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -383,9 +383,9 @@ if ( ! function_exists( 'newspack_mobile_cta' ) ) :
 	 * Echo a CTA link in the mobile header.
 	 */
 	function newspack_mobile_cta() {
-		$cta_show    = get_theme_mod( 'show_mobile_cta', false );
-		$cta_text    = get_theme_mod( 'mobile_cta_text', esc_html__( 'Donate', 'newspack' ) );
-		$cta_page_id = get_theme_mod( 'mobile_cta_page', 0 );
+		$cta_show    = get_theme_mod( 'show_header_cta', false );
+		$cta_text    = get_theme_mod( 'header_cta_text', esc_html__( 'Donate', 'newspack' ) );
+		$cta_page_id = get_theme_mod( 'header_cta_page', 0 );
 
 		if ( true === $cta_show && 0 !== $cta_page_id ) {
 			echo '<a class="button mb-cta" href="' . esc_url( get_permalink( $cta_page_id ) ) . '">' . esc_html( $cta_text ) . '</a>';

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -39,6 +39,29 @@
 	margin-left: auto;
 }
 
+// Mobile CTA
+.button.mb-cta {
+	background: #d33;
+	color: #fff;
+	font-size: $font__size-xs;
+	margin-left: auto;
+
+	&:hover {
+		background: $color__text-main;
+		color: #fff;
+	}
+
+	+ .mobile-menu-toggle {
+		margin-left: $size__spacing-unit;
+
+		span {
+			display: inline-block;
+			overflow: hidden;
+			width: 0;
+		}
+	}
+}
+
 // Hide desktop menu toggle on smaller screens
 .site-header .desktop-menu-toggle,
 .subpage-toggle-contain {
@@ -67,7 +90,8 @@
 
 	// Mobile Menu toggle
 	.h-dh .site-header .mobile-menu-toggle,
-	.h-sub .site-header .mobile-menu-toggle {
+	.h-sub .site-header .mobile-menu-toggle,
+	.h-dh .mb-cta {
 		display: none;
 	}
 
@@ -82,7 +106,8 @@
 	// Header - short height
 
 	// Mobile Menu toggle
-	.h-sh .site-header .mobile-menu-toggle {
+	.h-sh .site-header .mobile-menu-toggle,
+	.h-sh .mb-cta {
 		display: none;
 	}
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -43,8 +43,9 @@
 .button.mb-cta {
 	background: #d33;
 	color: #fff;
-	font-size: $font__size-xs;
+	font-size: 0.7em;
 	margin-left: auto;
+	padding: #{0.6 * $size__spacing-unit} #{0.75 * $size__spacing-unit};
 
 	&:hover {
 		background: $color__text-main;
@@ -58,6 +59,11 @@
 			display: inline-block;
 			overflow: hidden;
 			width: 0;
+		}
+
+		svg {
+			height: 29px;
+			width: 29px;
 		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -96,7 +96,7 @@
 // Middle bar
 .middle-header-contain .wrapper {
 	align-items: center;
-	padding: $size__spacing-unit 0;
+	padding: #{0.75 * $size__spacing-unit} 0;
 	@include media( tablet ) {
 		padding: #{1.5 * $size__spacing-unit} 0;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a mobile-only CTA button to the header.

When activated, it uses a red background by default, and the 'Menu' text next to the mobile menu is hidden.

The button will only display when enabled, and when a page is set for it. 

Some questions for testing:
* Does the CTA option's location in the Customizer make sense? (It's under Header Settings).
* Right now the option forces you to pick a page on the site; will this work, or should it be a text field for a URL instead so it can point to other sites. 
* Does the colour picker location make sense? The header background colour picker lives under the Colors panel, though that's largely due to the fact it's tied to tightly to the other colour settings.

Closes #977.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Switch to the default Newspack theme.
3. Navigate to Customize > Header Settings > Mobile Call-to-Action.
4. Check 'Show Mobile CTA', and pick a page under 'Button Link' -- the button won't show unless it is linked to something.
5. Navigate to Customize > Header Settings > Appearance, and uncheck 'Short Header' if it's checked.
6. Click 'Publish'.
7. Shrink down the browser window until the mobile menu appears; the Donate link should be next to it:

![image](https://user-images.githubusercontent.com/177561/86168175-a99db080-bacc-11ea-9f95-5c3b9ad9362b.png)

8. Navigate back to Customize > Header Settings > Mobile Call-to-Action and try changing the button text and background color -- if you pick a dark colour, the text should stay white, but if you pick a lighter colour, it should switch to black to maintain contrast.
9. Navigate to Customize > Typography and change the header font; this font should be picked up by the button, along with your text/colour changes:

![image](https://user-images.githubusercontent.com/177561/86168626-55470080-bacd-11ea-98f8-a81dd62df427.png)

10. Navigate to Customize > Header Settings > Appearance, and check 'Short Header' -- the mobile menu appears at a wider breakpoint with this settings, so it's important to make sure the button still appears only when the mobile menu is enabled at that wider breakpoint:

![image](https://user-images.githubusercontent.com/177561/86168797-8b848000-bacd-11ea-9d6e-5e40edf8450e.png)

11. Cycle through the different child themes and confirm that the button displays well; in all cases but the default, it should use squared corners:

**Joseph:**

![image](https://user-images.githubusercontent.com/177561/86169077-e918cc80-bacd-11ea-8301-6c8d23516726.png)

**Katharine:**

![image](https://user-images.githubusercontent.com/177561/86169125-fcc43300-bacd-11ea-953c-7f3a3a9aea60.png)

**Nelson:**

![image](https://user-images.githubusercontent.com/177561/86169166-11083000-bace-11ea-809e-2489c6443d22.png)

**Sacha:**

![image](https://user-images.githubusercontent.com/177561/86169226-25e4c380-bace-11ea-94b5-f99b7221a5ef.png)

**Scott:**

![image](https://user-images.githubusercontent.com/177561/86169305-457bec00-bace-11ea-8433-9824818de9ab.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
