### PR TITLE
fix: make sure amp fallback script always loads latest version

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -352,7 +352,7 @@ function newspack_scripts() {
 			'hide_order_details' => esc_html__( 'Hide details', 'newspack' ),
 		);
 
-		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), '1.0', true );
+		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}
 	// Load custom fonts, if any.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Unlike other scripts in the theme, the amp-fallback.js had a hard-coded version number of `1.0`, rather than one based off of the theme's current version (`wp_get_theme()->get( 'Version' )`). With the current set up, there's a risk that the old file will be cached, even when it's updated, because the version number is static; changing it to dynamically update will make sure browsers load the new version each time there's a new theme release. 

### How to test the changes in this Pull Request:

1. Load a non-AMP post or page on your test site.
2. View source and search for `amp-fallback.js`.
3. Confirm that the version number in the query string for the file is `?ver=1.0`.
4. Apply the PR.
5. Confirm that the version number now reflects the theme's dev release -- something like `amp-fallback.js?ver=1.0.0-alpha.33`. On live sites, it will use the 'official' release version (`?ver=1.11.0`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
