### PR TITLE
Refactor: remove missed stylepacks reference

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,7 +23,6 @@ parameters:
         - %currentWorkingDirectory%/inc/color-patterns.php
         - %currentWorkingDirectory%/classes/class-newspack-svg-icons.php
         - %currentWorkingDirectory%/classes/class-newspack-walker-comment.php
-        - %currentWorkingDirectory%/classes/class-newspack-style-packs-core.php
         - %currentWorkingDirectory%/inc/template-functions.php
         - %currentWorkingDirectory%/inc/color-filters.php
         - %currentWorkingDirectory%/inc/typography.php
@@ -33,7 +32,6 @@ parameters:
         - %currentWorkingDirectory%/inc/jetpack.php
         - %currentWorkingDirectory%/inc/woocommerce.php
         # Nothing to load
-        #- %currentWorkingDirectory%/inc/style-packs.php
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters invoked with [34567] parameters, 2 required\.$#'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a bit of code missed in #948.

### How to test the changes in this Pull Request:

1. Apply PR.
2. Confirm that there are no references to style packs in the remaining code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
