### PR TITLE
Trust Indicators support

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -257,6 +257,7 @@ input[type='submit'] {
 	@include media( tablet ) {
 		align-items: center;
 		display: flex;
+		flex-wrap: wrap;
 
 		.posted-on {
 			margin-left: #{1.5 * $size__spacing-unit};
@@ -447,14 +448,5 @@ textarea {
 			border-right: 0;
 			border-top: 0;
 		}
-	}
-}
-
-/* Trust Indicators */
-
-@include media( tablet ) {
-	.entry-meta a.trust-label {
-		margin-left: #{1.5 * $size__spacing-unit};
-		margin-top: 0;
 	}
 }

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -444,3 +444,12 @@ textarea {
 		}
 	}
 }
+
+/* Trust Indicators */
+
+@include media( tablet ) {
+	.entry-meta a.trust-label {
+		margin-left: #{1.5 * $size__spacing-unit};
+		margin-top: 0;
+	}
+}

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -568,19 +568,18 @@ blockquote {
 
 @include media( tablet ) {
 	.featured-image-beside {
-		.entry-meta a.trust-label {
-			color: #FFF;
+		.entry-meta .trust-label {
+			color: #fff;
 		}
-	} 
-}
-
-.featured-image-behind {
-	.entry-meta a.trust-label {
-		color: #FFF;
 	}
 }
 
-.entry-meta a.trust-label {
-	margin-top: #{.5 * $size__spacing-unit};
+.featured-image-behind {
+	.entry-meta .trust-label {
+		color: #fff;
+	}
 }
 
+.entry-meta .trust-label {
+	margin-top: #{0.5 * $size__spacing-unit};
+}

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -558,3 +558,24 @@ blockquote {
 		}
 	}
 }
+
+/* Trust Indicators */
+
+@include media( tablet ) {
+	.featured-image-beside {
+		.entry-meta a.trust-label {
+			color: #FFF;
+		}
+	} 
+}
+
+.featured-image-behind {
+	.entry-meta a.trust-label {
+		color: #FFF;
+	}
+}
+
+.entry-meta a.trust-label {
+	margin-top: #{.5 * $size__spacing-unit};
+}
+

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -517,3 +517,36 @@ cite {
 		}
 	}
 }
+
+// Trust Indicators
+
+.entry-meta a.trust-label {
+	max-width: 100%;
+	justify-content: center;
+}
+
+.featured-image-behind {
+	.entry-meta a.trust-label {
+		color: #FFF;
+	}
+
+	.entry-meta a.trust-label {
+		max-width: 100%;
+		justify-content: center;
+		margin-top: #{.5 * $size__spacing-unit};
+	}
+}
+
+@include media( mobile ) {
+	.entry-meta a.trust-label {
+		justify-content: left;
+	}
+}
+
+@include media( tablet ) {
+	.featured-image-beside {
+		.entry-meta a.trust-label {
+			justify-content: center;
+		}
+	}
+}

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -525,33 +525,32 @@ cite {
 
 // Trust Indicators
 
-.entry-meta a.trust-label {
+.entry-meta .trust-label {
 	max-width: 100%;
 	justify-content: center;
+
+	@include media( mobile ) {
+		justify-content: left;
+	}
 }
 
 .featured-image-behind {
-	.entry-meta a.trust-label {
-		color: #FFF;
-	}
-
-	.entry-meta a.trust-label {
-		max-width: 100%;
+	.entry-meta .trust-label {
+		color: #fff;
 		justify-content: center;
-		margin-top: #{.5 * $size__spacing-unit};
-	}
-}
-
-@include media( mobile ) {
-	.entry-meta a.trust-label {
-		justify-content: left;
+		margin-top: #{0.5 * $size__spacing-unit};
+		max-width: 100%;
 	}
 }
 
 @include media( tablet ) {
 	.featured-image-beside {
-		.entry-meta a.trust-label {
+		.entry-meta .trust-label {
 			justify-content: center;
 		}
 	}
+}
+
+.author-expanded-social-link {
+	justify-content: center;
 }

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -324,3 +324,10 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 		}
 	}
 }
+
+// Trust label
+.entry-subhead {
+	.trust-label {
+		margin-bottom: 5px;
+	}
+}

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -318,3 +318,18 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 		}
 	}
 }
+
+/* Trust Indicators */
+
+.featured-image-behind {
+	.entry-meta a.trust-label {
+		color: #FFF;
+	}
+}
+
+@include media( tablet ) {
+	.entry-meta a.trust-label {
+		margin-left: #{1.5 * $size__spacing-unit};
+		margin-top: 0;
+	}
+}

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -96,6 +96,7 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 		.entry-meta {
 			align-items: center;
 			display: flex;
+			flex-wrap: wrap;
 		}
 
 		&.single-featured-image-default .posted-on {
@@ -321,20 +322,5 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 			margin: 0 0.5em 0 0;
 			width: 0.75em;
 		}
-	}
-}
-
-/* Trust Indicators */
-
-.featured-image-behind {
-	.entry-meta a.trust-label {
-		color: #FFF;
-	}
-}
-
-@include media( tablet ) {
-	.entry-meta a.trust-label {
-		margin-left: #{1.5 * $size__spacing-unit};
-		margin-top: 0;
 	}
 }

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -45,6 +45,8 @@ get_header();
 			<span>
 				<?php the_archive_title( '<h1 class="page-title">', '</h1>' ); ?>
 
+				<?php do_action( 'newspack_theme_below_archive_title' ); ?>
+
 				<?php if ( '' !== get_the_archive_description() ) : ?>
 					<div class="taxonomy-description">
 						<?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?>
@@ -65,6 +67,9 @@ get_header();
 
 						<?php newspack_author_social_links( get_the_author_meta( 'ID' ), 20 ); ?>
 					</div><!-- .author-meta -->
+
+					<?php do_action( 'newspack_theme_below_author_archive_meta' ); ?>
+
 				<?php endif; ?>
 			</span>
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -899,3 +899,7 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 if ( class_exists( 'WooCommerce' ) ) {
 	require get_template_directory() . '/inc/woocommerce.php';
 }
+
+if ( class_exists( 'Trust_Indicators' ) ) {
+	require get_template_directory() . '/inc/trust-indicators.php';
+}

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -153,16 +153,18 @@ if ( ! function_exists( 'newspack_author_social_links' ) ) :
 				'title'  => array(),
 				'target' => array(),
 			),
-			'li' => array(),
+			'li' => array(
+				'class' => array(),
+			),
 		);
 		$allowed_html = array_merge( $allowed_html, newspack_sanitize_svgs() );
 
 		foreach ( $social_profiles as $profile ) {
 			if ( '' !== get_the_author_meta( $profile, $author_id ) ) {
 				if ( 'twitter' === $profile ) {
-					$links .= '<li><a href="https://twitter.com/' . esc_attr( get_the_author_meta( $profile, $author_id ) ) . '" target="_blank">' . newspack_get_social_icon_svg( $profile, $size, $profile ) . '</a></li>';
+					$links .= '<li class="twitter"><a href="https://twitter.com/' . esc_attr( get_the_author_meta( $profile, $author_id ) ) . '" target="_blank">' . newspack_get_social_icon_svg( $profile, $size, $profile ) . '</a></li>';
 				} else {
-					$links .= '<li><a href="' . esc_url( get_the_author_meta( $profile, $author_id ) ) . '" target="_blank">' . newspack_get_social_icon_svg( $profile, $size, $profile ) . '</a></li>';
+					$links .= '<li class="' . esc_attr( $profile ) . '"><a href="' . esc_url( get_the_author_meta( $profile, $author_id ) ) . '" target="_blank">' . newspack_get_social_icon_svg( $profile, $size, $profile ) . '</a></li>';
 				}
 			}
 		}
@@ -219,7 +221,7 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 				/* translators: 1: posted in label, only visible to screen readers. 2: list of categories. */
 				'<span class="cat-links"><span class="screen-reader-text">%1$s</span>%2$s</span>',
 				esc_html__( 'Posted in', 'newspack' ),
-				$categories_list
+				apply_filters( 'newspack_theme_categories', $categories_list )
 			); // WPCS: XSS OK.
 		}
 	}

--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Trust Indicators Compatibility File
+ *
+ * @link https://thetrustproject.org/
+ *
+ * @package Newspack
+ */
+
+/**
+ * Enqueue styles needed for trust indicators.
+ */
+function newspack_trust_indicators_enqueue_styles() {
+	wp_enqueue_style(
+		'newspack-trust-indicators-style',
+		get_template_directory_uri() . '/styles/trust-indicators.css',
+		array( 'newspack-style' ),
+		wp_get_theme()->get( 'Version' )
+	);
+	wp_style_add_data( 'newspack-trust-indicators-style', 'rtl', 'replace' );
+}
+add_action( 'wp_enqueue_scripts', 'newspack_trust_indicators_enqueue_styles' );
+
+/**
+ * Add custom colors to trust indicators.
+ */
+function newspack_trust_indicators_customizer_styles() {
+	$primary_color   = newspack_get_primary_color();
+
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
+		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
+	}
+
+	// Set colour contrasts.
+	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
+	?>
+	<style>
+		.cat-links .type-of-work {
+			color: <?php echo esc_attr( $primary_color_contrast ); ?>;
+			background: <?php echo esc_attr( $primary_color ) ?>;
+		}
+
+		h4.author-job-title {
+			color: <?php echo esc_attr( $primary_color ) ?>;
+		}
+
+	</style>
+	<?php
+}
+add_action( 'wp_head', 'newspack_trust_indicators_customizer_styles' );
+
+/**
+ * Add a label saying what type of work a post is (analysis, opinion, etc.)
+ *
+ * @param string $categories_html HTML for the category label on an article.
+ * @return string Modified $categories_html
+ */
+function newspack_trust_indicators_add_type_of_work_label( $categories_html ) {
+	if ( ! taxonomy_exists( 'type-of-work' ) ) {
+		return $categories_html;
+	}
+
+	$type_of_work_terms = get_the_terms( get_the_ID(), 'type-of-work' );
+	if ( $type_of_work_terms ) {
+		foreach ( $type_of_work_terms as $type_of_work_term ) {
+			$categories_html .= '<span class="type-of-work">' . esc_html( $type_of_work_term->name ) . '</span>';
+		}
+	}
+
+	return $categories_html;
+}
+add_filter( 'newspack_theme_categories', 'newspack_trust_indicators_add_type_of_work_label' );
+
+/**
+ * Output a "Why trust Sitename" link to the publishing principles in the post byline area.
+ */
+function newspack_trust_indicators_output_why_trust_link() {
+	$publishing_principles_url = get_option( 'publishing_principles', '' );
+	if ( ! $publishing_principles_url ) {
+		return;
+	}
+
+	$site_name = get_bloginfo( 'name' );
+
+	/* translators: %s - site name */
+	$message = sprintf( __( 'Why you can trust %s', 'newspack' ), $site_name );
+	?>
+	
+	<a href="<?php echo esc_url( $publishing_principles_url ); ?>" class="trust-label">
+		<svg data-v-22ae94a0="" data-v-2f899364="" width="16" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" class="trust-label__icon"><path data-v-22ae94a0="" d="M16.8 0C18.56 0 20 1.44 20 3.2v13.6c0 1.76-1.44 3.2-3.2 3.2H3.2A3.21 3.21 0 0 1 0 16.8V3.2C0 1.44 1.44 0 3.2 0h13.6zm0 1.2H3.2c-1.1 0-2 .9-2 2v13.6c0 1.1.9 2 2 2h13.6c1.1 0 2-.9 2-2V3.2c0-1.1-.9-2-2-2zm-1 3.38c.08 0 .14.06.14.14V8.2c0 .08-.06.14-.14.14h-3.54c-.08 0-.14.06-.14.14v6.74c0 .08-.06.14-.14.14H8.04c-.08 0-.14-.06-.14-.14V8.5c0-.1-.08-.18-.18-.18H4.2c-.08 0-.14-.06-.14-.14V4.72c0-.08.06-.14.14-.14h11.6z" fill="#666"></path></svg>
+		<span class="trust-label__message"><?php echo esc_html( $message ); ?></span> 
+	</a>
+	<?php
+}
+add_action( 'newspack_theme_entry_meta', 'newspack_trust_indicators_output_why_trust_link' );
+
+/**
+ * Output author role and work contact info on author archives.
+ */
+function newspack_trust_indicators_output_author_job_info() {
+	if ( ! is_author() || ! class_exists( 'Trust_Indicators_User_Settings' ) ) {
+		return;
+	}
+
+	$author = get_queried_object();
+	$role = get_user_meta( $author->ID, 'title', true );
+	if ( $role ) {
+		?><h4 class="author-job-title"><?php echo esc_html( $role ); ?></h4><?php
+	}
+
+	$author_email = '';
+	if ( true === get_theme_mod( 'show_author_email', false ) ) {
+		$author_email = get_user_meta( $author->ID, 'public_contact_info_email', true );
+		if ( ! $author_email ) {
+			$author_email = get_user_meta( $author->ID, 'user_email', true );
+		}
+	}
+
+	$author_phone = get_user_meta( $author->ID, 'public_contact_info_tel', true );
+	$author_twitter = get_user_meta( $author->ID, 'twitter', true );
+	?>
+	<div class="trust-indicators author-meta">
+		<?php if ( $author_email ) : ?>
+			<a class="author-expanded-social-link" href="mailto:<?php echo esc_attr( $author_email ); ?>">
+				<?php echo newspack_get_social_icon_svg( 'mail', 20 ); ?>
+				<?php echo esc_html( $author_email ); ?>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( $author_twitter ) : ?>
+			<a class="author-expanded-social-link" href="<?php echo esc_attr( 'https://twitter.com/' . $author_twitter ); ?>" target="_blank">
+				<?php echo newspack_get_social_icon_svg( 'twitter', 20 ); ?>
+				<?php echo esc_html( $author_twitter ); ?>
+			</a>
+		<?php endif; ?>
+
+		<?php if ( $author_phone ) : ?>
+			<span class="author-expanded-social-link">
+				<?php echo newspack_get_social_icon_svg( 'phone', 20 ); ?>
+				<?php echo esc_html( $author_phone ); ?>
+			</span>
+		<?php endif; ?>
+
+		<?php newspack_author_social_links( $author->ID, 20 ); ?>
+	</div>
+	<?php
+}
+add_action( 'newspack_theme_below_archive_title', 'newspack_trust_indicators_output_author_job_info' );
+
+/**
+ * Output location and expertise info on author archive pages.
+ */
+function newspack_trust_indicators_output_author_details() {
+	if ( ! is_author() || ! class_exists( 'Trust_Indicators_User_Settings' ) ) {
+		return;
+	}
+
+	$author = get_queried_object();
+
+	$all_settings_fields = Trust_Indicators_User_Settings::get_fields();
+	$fields = [
+		'location',
+		'languages_spoken',
+		'areas_of_expertise',
+		'location_expertise',
+	];
+
+	?>
+	<div class="author-additional-infos">
+		<?php foreach ( $fields as $field ) : ?>
+			<?php $value = get_user_meta( $author->ID, $field, true ); ?>
+			<?php if ( empty( $value ) ) : ?>
+				<?php continue; ?>
+			<?php endif; ?>
+
+			<div class="author-additional-info">
+				<h4><?php echo esc_html( $all_settings_fields[ $field ]['label'] ); ?></h4>
+				<p><?php echo wp_kses_post( wpautop( $value ) ); ?></p>
+			</div>
+		<?php endforeach; ?>
+	</div>
+	<?php
+}
+add_action( 'newspack_theme_below_author_archive_meta', 'newspack_trust_indicators_output_author_details' );

--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -39,11 +39,6 @@ function newspack_trust_indicators_customizer_styles() {
 			color: <?php echo esc_attr( $primary_color_contrast ); ?>;
 			background: <?php echo esc_attr( $primary_color ) ?>;
 		}
-
-		h4.author-job-title {
-			color: <?php echo esc_attr( $primary_color ) ?>;
-		}
-
 	</style>
 	<?php
 }
@@ -85,28 +80,24 @@ function newspack_trust_indicators_output_why_trust_link() {
 	/* translators: %s - site name */
 	$message = sprintf( __( 'Why you can trust %s', 'newspack' ), $site_name );
 	?>
-	
+
 	<a href="<?php echo esc_url( $publishing_principles_url ); ?>" class="trust-label">
 		<svg data-v-22ae94a0="" data-v-2f899364="" width="16" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" class="trust-label__icon"><path data-v-22ae94a0="" d="M16.8 0C18.56 0 20 1.44 20 3.2v13.6c0 1.76-1.44 3.2-3.2 3.2H3.2A3.21 3.21 0 0 1 0 16.8V3.2C0 1.44 1.44 0 3.2 0h13.6zm0 1.2H3.2c-1.1 0-2 .9-2 2v13.6c0 1.1.9 2 2 2h13.6c1.1 0 2-.9 2-2V3.2c0-1.1-.9-2-2-2zm-1 3.38c.08 0 .14.06.14.14V8.2c0 .08-.06.14-.14.14h-3.54c-.08 0-.14.06-.14.14v6.74c0 .08-.06.14-.14.14H8.04c-.08 0-.14-.06-.14-.14V8.5c0-.1-.08-.18-.18-.18H4.2c-.08 0-.14-.06-.14-.14V4.72c0-.08.06-.14.14-.14h11.6z" fill="#666"></path></svg>
-		<span class="trust-label__message"><?php echo esc_html( $message ); ?></span> 
+		<span class="trust-label__message"><?php echo esc_html( $message ); ?></span>
 	</a>
 	<?php
 }
 add_action( 'newspack_theme_entry_meta', 'newspack_trust_indicators_output_why_trust_link' );
 
 /**
- * Output author role and work contact info on author archives.
+ * Output author work contact info on author archives.
  */
-function newspack_trust_indicators_output_author_job_info() {
+function newspack_trust_indicators_output_author_info() {
 	if ( ! is_author() || ! class_exists( 'Trust_Indicators_User_Settings' ) ) {
 		return;
 	}
 
 	$author = get_queried_object();
-	$role = get_user_meta( $author->ID, 'title', true );
-	if ( $role ) {
-		?><h4 class="author-job-title"><?php echo esc_html( $role ); ?></h4><?php
-	}
 
 	$author_email = '';
 	if ( true === get_theme_mod( 'show_author_email', false ) ) {
@@ -145,7 +136,23 @@ function newspack_trust_indicators_output_author_job_info() {
 	</div>
 	<?php
 }
-add_action( 'newspack_theme_below_archive_title', 'newspack_trust_indicators_output_author_job_info' );
+add_action( 'newspack_theme_below_archive_title', 'newspack_trust_indicators_output_author_info' );
+
+
+/**
+ * Adds author title to the_archive_title().
+ */
+function newspack_trust_indicators_output_author_job_title( $title ) {
+	if ( is_author() ) {
+		$author = get_queried_object();
+		$role   = get_user_meta( $author->ID, 'title', true );
+		if ( $role ) {
+			$title .= '<span class="author-job-title">' . $role . '</span>';
+		}
+	}
+	return $title;
+}
+add_filter( 'get_the_archive_title', 'newspack_trust_indicators_output_author_job_title' );
 
 /**
  * Output location and expertise info on author archive pages.
@@ -175,7 +182,7 @@ function newspack_trust_indicators_output_author_details() {
 
 			<div class="author-additional-info">
 				<h4><?php echo esc_html( $all_settings_fields[ $field ]['label'] ); ?></h4>
-				<p><?php echo wp_kses_post( wpautop( $value ) ); ?></p>
+				<?php echo wp_kses_post( wpautop( $value ) ); ?>
 			</div>
 		<?php endforeach; ?>
 	</div>

--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -51,7 +51,7 @@ add_action( 'wp_head', 'newspack_trust_indicators_customizer_styles' );
  * @return string Modified $categories_html
  */
 function newspack_trust_indicators_add_type_of_work_label( $categories_html ) {
-	if ( ! taxonomy_exists( 'type-of-work' ) ) {
+	if ( ! taxonomy_exists( 'type-of-work' ) || ! is_single() ) {
 		return $categories_html;
 	}
 

--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -22,29 +22,6 @@ function newspack_trust_indicators_enqueue_styles() {
 add_action( 'wp_enqueue_scripts', 'newspack_trust_indicators_enqueue_styles' );
 
 /**
- * Add custom colors to trust indicators.
- */
-function newspack_trust_indicators_customizer_styles() {
-	$primary_color   = newspack_get_primary_color();
-
-	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-	}
-
-	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	?>
-	<style>
-		.cat-links .type-of-work {
-			color: <?php echo esc_attr( $primary_color_contrast ); ?>;
-			background: <?php echo esc_attr( $primary_color ) ?>;
-		}
-	</style>
-	<?php
-}
-add_action( 'wp_head', 'newspack_trust_indicators_customizer_styles' );
-
-/**
  * Add a label saying what type of work a post is (analysis, opinion, etc.)
  *
  * @param string $categories_html HTML for the category label on an article.
@@ -57,9 +34,8 @@ function newspack_trust_indicators_add_type_of_work_label( $categories_html ) {
 
 	$type_of_work_terms = get_the_terms( get_the_ID(), 'type-of-work' );
 	if ( $type_of_work_terms ) {
-		foreach ( $type_of_work_terms as $type_of_work_term ) {
-			$categories_html .= '<span class="type-of-work">' . esc_html( $type_of_work_term->name ) . '</span>';
-		}
+		$terms_list      = join( ', ', wp_list_pluck( $type_of_work_terms, 'name' ) );
+		$categories_html = '<span class="type-of-work">' . esc_html( $terms_list ) . ':</span>' . $categories_html;
 	}
 
 	return $categories_html;

--- a/newspack-theme/sass/plugins/trust-indicators.scss
+++ b/newspack-theme/sass/plugins/trust-indicators.scss
@@ -35,15 +35,6 @@
 
 /* Author archives */
 .archive.author {
-	// Hide sidebar
-	#secondary {
-		display: none;
-	}
-	#main {
-		margin-left: auto;
-		margin-right: auto;
-	}
-
 	// Hide default archive title & accent
 	.page-subtitle,
 	.page-title::before,

--- a/newspack-theme/sass/plugins/trust-indicators.scss
+++ b/newspack-theme/sass/plugins/trust-indicators.scss
@@ -1,19 +1,21 @@
 @import '../variables-site/variables-site';
 @import '../mixins/mixins-master';
 
-a.trust-label {
-	display: flex;
-	align-items: center;
-	max-width: 300px;
-}
+.trust-label {
+	display: block;
+	font-size: 90%;
 
-span.trust-label__message {
-	margin-left: 0.5em;
+	@include media( mobile ) {
+		display: inline;
+		margin-left: $size__spacing-unit;
+	}
+	svg {
+		margin-right: #{0.25 * $size__spacing-unit};
+		vertical-align: middle;
+	}
 }
 
 .single .cat-links {
-	font-size: 0.66rem;
-
 	.type-of-work {
 		margin-left: 0.5em;
 		padding: 0.5em;
@@ -23,7 +25,8 @@ span.trust-label__message {
 .author-expanded-social-link {
 	display: flex;
 	align-items: center;
-	margin-right: 1rem;
+	margin: 0 1rem 0.5rem 0;
+	width: 100%;
 
 	svg {
 		margin-right: 0.33rem;
@@ -32,8 +35,7 @@ span.trust-label__message {
 
 /* Author archives */
 .archive.author {
-
-	/* Hide sidebar */
+	// Hide sidebar
 	#secondary {
 		display: none;
 	}
@@ -42,28 +44,28 @@ span.trust-label__message {
 		margin-right: auto;
 	}
 
-	/* Hide default archive title */
-	.page-title .page-subtitle {
-		display: none;
-	}
-
-	/* Hide default social links */
+	// Hide default archive title & accent
+	.page-subtitle,
+	.page-title::before,
+	// Hide default social links
 	.author-meta {
 		display: none;
 	}
 
+	.author-job-title {
+		display: block;
+		margin-top: #{0.25 * $size__spacing-unit};
+	}
+
 	.author-meta.trust-indicators {
 		display: flex;
+		flex-wrap: wrap;
 	}
 
 	.author-social-links {
 		border-left: none;
 		margin-left: 0;
 		padding-left: 0;
-	}
-
-	.author-meta.trust-indicators {
-		flex-wrap: wrap;
 	}
 
 	/* Hide small Twitter icon, because a bigger one is present */
@@ -75,15 +77,17 @@ span.trust-label__message {
 .author-additional-infos {
 	display: flex;
 	flex-wrap: wrap;
+	font-size: $font__size-sm;
 }
 
 .author-additional-info {
 	width: 100%;
-}
-
-.author-expanded-social-link {
-	width: 100%;
-	margin-bottom: 0.5rem;
+	h4 {
+		margin-bottom: 0;
+	}
+	p {
+		margin-top: 0;
+	}
 }
 
 .featured-image-behind,
@@ -98,8 +102,16 @@ span.trust-label__message {
 }
 
 .featured-image-behind {
-	a.trust-label {
-		color: #FFF;
+	.trust-label {
+		color: #fff;
+	}
+}
+
+.featured-image-beside {
+	.trust-label {
+		display: block;
+		margin: #{0.25 * $size__spacing-unit} 0 0;
+		width: 100%;
 	}
 }
 
@@ -112,22 +124,9 @@ span.trust-label__message {
 	}
 	.archive.author {
 		.author-meta.trust-indicators {
-			flex-wrap: nowrap;
-
 			.author-social-links {
-				margin: 0;
-				margin-bottom: 0.33rem;
+				margin: 0 0 0.33rem;
 			}
 		}
-	}
-
-	a.trust-label {
-		margin-top: 0.33rem;
-	}
-}
-
-@include media( tablet ) {
-	.single .cat-links {
-		font-size: inherit;
 	}
 }

--- a/newspack-theme/sass/plugins/trust-indicators.scss
+++ b/newspack-theme/sass/plugins/trust-indicators.scss
@@ -10,15 +10,17 @@
 		margin-left: $size__spacing-unit;
 	}
 	svg {
-		margin-right: #{0.25 * $size__spacing-unit};
-		vertical-align: middle;
+		margin-right: #{0.1 * $size__spacing-unit};
+		position: relative;
+		top: 5px;
 	}
 }
 
 .single .cat-links {
+	vertical-align: middle;
 	.type-of-work {
-		margin-left: 0.5em;
-		padding: 0.5em;
+		color: $color__text-main;
+		margin-right: 0.5em;
 	}
 }
 
@@ -29,7 +31,7 @@
 	width: 100%;
 
 	svg {
-		margin-right: 0.33rem;
+		margin-right: #{0.25 * $size__spacing-unit};
 	}
 }
 
@@ -83,6 +85,7 @@
 
 .featured-image-behind,
 .featured-image-beside {
+	.cat-links .type-of-work,
 	.trust-label:hover {
 		color: inherit;
 	}

--- a/newspack-theme/sass/plugins/trust-indicators.scss
+++ b/newspack-theme/sass/plugins/trust-indicators.scss
@@ -1,0 +1,133 @@
+@import '../variables-site/variables-site';
+@import '../mixins/mixins-master';
+
+a.trust-label {
+	display: flex;
+	align-items: center;
+	max-width: 300px;
+}
+
+span.trust-label__message {
+	margin-left: 0.5em;
+}
+
+.single .cat-links {
+	font-size: 0.66rem;
+
+	.type-of-work {
+		margin-left: 0.5em;
+		padding: 0.5em;
+	}
+}
+
+.author-expanded-social-link {
+	display: flex;
+	align-items: center;
+	margin-right: 1rem;
+
+	svg {
+		margin-right: 0.33rem;
+	}
+}
+
+/* Author archives */
+.archive.author {
+
+	/* Hide sidebar */
+	#secondary {
+		display: none;
+	}
+	#main {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	/* Hide default archive title */
+	.page-title .page-subtitle {
+		display: none;
+	}
+
+	/* Hide default social links */
+	.author-meta {
+		display: none;
+	}
+
+	.author-meta.trust-indicators {
+		display: flex;
+	}
+
+	.author-social-links {
+		border-left: none;
+		margin-left: 0;
+		padding-left: 0;
+	}
+
+	.author-meta.trust-indicators {
+		flex-wrap: wrap;
+	}
+
+	/* Hide small Twitter icon, because a bigger one is present */
+	.author-social-links .twitter {
+		display: none;
+	}
+}
+
+.author-additional-infos {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.author-additional-info {
+	width: 100%;
+}
+
+.author-expanded-social-link {
+	width: 100%;
+	margin-bottom: 0.5rem;
+}
+
+.featured-image-behind,
+.featured-image-beside {
+	.trust-label:hover {
+		color: inherit;
+	}
+
+	svg.trust-label__icon path {
+		fill: inherit;
+	}
+}
+
+.featured-image-behind {
+	a.trust-label {
+		color: #FFF;
+	}
+}
+
+@include media( mobile ) {
+	.author-additional-info {
+		width: 50%;
+	}
+	.author-expanded-social-link {
+		width: inherit;
+	}
+	.archive.author {
+		.author-meta.trust-indicators {
+			flex-wrap: nowrap;
+
+			.author-social-links {
+				margin: 0;
+				margin-bottom: 0.33rem;
+			}
+		}
+	}
+
+	a.trust-label {
+		margin-top: 0.33rem;
+	}
+}
+
+@include media( tablet ) {
+	.single .cat-links {
+		font-size: inherit;
+	}
+}

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -78,7 +78,7 @@
 		color: #fff;
 		display: inline-block;
 		margin: 0 #{0.25 * $size__spacing-unit} #{0.25 * $size__spacing-unit} 0;
-		padding: 0.5em 0.75em;
+		padding: 0.35em 0.5em;
 
 		&:visited {
 			color: #fff;

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -38,6 +38,7 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 		<div class="entry-meta">
 			<?php newspack_posted_by(); ?>
 			<?php newspack_posted_on(); ?>
+			<?php do_action( 'newspack_theme_entry_meta' ); ?>
 		</div><!-- .meta-info -->
 		<?php
 			// Display Jetpack Share icons, if enabled

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -103,6 +103,11 @@ const SASS_STYLESHEETS = [
 		outFile: 'newspack-theme/styles/woocommerce.css',
 		withRTL: true,
 	},
+	{
+		inFile: 'newspack-theme/sass/plugins/trust-indicators.scss',
+		outFile: 'newspack-theme/styles/trust-indicators.css',
+		withRTL: true,
+	},
 	{ inFile: 'newspack-theme/sass/print.scss', outFile: 'newspack-theme/styles/print.css' },
 	// Newspack Sacha Child theme
 	{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds support for Trust Project's Trust Indicators plugin. It does this in the following ways:
- Adds a Type of Work label next to the category label on posts.
- Adds a "Why trust sitename" link in the post byline. This follows @laurelfulford's designs where possible, however I did take a couple liberties in the hope of keeping the maintenance and logic simple.
- Enhances the author archive pages to display additional Trust Project-related info.

A bunch of screenshots are available within the details:
<details>

### Newspack Theme - Post

<img width="1274" alt="post-newspack" src="https://user-images.githubusercontent.com/7317227/87190957-5388f400-c2a8-11ea-995e-3047f3a3d2aa.png">

### Joseph - Post

<img width="1451" alt="post-joseph" src="https://user-images.githubusercontent.com/7317227/87190967-57b51180-c2a8-11ea-9379-c2f7c154ea98.png">

### Katharine - Post

<img width="1436" alt="post-katharine" src="https://user-images.githubusercontent.com/7317227/87190975-5c79c580-c2a8-11ea-87c7-ae810eff61b4.png">

### Nelson - Post

<img width="1419" alt="post-nelson" src="https://user-images.githubusercontent.com/7317227/87190988-626fa680-c2a8-11ea-88bd-91260eeafa81.png">

### Sacha - Post

<img width="1433" alt="post-sacha" src="https://user-images.githubusercontent.com/7317227/87191007-6996b480-c2a8-11ea-9acf-3ff4c390732e.png">

### Scott - Post

<img width="1413" alt="post-scott" src="https://user-images.githubusercontent.com/7317227/87191020-6dc2d200-c2a8-11ea-9833-3473958a7bd0.png">

### Mobile Post

<img width="378" alt="mobile-post" src="https://user-images.githubusercontent.com/7317227/87191027-74e9e000-c2a8-11ea-8407-09dbc05f7adb.png">

### Behind Featured Image

<img width="1463" alt="behind" src="https://user-images.githubusercontent.com/7317227/87191040-7b785780-c2a8-11ea-8913-1e0f3d607a95.png">

### Beside Featured Image

<img width="1467" alt="beside" src="https://user-images.githubusercontent.com/7317227/87191070-859a5600-c2a8-11ea-8e64-2ee288599ed7.png">

### Author Archives

<img width="1184" alt="katharine-author" src="https://user-images.githubusercontent.com/7317227/87191109-91861800-c2a8-11ea-9276-dfaaee3e0d1d.png">

<img width="1172" alt="joseph-author" src="https://user-images.githubusercontent.com/7317227/87191100-8e8b2780-c2a8-11ea-9ce5-84c62731f73a.png">

<img width="383" alt="mobile-author" src="https://user-images.githubusercontent.com/7317227/87191111-92b74500-c2a8-11ea-926a-5abfa8d1ea8d.png">

</details>


### How to test the changes in this Pull Request:

0. Get and activate a copy of the Trust Indicators plugin. Let me (or Jeff or Andrew) know if you need a copy.
1. In user settings, fill in the trust fields:

<img width="1408" alt="Screen Shot 2020-07-10 at 12 29 59 PM" src="https://user-images.githubusercontent.com/7317227/87191359-1cffa900-c2a9-11ea-8d46-7b8082d9ea4a.png">

2. In WP Admin > Settings > Trust Indicators, add a standards page:
<img width="1312" alt="Screen Shot 2020-07-10 at 12 30 54 PM" src="https://user-images.githubusercontent.com/7317227/87191422-3d2f6800-c2a9-11ea-9012-397ad2a571e7.png">

3. At the bottom of the settings, set 'post' to the Article Post types:
<img width="662" alt="Screen Shot 2020-07-10 at 12 31 22 PM" src="https://user-images.githubusercontent.com/7317227/87191476-5506ec00-c2a9-11ea-9ff4-5409283e2535.png">

4. On posts you should now see a Type of Work taxonomy, pre-populated with categories. Select one or more and verify the type of work appears on the frontend next to the category, like in the example screenshots above in details.

<img width="284" alt="Screen Shot 2020-07-10 at 12 32 32 PM" src="https://user-images.githubusercontent.com/7317227/87191576-8ed7f280-c2a9-11ea-8dbc-04264809698f.png">

5. On a variety of themes, and post settings (behind featured image, etc.), and mobile/desktop verify author archives and posts look good.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
