### PR TITLE
Make secondary menu visible when using the short header

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -77,7 +77,7 @@ endif;
 			<?php if ( has_nav_menu( 'secondary-menu' ) || ( true === $show_slideout_sidebar && false === $header_simplified ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
-						<?php if ( true === $show_slideout_sidebar ) : ?>
+						<?php if ( true === $show_slideout_sidebar && has_nav_menu( 'secondary-menu' ) ) : ?>
 							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
@@ -113,7 +113,7 @@ endif;
 
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( true === $show_slideout_sidebar && ( ! has_nav_menu( 'secondary-menu' ) && true === $header_simplified ) ) : ?>
+					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -29,6 +29,11 @@ $header_center_logo    = get_theme_mod( 'header_center_logo', false );
 $show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
 $header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
 
+// Even if 'Show Slideout Sidebar' is checked, don't show it if no widgets are assigned.
+if ( ! is_active_sidebar( 'header-1' ) ) {
+	$show_slideout_sidebar = false;
+}
+
 get_template_part( 'template-parts/header/mobile', 'sidebar' );
 get_template_part( 'template-parts/header/desktop', 'sidebar' );
 
@@ -45,7 +50,7 @@ endif;
 		<?php if ( true === $header_sub_simplified && ! is_front_page() ) : ?>
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( newspack_has_menus() || ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) ) : ?>
+					<?php if ( newspack_has_menus() || true === $show_slideout_sidebar ) : ?>
 						<div class="subpage-toggle-contain">
 							<button class="subpage-toggle" on="tap:subpage-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
@@ -69,14 +74,10 @@ endif;
 				</div>
 			</div><!-- .wrapper -->
 		<?php else : ?>
-
-			<?php
-			// If header is NOT short, and if there's a Secondary Menu or Slide-out Sidebar widget.
-			if ( false === $header_simplified && ( is_active_sidebar( 'header-1' ) || has_nav_menu( 'secondary-menu' ) ) ) :
-			?>
+			<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
-						<?php if ( true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
+						<?php if ( true === $show_slideout_sidebar ) : ?>
 							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
@@ -92,8 +93,11 @@ endif;
 						</div>
 
 						<?php
-						// Logo is NOT centered:
-						if ( false === $header_center_logo ) :
+						// If logo is NOT centered:
+						if (
+							( false === $header_center_logo && false === $header_simplified ) ||
+							( true === $header_simplified )
+							) :
 						?>
 							<div id="social-nav-contain">
 								<?php
@@ -109,7 +113,7 @@ endif;
 
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( true === $header_simplified && true === $show_slideout_sidebar && is_active_sidebar( 'header-1' ) ) : ?>
+					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -74,7 +74,7 @@ endif;
 				</div>
 			</div><!-- .wrapper -->
 		<?php else : ?>
-			<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
+			<?php if ( has_nav_menu( 'secondary-menu' ) || ( true === $show_slideout_sidebar && false === $header_simplified ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
 						<?php if ( true === $show_slideout_sidebar ) : ?>
@@ -113,7 +113,7 @@ endif;
 
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) ) : ?>
+					<?php if ( true === $show_slideout_sidebar && ( ! has_nav_menu( 'secondary-menu' ) && true === $header_simplified ) ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -448,7 +448,7 @@ function newspack_secondary_menu() {
 
 	// Only set a toolbar-target attributes if the secondary menu container exists in the header - if not short or subpage header.
 	$toolbar_attributes = '';
-	if ( false === get_theme_mod( 'header_simplified', false ) && ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) ) {
+	if ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) {
 		$toolbar_attributes = 'toolbar-target="secondary-nav-contain" toolbar="(min-width: 767px)"';
 	}
 
@@ -524,7 +524,7 @@ function newspack_social_menu_header() {
 
 	// Only set a toolbar-target attributes if the social menu container exists in the header - if not short or subpage header.
 	$toolbar_attributes = '';
-	if ( false === get_theme_mod( 'header_simplified', false ) && ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) ) {
+	if ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) {
 		$toolbar_attributes = 'toolbar="(min-width: 767px)" toolbar-target="social-nav-contain"';
 	}
 	?>

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -522,10 +522,19 @@ function newspack_social_menu_header() {
 		return;
 	}
 
-	// Only set a toolbar-target attributes if the social menu container exists in the header - if not short or subpage header.
-	$toolbar_attributes = '';
-	if ( false === get_theme_mod( 'header_sub_simplified', false ) || is_front_page() ) {
-		$toolbar_attributes = 'toolbar="(min-width: 767px)" toolbar-target="social-nav-contain"';
+	$header_simplified     = get_theme_mod( 'header_simplified', false );
+	$header_center_logo    = get_theme_mod( 'header_center_logo', false );
+	$header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
+
+	$toolbar_attributes = 'toolbar="(min-width: 767px)" toolbar-target="social-nav-contain"';
+
+	// In some cases when this menu won't appear on desktop, override the Toobar Attributes for AMP, so it doesn't try to "move" it.
+	if (
+		( true === $header_simplified && ! has_nav_menu( 'secondary-menu' ) ) ||
+		( true === $header_sub_simplified && ! is_front_page() ) ||
+		( false === $header_simplified && ! has_nav_menu( 'secondary-menu' ) && false === $header_center_logo )
+	) {
+		$toolbar_attributes = '';
 	}
 	?>
 	<nav class="social-navigation" aria-label="<?php esc_attr_e( 'Social Links Menu', 'newspack' ); ?>" <?php echo $toolbar_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -20,7 +20,7 @@
 }
 
 .mobile-menu-toggle,
-.h-dh .desktop-menu-toggle {
+.desktop-menu-toggle {
 	svg {
 		margin-right: #{0.25 * $size__spacing-unit};
 	}

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -26,6 +26,10 @@
 	}
 }
 
+.middle-header-contain .desktop-menu-toggle svg {
+	margin-right: 0;
+}
+
 .site-header .mobile-menu-toggle,
 .site-header .desktop-menu-toggle,
 .site-header .subpage-toggle {

--- a/newspack-theme/sass/navigation/_menu-social-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-social-navigation.scss
@@ -54,3 +54,8 @@
 	flex-wrap: nowrap;
 	overflow: visible;
 }
+
+.h-sh .top-header-contain .social-links-menu li a svg {
+	height: 20px;
+	width: 20px;
+}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -80,6 +80,7 @@
 	color: #fff;
 
 	.wrapper {
+		align-items: center;
 		justify-content: flex-start;
 	}
 
@@ -91,6 +92,10 @@
 	#social-nav-contain {
 		margin-left: auto;
 	}
+}
+
+.h-sh .top-header-contain nav {
+	padding: #{0.125 * $size__spacing-unit} 0;
 }
 
 // Middle bar

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -7,7 +7,7 @@
 	justify-content: flex-start;
 	position: relative;
 	@include media( tablet ) {
-		flex-basis: 60%;
+		margin-right: auto;
 	}
 }
 
@@ -186,6 +186,7 @@
 			width: 35%;
 
 			&.site-branding {
+				margin-right: auto;
 				width: 30%;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, when you're using the 'short' header, the secondary menu will not appear on desktop, even if assigned. 

There's not really a great reason for this, since the short header is still shorter than the standard header, and you can have that section not-appear simply by not assigning a secondary menu. 

This PR updates the short header to act like the regular header: if the secondary menu is assigned, it will appear there; if the social links menu or slide out menu is assigned, they will also appear in the top bar _only_ when the secondary menu is assigned. Otherwise, they'll appear in their fallback positions (in the footer or to the left of the logo, respectively). 

As part of this change, I went through all of our current live and staging sites, and just found one that uses the Secondary Menu with the short menu (CalMatters) -- in their case, it acts as a simplified menu for mobile, and I was able to preemptively add some CSS to hide it so this change won't cause issues.

Closes #991.

### How to test the changes in this Pull Request:

1. Enable AMP, and open the Console to watch for errors; this will help make sure no errors are thrown when AMP is trying to move a menu from the mobile menu space to the desktop menu space, but can't find the containing element. 
2. Apply the PR and run `npm run build`.
3. Navigate to Customizer > Header Settings > Appearance, and uncheck 'Center Logo' and 'Short Header' if checked.
4. Add a menu to the primary, secondary, tertiary, social locations, and turn on and add widgets to the Slide-out Sidebar (under Header Settings > Slide-out Sidebar). 
5. View on the front-end -- you should have something like: 

![image](https://user-images.githubusercontent.com/177561/87581809-61ff5300-c68e-11ea-8ba2-7b29fa16b808.png)

6. Disable the Secondary Menu; confirm that the top section disappears, and the menu toggle moves next to the logo (this is a deviation from current behaviour, but if any publisher wants the toggle at the top, assigning an empty menu to the Secondary menu slot is a good work-around). The social links will not 'keep' this menu section open on their own, which matches the current behaviour -- they will appear in the footer:

![image](https://user-images.githubusercontent.com/177561/88109694-d0955280-cb5f-11ea-97ab-cd37f20eb4bb.png)

7. Under Header Settings > Appearance, check 'Center Logo'; confirm the slide-out toggle appears on the left:

![image](https://user-images.githubusercontent.com/177561/88109992-4bf70400-cb60-11ea-9aa0-c858acd4a0cf.png)

8. Under Header Settings > Appearance, uncheck 'Center Logo' and check 'Short Header'; confirm the slide-out menu toggle appears to the left of the logo: 

![image](https://user-images.githubusercontent.com/177561/87597637-fd042700-c6a6-11ea-9847-e1d5aaa8c16b.png)

9. Assign a secondary menu; confirm the top bar now appears, with the secondary menu and slide-out menu toggle:

![image](https://user-images.githubusercontent.com/177561/88110139-882a6480-cb60-11ea-9e4e-457f612be06e.png)

10. Under Header Settings > Appearance, center the logo:

![image](https://user-images.githubusercontent.com/177561/88110242-bad45d00-cb60-11ea-8fe6-9d584bcc3718.png)

11. Remove the Secondary Menu again; confirm the menu toggle moves to the left of the primary menu:

![image](https://user-images.githubusercontent.com/177561/87597903-713eca80-c6a7-11ea-8f05-8e42b7d5168e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
