### PR TITLE
fix: remove URLs from print styles

### DIFF
--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -100,26 +100,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 		text-align: left;
 	}
 
-	a {
-		page-break-inside: avoid;
-	}
-
-	a[href^='http']::after {
-		content: ' < ' attr( href ) '> ';
-	}
-
-	a::after > img {
-		content: '';
-	}
-
-	article a[href^='#']::after {
-		content: '';
-	}
-
-	a::after {
-		content: ' < ' attr( href ) '> ';
-	}
-
 	/* Visibility */
 	.nav1,
 	.site-title + .nav1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Print styles append URLs to the end of links in the content; this can create quite a jumble of links, especially when printing the front-page of a Newspack site. 

This PR removes the style that does this; we may want to revisit in the future on an article body level, but as can make printed copies of site not very usable. (The print styles overall also need a review/overhaul as per #516 -- it's just been a lower priority). 

### How to test the changes in this Pull Request:

1. Print or print preview a page on a Newspack site; note the URLs next to any content with links -- if you don't have a printer, you can choose "Open in Preview" at the bottom of the print dialog box to get the same effect:

![image](https://user-images.githubusercontent.com/177561/88246961-fd756280-cc50-11ea-90d5-5b3665be1ce5.png)

![image](https://user-images.githubusercontent.com/177561/88246969-023a1680-cc51-11ea-9ba0-7e03d509507a.png)

2. Apply the PR and run `npm run build`.
3. Confirm that the URLs are now gone:

![image](https://user-images.githubusercontent.com/177561/88246990-0ebe6f00-cc51-11ea-9f6c-f5dff903d8da.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
