### PR TITLE
Remove assumption of hosted Newspack in footer wording

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -37,7 +37,7 @@
 				<?php endif; ?>
 
 				<a href="<?php echo esc_url( __( 'https://newspack.pub/', 'newspack' ) ); ?>" class="imprint">
-					<?php echo esc_html__( 'Proudly powered by Newspack on WordPress.com', 'newspack' ); ?>
+					<?php echo esc_html__( 'Proudly powered by Newspack by Automattic', 'newspack' ); ?>
 				</a>
 
 				<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Alters the wording in the footer credit so that the theme isn't assuming the site is hosted on Newspack on WordPress.com. Instead, credit "Newspack by Automattic" which is more consistent with our wider branding.

Closes #1005.

### How to test the changes in this Pull Request:

1. View the footer, observe "Newspack on WordPress.com" in the credit
2. Apply this PR, observe "Newspack by Automattic" In the credit

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
