### PR TITLE
Fix: hide customize buttons link for share buttons

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -320,16 +320,17 @@ body.page {
 			}
 		}
 	}
+}
 
-	div.sharedaddy h3.sd-title {
-		display: none;
-	}
+div.sharedaddy h3.sd-title,
+.share-customize-link {
+	display: none;
+}
 
-	.sd-content {
-		margin-bottom: -0.7em; // offsets Jetpack's default styles w/out using !important
-		ul li {
-			margin-bottom: 0;
-		}
+.sd-content {
+	margin-bottom: -0.7em; // offsets Jetpack's default styles w/out using !important
+	ul li {
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jetpack 8.8 introduces a 'Customize buttons' link beneath the share buttons; right now there is a bug where it is quite large when AMP is enabled. It's also very prominent in the Newspack theme, since the share buttons have been moved from the bottom of the post to the top. Because of that, I think it makes sense to hide it.

Closes #1012 .

### How to test the changes in this Pull Request:

1. Make sure Jetpack is up to date, and view a post with share buttons.
2. Note the link that now appears below the buttons:

![image](https://user-images.githubusercontent.com/177561/89455715-97d8aa00-d717-11ea-9f4d-5205243ec418.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the link is now hidden:

![image](https://user-images.githubusercontent.com/177561/89455763-a6bf5c80-d717-11ea-8333-fc5f39127e82.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
