### PR TITLE
fix: prevent wrapping with mobile CTA

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -114,6 +114,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'h-dh'; // Header default height.
 	}
 
+	$cta_show = get_theme_mod( 'show_header_cta', false );
+	$cta_url  = get_theme_mod( 'header_cta_url', '' );
+	if ( true === $cta_show && '' !== $cta_url ) {
+		$classes[] = 'h-cta'; // Mobile CTA is showing.
+	}
+
 	// Adds classes if menus are assigned
 	if ( has_nav_menu( 'tertiary-menu' ) ) {
 		$classes[] = 'has-tertiary-menu';

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -45,7 +45,7 @@
 	color: #fff;
 	font-size: 0.7em;
 	margin-left: auto;
-	padding: #{0.6 * $size__spacing-unit} #{0.75 * $size__spacing-unit};
+	padding: #{0.6 * $size__spacing-unit} #{0.5 * $size__spacing-unit};
 
 	&:hover {
 		background: $color__text-main;
@@ -53,7 +53,7 @@
 	}
 
 	+ .mobile-menu-toggle {
-		margin-left: $size__spacing-unit;
+		margin-left: #{0.5 * $size__spacing-unit};
 
 		span {
 			display: inline-block;

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -17,6 +17,16 @@
 	line-height: 1;
 	margin: 0 $size__spacing-unit 0 0;
 	overflow: hidden;
+	@include media( mobile ) {
+		margin-right: #{0.5 * $size__spacing-unit};
+	}
+}
+
+.h-cta .custom-logo-link {
+	max-width: 130px;
+	@include media( mobile ) {
+		max-width: 100%;
+	}
 }
 
 .site-header .custom-logo-link .custom-logo {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The mobile CTA doesn't always leave a lot of room for the maximum allowed logo size; this PR gives the logo a max-width to prevent the mobile menu toggle from wrapping.

### How to test the changes in this Pull Request:

1. Set up the header with a horizontal logo and the mobile menu CTA enabled under Header Settings > Mobile CTA (note: you need to both set the CTA to display, and give it a URL, before it will be written to the page).
2. View using a narrower device, like an iPhone 5 (around 320px wide); note the wrapping:

![image](https://user-images.githubusercontent.com/177561/89939511-e8934b80-dbcc-11ea-94f8-1bfe4546d58a.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the logo is narrower and everything appears on one line. 

![image](https://user-images.githubusercontent.com/177561/89939716-3c059980-dbcd-11ea-93d3-557b17cc3c6e.png)

(Long button labels will still wrap, but this should cover most reasonable cases). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
