### PR TITLE
fix: hide sponsor flag on sponsored category/tag archives

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -83,7 +83,7 @@ function newspack_has_sponsors( $id, $scope = 'native', $type = 'post' ) {
 function newspack_sponsor_body_classes( $classes ) {
 
 	if ( ( is_category() || is_tag() ) && newspack_has_sponsors( get_queried_object_id(), 'native', 'archive' ) ) {
-		$classes[] = 'native-sponsor';
+		$classes[] = 'sponsored-archive';
 	}
 	return $classes;
 }

--- a/newspack-theme/sass/plugins/newspack-sponsors.scss
+++ b/newspack-theme/sass/plugins/newspack-sponsors.scss
@@ -236,6 +236,13 @@
 	}
 }
 
+// Hide sponsor flags on articles in native-sponsor archives.
+.native-sponsor {
+	article .sponsor-label {
+		display: none;
+	}
+}
+
 // Underwritten content
 .sponsor-uw-info {
 	align-items: center;

--- a/newspack-theme/sass/plugins/newspack-sponsors.scss
+++ b/newspack-theme/sass/plugins/newspack-sponsors.scss
@@ -237,7 +237,7 @@
 }
 
 // Hide sponsor flags on articles in native-sponsor archives.
-.native-sponsor {
+.sponsored-archive {
 	article .sponsor-label {
 		display: none;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the 'Sponsored' flags when you're viewing a sponsored category or tag archive. It will hide all flags -- even on posts that have multiple category/tag sponsors or a direct sponsor -- but leave the sponsor bylines in tact. 

Closes #1026

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Visit a sponsored tag and sponsored category archive. Confirm the yellow 'sponsored' flag only appears at the top of the archive, but not for each post. 
3. View a regular archive page (non-sponsored category/tag and/or author), and confirm the 'sponsored' flags still display on the appropriate posts. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
