### PR TITLE
Create releases on external repos on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,12 @@ jobs:
       - run:
           name: Release new version
           command: npm run release
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
 
-  # Reset alpha branch after a release
+  # Reset alpha branch after a release and publish child themes' releases
   post_release:
     docker:
       - image: circleci/node:12
@@ -52,8 +56,11 @@ jobs:
           command: |
             git pull origin release
             git checkout alpha
-            git reset --hard release
+            git reset --hard release --
             git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+      - run:
+          name: Publish child themes' releases
+          command: node scripts/create-child-releases.js --run
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -4405,49 +4405,65 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
-      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0"
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
-      "integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+      "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
-        "is-plain-object": "^3.0.0",
-        "universal-user-agent": "^4.0.0"
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^4.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
           "dev": true
         }
       }
     },
-    "@octokit/plugin-paginate-rest": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
-      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+    "@octokit/graphql": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.4.tgz",
+      "integrity": "sha512-ITpZ+dQc0cXAW1FmDkHJJM+8Lb6anUnin0VB5hLBilnYVdLC0ICFU/KIvT7OXfW9S81DE3U4Vx2EypDG1OYaPA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.1"
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.3.0.tgz",
+      "integrity": "sha512-Ye2ZJreP0ZlqJQz8fz+hXvrEAEYK4ay7br1eDpWzr6j76VXs/gKqxFcH8qRzkB3fo/2xh4Vy9VtGii4ZDc9qlA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^5.2.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -4457,44 +4473,35 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
-      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.1.2.tgz",
+      "integrity": "sha512-PTI7wpbGEZ2IR87TVh+TNWaLcgX/RsZQalFbQCq8XxYUrQ36RHyERrHSNXFy5gkWpspUAOYRSV707JJv6BhqJA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.1",
+        "@octokit/types": "^5.1.1",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+      "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
       "dev": true,
       "requires": {
-        "@octokit/endpoint": "^5.5.0",
-        "@octokit/request-error": "^1.0.1",
-        "@octokit/types": "^2.0.0",
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
-        "is-plain-object": "^3.0.0",
+        "is-plain-object": "^4.0.0",
         "node-fetch": "^2.3.0",
         "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
+        "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+          "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
           "dev": true
         },
         "node-fetch": {
@@ -4506,44 +4513,32 @@
       }
     },
     "@octokit/request-error": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
-      "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^5.0.1",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "16.43.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
-      "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.3.tgz",
+      "integrity": "sha512-GubgemnLvUJlkhouTM2BtX+g/voYT/Mqh0SASGwTnLvSkW1irjt14N911/ABb6m1Hru0TwScOgFgMFggp3igfQ==",
       "dev": true,
       "requires": {
-        "@octokit/auth-token": "^2.4.0",
-        "@octokit/plugin-paginate-rest": "^1.1.1",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
-        "@octokit/request": "^5.2.0",
-        "@octokit/request-error": "^1.0.2",
-        "atob-lite": "^2.0.0",
-        "before-after-hook": "^2.0.0",
-        "btoa-lite": "^1.0.0",
-        "deprecation": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "lodash.uniq": "^4.5.0",
-        "octokit-pagination-methods": "^1.1.0",
-        "once": "^1.4.0",
-        "universal-user-agent": "^4.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "4.1.2"
       }
     },
     "@octokit/types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.1.1.tgz",
-      "integrity": "sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.0.tgz",
+      "integrity": "sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -4976,6 +4971,69 @@
           "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
           "dev": true
         },
+        "@octokit/plugin-paginate-rest": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+          "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.1"
+          }
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+          "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.1",
+            "deprecation": "^2.3.1"
+          }
+        },
+        "@octokit/request-error": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+          "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+          "dev": true,
+          "requires": {
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "once": "^1.4.0"
+          }
+        },
+        "@octokit/rest": {
+          "version": "16.43.2",
+          "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+          "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
+          "dev": true,
+          "requires": {
+            "@octokit/auth-token": "^2.4.0",
+            "@octokit/plugin-paginate-rest": "^1.1.1",
+            "@octokit/plugin-request-log": "^1.0.0",
+            "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+            "@octokit/request": "^5.2.0",
+            "@octokit/request-error": "^1.0.2",
+            "atob-lite": "^2.0.0",
+            "before-after-hook": "^2.0.0",
+            "btoa-lite": "^1.0.0",
+            "deprecation": "^2.0.0",
+            "lodash.get": "^4.4.2",
+            "lodash.set": "^4.3.2",
+            "lodash.uniq": "^4.5.0",
+            "octokit-pagination-methods": "^1.1.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^4.0.0"
+          }
+        },
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "dev": true,
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        },
         "array-union": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -5133,6 +5191,15 @@
           "dev": true,
           "requires": {
             "is-number": "^7.0.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+          "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+          "dev": true,
+          "requires": {
+            "os-name": "^3.1.0"
           }
         }
       }
@@ -8995,6 +9062,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -13972,14 +14045,39 @@
       }
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
       }
     },
     "fs-minipass": {
@@ -18657,9 +18755,9 @@
       }
     },
     "macos-release": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
-      "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
       "dev": true
     },
     "make-dir": {
@@ -24118,6 +24216,17 @@
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "get-stdin": {
@@ -30064,13 +30173,10 @@
       }
     },
     "universal-user-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-      "dev": true,
-      "requires": {
-        "os-name": "^3.1.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -30615,9 +30721,9 @@
       }
     },
     "windows-release": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
-      "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+      "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@babel/core": "^7.4.0",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
+    "@octokit/rest": "^18.0.3",
     "@semantic-release/changelog": "^5.0.0",
     "@semantic-release/git": "^9.0.0",
     "@wordpress/blocks": "^6.2.0",
@@ -37,6 +38,7 @@
     "eslint-plugin-jsdoc": "^20.3.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
+    "fs-extra": "^9.0.1",
     "grunt": "^0.4.5",
     "grunt-wp-i18n": "^0.5.4",
     "grunt-wp-readme-to-markdown": "^1.0.0",
@@ -104,5 +106,6 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/release.config.js
+++ b/release.config.js
@@ -1,11 +1,4 @@
-const THEMES = [
-	'newspack-joseph',
-	'newspack-katharine',
-	'newspack-nelson',
-	'newspack-sacha',
-	'newspack-scott',
-	'newspack-theme',
-];
+const { THEMES } = require( './scripts/create-child-releases.js' );
 
 module.exports = {
 	branches: [

--- a/scripts/create-child-releases.js
+++ b/scripts/create-child-releases.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-console */
+
+const { basename, resolve } = require( 'path' );
+const { stat, readFile } = require( 'fs-extra' );
+const { Octokit } = require( '@octokit/rest' );
+
+const THEMES = [
+	'newspack-theme',
+	'newspack-joseph',
+	'newspack-katharine',
+	'newspack-nelson',
+	'newspack-sacha',
+	'newspack-scott',
+];
+
+/**
+ * Because all the themes are in a monorepo, some internal processes
+ * have a hard time automatically deploying the changes. For this reason
+ * the themes have individual repos just for the releases.
+ * These releases are automatically published using this script.
+ */
+const createExternalReleasesOfThemes = async () => {
+	const { version } = require( '../package.json' );
+
+	const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+	if ( ! TOKEN ) {
+		console.error( 'Missing github token.' );
+		process.exit( 1 );
+	}
+
+	const octokit = new Octokit( {
+		auth: TOKEN,
+	} );
+
+	const RELEASES = THEMES.map( name => ( {
+		filePath: resolve( __dirname, `../release/${ name }.zip` ),
+		repoName: `${ name }-theme`,
+	} ) );
+
+	const owner = 'Automattic';
+
+	RELEASES.forEach( async ( { filePath, repoName } ) => {
+		console.log( `Crating a release for ${ owner }/${ repoName }…` );
+
+		const {
+			data: { upload_url: uploadUrl, id: releaseId },
+		} = await octokit.repos.createRelease( {
+			owner,
+			repo: repoName,
+			tag_name: `v${ version }`,
+			name: `v${ version }`,
+			body: `Release v${ version }`,
+			// We'll create a draft release, append the assets to it, and then publish it.
+			// This is so that the assets are available when we get a Github release event.
+			draft: true,
+		} );
+
+		const file = await stat( resolve( filePath ) );
+		const upload = {
+			url: uploadUrl,
+			data: await readFile( filePath ),
+			name: basename( filePath ),
+			headers: {
+				'content-type': 'application/zip',
+				'content-length': file.size,
+			},
+		};
+
+		const {
+			data: { browser_download_url: downloadUrl },
+		} = await octokit.repos.uploadReleaseAsset( upload );
+
+		console.log( `Published file ${ downloadUrl }` );
+		const {
+			data: { html_url: url },
+		} = await octokit.repos.updateRelease( {
+			owner,
+			repo: repoName,
+			release_id: releaseId,
+			draft: false,
+		} );
+
+		console.log( `Published GitHub release: ${ url }` );
+	} );
+};
+
+if ( process.argv.some( arg => arg.startsWith( '--run' ) ) ) {
+	createExternalReleasesOfThemes();
+}
+
+// Export for use of semantic-release config.
+module.exports = {
+	THEMES,
+};


### PR DESCRIPTION
Because all the themes are in this monorepo, some internal deployment processes would have a hard time automatically deploying the changes. 
To mitigate that, I've created a GH repository for each theme, which does not contain any code and is just a vessel for a release. The post-release script in this PR will publish the releases to the relevant repositories.

## How to test these changes 

1. Create two new GH repositories (under your name) – `newspack-theme`, `newspack-theme-theme`
2. Set up `newspack-theme-theme` with an empty initial commit: 
    1. Create a new folder `newspack-theme-theme`
    2. Push an empty commit (a repository cannot be empty for releases to work): `$ git init && git commit -m "initial commit" --allow-empty && git remote add origin git@github.com:<username>/newspack-theme-theme.git && git push -u origin master`
2. In this repository, add `newspack-theme` as a new remote: `$ git remote add copy git@github.com:<username>/newspack-theme.git`
3. Change the value of `owner` in the script to your username, comment out lines 9-13 (so the script handles just one external repository), and disable commenting on release by adding `successComment: false` to `@semantic-release/github` options in `release.config.js`
4. Commit and push to the `copy` remote: `$ git push -u copy add/create-releases:master`
5. Set up the project on [CircleCI](https://app.circleci.com/) and add release-related environment variables
5. Add an alpha branch to the `copy` remote: `$ git checkout -b copy-alpha && git push -u copy copy-alpha:alpha`
6. Create a release by pushing onto the release branch: `git checkout -b copy-release && git push -u copy copy-release:release`
7. Observe a new (`v1.0.0`) release published on your `newspack-theme` repository
8. Observe that same release (same tag, same assets) also published on the `newspack-theme-theme` repository 