### PR TITLE
Fix: prevent JavaScript error in sponsor AMP-fallback code

### DIFF
--- a/newspack-theme/js/src/amp-fallback-newspack-sponsors.js
+++ b/newspack-theme/js/src/amp-fallback-newspack-sponsors.js
@@ -6,28 +6,31 @@
 
 ( function() {
 	// Support info toggle.
-	const supportToggle = document.getElementById( 'sponsor-info-toggle' ),
-		supportLabel = supportToggle.parentNode,
-		supportInfo = document.getElementById( 'sponsor-info' ),
-		supportToggleTextContain = supportToggle.getElementsByTagName( 'span' )[ 0 ],
-		supportToggleTextDefault = supportToggleTextContain.innerText;
+	const supportToggle = document.getElementById( 'sponsor-info-toggle' );
 
-	supportToggle.addEventListener(
-		'click',
-		function() {
-			supportLabel.classList.toggle( 'show-info' );
-			// Toggle screen reader text label and aria settings.
-			if ( supportToggleTextDefault === supportToggleTextContain.innerText ) {
-				supportToggleTextContain.innerText = newspackScreenReaderText.close_info;
+	if ( null !== supportToggle ) {
+		const supportLabel = supportToggle.parentNode,
+			supportInfo = document.getElementById( 'sponsor-info' ),
+			supportToggleTextContain = supportToggle.getElementsByTagName( 'span' )[ 0 ],
+			supportToggleTextDefault = supportToggleTextContain.innerText;
 
-				supportInfo.setAttribute( 'aria-expanded', 'true' );
-				supportToggle.setAttribute( 'aria-expanded', 'true' );
-			} else {
-				supportToggleTextContain.innerText = supportToggleTextDefault;
-				supportInfo.setAttribute( 'aria-expanded', 'false' );
-				supportToggle.setAttribute( 'aria-expanded', 'false' );
-			}
-		},
-		false
-	);
+		supportToggle.addEventListener(
+			'click',
+			function() {
+				supportLabel.classList.toggle( 'show-info' );
+				// Toggle screen reader text label and aria settings.
+				if ( supportToggleTextDefault === supportToggleTextContain.innerText ) {
+					supportToggleTextContain.innerText = newspackScreenReaderText.close_info;
+
+					supportInfo.setAttribute( 'aria-expanded', 'true' );
+					supportToggle.setAttribute( 'aria-expanded', 'true' );
+				} else {
+					supportToggleTextContain.innerText = supportToggleTextDefault;
+					supportInfo.setAttribute( 'aria-expanded', 'false' );
+					supportToggle.setAttribute( 'aria-expanded', 'false' );
+				}
+			},
+			false
+		);
+	}
 } )();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the AMP-fallback JavaScript for the sponsored content flag checks for the existence of the flag; otherwise it throws an error on non-sponsored posts.  

Closes #1030 

### How to test the changes in this Pull Request:

1. Start with a site running the sponsored content plugin, set up with native sponsored content.
2. Switch AMP to Transitional mode, or Reader mode, so it's not run by default.
3. Navigate to a post that is not sponsored, and view the console; note the JavaScript error.
4. Apply the PR and run `npm run build`.
5. Refresh the post; confirm that the error no longer occurs.
6. Navigate to a sponsored post; click on the `?` next to the sponsored flag, and confirm the info bubble still opens. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
