### PR TITLE
fix: prevent errors when no sponsors assigned

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -56,6 +56,10 @@ function newspack_has_sponsors( $id, $scope = 'native', $type = 'post' ) {
 			$sponsors_all = \Newspack_Sponsors\get_sponsors_for_post( $id ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 		}
 
+		if ( empty( $sponsors_all ) ) {
+			return false;
+		}
+
 		// Loop through sponsors and remove duplicates.
 		$sponsors   = array();
 		$duplicates = array();
@@ -70,11 +74,7 @@ function newspack_has_sponsors( $id, $scope = 'native', $type = 'post' ) {
 		}
 	}
 
-	if ( ! empty( $sponsors ) ) {
-		return $sponsors;
-	} else {
-		return false;
-	}
+	return $sponsors;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the function that checks for sponsors to return earlier when it's empty, to prevent errors on posts without sponsors.

See #1030 

### How to test the changes in this Pull Request:

1. Start with a test site with the sponsored plugin. 
2. View a post without any sponsors, either on an archive/search, or single post. 
3. Note the following PHP error:

`Warning: Invalid argument supplied for foreach() in /srv/www/newspack-build/public_html/wp-content/themes/newspack-theme/inc/newspack-sponsors.php on line 62`

4. Apply the PR.
5. Confirm the error is now gone from non-sponsored posts.
6. Confirm that sponsored posts are still displaying the flag, sponsor as author, etc. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
