### PR TITLE
fix: correct logic for when top menu area should be shown

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -77,7 +77,7 @@ endif;
 			<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
-						<?php if ( true === $show_slideout_sidebar && has_nav_menu( 'secondary-menu' ) ) : ?>
+						<?php if ( true === $show_slideout_sidebar ) : ?>
 							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -74,7 +74,7 @@ endif;
 				</div>
 			</div><!-- .wrapper -->
 		<?php else : ?>
-			<?php if ( has_nav_menu( 'secondary-menu' ) || ( true === $show_slideout_sidebar && false === $header_simplified ) ) : ?>
+			<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
 						<?php if ( true === $show_slideout_sidebar && has_nav_menu( 'secondary-menu' ) ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A minor logic error was introduced with #1001. The 'top menu area' should only appear when you have a secondary menu assigned. However, there's a weird case right now where it will also appear if you have this combination of settings:

* A slide-out sidebar assigned.
* A default-height header assigned.
* The logo aligned left. 
* The secondary menu is not assigned, but the social links menu is.

If you have a short header, or a centered logo, it displays as expected. 

This doesn't affect any sites at the moment; but if anyone would like it to work this way, they can assign an empty secondary menu to get the slide-out sidebar and social links appearing at the top. 

### How to test the changes in this Pull Request:

1. Navigate to Customize > Header Settings > Appearance, and uncheck Center Logo and Short Header.
2. Navigate to Customize > Header Settings > Slide-out Sidebar and set up the slide-out sidebar.
3. Unassign the Secondary Menu; assign a social links menu.
4. View on the front-end; the slide-out sidebar toggle will appear next to the logo, but the social links will appear in the grey bar on top:

![image](https://user-images.githubusercontent.com/177561/90573854-54952700-e16c-11ea-89d6-df2495258327.png)

5. Apply the PR.
6. Confirm that the top bar is now gone:

![image](https://user-images.githubusercontent.com/177561/90573898-68d92400-e16c-11ea-9e07-db0ad8e07cc7.png)

7. Try activating the secondary menu again, and make sure the top bar still appears:

![image](https://user-images.githubusercontent.com/177561/90573977-94f4a500-e16c-11ea-8b0c-d908e974ab28.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
