### PR TITLE
Update sponsor code to use improved functions

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -6,7 +6,6 @@
  *
  * @package Newspack
  */
-
 get_header();
 ?>
 
@@ -45,7 +44,7 @@ get_header();
 			<span>
 
 				<?php
-					if ( ( is_category() || is_tag() ) && function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_queried_object_id(), 'native', 'archive' ) ) {
+					if ( ( is_category() || is_tag() ) && function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id() ) ) {
 						newspack_sponsor_label( get_queried_object_id(), true, 'native', 'archive' );
 					}
 				?>
@@ -54,7 +53,7 @@ get_header();
 
 				<?php do_action( 'newspack_theme_below_archive_title' ); ?>
 
-				<?php if ( ( is_category() || is_tag() ) && function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_queried_object_id(), 'native', 'archive' ) ) : ?>
+				<?php if ( ( is_category() || is_tag() ) && function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id(), 'native' ) ) : ?>
 					<?php newspack_sponsor_archive_description( get_queried_object_id(), 'native', 'archive' ); ?>
 				<?php elseif ( '' !== get_the_archive_description() ) : ?>
 					<div class="taxonomy-description">
@@ -64,7 +63,7 @@ get_header();
 
 				<?php
 				if ( is_category() || is_tag() ) {
-					if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_queried_object_id(), 'underwritten', 'archive' ) ) {
+					if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id(), 'underwritten', 'archive' ) ) {
 						newspack_sponsored_underwriters_info( get_queried_object_id(), 'underwritten', 'archive' );
 					}
 				}

--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -44,7 +44,7 @@ function newspack_sponsor_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'newspack_sponsor_editor_styles' );
 
 /**
- *
+ * Returns post or category sponsors.
  */
 function newspack_get_all_sponsors( $id = null, $scope = null, $type = null, $logo_options = array() ) {
 	if ( function_exists( '\Newspack_Sponsors\get_all_sponsors' ) ) {

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -6,7 +6,6 @@
  *
  * @package Newspack
  */
-
 ?>
 
 
@@ -15,7 +14,7 @@
 
 	<div class="entry-container">
 		<?php
-			if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) :
+			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) :
 				newspack_sponsor_label( get_the_id() );
 			endif;
 		?>
@@ -24,7 +23,7 @@
 		</header><!-- .entry-header -->
 
 		<?php if ( ! is_page() ) : ?>
-			<?php if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) : ?>
+			<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) : ?>
 				<div class="entry-meta entry-sponsor">
 					<?php newspack_sponsor_logo_list( get_the_id() ); ?>
 					<span>

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -6,9 +6,7 @@
  *
  * @package Newspack
  */
-
 ?>
-
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<?php newspack_post_thumbnail(); ?>
@@ -16,7 +14,7 @@
 	<div class="entry-container">
 		<?php
 		if ( 'page' !== get_post_type() ) :
-			if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) :
+			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) :
 				newspack_sponsor_label( get_the_id() );
 			elseif ( ! is_archive() ) :
 				newspack_categories();
@@ -28,7 +26,7 @@
 		</header><!-- .entry-header -->
 
 		<?php if ( 'page' !== get_post_type() ) : ?>
-			<?php if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) : ?>
+			<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) : ?>
 				<div class="entry-meta entry-sponsor">
 					<?php newspack_sponsor_logo_list( get_the_id() ); ?>
 					<span>

--- a/newspack-theme/template-parts/content/content-single.php
+++ b/newspack-theme/template-parts/content/content-single.php
@@ -6,14 +6,13 @@
  *
  * @package Newspack
  */
-
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<div class="entry-content">
 
 		<?php
-			if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id(), 'underwritten' ) ) :
+			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'underwritten' ) ) :
 				newspack_sponsored_underwriters_info( get_the_id(), 'underwritten' );
 			endif;
 		?>
@@ -52,7 +51,7 @@
 	</footer><!-- .entry-footer -->
 
 	<?php
-	if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) :
+	if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native' ) ) :
 		newspack_sponsor_footer_bio( get_the_id() );
 	elseif ( ! is_singular( 'attachment' ) ) :
 		get_template_part( 'template-parts/post/author', 'bio' );

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -5,13 +5,14 @@
  * @package Newspack
  */
 
-$discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_discussion_data() : null; ?>
+$discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_discussion_data() : null;
 
+?>
 
 <?php if ( is_singular() ) : ?>
 	<?php
 	if ( ! is_page() ) :
-		if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) {
+		if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id() ) ) {
 			newspack_sponsor_label( get_the_id(), true );
 		} else {
 			newspack_categories();
@@ -40,7 +41,7 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 
 <?php if ( ! is_page() ) : ?>
 	<div class="entry-subhead">
-		<?php if ( function_exists( 'newspack_has_sponsors' ) && newspack_has_sponsors( get_the_id() ) ) : ?>
+		<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native' ) ) : ?>
 			<div class="entry-meta entry-sponsor">
 				<?php newspack_sponsor_logo_list( get_the_id() ); ?>
 				<span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the sponsor code to use the updated function from the sponsors plugin, introduced here: https://github.com/Automattic/newspack-sponsors/pull/17

Note: I still created a function to stand in for the `\Newspack_Sponsors\get_all_sponsors` function; I did manage to get `use` to work, using `use function`, but the linting in the theme repo didn't like that, either (and for some reason, the `use` version of the function also didn't return true with `function_exists()`, so I still had to use a mix of both). I figured a new function was a good way to avoid adding `phpcs:ignore` throughout the code. 

### How to test the changes in this Pull Request:

1. Start with a test site with the sponsors plugin; the content should include at least one native-sponsored and one undewritten-sponsor category, and at least one native-sponsored and one underwritten-sponsored post. 
2. Apply the PR.
3. Cycle through the different views, and confirm that the correct sponsor flair is displaying for each:

**Single post - native sponsor**

Top:
![image](https://user-images.githubusercontent.com/177561/90686984-fd9d5980-e220-11ea-8434-977a40bed366.png)

Bottom:
![image](https://user-images.githubusercontent.com/177561/90687013-07bf5800-e221-11ea-9c28-272d8663d949.png)

**Single post - underwritten sponsor**

![image](https://user-images.githubusercontent.com/177561/90686971-f8400f00-e220-11ea-9659-bf14ad5188d9.png)

**Archive - native sponsor**

Top:
![image](https://user-images.githubusercontent.com/177561/90687032-10179300-e221-11ea-8c65-f27cb26f7080.png)

Each post:
![image](https://user-images.githubusercontent.com/177561/90687047-173ea100-e221-11ea-9b51-b890cbe72609.png)

**Archive - underwritten sponsor**

![image](https://user-images.githubusercontent.com/177561/90687076-2291cc80-e221-11ea-9a3b-e6dc852539ec.png)

**Post - native sponsor in non-sponsored archives**

First post is not sponsored; second post is sponsored:
![image](https://user-images.githubusercontent.com/177561/90687124-363d3300-e221-11ea-86e9-5cd783831022.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
