### PR TITLE
Adds/desktop slideout control

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -27,6 +27,7 @@ do_action( 'before_header' );
 $header_simplified     = get_theme_mod( 'header_simplified', false );
 $header_center_logo    = get_theme_mod( 'header_center_logo', false );
 $show_slideout_sidebar = get_theme_mod( 'header_show_slideout', false );
+$slideout_sidebar_side = get_theme_mod( 'slideout_sidebar_side', 'left' );
 $header_sub_simplified = get_theme_mod( 'header_sub_simplified', false );
 
 // Even if 'Show Slideout Sidebar' is checked, don't show it if no widgets are assigned.

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -81,7 +81,7 @@ endif;
 						<?php if ( true === $show_slideout_sidebar && 'left' === $slideout_sidebar_side ) : ?>
 							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
+								<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
 							</button>
 						<?php endif; ?>
 
@@ -110,9 +110,9 @@ endif;
 						<?php endif; ?>
 
 						<?php if ( true === $show_slideout_sidebar && 'right' === $slideout_sidebar_side ) : ?>
-							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+							<button class="desktop-menu-toggle dir-right" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
-								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
+								<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
 							</button>
 						<?php endif; ?>
 					</div><!-- .wrapper -->
@@ -205,7 +205,7 @@ endif;
 					<?php newspack_mobile_cta(); ?>
 
 					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) && 'right' === $slideout_sidebar_side ) : ?>
-						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+						<button class="desktop-menu-toggle dir-right" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
 						</button>

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -78,7 +78,7 @@ endif;
 			<?php if ( has_nav_menu( 'secondary-menu' ) ) : ?>
 				<div class="top-header-contain desktop-only">
 					<div class="wrapper">
-						<?php if ( true === $show_slideout_sidebar ) : ?>
+						<?php if ( true === $show_slideout_sidebar && 'left' === $slideout_sidebar_side ) : ?>
 							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
@@ -108,13 +108,20 @@ endif;
 								?>
 							</div>
 						<?php endif; ?>
+
+						<?php if ( true === $show_slideout_sidebar && 'right' === $slideout_sidebar_side ) : ?>
+							<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+								<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+								<?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?>
+							</button>
+						<?php endif; ?>
 					</div><!-- .wrapper -->
 				</div><!-- .top-header-contain -->
 			<?php endif; ?>
 
 			<div class="middle-header-contain">
 				<div class="wrapper">
-					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) ) : ?>
+					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) && 'left' === $slideout_sidebar_side ) : ?>
 						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
@@ -196,6 +203,13 @@ endif;
 					</div><!-- .nav-wrapper -->
 
 					<?php newspack_mobile_cta(); ?>
+
+					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) && 'right' === $slideout_sidebar_side ) : ?>
+						<button class="desktop-menu-toggle" on="tap:desktop-sidebar.toggle">
+							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
+							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
+						</button>
+					<?php endif; ?>
 
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -177,6 +177,27 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Header - slide out menu position
+	$wp_customize->add_setting(
+		'slideout_sidebar_side',
+		array(
+			'default'           => 'left',
+			'sanitize_callback' => 'newspack_sanitize_slideout_sidebar_side',
+		)
+	);
+	$wp_customize->add_control(
+		'slideout_sidebar_side',
+		array(
+			'type'    => 'radio',
+			'label'   => esc_html__( 'Slide-out sidebar side', 'newspack' ),
+			'choices' => array(
+				'left'  => _x( 'Left', 'slide-out menu side', 'newspack' ),
+				'right' => _x( 'Right', 'slide-out menu side', 'newspack' ),
+			),
+			'section' => 'header_section_slideout',
+		)
+	);
+
 	/**
 	 * Header Slideouts
 	 */
@@ -1066,6 +1087,26 @@ function newspack_sanitize_post_template( $choice ) {
 	}
 
 	return 'default';
+}
+
+/**
+ * Sanitize slide-out sidebar side
+ *
+ * @param string $choice The side to display the slide-out sidebar.
+ *
+ * @return string
+ */
+function newspack_sanitize_slideout_sidebar_side( $choice ) {
+	$valid = array(
+		'left',
+		'right',
+	);
+
+	if ( in_array( $choice, $valid, true ) ) {
+		return $choice;
+	}
+
+	return 'left';
 }
 
 /**

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -171,6 +171,17 @@
 				visibility();
 				setting.bind( visibility );
 			} );
+			wp.customize.control( 'slideout_sidebar_side', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
 		} );
 
 		// Only show Alternative Logo option if 'simple subpage header' is picked

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -103,7 +103,7 @@
 	}
 
 	&.dir-right {
-		margin: 0 0 0 $size__spacing-unit;
+		margin: 0 0 0 #{0.75 * $size__spacing-unit};
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -315,11 +315,14 @@
 }
 
 // Fallback - open from the right
-#mobile-sidebar-fallback {
+#mobile-sidebar-fallback,
+#desktop-sidebar-fallback.dir-right {
+	left: auto;
 	right: -100%;
 	transition: right 0.2s;
 }
 
+.desktop-menu-opened #desktop-sidebar-fallback.dir-right,
 .mobile-menu-opened #mobile-sidebar-fallback {
 	right: 0;
 }

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -84,14 +84,26 @@
 
 .site-header .desktop-menu-toggle,
 .h-ll .subpage-toggle-contain {
-	margin-right: #{1.25 * $size__spacing-unit};
+	margin: 0 #{1.25 * $size__spacing-unit} 0 0;
+}
+
+.site-header .desktop-menu-toggle.dir-right {
+	margin: 0 0 0 #{1.25 * $size__spacing-unit};
+}
+
+.site-header #secondary-nav-contain + .desktop-menu-toggle.dir-right {
+	margin: 0 0 0 auto;
 }
 
 .middle-header-contain .desktop-menu-toggle {
-	margin-right: $size__spacing-unit;
+	margin: 0 $size__spacing-unit 0 0;
 	span {
 		left: -99999em;
 		position: absolute;
+	}
+
+	&.dir-right {
+		margin: 0 0 0 $size__spacing-unit;
 	}
 }
 

--- a/newspack-theme/template-parts/header/desktop-sidebar.php
+++ b/newspack-theme/template-parts/header/desktop-sidebar.php
@@ -14,7 +14,7 @@ if ( newspack_is_amp() ) : ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>
 		</button>
 <?php else : ?>
-	<aside id="desktop-sidebar-fallback" class="desktop-sidebar">
+	<aside id="desktop-sidebar-fallback" class="desktop-sidebar dir-<?php echo esc_attr( $slideout_sidebar_side ); ?>">
 		<button class="desktop-menu-toggle">
 			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>

--- a/newspack-theme/template-parts/header/desktop-sidebar.php
+++ b/newspack-theme/template-parts/header/desktop-sidebar.php
@@ -5,8 +5,10 @@
  * @package Newspack
  */
 
+$slideout_sidebar_side = get_theme_mod( 'slideout_sidebar_side', 'left' );
+
 if ( newspack_is_amp() ) : ?>
-	<amp-sidebar id="desktop-sidebar" layout="nodisplay" side="left" class="desktop-sidebar">
+	<amp-sidebar id="desktop-sidebar" layout="nodisplay" side="<?php echo esc_attr( $slideout_sidebar_side ); ?>" class="desktop-sidebar">
 		<button class="desktop-menu-toggle" on='tap:desktop-sidebar.toggle'>
 			<?php echo wp_kses( newspack_get_icon_svg( 'close', 20 ), newspack_sanitize_svgs() ); ?>
 			<?php esc_html_e( 'Close', 'newspack' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to flip the slide that the slide-out sidebar is on. We've had this request a few times; so far we've just been moving the toggle from left to right with CSS, but `amp-sidebar` makes it tricky to move the sidebar in the same way, because the alignment is set inline. 

It also adds a `<span>` around the menu label when the toggle appears in the top section of the header.

Unfortunately there's a lot of Customizer options to test here; I'd recommend having it open in one tab, and the front-end in the other.

This PR should be tested after #1035 lands, since that fix will also affect code here.

Closes #1022.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Switch AMP to transitional mode, to make it easier to toggle between AMP and non-AMP. 
3. Navigate to Customizer > Header Settings > Slide-Out Sidebar; confirm there's a control at the bottom labelled "Slide-out sidebar side", and when you toggle off "Show Slide-out Sidebar" at the top, this new control hides with the others when the Show Slide-out Sidebar is unchecked. 
4. Change Slide-out Sidebar side to 'Right'.
5. Navigate to Customizer > Header Settings > Appearance; uncheck Center Logo and Short Header if checked. 
6. Navigate to Customizer > Menus, and add menus to the Secondary and Social menus. 
7. View on the front-end; confirm the Menu toggle is in the top right, next to the social links:

![image](https://user-images.githubusercontent.com/177561/90842059-29007100-e313-11ea-8aa4-08ef4eff26cf.png)

8. Click on the menu toggle, and confirm that the menu comes out from the right. Do this with both the AMP and non-AMP version of the page:

![image](https://user-images.githubusercontent.com/177561/90842275-bcd23d00-e313-11ea-9837-986e5906c8b0.png)

9. Under Customizer > Menu, unassign the Social Menu, and confirm the slide-out sidebar toggle remains in place:

![image](https://user-images.githubusercontent.com/177561/90842166-711f9380-e313-11ea-9f43-86b9c0fa3328.png)

10. Under Customizer > Menu, turn off the Secondary menu; confirm the toggle now sits in the middle section:

![image](https://user-images.githubusercontent.com/177561/90842221-9a402400-e313-11ea-90f7-879f92f78a4d.png)

11. Navigate to Customizer > Header Settings > Appearance, and turn on the Center Logo option:

![image](https://user-images.githubusercontent.com/177561/90842338-de332900-e313-11ea-80bc-f09d9ba8be0e.png)

12. Turn back on the Secondary and Social Menus:

![image](https://user-images.githubusercontent.com/177561/90842388-fefb7e80-e313-11ea-8625-ae0ce8db68cc.png)

13. Navigate back to Customizer > Header Settings > Appearance, and uncheck Center Logo, and check Short Header:

![image](https://user-images.githubusercontent.com/177561/90842479-3cf8a280-e314-11ea-96c1-37f3252e5722.png)

14. Navigate back to Customizer > Menus, and turn off the Secondary Menu:

![image](https://user-images.githubusercontent.com/177561/90842521-5ac60780-e314-11ea-9720-bcd414e7721e.png)

15. Navigate to Customizer > Header Settings > Appearance, and check 'Center logo':

![image](https://user-images.githubusercontent.com/177561/90842554-76c9a900-e314-11ea-9127-6aa94e280c16.png)

16. Navigate back to Customizer > Menus, and turn back on the Secondary Menu:

![image](https://user-images.githubusercontent.com/177561/90842602-919c1d80-e314-11ea-9b3d-23ca65d1ea64.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
