### PR TITLE
Newspack Nelson: prevent gap above the short header

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -47,18 +47,24 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 
 // Header short
 .h-sh {
-	.site-header {
+	.middle-header-contain {
 		@include media( tablet ) {
 			padding-top: #{0.5 * $size__spacing-unit};
 		}
 
 		@include media( desktop ) {
-			padding: $size__spacing-unit 0 #{10 * $size__spacing-unit};
+			padding-top: $size__spacing-unit 0;
+		}
+	}
 
-			.highlight-menu-contain {
-				position: relative;
-				top: #{3 * $size__spacing-unit};
-			}
+	@include media( desktop ) {
+		.site-header {
+			padding-bottom: #{10 * $size__spacing-unit};
+		}
+
+		.highlight-menu-contain {
+			position: relative;
+			top: #{3 * $size__spacing-unit};
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In Newspack Nelson, if you pair a short header with the secondary menu, it displays a gap at the top of the header. This PR fixes that. 

### How to test the changes in this Pull Request:

1. Change your theme to Newspack Nelson.
2. Navigate to Customizer > Header Settings > Appearance and check 'Short header'.
3. Navigate to Customizer > Menus, and assign a menu to the secondary location.
4. View on front-end, and note the gap at the very top:

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/177561/91077614-3c9f2680-e5f6-11ea-9468-912ec577f1fe.png">

5. Apply the PR and run `npm run build`
6. Confirm the gap is gone, but the spacing otherwise remains the same; try scaling down the browser window, too, to make sure the other breakpoints are still OK:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/177561/91077546-1e392b00-e5f6-11ea-8afe-43ac2098b0a0.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
