### PR TITLE
Sponsors: Make sure sponsor links, logos exist before outputting

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -96,13 +96,15 @@ if ( ! function_exists( 'newspack_sponsor_byline' ) ) :
 						$sep = '';
 					endif;
 
-					printf(
-						/* translators: 1: sponsor link. 2: sponsor name. 3: sponsor seperator - either a comma or 'and'. */
-						'<span class="author"><a target="_blank" href="%1$s">%2$s</a></span>%3$s',
-						esc_url( $sponsor['sponsor_url'] ),
-						esc_html( $sponsor['sponsor_name'] ),
-						esc_html( $sep )
-					);
+					echo '<span class="author">';
+					if ( '' !== $sponsor['sponsor_url'] ) {
+						echo '<a target="_blank" href="' . esc_url( $sponsor['sponsor_url'] ) . '">';
+					}
+					echo esc_html( $sponsor['sponsor_name'] );
+					if ( '' !== $sponsor['sponsor_url'] ) {
+						echo '</a>';
+					}
+					echo '</span>' . esc_html( $sep );
 				}
 				?>
 			</span><!-- .byline -->
@@ -168,7 +170,7 @@ if ( ! function_exists( 'newspack_sponsor_logo_list' ) ) :
 		if ( ! empty( $sponsors ) ) {
 			echo '<span class="sponsor-logos">';
 				foreach ( $sponsors as $sponsor ) {
-					if ( '' !== $sponsor['sponsor_logo'] ) :
+					if ( ! empty( $sponsor['sponsor_logo'] ) ) :
 						if ( '' !== $sponsor['sponsor_url'] ) {
 							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
 						}
@@ -204,34 +206,48 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 			?>
 
 				<div class="author-bio sponsor-bio">
-					<a href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>" class="avatar" target="_blank">
-						<img src="<?php echo esc_url( $sponsor['sponsor_logo']['src'] ); ?>" width="<?php echo esc_attr( $sponsor['sponsor_logo']['img_width'] ); ?>" height="<?php echo esc_attr( $sponsor['sponsor_logo']['img_height'] ); ?>">
-					</a>
+
+					<?php
+					if ( ! empty( $sponsor['sponsor_logo'] ) ) {
+						if ( '' !== $sponsor['sponsor_url'] ) {
+							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" class="avatar" target="_blank">';
+						}
+						echo '<img src="' . esc_url( $sponsor['sponsor_logo']['src'] ) . '" width="' . esc_attr( $sponsor['sponsor_logo']['img_width'] ) . '" height="' . esc_attr( $sponsor['sponsor_logo']['img_height'] ) . '">';
+						if ( '' !== $sponsor['sponsor_url'] ) {
+							echo '</a>';
+						}
+					}
+					?>
 
 					<div class="author-bio-text">
 						<div class="author-bio-header">
-							<?php
-								printf(
-									/* translators: 1: sponsor preface. 2: sponsor link. 3: sponsor name. */
-									'<h2 class="accent-header">%1$s <a target="_blank" href="%2$s">%3$s</a></h2>',
-									esc_html( $sponsor['sponsor_byline'] ),
-									esc_url( $sponsor['sponsor_url'] ),
-									esc_html( $sponsor['sponsor_name'] )
-									);
+							<h2 class="accent-header">
+								<?php
+								echo esc_html( $sponsor['sponsor_byline'] ) . ' ';
+								if ( '' !== $sponsor['sponsor_url'] ) {
+									echo '<a target="_blank" href="' . esc_url( $sponsor['sponsor_url'] ) . '">';
+								}
+								echo esc_html( $sponsor['sponsor_name'] );
+								if ( '' !== $sponsor['sponsor_url'] ) {
+									echo '</a>';
+								}
 								?>
+							</h2>
 						</div><!-- .author-bio-header -->
 
 						<?php echo wp_kses_post( $sponsor['sponsor_blurb'] ); ?>
 
-						<a class="author-link" target="_blank" href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>">
-							<?php
-								printf(
-									/* translators: %s is the post's sponsor's name. */
-									esc_html__( 'Learn more about %s', 'newspack' ),
-									esc_html( $sponsor['sponsor_name'] )
-								);
-							?>
-						</a>
+						<?php if ( '' !== $sponsor['sponsor_url'] ) : ?>
+							<a class="author-link" target="_blank" href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>">
+								<?php
+									printf(
+										/* translators: %s is the post's sponsor's name. */
+										esc_html__( 'Learn more about %s', 'newspack' ),
+										esc_html( $sponsor['sponsor_name'] )
+									);
+								?>
+							</a>
+						<?php endif; ?>
 
 					</div><!-- .author-bio-text -->
 				</div><!-- .author-bio -->
@@ -252,7 +268,7 @@ function newspack_sponsor_archive_description( $id, $scope = 'native', $type = '
 			<div class="sponsor-archive">
 				<span class="details">
 					<?php
-					if ( '' !== $sponsor['sponsor_logo'] ) :
+					if ( ! empty( $sponsor['sponsor_logo'] ) ) :
 						if ( '' !== $sponsor['sponsor_url'] ) {
 							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
 						}
@@ -298,7 +314,7 @@ function newspack_sponsored_underwriters_info( $id, $scope = 'native', $type = '
 			?>
 			<div class="sponsor-uw-info">
 				<span class="logo">
-					<?php if ( '' !== $sponsor['sponsor_logo'] ) : ?>
+					<?php if ( ! empty( $sponsor['sponsor_logo'] ) ) : ?>
 						<?php
 						if ( '' !== $sponsor['sponsor_url'] ) {
 							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -98,9 +98,12 @@ body.page {
 	.byline {
 		display: block;
 
+		.author {
+			font-weight: bold;
+		}
+
 		a {
 			color: $color__primary;
-			font-weight: bold;
 			text-decoration: none;
 
 			&:visited {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a check before sponsor links and logos to make sure they exist before trying to write them to the page. 

### How to test the changes in this Pull Request:

1. Start with two native sponsors (one with a logo and URL, one without), and two underwritten sponsors (one with a logo and URL, one without). 
2. Check single posts in all cases; make sure the logos/links are displaying when added -- screenshots below show proper placement:

Native sponsor: 

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/177561/91198831-ef808a80-e6b1-11ea-8eb9-fbde7abf3511.png">

Underwritten sponsor (just above content):

<img width="842" alt="image" src="https://user-images.githubusercontent.com/177561/91198631-a4667780-e6b1-11ea-9dd4-362cf5ee5b00.png">

3. Check archives in all cases; make sure the logos/links are displaying when added, but not when they are empty - screenshots below show proper placement:

Native sponsor:

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/177561/91198609-9c0e3c80-e6b1-11ea-8e4e-9a5a235b4ce2.png">

<img width="823" alt="image" src="https://user-images.githubusercontent.com/177561/91198956-163ec100-e6b2-11ea-9d88-279dc60311b6.png">

Underwritten sponsor: 

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/177561/91198930-0de68600-e6b2-11ea-8558-ad06946f2567.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
