### PR TITLE
fix: update sharing title styles to be more specific

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -322,7 +322,7 @@ body.page {
 	}
 }
 
-div.sharedaddy h3.sd-title,
+div.sharedaddy .sd-social h3.sd-title,
 .share-customize-link {
 	display: none;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

It looks like a recent change in Jetpack made the sharing button label styles more specific, so it was no longer being hidden by the theme when AMP is disabled. This PR fixes that.

### How to test the changes in this Pull Request:

1. Set up a testing site with share buttons, and disable AMP.
2. View on the front-end; note the label:

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/177561/91474204-c47f6d80-e84e-11ea-808d-18793cd8b3d8.png">

3. Apply the PR and run `npm run build`.
4. Confirm that the label is now hidden again:

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/177561/91474064-9a2db000-e84e-11ea-85f6-9bffb31d388b.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
