### PR TITLE
fix: make sure sponsor flag is not cut off for Newspack Katharine

### DIFF
--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -34,14 +34,19 @@ Newspack Katharine Editor Styles
 }
 
 .wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not( .show-caption ):not( .show-category )
-	.post-has-image
+	.post-has-image {
 	.entry-title {
-	background-color: $color__background-body;
-	margin-top: -1.75em;
-	padding: 0.5em 0.25em 0 0;
-	position: relative;
-	width: 85%;
-	z-index: 1;
+		background-color: $color__background-body;
+		margin-top: -1.75em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
+	}
+	.sponsor-label + .entry-title {
+		margin-top: 0;
+		padding: 0;
+	}
 }
 
 .wp-block-newspack-blocks-homepage-articles figcaption::after {

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -138,15 +138,19 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	border-bottom-color: $color__text-main;
 }
 
-.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category )
-	.post-has-image
+.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category ) .post-has-image {
 	.entry-title {
-	background-color: $color__background-body;
-	margin-top: -1.5em;
-	padding: 0.5em 0.25em 0 0;
-	position: relative;
-	width: 85%;
-	z-index: 1;
+		background-color: $color__background-body;
+		margin-top: -1.5em;
+		padding: 0.5em 0.25em 0 0;
+		position: relative;
+		width: 85%;
+		z-index: 1;
+	}
+	.sponsor-label + .entry-title {
+		margin-top: 0;
+		padding: 0;
+	}
 }
 
 .wpnbha figcaption::after {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newspack Katharine's 'header overlap image' style was cutting off the sponsored content flag -- this PR makes sure that doesn't happen.

### How to test the changes in this Pull Request:

1. On a test site with sponsored content, set up some blocks that will show the sponsored content, and make sure at least one of the posts has a featured image.
2. Switch to Newspack Katharine.
3. Note the sponsored content flag is cut off on the posts with images:

<img width="829" alt="image" src="https://user-images.githubusercontent.com/177561/91482295-b1729a80-e85a-11ea-959b-233f06f4e81e.png">

4. Apply the PR and run `npm run build`.
5. Confirm the sponsored content flag is no longer cut off:

<img width="845" alt="image" src="https://user-images.githubusercontent.com/177561/91482190-85571980-e85a-11ea-8ef3-49089ad72d02.png">

Note: this is similar to how the block acts when categories or captions are enabled. I think for categories and sponsors, it could be refactored so the overlap still happens in the future.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
