### PR TITLE
Improve logo size behavior with mobile CTA

### DIFF
--- a/newspack-theme/sass/mixins/_utilities.scss
+++ b/newspack-theme/sass/mixins/_utilities.scss
@@ -1,4 +1,10 @@
 @mixin media( $res ) {
+	@if mobileonly == $res {
+		@media only screen and ( max-width: $mobile_width - 1 ) {
+			@content;
+		}
+	}
+
 	@if mobile == $res {
 		@media only screen and ( min-width: $mobile_width ) {
 			@content;

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -22,10 +22,13 @@
 	}
 }
 
-.h-cta .custom-logo-link {
-	max-width: 130px;
-	@include media( mobile ) {
-		max-width: 100%;
+@include media( mobileonly ) {
+	.h-cta .site-header .custom-logo-link {
+		max-width: 140px;
+
+		.custom-logo {
+			max-width: 100%;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The styles added in #1017 -- to shrink the logo when you're using the Mobile CTA -- currently can cut off the logo on non-AMP sites. 

This PR fixes that, and increases the maximum logo size a bit, since the real estate is available.

### How to test the changes in this Pull Request:

1. Set up a test site with the Mobile CTA, and with AMP set to "Transitional", so you can easily toggle between AMP being enabled or disabled on a page. 
2. Set a smaller (< 600px wide) browser window, and test both versions of your test site's header. Note that the logo looks okay in the AMP verison, but is cut off in the non-AMP version:

AMP:

![image](https://user-images.githubusercontent.com/177561/91772925-a9886280-eb9a-11ea-80f2-44fe1bb578f2.png)

Non-AMP:

![image](https://user-images.githubusercontent.com/177561/91772918-a2615480-eb9a-11ea-8dc1-06a18281bed9.png)

3. Apply the PR and run `npm run build`
4. Confirm that the logo is no longer getting cut off in the non-AMP version, and that everything still fits on one line for smaller mobile sizes:

AMP:

![image](https://user-images.githubusercontent.com/177561/91773064-e3f1ff80-eb9a-11ea-9785-692a05f6acde.png)

Non-AMP:

![image](https://user-images.githubusercontent.com/177561/91773052-dfc5e200-eb9a-11ea-850d-9dfbbdae3b2e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
