### PR TITLE
Header: prevent gap between mobile CTA and menu toggle

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -202,14 +202,14 @@ endif;
 						?>
 					</div><!-- .nav-wrapper -->
 
-					<?php newspack_mobile_cta(); ?>
-
 					<?php if ( true === $show_slideout_sidebar && ! has_nav_menu( 'secondary-menu' ) && 'right' === $slideout_sidebar_side ) : ?>
 						<button class="desktop-menu-toggle dir-right" on="tap:desktop-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php echo esc_html( get_theme_mod( 'slideout_label', esc_html__( 'Menu', 'newspack' ) ) ); ?></span>
 						</button>
 					<?php endif; ?>
+
+					<?php newspack_mobile_cta(); ?>
 
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With a very specific combination of header settings, you end up with a gap between the mobile CTA and the mobile menu toggle. 

The issue arises because the CSS expects the mobile CTA and mobile menu toggle to be right after each other in the markup when enabled; however, if you align the slide-out sidebar to the right, that toggle ends up between them. This PR fixes that. 

### How to test the changes in this Pull Request:

1. Set up a test site with the following settings:
* No secondary menu
* Slide-out sidebar menu enabled, and aligned right
* Mobile CTA enabled.
2. View the site; make the browser window narrow enough that the mobile CTA appears; note its appearance:

![image](https://user-images.githubusercontent.com/177561/91901156-af427e80-ec54-11ea-92f7-f9ac321bd793.png)

3. Apply the PR.
4. Confirm that the gap is now gone:

![image](https://user-images.githubusercontent.com/177561/91901219-c5503f00-ec54-11ea-8e56-22ddaff2b7a7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
