### PR TITLE
fix: harmonise how the author link is printed regardless of truncation

### DIFF
--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -141,7 +141,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<?php else : ?>
 			<?php echo wp_kses_post( wpautop( get_the_author_meta( 'description' ) ) ); ?>
 
-			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */
 					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug where the "more by [author]" link was missing the actual username when the option to truncate author bios was not on.

### How to test the changes in this Pull Request:

1. In Customiser, under "Author Bio Settings" make sure that "Display Author Bio" is checked and "Truncate Author Bio" is unchecked
2. Visit any single post authored by a user with a filled in bio
3. Observe that there is a "More by [author]" link, where [author] is the user's name
4. Observe that the link looks like this: https://newspack.test/author/ (missing the username from the end)
5. Apply this PR and observe that the link now points correctly to the author archive page (e.g. https://newspack.test/author/admin)
6. Turn the "Truncate Author Bio" setting on in customiser and check that the author link is still correct
