### PR TITLE
Opt out of the block-based widget area

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -210,6 +210,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
+		// Remove support for block widgets for now.
+		remove_theme_support( 'widgets-block-editor' );
+
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Gutenberg 8.9 introduces a new block-based widget area, which, unfortunately, does not have parity with the original widgets; we may want to remove theme support for it for the short-term. 

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
