### PR TITLE
Image Block: prevent gaps above captions in mobile Safari

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -702,16 +702,19 @@
 			display: block;
 		}
 
-		.aligncenter {
-			margin: 0 auto;
-		}
-
 		figcaption {
 			text-align: left;
 		}
 
-		.alignleft > figcaption,
-		.alignright > figcaption {
+		.alignleft,
+		.aligncenter,
+		.alignright {
+			figcaption {
+				display: block;
+			}
+		}
+
+		.aligncenter {
 			display: block;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Mobile Safari randomly adds a lot of space above captions on page load, though they eventually snap into place. This can be a bit disconcerting, though. The issue seems to be related to `aligncenter` and the block using `display: table`; this PR fixes the issue by switching the block to use `display: block`.

Closes #1055.

### How to test the changes in this Pull Request:

1. Set up an image block with a caption, and align the block center.
2. View on an iOS device in Safari, or using the iOS simulator on Mac. Refresh a few times; turning on AMP can also help in recreating the issue more consistently, though I'm not sure why.
3. Refresh until you observe this weird issue:

![IMG_1507](https://user-images.githubusercontent.com/177561/92278063-39832080-eea9-11ea-9559-cd8ab54d3846.jpg)

4. Apply the PR and run `npm run build`.
5. Clear your browser cache; repeat refreshing/reloading the page to make sure the issue doesn't reoccur (unfortunately, since it doesn't happen all the time, it needs to be hammered a bit to verify):

![IMG_1508](https://user-images.githubusercontent.com/177561/92278109-54ee2b80-eea9-11ea-9d8d-02a78eeb767a.jpg)

6. Confirm on desktop that there are no new issues introduced with this change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
