### PR TITLE
Add 'time ago' date option to theme

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -17,6 +17,7 @@
 
 	<footer id="colophon" class="site-footer">
 
+		<?php remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'branding' ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -643,7 +643,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Add option to hide the whole author bio.
+	// Add option to set a featured image default.
 	$wp_customize->add_setting(
 		'featured_image_default',
 		array(
@@ -686,6 +686,41 @@ function newspack_customize_register( $wp_customize ) {
 				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
 			'section' => 'post_default_settings',
+		)
+	);
+
+	// Add option to use a time ago date format
+	$wp_customize->add_setting(
+		'post_time_ago',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'post_time_ago',
+		array(
+			'type'    => 'checkbox',
+			'label'   => __( 'Use "time ago" date format', 'newspack' ),
+			'section' => 'post_default_settings',
+		)
+	);
+
+	$wp_customize->add_setting(
+		'post_time_ago_cut_off',
+		array(
+			'default'           => 1209600, // Two weeks.
+			'sanitize_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'post_time_ago_cut_off',
+		array(
+			'type'        => 'text',
+			'label'       => esc_html__( 'Cut off for "time ago" date in seconds', 'newspack' ),
+			'description' => esc_html__( 'The default (1209600 seconds) is equal to two weeks. 604800 seconds equals one week.', 'newspack' ),
+			'section'     => 'post_default_settings',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -701,7 +701,7 @@ function newspack_customize_register( $wp_customize ) {
 		'post_time_ago',
 		array(
 			'type'    => 'checkbox',
-			'label'   => __( 'Use "time ago" date format', 'newspack' ),
+			'label'   => esc_html__( 'Use "time ago" date format', 'newspack' ),
 			'section' => 'post_default_settings',
 		)
 	);
@@ -709,7 +709,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'post_time_ago_cut_off',
 		array(
-			'default'           => 1209600, // Two weeks.
+			'default'           => '14', // Two weeks.
 			'sanitize_callback' => 'absint',
 		)
 	);
@@ -717,10 +717,9 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'post_time_ago_cut_off',
 		array(
-			'type'        => 'text',
-			'label'       => esc_html__( 'Cut off for "time ago" date in seconds', 'newspack' ),
-			'description' => esc_html__( 'The default (1209600 seconds) is equal to two weeks. 604800 seconds equals one week.', 'newspack' ),
-			'section'     => 'post_default_settings',
+			'type'    => 'text',
+			'label'   => esc_html__( 'Cut off for "time ago" date in days.', 'newspack' ),
+			'section' => 'post_default_settings',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -717,7 +717,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'post_time_ago_cut_off',
 		array(
-			'type'    => 'text',
+			'type'    => 'number',
 			'label'   => esc_html__( 'Cut off for "time ago" date in days.', 'newspack' ),
 			'section' => 'post_default_settings',
 		)

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -534,9 +534,12 @@ function newspack_convert_to_time_ago( $post_time ) {
 		$date         = new DateTime();
 		$current_time = $date->getTimestamp();
 		$org_time     = strtotime( $post->post_date );
-		$cut_off      = get_theme_mod( 'post_time_ago_cut_off', '1209600' );
+		$cut_off      = get_theme_mod( 'post_time_ago_cut_off', '14' );
 
-		if ( $cut_off >= ( $current_time - $org_time ) ) {
+		// Transform cut off from days to seconds.
+		$cut_off_seconds = $cut_off * 86400;
+
+		if ( $cut_off_seconds >= ( $current_time - $org_time ) ) {
 			$post_time = sprintf(
 				/* translators: %s: Time ago date format */
 				esc_html__( '%s ago', 'newspack' ),

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -532,11 +532,12 @@ function newspack_the_custom_logo() {
 /**
  * Change date to 'time ago' format if enabled in the Customizer.
  */
-function newspack_convert_to_time_ago( $post_time ) {
+function newspack_convert_to_time_ago( $post_time, $format ) {
 	global $post;
 	$use_time_ago = get_theme_mod( 'post_time_ago', false );
 
-	if ( true === $use_time_ago ) {
+	// Only filter time when $use_time_ago is enabled, and it's not using a machine-readable format (for datetime).
+	if ( true === $use_time_ago && 'Y-m-d\TH:i:sP' !== $format ) {
 		$date         = new DateTime();
 		$current_time = $date->getTimestamp();
 		$org_time     = strtotime( $post->post_date );
@@ -555,4 +556,4 @@ function newspack_convert_to_time_ago( $post_time ) {
 	}
 	return $post_time;
 }
-add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -220,11 +220,17 @@ function newspack_get_the_archive_title() {
 	} elseif ( is_author() ) {
 		$title = esc_html__( 'Author Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_author_meta( 'display_name' ) . '</span>';
 	} elseif ( is_year() ) {
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 		$title = esc_html__( 'Yearly Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date( _x( 'Y', 'yearly archives date format', 'newspack' ) ) . '</span>';
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 	} elseif ( is_month() ) {
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 		$title = esc_html__( 'Monthly Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date( _x( 'F Y', 'monthly archives date format', 'newspack' ) ) . '</span>';
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 	} elseif ( is_day() ) {
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 		$title = esc_html__( 'Daily Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date() . '</span>';
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
 	} elseif ( is_post_type_archive() ) {
 		$title = esc_html__( 'Post Type Archives: ', 'newspack' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
 	} elseif ( is_tax() ) {
@@ -549,8 +555,4 @@ function newspack_convert_to_time_ago( $post_time ) {
 	}
 	return $post_time;
 }
-
 add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
-add_filter( 'the_date', 'newspack_convert_to_time_ago', 10, 1 );
-add_filter( 'get_the_time', 'newspack_convert_to_time_ago', 10, 1 );
-add_filter( 'the_time', 'newspack_convert_to_time_ago', 10, 1 );

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -522,3 +522,32 @@ function newspack_the_custom_logo() {
 		the_custom_logo();
 	}
 }
+
+/**
+ * Change date to 'time ago' format if enabled in the Customizer.
+ */
+function newspack_convert_to_time_ago( $post_time ) {
+	global $post;
+	$use_time_ago = get_theme_mod( 'post_time_ago', false );
+
+	if ( true === $use_time_ago ) {
+		$date         = new DateTime();
+		$current_time = $date->getTimestamp();
+		$org_time     = strtotime( $post->post_date );
+		$cut_off      = get_theme_mod( 'post_time_ago_cut_off', '1209600' );
+
+		if ( $cut_off >= ( $current_time - $org_time ) ) {
+			$post_time = sprintf(
+				/* translators: %s: Time ago date format */
+				esc_html__( '%s ago', 'newspack' ),
+				human_time_diff( $org_time, $current_time )
+			);
+		}
+	}
+	return $post_time;
+}
+
+add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+add_filter( 'the_date', 'newspack_convert_to_time_ago', 10, 1 );
+add_filter( 'get_the_time', 'newspack_convert_to_time_ago', 10, 1 );
+add_filter( 'the_time', 'newspack_convert_to_time_ago', 10, 1 );

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -214,6 +214,21 @@
 			} );
 		} );
 
+		// Only show 'time ago' cutoff field when enabled.
+		wp.customize( 'post_time_ago', function( setting ) {
+			wp.customize.control( 'post_time_ago_cut_off', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
 		// Lets you jump to specific sections in the Customizer
 		$( [ 'control', 'section', 'panel' ] ).each( function( i, type ) {
 			$( 'a[rel="goto-' + type + '"]' ).click( function( e ) {

--- a/newspack-theme/sidebar.php
+++ b/newspack-theme/sidebar.php
@@ -12,6 +12,7 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 ?>
 
 <aside id="secondary" class="widget-area">
+	<?php remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 ); ?>
 	<?php do_action( 'before_sidebar' ); ?>
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
 	<?php do_action( 'after_sidebar' ); ?>

--- a/newspack-theme/sidebar.php
+++ b/newspack-theme/sidebar.php
@@ -12,8 +12,11 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 ?>
 
 <aside id="secondary" class="widget-area">
-	<?php remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 ); ?>
-	<?php do_action( 'before_sidebar' ); ?>
-	<?php dynamic_sidebar( 'sidebar-1' ); ?>
-	<?php do_action( 'after_sidebar' ); ?>
+	<?php
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		do_action( 'before_sidebar' );
+		dynamic_sidebar( 'sidebar-1' );
+		do_action( 'after_sidebar' );
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+	?>
 </aside><!-- #secondary -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to display post (and block) dates using a 'time ago' option, and set a cut off for when this date format is applied in seconds (the default is two weeks). 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Navigate to Customizer > Template Settings, and check "Use 'time ago' date format"; as part of this, confirm that the "Cut off for 'time ago'..." section is not visible by default, but appears when "Use 'time ago' date format" is checked:

![image](https://user-images.githubusercontent.com/177561/92411468-d2f64080-f0fc-11ea-8b5d-7940c9dacabe.png)

3. View posts of various ages, on single posts, archives, search, and in the Homepage Posts and Post Carousel blocks, and confirm posts newer than two weeks old use the 'time ago' format:

Blocks:
![image](https://user-images.githubusercontent.com/177561/92411942-cb379b80-f0fe-11ea-9aeb-dd1fc6d1886f.png)

![image](https://user-images.githubusercontent.com/177561/92411945-d094e600-f0fe-11ea-95f4-7cee03be6672.png)

Single post:
![image](https://user-images.githubusercontent.com/177561/92411958-d985b780-f0fe-11ea-84fc-0f256cebee2a.png)

Search:
![image](https://user-images.githubusercontent.com/177561/92411968-e60a1000-f0fe-11ea-9e1e-26317def0bf7.png)

Archive:
![image](https://user-images.githubusercontent.com/177561/92411985-f15d3b80-f0fe-11ea-88f8-7c17125f98e1.png)

4. Confirm that the date format is not being picked up where it shouldn't be (like in the archive date header for www.yoursite.com/2020/09, or the Recent Posts widgets when dates are set to show (dates in widgets seem to get confused and pick up the current post date, not their actual dates)).
5. Navigate to Customize > Template Settings, and change the cut off from 14 days to a higher or lower value.
6. Confirm that the new cut off is being accurately picked up eg. if you changed it to 7 days, confirm that posts older than 7 days are now showing the date format set in WordPress, not the 'time ago' format.

Notes: 
* The `'Y-m-d\TH:i:sP' !== $format` check is to make sure `get_the_date( DATE_W3C )` is not filtered (which is used for the `datetime` attribute in the `time` tag).
* `DateTime()` and `$date->getTimestamp()` are used instead of `current_time( 'u' )` to avoid this PHPCS error and potential issue: `Calling current_time() with a $type of "timestamp" or "U" is strongly discouraged as it will not return a Unix (UTC) timestamp. Please consider using a non-timestamp format or otherwise refactoring this code. (WordPress.DateTime.CurrentTimeTimestamp.Requested)`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
