### PR TITLE
Add simplified gradient set

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -210,6 +210,42 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
+		add_theme_support(
+			'editor-gradient-presets',
+			array(
+				array(
+					'name'     => __( 'Black to medium gray', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(17, 17, 17) 0%, rgb(85, 85, 85) 100%)',
+					'slug'     => 'grad-1',
+				),
+				array(
+					'name'     => __( 'Medium gray to light gray', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(85, 85, 85) 0%, rgb(221, 221, 221) 100%)',
+					'slug'     => 'grad-2',
+				),
+				array(
+					'name'     => __( 'Light gray to white', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(221, 221, 221) 0%, rgb(255, 255, 255) 100%)',
+					'slug'     => 'grad-3',
+				),
+				array(
+					'name'     => __( 'Blue to light blue', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(0, 113, 161) 0%, rgb(142, 209, 252) 100%)',
+					'slug'     => 'grad-4',
+				),
+				array(
+					'name'     => __( 'Red to orange', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(207, 46, 46) 0%, rgb(255, 105, 0) 100%)',
+					'slug'     => 'grad-5',
+				),
+				array(
+					'name'     => __( 'Orange to yellow', 'newspack' ),
+					'gradient' => 'linear-gradient(135deg, rgb(255, 105, 0) 0%, rgb(252, 185, 0) 100%)',
+					'slug'     => 'grad-6',
+				),
+			)
+		);
+
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -155,6 +155,14 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		$primary_color   = newspack_get_primary_color();
 		$secondary_color = newspack_get_secondary_color();
 
+		if ( 'default' !== get_theme_mod( 'theme_colors' ) ) {
+			$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
+			$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
+		}
+
+		$primary_color_variation   = newspack_adjust_brightness( $primary_color, -40 );
+		$secondary_color_variation = newspack_adjust_brightness( $secondary_color, -40 );
+
 		// Editor color palette.
 		add_theme_support(
 			'editor-color-palette',
@@ -162,30 +170,22 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 				array(
 					'name'  => __( 'Primary', 'newspack' ),
 					'slug'  => 'primary',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						$primary_color :
-						get_theme_mod( 'primary_color_hex', $primary_color ),
+					'color' => $primary_color,
 				),
 				array(
 					'name'  => __( 'Primary Variation', 'newspack' ),
 					'slug'  => 'primary-variation',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						newspack_adjust_brightness( $primary_color, -40 ) :
-						newspack_adjust_brightness( get_theme_mod( 'primary_color_hex', $primary_color ), -40 ),
+					'color' => $primary_color_variation,
 				),
 				array(
 					'name'  => __( 'Secondary', 'newspack' ),
 					'slug'  => 'secondary',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						$secondary_color :
-						get_theme_mod( 'secondary_color_hex', $secondary_color ),
+					'color' => $secondary_color,
 				),
 				array(
 					'name'  => __( 'Secondary Variation', 'newspack' ),
 					'slug'  => 'secondary-variation',
-					'color' => 'default' === get_theme_mod( 'theme_colors' ) ?
-						newspack_adjust_brightness( $secondary_color, -40 ) :
-						newspack_adjust_brightness( get_theme_mod( 'secondary_color_hex', $secondary_color ), -40 ),
+					'color' => $secondary_color_variation,
 				),
 				array(
 					'name'  => __( 'Dark Gray', 'newspack' ),
@@ -232,6 +232,16 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 					'name'     => __( 'Light gray to white', 'newspack' ),
 					'gradient' => 'linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% )',
 					'slug'     => 'grad-4',
+				),
+				array(
+					'name'     => __( 'Primary to primary variation', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $primary_color_variation ) . ' 100% )',
+					'slug'     => 'grad-5',
+				),
+				array(
+					'name'     => __( 'Secondary to secondary variation', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $secondary_color ) . ' 0%, ' . esc_attr( $secondary_color_variation ) . ' 100% )',
+					'slug'     => 'grad-6',
 				),
 			)
 		);

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -215,33 +215,23 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			array(
 				array(
 					'name'     => __( 'Black to medium gray', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(17, 17, 17) 0%, rgb(85, 85, 85) 100%)',
+					'gradient' => 'linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% )',
 					'slug'     => 'grad-1',
 				),
 				array(
-					'name'     => __( 'Medium gray to light gray', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(85, 85, 85) 0%, rgb(221, 221, 221) 100%)',
+					'name'     => __( 'Dark gray to medium gray', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% )',
 					'slug'     => 'grad-2',
 				),
 				array(
-					'name'     => __( 'Light gray to white', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(221, 221, 221) 0%, rgb(255, 255, 255) 100%)',
+					'name'     => __( 'Medium gray to light gray', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% )',
 					'slug'     => 'grad-3',
 				),
 				array(
-					'name'     => __( 'Blue to light blue', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(0, 113, 161) 0%, rgb(142, 209, 252) 100%)',
+					'name'     => __( 'Light gray to white', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% )',
 					'slug'     => 'grad-4',
-				),
-				array(
-					'name'     => __( 'Red to orange', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(207, 46, 46) 0%, rgb(255, 105, 0) 100%)',
-					'slug'     => 'grad-5',
-				),
-				array(
-					'name'     => __( 'Orange to yellow', 'newspack' ),
-					'gradient' => 'linear-gradient(135deg, rgb(255, 105, 0) 0%, rgb(252, 185, 0) 100%)',
-					'slug'     => 'grad-6',
 				),
 			)
 		);

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -215,12 +215,12 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			array(
 				array(
 					'name'     => __( 'Primary to primary variation', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $primary_color_variation ) . ' 100% )',
+					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( newspack_hex_to_rgb( $primary_color ) ) . ' 0%, ' . esc_attr( newspack_hex_to_rgb( $primary_color_variation ) ) . ' 100% )',
 					'slug'     => 'grad-1',
 				),
 				array(
 					'name'     => __( 'Secondary to secondary variation', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $secondary_color ) . ' 0%, ' . esc_attr( $secondary_color_variation ) . ' 100% )',
+					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( newspack_hex_to_rgb( $secondary_color ) ) . ' 0%, ' . esc_attr( newspack_hex_to_rgb( $secondary_color_variation ) ) . ' 100% )',
 					'slug'     => 'grad-2',
 				),
 				array(

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -214,33 +214,33 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			'editor-gradient-presets',
 			array(
 				array(
-					'name'     => __( 'Black to medium gray', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% )',
-					'slug'     => 'grad-1',
-				),
-				array(
-					'name'     => __( 'Dark gray to medium gray', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% )',
-					'slug'     => 'grad-2',
-				),
-				array(
-					'name'     => __( 'Medium gray to light gray', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% )',
-					'slug'     => 'grad-3',
-				),
-				array(
-					'name'     => __( 'Light gray to white', 'newspack' ),
-					'gradient' => 'linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% )',
-					'slug'     => 'grad-4',
-				),
-				array(
 					'name'     => __( 'Primary to primary variation', 'newspack' ),
 					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $primary_color ) . ' 0%, ' . esc_attr( $primary_color_variation ) . ' 100% )',
-					'slug'     => 'grad-5',
+					'slug'     => 'grad-1',
 				),
 				array(
 					'name'     => __( 'Secondary to secondary variation', 'newspack' ),
 					'gradient' => 'linear-gradient( 135deg, ' . esc_attr( $secondary_color ) . ' 0%, ' . esc_attr( $secondary_color_variation ) . ' 100% )',
+					'slug'     => 'grad-2',
+				),
+				array(
+					'name'     => __( 'Black to medium gray', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% )',
+					'slug'     => 'grad-3',
+				),
+				array(
+					'name'     => __( 'Dark gray to medium gray', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% )',
+					'slug'     => 'grad-4',
+				),
+				array(
+					'name'     => __( 'Medium gray to light gray', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% )',
+					'slug'     => 'grad-5',
+				),
+				array(
+					'name'     => __( 'Light gray to white', 'newspack' ),
+					'gradient' => 'linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% )',
 					'slug'     => 'grad-6',
 				),
 			)

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -225,6 +225,14 @@ function newspack_custom_colors_css() {
 			.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
 				color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
 			}
+
+			/* Set gradients */
+			.entry .entry-content .has-grad-5-gradient-background {
+				background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
+			}
+			.entry .entry-content .has-grad-6-gradient-background {
+				background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
+			}
 			';
 
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
@@ -447,6 +455,14 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-background-color {
 			background-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+		}
+
+		/* Set gradients */
+		.edit-post-visual-editor.editor-styles-wrapper .has-grad-5-gradient-background {
+			background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
+		}
+		.edit-post-visual-editor.editor-styles-wrapper .has-grad-6-gradient-background {
+			background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
 		}
 		';
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -227,10 +227,10 @@ function newspack_custom_colors_css() {
 			}
 
 			/* Set gradients */
-			.entry .entry-content .has-grad-5-gradient-background {
+			.entry .entry-content .has-grad-1-gradient-background {
 				background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
 			}
-			.entry .entry-content .has-grad-6-gradient-background {
+			.entry .entry-content .has-grad-2-gradient-background {
 				background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
 			}
 			';
@@ -458,10 +458,10 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Set gradients */
-		.edit-post-visual-editor.editor-styles-wrapper .has-grad-5-gradient-background {
+		.edit-post-visual-editor.editor-styles-wrapper .has-grad-1-gradient-background {
 			background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
 		}
-		.edit-post-visual-editor.editor-styles-wrapper .has-grad-6-gradient-background {
+		.edit-post-visual-editor.editor-styles-wrapper .has-grad-2-gradient-background {
 			background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
 		}
 		';

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -488,6 +488,14 @@ function newspack_color_with_contrast( $color ) {
 }
 
 /**
+ * Turns hex color value into RGB.
+ */
+function newspack_hex_to_rgb( $hex ) {
+	list( $r, $g, $b ) = sscanf( $hex, '#%02x%02x%02x' );
+	return 'rgb( ' . $r . ', ' . $g . ', ' . $b . ')';
+}
+
+/**
  * Decides which logo to use, based on Customizer settings and current post.
  */
 function newspack_the_custom_logo() {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -987,6 +987,16 @@
 	.has-grad-4-gradient-background {
 		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 	}
+	.has-grad-5-gradient-background {
+		background-image: linear-gradient( 135deg, $color__primary 0%, $color__primary-variation 100% );
+	}
+	.has-grad-6-gradient-background {
+		background-image: linear-gradient(
+			135deg,
+			$color__secondary 0%,
+			$color__secondary-variation 100%
+		);
+	}
 }
 
 .newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -979,19 +979,13 @@
 		background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
 	}
 	.has-grad-2-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 85, 85, 85 ) 0%, rgb( 221, 221, 221 ) 100% );
+		background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
 	}
 	.has-grad-3-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
+		background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
 	}
 	.has-grad-4-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 0, 113, 161 ) 0%, rgb( 142, 209, 252 ) 100% );
-	}
-	.has-grad-5-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 207, 46, 46 ) 0%, rgb( 255, 105, 0 ) 100% );
-	}
-	.has-grad-6-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 255, 105, 0 ) 0%, rgb( 252, 185, 0 ) 100% );
+		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -976,26 +976,26 @@
 
 	// Gradients
 	.has-grad-1-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
-	}
-	.has-grad-2-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
-	}
-	.has-grad-3-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
-	}
-	.has-grad-4-gradient-background {
-		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
-	}
-	.has-grad-5-gradient-background {
 		background-image: linear-gradient( 135deg, $color__primary 0%, $color__primary-variation 100% );
 	}
-	.has-grad-6-gradient-background {
+	.has-grad-2-gradient-background {
 		background-image: linear-gradient(
 			135deg,
 			$color__secondary 0%,
 			$color__secondary-variation 100%
 		);
+	}
+	.has-grad-3-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
+	}
+	.has-grad-4-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
+	}
+	.has-grad-5-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
+	}
+	.has-grad-6-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -973,6 +973,26 @@
 	.wp-block-button__link.is-style-outline.has-white-color:not( :hover ) {
 		color: #fff;
 	}
+
+	// Gradients
+	.has-grad-1-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
+	}
+	.has-grad-2-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 85, 85, 85 ) 0%, rgb( 221, 221, 221 ) 100% );
+	}
+	.has-grad-3-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
+	}
+	.has-grad-4-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 0, 113, 161 ) 0%, rgb( 142, 209, 252 ) 100% );
+	}
+	.has-grad-5-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 207, 46, 46 ) 0%, rgb( 255, 105, 0 ) 100% );
+	}
+	.has-grad-6-gradient-background {
+		background-image: linear-gradient( 135deg, rgb( 255, 105, 0 ) 0%, rgb( 252, 185, 0 ) 100% );
+	}
 }
 
 .newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -940,3 +940,13 @@ ul.wp-block-archives,
 .has-grad-4-gradient-background {
 	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 }
+.has-grad-5-gradient-background {
+	background-image: linear-gradient( 135deg, $color__primary 0%, $color__primary-variation 100% );
+}
+.has-grad-6-gradient-background {
+	background-image: linear-gradient(
+		135deg,
+		$color__secondary 0%,
+		$color__secondary-variation 100%
+	);
+}

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -932,17 +932,11 @@ ul.wp-block-archives,
 	background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
 }
 .has-grad-2-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 85, 85, 85 ) 0%, rgb( 221, 221, 221 ) 100% );
+	background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
 }
 .has-grad-3-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
+	background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
 }
 .has-grad-4-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 0, 113, 161 ) 0%, rgb( 142, 209, 252 ) 100% );
-}
-.has-grad-5-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 207, 46, 46 ) 0%, rgb( 255, 105, 0 ) 100% );
-}
-.has-grad-6-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 255, 105, 0 ) 0%, rgb( 252, 185, 0 ) 100% );
+	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -926,3 +926,23 @@ ul.wp-block-archives,
 .wp-block-button__link.is-style-outline.has-white-color {
 	color: #fff;
 }
+
+// Gradients
+.has-grad-1-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
+}
+.has-grad-2-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 85, 85, 85 ) 0%, rgb( 221, 221, 221 ) 100% );
+}
+.has-grad-3-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
+}
+.has-grad-4-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 0, 113, 161 ) 0%, rgb( 142, 209, 252 ) 100% );
+}
+.has-grad-5-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 207, 46, 46 ) 0%, rgb( 255, 105, 0 ) 100% );
+}
+.has-grad-6-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 255, 105, 0 ) 0%, rgb( 252, 185, 0 ) 100% );
+}

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -929,24 +929,24 @@ ul.wp-block-archives,
 
 // Gradients
 .has-grad-1-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
-}
-.has-grad-2-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
-}
-.has-grad-3-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
-}
-.has-grad-4-gradient-background {
-	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
-}
-.has-grad-5-gradient-background {
 	background-image: linear-gradient( 135deg, $color__primary 0%, $color__primary-variation 100% );
 }
-.has-grad-6-gradient-background {
+.has-grad-2-gradient-background {
 	background-image: linear-gradient(
 		135deg,
 		$color__secondary 0%,
 		$color__secondary-variation 100%
 	);
+}
+.has-grad-3-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 17, 17, 17 ) 0%, rgb( 85, 85, 85 ) 100% );
+}
+.has-grad-4-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 68, 68, 68 ) 0%, rgb( 136, 136, 136 ) 100% );
+}
+.has-grad-5-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 119, 119, 119 ) 0%, rgb( 221, 221, 221 ) 100% );
+}
+.has-grad-6-gradient-background {
+	background-image: linear-gradient( 135deg, rgb( 221, 221, 221 ) 0%, rgb( 255, 255, 255 ) 100% );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces Gutenberg's default set of gradients with a simplified set of all grey options. The purpose is to keep the options available, but to remove the examples Gutenberg provides; they're great to show off what gradients can do, but don't really fit in visually on news sites. Hopefully this will encourage use of the simpler options, and exploring custom gradients that better fit in with existing site colour schemes. 

I'd be interested both in testing feedback, and a yay-nay opinion on the gradients. I had also considered including some really basic gradients (blue, red, yellow), but I'm not sure if that would negate making this change at all. 

### How to test the changes in this Pull Request:

1. Set up at least one gradient using the default set, like as a group background.
2. Apply the PR and run `npm run build`.
3. Confirm that the default gradients are replaced with a smaller set: 

![image](https://user-images.githubusercontent.com/177561/92422049-6ac15200-f130-11ea-9043-efc273df662f.png)

4. Confirm that the gradient you added still works. 
5. Apply each of the new gradients to an element, like a group block, and confirm it works in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/92422084-a3f9c200-f130-11ea-9bbc-59b5592fccaf.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
