### PR TITLE
Update method for getting current time

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -538,8 +538,7 @@ function newspack_convert_to_time_ago( $post_time, $format ) {
 
 	// Only filter time when $use_time_ago is enabled, and it's not using a machine-readable format (for datetime).
 	if ( true === $use_time_ago && 'Y-m-d\TH:i:sP' !== $format ) {
-		$date         = new DateTime();
-		$current_time = $date->getTimestamp();
+		$current_time = current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 		$org_time     = strtotime( $post->post_date );
 		$cut_off      = get_theme_mod( 'post_time_ago_cut_off', '14' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR changes how the current time is established, to avoid issues with daylight savings time.

Closes #1067.

### How to test the changes in this Pull Request:

1. Set your time zone to one that currently has daylight savings time (London, Vancouver...)
2. Navigate to Customize > Template Settings, and turn on the 'time ago' setting.
3. Publish a post; note that the 'time ago' time is incorrect.
4. Apply this PR.
5. Publish a new post; confirm that the 'time ago' time is correct on the new post.
6. Switch to a non-daylight savings time.
7. Publish a new post and confirm that the 'time ago' time is correct on this new post. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
