### PR TITLE
Fix: improve contrast in light grey text

### DIFF
--- a/newspack-theme/sass/variables-site/_colors.scss
+++ b/newspack-theme/sass/variables-site/_colors.scss
@@ -23,7 +23,7 @@ $color__background-dark: #333;
 
 // Text
 $color__text-main: #111;
-$color__text-light: #595959;
+$color__text-light: #515151;
 $color__text-hover: lighten( #111, 22.5% );
 $color__text-screen: #21759b;
 $color__text-input: #666;

--- a/newspack-theme/sass/variables-site/_colors.scss
+++ b/newspack-theme/sass/variables-site/_colors.scss
@@ -23,7 +23,7 @@ $color__background-dark: #333;
 
 // Text
 $color__text-main: #111;
-$color__text-light: #767676;
+$color__text-light: #595959;
 $color__text-hover: lighten( #111, 22.5% );
 $color__text-screen: #21759b;
 $color__text-input: #666;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR increases the contrast of the 'light' text colour. It was originally `#767676`, which does meet AA, but was being used for pretty small text. It's been updated to `#515151`, which will meet AAA. 

Closes #1069.

### How to test the changes in this Pull Request:

1. Start with a site using Newspack Scott, and set up some homepage blocks; the light grey text is used for the post meta (date and author).
2. Apply the PR and run `npm run build`.
3. Confirm that the post meta in the blocks is now a slightly darker grey, `#515151`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
