### PR TITLE
Fix PHP errors from the "time ago" functionality

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -17,7 +17,7 @@
 
 	<footer id="colophon" class="site-footer">
 
-		<?php remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 ); ?>
+		<?php remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'branding' ); ?>
 		<?php get_template_part( 'template-parts/footer/footer', 'widgets' ); ?>
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -220,17 +220,17 @@ function newspack_get_the_archive_title() {
 	} elseif ( is_author() ) {
 		$title = esc_html__( 'Author Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_author_meta( 'display_name' ) . '</span>';
 	} elseif ( is_year() ) {
-		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 		$title = esc_html__( 'Yearly Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date( _x( 'Y', 'yearly archives date format', 'newspack' ) ) . '</span>';
-		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 	} elseif ( is_month() ) {
-		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 		$title = esc_html__( 'Monthly Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date( _x( 'F Y', 'monthly archives date format', 'newspack' ) ) . '</span>';
-		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 	} elseif ( is_day() ) {
-		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 		$title = esc_html__( 'Daily Archives: ', 'newspack' ) . '<span class="page-description">' . get_the_date() . '</span>';
-		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 	} elseif ( is_post_type_archive() ) {
 		$title = esc_html__( 'Post Type Archives: ', 'newspack' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
 	} elseif ( is_tax() ) {

--- a/newspack-theme/sidebar.php
+++ b/newspack-theme/sidebar.php
@@ -13,10 +13,10 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 
 <aside id="secondary" class="widget-area">
 	<?php
-		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		remove_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 		do_action( 'before_sidebar' );
 		dynamic_sidebar( 'sidebar-1' );
 		do_action( 'after_sidebar' );
-		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 1 );
+		add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 2 );
 	?>
 </aside><!-- #secondary -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The new 'time ago' functionality was throwing PHP errors, because the number of arguments when the filter was removed/readded was not correct.

### How to test the changes in this Pull Request:

1. Navigate to a location where the filter is added/removed -- this will happen if you have footer widgets, if you visit a date archive (like /2020 or /2020/09), or a single post with sidebar widgets.
2. Note the PHP error `PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function newspack_convert_to_time_ago()`
3. Apply the PR.
4. Confirm that the error is gone.
5. Confirm that the time ago functionality still works (it can be turned on under Customizer > Template Settings). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
