### PR TITLE
Add support for the Aside post format

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -223,6 +223,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 
 		// Add custom theme support - post subtitle
 		add_theme_support( 'post-subtitle' );
+
+		// Add post format support.
+		add_theme_support( 'post-formats', array( 'aside' ) );
 	}
 endif;
 add_action( 'after_setup_theme', 'newspack_setup' );

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -153,6 +153,35 @@
 	figcaption {
 		max-width: 100%;
 	}
+
+	article.format-aside {
+		font-family: $font__heading;
+
+		.entry-wrapper {
+			//border: 1px solid rgba(200,200,200,0.5);
+			//padding: #{ 1.5 * $size__spacing-unit };
+		}
+
+		.entry-meta > a,
+		.entry-meta .byline {
+			display: none;
+		}
+
+		.entry-title {
+			display: flex;
+			align-items: center;
+		}
+
+		.entry-title::before {
+			background-image: url( 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE3IDNIN2MtMS4xIDAtMS45OS45LTEuOTkgMkw1IDIxbDctMyA3IDNWNWMwLTEuMS0uOS0yLTItMnoiLz48L3N2Zz4=' );
+			content: '';
+			display: inline-block;
+			height: 1.25em;
+			width: 1.25em;
+			margin-right: #{0.25 * $size__spacing-unit};
+			background-size: contain;
+		}
+	}
 }
 
 //! Newspack Carousel Block

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -155,32 +155,35 @@
 	}
 
 	article.format-aside {
-		font-family: $font__heading;
-
-		.entry-wrapper {
-			//border: 1px solid rgba(200,200,200,0.5);
-			//padding: #{ 1.5 * $size__spacing-unit };
-		}
-
 		.entry-meta > a,
 		.entry-meta .byline {
 			display: none;
 		}
+	}
 
-		.entry-title {
-			display: flex;
-			align-items: center;
+	&.ts-4,
+	&.ts-5,
+	&.ts-6,
+	&.ts-7,
+	&.ts-8,
+	&.ts-9,
+	&.ts-10 {
+		article.format-aside {
+			.entry-title {
+				font-size: 1em;
+			}
+			.entry-wrapper {
+				font-size: 90%;
+			}
 		}
+	}
 
-		.entry-title::before {
-			background-image: url( 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTE3IDNIN2MtMS4xIDAtMS45OS45LTEuOTkgMkw1IDIxbDctMyA3IDNWNWMwLTEuMS0uOS0yLTItMnoiLz48L3N2Zz4=' );
-			content: '';
-			display: inline-block;
-			height: 1.25em;
-			width: 1.25em;
-			margin-right: #{0.25 * $size__spacing-unit};
-			background-size: contain;
-		}
+	&.ts-3 article.format-aside .entry-title {
+		font-size: 0.8em;
+	}
+
+	&.ts-2 article.format-aside .entry-title {
+		font-size: 0.7em;
 	}
 }
 

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -64,6 +64,10 @@
 			margin-right: $size__spacing-unit;
 		}
 	}
+
+	.format-aside .byline {
+		display: none;
+	}
 }
 
 .archive {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -741,6 +741,15 @@ div.sharedaddy h3.sd-title,
 	}
 }
 
+/* Aside */
+.single-format-aside {
+	.author-avatar,
+	.byline,
+	.author-bio {
+		display: none;
+	}
+}
+
 /* Related Posts */
 
 .jp-relatedposts-i2 {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -171,6 +171,46 @@ figcaption,
 	position: relative;
 }
 
+/** === Homepage Posts === */
+
+.wpnbha {
+	article.format-aside {
+		.entry-meta > a,
+		.entry-meta .byline {
+			display: none;
+		}
+	}
+
+	&.ts-4,
+	&.ts-5,
+	&.ts-6,
+	&.ts-7,
+	&.ts-8,
+	&.ts-9,
+	&.ts-10 {
+		article.format-aside {
+			.entry-title {
+				font-size: 1em;
+			}
+			.entry-wrapper {
+				font-size: 90%;
+			}
+
+			p {
+				font-size: inherit;
+			}
+		}
+	}
+
+	&.ts-3 article.format-aside .entry-title {
+		font-size: 0.8em;
+	}
+
+	&.ts-2 article.format-aside .entry-title {
+		font-size: 0.7em;
+	}
+}
+
 /** === Newspack Carousel === */
 .wp-block-newspack-blocks-carousel h3 a,
 .wp-block-newspack-blocks-carousel h3 a:visited {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -176,7 +176,8 @@ figcaption,
 .wpnbha {
 	article.format-aside {
 		.entry-meta > a,
-		.entry-meta .byline {
+		.entry-meta .byline,
+		.entry-meta .author-avatar {
 			display: none;
 		}
 	}

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -41,7 +41,7 @@ get_header();
 						newspack_post_thumbnail();
 					endif;
 
-					get_template_part( 'template-parts/content/content', 'single' );
+					get_template_part( 'template-parts/content/content-single', 'single' );
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-blocks/pull/591, add support for the Aside post format to the theme and Homepage Posts block. By using the Aside block, you can create a short, non-linked post that will appear in the Homepage Posts block; there it will display the full content, rather than an excerpt. The purpose is to allow very short updates, or posts linking off to other sites, as part of the homepage. 

The styles are baked into the theme, rather than the blocks, since they're pretty opinionated based on this use case. 

This needs to be tested with https://github.com/Automattic/newspack-blocks/pull/591. 

### How to test the changes in this Pull Request:

1. Apply this PR and the blocks PR, and run `npm run build` in each directory.
2. Add a new post, and confirm you have the option to pick a Post Format; select 'Aside'.
3. Add a couple lines of text to the post, including a link, and publish.
4. View the post, and try searching for it; confirm that it looks like a regular post, but the author/author bio is hidden (it's unlikely anyone will see this view, but it should look okay if it comes up in search results/archives):

![image](https://user-images.githubusercontent.com/177561/92810111-19080a00-f372-11ea-8ce5-f0341d7fc37e.png)

![image](https://user-images.githubusercontent.com/177561/92811600-76508b00-f373-11ea-8f58-9560f2541ba2.png)

5. Add a homepage posts block that will show your aside post.
6. View on the front end -- confirm that the title is smaller (matching the text) and is not linked; the author does not display, and the full post (links and all) is displayed: 

![image](https://user-images.githubusercontent.com/177561/92812514-481f7b00-f374-11ea-9d63-e78c0570f3c6.png)

7. Try a few different type scale options in the block -- the Aside is set up so it will be 90% of the text size for type scale 4 and up, and the same size for three and lower; the title should always be the same size as the text:

![image](https://user-images.githubusercontent.com/177561/92812755-b6fcd400-f374-11ea-823a-72c3c9c9a0c4.png)

![image](https://user-images.githubusercontent.com/177561/92812987-35597600-f375-11ea-80d2-c07d581b9e70.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
