### PR TITLE
fix: show credit if credit is set and caption is not

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -302,6 +302,14 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 					// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
 					$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
 
+					// Account for featured images that have a credit but no caption.
+					if ( ! $caption_exists && class_exists( 'Newspack_Image_Credits' ) ) {
+						$maybe_newspack_image_credit = Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
+						if ( strlen( wp_strip_all_tags( $maybe_newspack_image_credit ) ) ) {
+							$caption_exists = true;
+						}
+					}
+
 					if ( $caption_exists ) :
 					?>
 						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes an issue where, with Newspack Image Credits installed, a featured image with a credit but no caption would not display any text at all. 

Closes https://github.com/Automattic/newspack-theme/issues/1076

### How to test the changes in this Pull Request:

1. Install [Newspack Image Credits](https://github.com/Automattic/newspack-image-credits). 
2. Create 4 posts all with featured images. a) no caption or credit b) caption and credit c) caption only d) credit only.
3. View the posts and verify the correct caption/credit combo is being displayed.
4. Deactivate Newpack Image Credits, verify there are no errors or warnings.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
