### PR TITLE
Sponsored Content: Remove $ symbol

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -127,7 +127,6 @@ if ( ! function_exists( 'newspack_sponsor_label' ) ) :
 			<span class="cat-links sponsor-label" [class]="infoVisible ? 'cat-links sponsor-label show-info' : 'cat-links sponsor-label'">
 				<span class="flag">
 					<?php
-						echo wp_kses( newspack_get_icon_svg( 'money', 16 ), newspack_sanitize_svgs() );
 						// If multiple sponsors, use Sponsor Flag from the first one in the array.
 						echo esc_html( $sponsors[0]['sponsor_flag'] );
 					?>

--- a/newspack-theme/sass/plugins/newspack-sponsors.scss
+++ b/newspack-theme/sass/plugins/newspack-sponsors.scss
@@ -7,16 +7,11 @@
 	display: inline-flex;
 	position: relative;
 
-	.flag,
 	button {
 		align-items: center;
-		display: inline-flex;
-		position: relative;
-	}
-
-	button {
 		background: transparent;
 		color: $color__text-light;
+		display: inline-flex;
 		margin-left: #{0.25 * $size__spacing-unit};
 		padding: 0;
 		position: relative;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The original version of the Sponsored Content 'flag' in the theme included a SVG of a dollar sign (`$`). However, this is not inclusive of all the currencies and countries we support in Newspack. 

To keep things simple, I've opted to remove icon all together, rather than try to support all the different currency symbols out there -- I worry that'll add a lot of complexity. We could also add an option to hide it, but I don't love the idea of supporting an icon for a small number of currencies, and nothing for the rest. Removing the icon does also help the theme line up visually with the blocks, since they don't include the icon in the flag.

I'm open to feedback if anyone thinks removing the option is a bad idea.

Closes #1085.

### How to test the changes in this Pull Request:

1. Set up a sponsored post, using the [Newspack Sponsors plugin](https://github.com/automattic/newspack-sponsors).
2. View a single post on the front end; note the dollar sign:

![image](https://user-images.githubusercontent.com/177561/94487915-92876100-0196-11eb-87c0-55e7f1c579bf.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the flag still displays correctly, minus the icon:

![image](https://user-images.githubusercontent.com/177561/94487879-80a5be00-0196-11eb-9ce4-a5f7be13ce5d.png)

Search results:

![image](https://user-images.githubusercontent.com/177561/94487976-ab901200-0196-11eb-8ca4-23424657b2de.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
