### PR TITLE
Newspack Scott: Make sure footer widgets pick up correct custom font

### DIFF
--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -305,7 +305,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-#colophon .widget,
 // If custom font is set, `#colophon .site-info` selector would override it
 // (See issue #663)
 .site-info {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The CSS styling the footer widgets in Newspack Scott is too specific, so the custom fonts don't override what the child theme is setting with certain widgets.

See #1066.

### How to test the changes in this Pull Request:

1. Switch your test site to Newspack Scott.
2. Add at least one text widget to the footer and above copyright areas; add a few other widget types to the mix, too, to test.
3. Apply a custom header font. 
4. View on the front end; note that the text widget isn't picking up your custom header font like the other widgets are -- in this example, it should be using Impact but it's still using the default Fira Sans Condensed:

![image](https://user-images.githubusercontent.com/177561/94504815-8a431c00-01be-11eb-8e45-3267583778cb.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the widgets are now picking up your custom fonts:

![image](https://user-images.githubusercontent.com/177561/94504721-46e8ad80-01be-11eb-91ce-341cf6477bef.png)

7. Switch back to the default fonts and confirm that they are also getting picked up correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
