### PR TITLE
Tagline: Make sure it's picking up custom fonts

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -40,6 +40,7 @@ function newspack_custom_typography_css() {
 		.pagination .nav-links,
 		.sticky-post,
 		.site-title,
+		.site-description,
 		.site-info,
 		#cancel-comment-reply-link,
 		.entry .entry-content .jp-relatedposts-i2 a,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the tagline does not pick up the custom fonts -- it continues to use whatever the child theme's header font is. This PR (finally!) fixes that.

See #1066.

### How to test the changes in this Pull Request:

1. Set up a site with a visible tagline, and give the site a custom header font.
2. View on front end, and note that the custom font is not being picked up -- in this example, it should be using Impact, but it's picking up the child theme's unbolded header font:

![image](https://user-images.githubusercontent.com/177561/94505687-7c8e9600-01c0-11eb-83cd-f6761d49548f.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the tagline is now picking up the custom header font:

![image](https://user-images.githubusercontent.com/177561/94505644-684a9900-01c0-11eb-8fe6-220e6eb416ab.png)

5. Cycle through the child themes and confirm that it's being applied to all of them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
