### PR TITLE
Add option to turn off Yoast's primary category, so all categories display

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -723,6 +723,25 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to turn off Yoast's Primary Category functionality.
+	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+		$wp_customize->add_setting(
+			'post_primary_category',
+			array(
+				'default'           => 'true',
+				'sanitize_callback' => 'newspack_sanitize_checkbox',
+			)
+		);
+		$wp_customize->add_control(
+			'post_primary_category',
+			array(
+				'type'    => 'checkbox',
+				'label'   => __( 'Use Yoast\'s primary category functionality', 'newspack' ),
+				'section' => 'post_default_settings',
+			)
+		);
+	}
+
 	/**
 	 * Comments settings
 	 */

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -198,9 +198,10 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 	 */
 	function newspack_categories() {
 		$categories_list = '';
+		$primary_cat_enabled = get_theme_mod( 'post_primary_category', true );
 
 		// Only display Yoast primary category if set.
-		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+		if ( class_exists( 'WPSEO_Primary_Term' ) && true === $primary_cat_enabled ) {
 			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
 			$category_id = $primary_term->get_primary_term();
 			if ( $category_id ) {

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -201,7 +201,7 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 		$primary_cat_enabled = get_theme_mod( 'post_primary_category', true );
 
 		// Only display Yoast primary category if set.
-		if ( class_exists( 'WPSEO_Primary_Term' ) && true === $primary_cat_enabled ) {
+		if ( class_exists( 'WPSEO_Primary_Term' ) && $primary_cat_enabled ) {
 			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
 			$category_id = $primary_term->get_primary_term();
 			if ( $category_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an option to the Customizer to turn off Yoast's Primary Category feature, so you can display all of your categories on theme pages (single posts, search, blog posts page). 

This change doesn't affect the Homepage Posts block; if we do opt to add a control for that it will need to be done on the block level, since the block uses a combination of Yoast's Primary Category feature, with a 'grabbing the first category' fallback.

Closes #861 

### How to test the changes in this Pull Request:

1. Start on a site with Yoast enabled. 
2. Set up a post with multiple categories. 
3. Apply the PR.
4. View on the front-end; confirm that only one category is showing:

![image](https://user-images.githubusercontent.com/177561/95386978-f7347100-08a4-11eb-9e66-7accf4f1e746.png)

5. Navigate to the Customizer > Template Settings; confirm you now have a checkbox to enable Yoast's Primary Category feature, and that it's enabled by default:

![image](https://user-images.githubusercontent.com/177561/95386964-f00d6300-08a4-11eb-9acb-5a57a4ac69be.png)

6. Uncheck the primary category option.
7. Confirm that it updates the category display to show all of your posts categories:

![image](https://user-images.githubusercontent.com/177561/95387005-01ef0600-08a5-11eb-9b59-8ae5c09b6c29.png)

8. Uncheck the option and confirm the post goes back to showing your primary category.
9. Disable the Yoast plugin and confirm that the category option disappears from the Customizer > Template Settings panel.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
