### PR TITLE
Image Block: Target only smaller screen sizes for image block fix

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -738,16 +738,18 @@
 			text-align: left;
 		}
 
-		.alignleft,
-		.aligncenter,
-		.alignright {
-			figcaption {
+		@include media( mobileonly ) {
+			.alignleft,
+			.aligncenter,
+			.alignright {
+				figcaption {
+					display: block;
+				}
+			}
+
+			.aligncenter {
 				display: block;
 			}
-		}
-
-		.aligncenter {
-			display: block;
 		}
 	}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -749,6 +749,11 @@
 
 			.aligncenter {
 				display: block;
+
+				img {
+					margin-left: auto;
+					margin-right: auto;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes issues introduced in #1058 -- those changes were intended to fix visual issues in mobile Safari (gaps between images and their captions), but they are causing some visual issues on desktop with smaller images. Since the original issue only occurs on smaller screens, the best approach seems to be to target those smaller screen sizes win the original fix. 

Closes #1065

### How to test the changes in this Pull Request:

1. Set up a post with eight smaller images (less than 300px wide) -- they can all be the same image. Add a caption to every other one that is longer, so it would be wider than the image. Align two center, two to the left, and two to the right -- you should end up with an image block with and without a caption for each alignment: none, center, left and right.
2. View on desktop; note some odd alignment or spacing issues with the centered, left and right images -- the centered image caption won't be centered (and the centered image itself won't be centered if AMP is not enabled). The left and right images with captions have them stick out past the images:

Centre-aligned with AMP and caption:

![image](https://user-images.githubusercontent.com/177561/96022160-4a5a7680-0e05-11eb-8f0a-fb5e2e1e87fb.png)

Centre-aligned without AMP:

![image](https://user-images.githubusercontent.com/177561/96022114-3b73c400-0e05-11eb-9cfd-6598e3cf5dd1.png)

Left aligned with caption (is flush-left with AMP disabled):

![image](https://user-images.githubusercontent.com/177561/96022196-59d9bf80-0e05-11eb-8875-d491ca710a11.png)

Right aligned with caption (is flush-left with AMP disabled):

![image](https://user-images.githubusercontent.com/177561/96022224-65c58180-0e05-11eb-9c7d-5d43555f1d28.png)

3. Apply the PR and run `npm run build`.
4. Refresh the page; note that the above images now display as expected:

Centred image with caption:

![image](https://user-images.githubusercontent.com/177561/96024154-395f3480-0e08-11eb-937f-85f3528dc4aa.png)

Left-aligned image with caption: 

![image](https://user-images.githubusercontent.com/177561/96024178-411ed900-0e08-11eb-8cec-46e15ca08ebf.png)

Right-aligned image with caption: 

![image](https://user-images.githubusercontent.com/177561/96024202-4845e700-0e08-11eb-8c0d-61bdec6668ee.png)

5. View on an iPhone, with AMP enabled (since it greatly increases the odds of the original issue occuring); confirm that the gap image between images and captions can't be reproduced.

**Note:** There will still be some minor issues with small centred images -- the captions will extend past the edges of the image. I think this is a fair trade off, as that exact issue hasn't been reported yet with the current version of the fix in place, and it will be less likely to happen (since on smaller screen sizes you'd need a dang tiny image to notice it):

![image](https://user-images.githubusercontent.com/177561/96023799-d1a8e980-0e07-11eb-875e-902a0b86269f.png)

One work around would be to centre the caption text in that case, but I think, since it would look out of place unless the original image was quite small -- it's best to leave it left aligned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
