### PR TITLE
Newspack Katharine: Fix menu hover background in dropdowns

### DIFF
--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -79,11 +79,6 @@ function newspack_katharine_custom_colors_css() {
 					color: ' . esc_html( $primary_color_contrast ) . ';
 				}
 			}
-
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-			}
 		';
 
 

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -40,24 +40,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-// Header solid bg; header short height
-.h-sb.h-sh {
-	.site-header .nav1 .main-menu .sub-menu {
-		a {
-			background-color: $color__text-main;
-
-			&:hover,
-			&:focus {
-				background-color: $color__primary;
-			}
-		}
-
-		&::before {
-			border-color: transparent transparent $color__text-main transparent;
-		}
-	}
-}
-
 // Mobile CTA
 .button.mb-cta {
 	border-radius: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some dropdown colour inconsistencies in Newspack Katharine.

### How to test the changes in this Pull Request:

1. Start with a test site with Nespack Katharine.
2. Set up the site with a short header, with a solid background colour.
3. View on the front-end and open a dropdown menu; note that the dropdown uses the primary colour on hover, instead of the correct darker grey:

![image](https://user-images.githubusercontent.com/177561/96050376-59a1ea00-0e2e-11eb-8ff4-18c7f61f977e.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the menu dropdown is now dark grey:

![image](https://user-images.githubusercontent.com/177561/96050480-8b1ab580-0e2e-11eb-9ce0-3b555cefe94e.png) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
