### PR TITLE
fix: correct dropdown colors for Newspack Sacha

### DIFF
--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -46,13 +46,6 @@ function newspack_sacha_custom_colors_css() {
 	';
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
-		$theme_css .= '
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:hover,
-			.h-sb.h-sh .site-header .nav1 .main-menu .sub-menu a:focus {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
-			}
-		';
-
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$theme_css .= '
 				/* Header solid background */

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -39,24 +39,6 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-// Header solid background; header short height
-.h-sb.h-sh {
-	.site-header .nav1 .main-menu .sub-menu {
-		a {
-			background-color: $color__text-main;
-
-			&:hover,
-			&:focus {
-				background-color: $color__primary;
-			}
-		}
-
-		&::before {
-			border-color: transparent transparent $color__text-main transparent;
-		}
-	}
-}
-
 // Subpage header with a solid background
 .h-sub.h-sb.single-featured-image-beside {
 	@include media( tablet ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #1110, this PR fixes some dropdown colour inconsistencies in Newspack Sacha.

### How to test the changes in this Pull Request:

1. Start with a test site with Nespack Sacha.
2. Set up the site with a short header, with a solid background colour.
3. View on the front-end and open a dropdown menu; note that the dropdown uses the primary colour on hover, instead of the correct darker grey:

![image](https://user-images.githubusercontent.com/177561/96051548-9bcc2b00-0e30-11eb-8029-0527050e9fb9.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the menu dropdown is now dark grey:

![image](https://user-images.githubusercontent.com/177561/96051506-85be6a80-0e30-11eb-93d7-d714b8e12f01.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
