### PR TITLE
fix: make sure accent header in the editor matches the front end

### DIFF
--- a/newspack-joseph/inc/child-typography.php
+++ b/newspack-joseph/inc/child-typography.php
@@ -51,7 +51,7 @@ function newspack_joseph_custom_typography_css() {
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header {
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header {
 				font-family: inherit;
 			}';
 	}
@@ -76,7 +76,7 @@ function newspack_joseph_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -140,7 +140,8 @@ Newspack Sacha Editor Styles
 		content: '';
 		flex: 1 0 0.25rem;
 		height: 1px;
-		margin: 0 0 0 0.25rem;
+		left: 50%;
+		top: 50%;
 	}
 }
 

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -140,8 +140,8 @@ Newspack Sacha Editor Styles
 		content: '';
 		flex: 1 0 0.25rem;
 		height: 1px;
-		left: 50%;
-		top: 50%;
+		margin: 0 0 0 0.25rem;
+		position: relative !important;
 	}
 }
 

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -118,12 +118,12 @@ function newspack_katharine_custom_colors_css() {
 
 	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
-		.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+		.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
-		.block-editor-block-list__layout .block-editor-block-list__block .accent-header:before,
+		.block-editor-block-list__layout .block-editor-block-list__block.accent-header:before,
 		.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before,
 		.block-editor-block-list__layout .block-editor-block-list__block figcaption:after,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-caption-text:after {

--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -42,7 +42,7 @@ function newspack_katharine_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .entry-date {

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -11,7 +11,8 @@ Newspack Katharine Editor Styles
 .article-section-title {
 	color: $color__primary;
 	font-size: $font__size-xs;
-	margin: 0 0 #{1.5 * $size__spacing-unit};
+	margin-bottom: #{1.5 * $size__spacing-unit};
+	margin-top: 0;
 
 	&::before {
 		background-color: $color__primary;

--- a/newspack-nelson/inc/child-typography.php
+++ b/newspack-nelson/inc/child-typography.php
@@ -48,7 +48,7 @@ function newspack_nelson_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .cat-links {

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -84,7 +84,7 @@ function newspack_sacha_custom_colors_css() {
 
 	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
-		.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+		.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}

--- a/newspack-sacha/inc/child-typography.php
+++ b/newspack-sacha/inc/child-typography.php
@@ -43,7 +43,7 @@ function newspack_sacha_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -78,7 +78,7 @@ function newspack_scott_custom_colors_css() {
 	}
 
 	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .accent-header:not(.widget-title):before,
+		.block-editor-block-list__layout .block-editor-block-list__block.accent-header:before,
 		.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}

--- a/newspack-scott/inc/child-typography.php
+++ b/newspack-scott/inc/child-typography.php
@@ -45,7 +45,7 @@ function newspack_scott_custom_typography_css() {
 			}
 		';
 		$editor_css_blocks .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 			.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 				text-transform: uppercase;
 			}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -457,7 +457,7 @@ function newspack_custom_colors_css() {
 		$editor_css .= '
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
-			.block-editor-block-list__layout .block-editor-block-list__block .accent-header {
+			.block-editor-block-list__layout .block-editor-block-list__block.accent-header {
 				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 			}
 		';

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -253,7 +253,7 @@ function newspack_custom_typography_css() {
 				}
 			';
 			$editor_css_blocks .= '
-				.block-editor-block-list__layout .block-editor-block-list__block .accent-header,
+				.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
 				.block-editor-block-list__layout .block-editor-block-list__block .article-section-title {
 					text-transform: uppercase;
 				}

--- a/newspack-theme/sass/styles/style-default/style-default-editor.scss
+++ b/newspack-theme/sass/styles/style-default/style-default-editor.scss
@@ -3,6 +3,7 @@
 	border-bottom: 4px solid $color__border;
 	color: $color__primary;
 	font-size: $font__size-sm;
-	margin: 0 0 #{$size__spacing-unit * 0.75};
+	margin-top: 0;
+	margin-bottom: #{$size__spacing-unit * 0.75};
 	padding: 0 0 #{$size__spacing-unit * 0.33};
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme includes styles for a class, `accent-header`, that can be added to H1-H6 to make it match the header above the homepage posts block.

Due to changes in Gutenberg, it has stopped picking up some of the styles in the editor -- including the proper alignment, and custom colours and fonts. This PR fixes that.

### How to test the changes in this Pull Request:

1. Set your theme to Newspack; set a darker custom colour (so it doesn't get switched to grey for lack of contrast), and a custom header and body font; also check 'Use all-caps for accent text.' in the Typography panel.
2. In the editor, add a Header block and add the class `accent-header`; below it, add a homepage posts block, and fill in the header space at the top of the block.
3. Note the appearance of the `accent-header` in the editor compared to the header that's part of the Homepage Posts block -- with the default theme, it won't be picking up the custom colour, uppercase font or alignment:

![image](https://user-images.githubusercontent.com/177561/96061115-39325980-0e47-11eb-85de-401a37a2c896.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the header is previewing correctly in the editor now:

![image](https://user-images.githubusercontent.com/177561/96061190-6d0d7f00-0e47-11eb-9bc9-0ccabd5f8d73.png)

6. Cycle through the child themes and confirm that the accent header matches the homepage posts block:

**Newspack Joseph** (the `accent-header` should use the body font, not the header font):

![image](https://user-images.githubusercontent.com/177561/96061232-8f9f9800-0e47-11eb-87f0-c6bd89209f4b.png)

**Newspack Katharine**:

![image](https://user-images.githubusercontent.com/177561/96061274-ad6cfd00-0e47-11eb-9486-665aa17ea1aa.png)

**Newspack Nelson**:

![image](https://user-images.githubusercontent.com/177561/96061345-d42b3380-0e47-11eb-8348-4e993ca2c2cd.png)

**Newspack Sacha** (the `accent-header` doesn't pick up the border style; this needs fixing in a seperate PR for both the editor and front-end):

![image](https://user-images.githubusercontent.com/177561/96061393-f2912f00-0e47-11eb-94bd-f2b2f79ba603.png)

**Newspack Scott**:

![image](https://user-images.githubusercontent.com/177561/96061437-10f72a80-0e48-11eb-9d04-085b1a3b0f0d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
