### PR TITLE
fix: prevent captions from getting cut off with image-beside setting

### DIFF
--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -12,7 +12,6 @@ figcaption,
 .wp-caption-text {
 	color: $color__text-light;
 	margin: 0 auto;
-	max-width: 780px;
 	padding: 0;
 	text-align: left;
 }
@@ -23,13 +22,4 @@ figcaption,
 	font-size: $font__size-xs;
 	font-family: $font__heading;
 	line-height: $font__line-height-pre;
-}
-
-.newspack-front-page,
-.post-template-single-wide,
-.page-template-single-wide {
-	figcaption,
-	.wp-caption-text {
-		max-width: 1200px;
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes some unnecessary caption width styles, which were causing issues with the featured image caption when applied to the featured image beside style. The theme had been setting the max-width for the captions to match the content width, but it works just as well set to a max-width of 100%, and fixes this issue.

Closes #1101.

### How to test the changes in this Pull Request:

1. Set up a single post and give it the 'one column wide' template.
2. Add a few images with longer captions; set a featured image with a longer caption, and give it the image beside placement.
3. View on the front-end and adjust the browser window down to mobile; note that the featured image caption runs off-screen:

![image](https://user-images.githubusercontent.com/177561/96189858-26c32900-0ef6-11eb-9a4c-876ff62e13d0.png)

4. Apply the PR and run `npm run build`.
5. Refresh the page and confirm that the caption now fits the screen:

![image](https://user-images.githubusercontent.com/177561/96189772-fbd8d500-0ef5-11eb-9e0d-8a4d6c45678d.png)

6. Cycle through some of the other featured image and template settings, and confirm that none of the captions on your page get cut off on different screen sizes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
