### PR TITLE
fix: make pullquote citations inherit correct color

### DIFF
--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -283,10 +283,6 @@ figcaption,
 		}
 	}
 
-	cite {
-		color: $color__text-light;
-	}
-
 	cite,
 	&.is-style-solid-color blockquote cite {
 		text-transform: uppercase;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -335,10 +335,12 @@
 
 	cite {
 		display: inline-block;
+		color: inherit;
 		font-family: $font__heading;
+		font-size: $font__size-xs;
+		opacity: 0.8;
 		line-height: 1.6;
 		text-transform: none;
-		font-size: $font__size-xs;
 
 		&::before {
 			content: '\2014';

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -245,7 +245,8 @@ figcaption,
 	.entry-meta a,
 	.entry-meta a:visited,
 	.entry-meta .byline a,
-	.entry-meta .byline a:visited {
+	.entry-meta .byline a:visited,
+	cite {
 		color: inherit;
 	}
 
@@ -498,6 +499,10 @@ figcaption,
 			content: '\2014';
 			margin-right: #{0.25 * $size__spacing-unit};
 		}
+	}
+
+	div.wp-block-pullquote__citation {
+		opacity: 0.8;
 	}
 
 	em {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR primarily fixes a couple issues where the citation in the pullquote block is not picking up the correct colour:

* In some cases when a text colour is set, the citation is not picking it up on the front-page.
* When nested in a cover block, the quote itself automatically switches to white, but the citation does not on the front end. 

Closes #1115

### How to test the changes in this Pull Request:

1. Set up a couple pullquote blocks -- one default, one with a text colour, one with a background colour, and one in a cover block without any text colour set (it should switch to white on its own). 
2. Save and publish.
3. View on the front-end; note the quotes with the text colour still have grey citations, and the one in the cover block has a nearly illegible citation:

![image](https://user-images.githubusercontent.com/177561/96509050-58970100-1210-11eb-9e2f-0f55e3eec0c0.png)

![image](https://user-images.githubusercontent.com/177561/96509064-5cc31e80-1210-11eb-95de-7958a1e89b4e.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the citations are now picking up the same text colour as the rest of the pullquote blocks:

![image](https://user-images.githubusercontent.com/177561/96509184-83815500-1210-11eb-8569-30a530486fa3.png)

![image](https://user-images.githubusercontent.com/177561/96509196-87ad7280-1210-11eb-94cf-82956512d005.png)

6. Since its the only child theme that was edited, confirm that the colours are displaying as expected on the front-end with Newspack Katharine:

![image](https://user-images.githubusercontent.com/177561/96509390-c9d6b400-1210-11eb-82d0-08fb5cf53985.png)

![image](https://user-images.githubusercontent.com/177561/96509396-cd6a3b00-1210-11eb-82a6-27570a4ba321.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
