### PR TITLE
Make sure featured image placements aren't applied to CPTs

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -140,12 +140,14 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Adds special classes, depending on the featured image position.
-	if ( 'behind' === newspack_featured_image_position() ) {
-		$classes[] = 'single-featured-image-behind';
-	} elseif ( 'beside' === newspack_featured_image_position() ) {
-		$classes[] = 'single-featured-image-beside';
-	} elseif ( is_single() ) {
-		$classes[] = 'single-featured-image-default';
+	if ( is_singular( 'post' ) ) {
+		if ( 'behind' === newspack_featured_image_position() ) {
+			$classes[] = 'single-featured-image-behind';
+		} elseif ( 'beside' === newspack_featured_image_position() ) {
+			$classes[] = 'single-featured-image-beside';
+		} elseif ( is_single() ) {
+			$classes[] = 'single-featured-image-default';
+		}
 	}
 
 	// Adds a class if singular post has a large featured image

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -38,8 +38,8 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			$position = $default_image_pos;
 		}
 
-		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large.
-		if ( 'large' === $position && 1200 > $img_width ) {
+		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large, or if not a post post-type.
+		if ( ( 'large' === $position && 1200 > $img_width ) || ! is_singular( 'post' ) ) {
 			$position = 'small';
 		}
 
@@ -140,14 +140,12 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Adds special classes, depending on the featured image position.
-	if ( is_singular( 'post' ) ) {
-		if ( 'behind' === newspack_featured_image_position() ) {
-			$classes[] = 'single-featured-image-behind';
-		} elseif ( 'beside' === newspack_featured_image_position() ) {
-			$classes[] = 'single-featured-image-beside';
-		} elseif ( is_single() ) {
-			$classes[] = 'single-featured-image-default';
-		}
+	if ( 'behind' === newspack_featured_image_position() ) {
+		$classes[] = 'single-featured-image-behind';
+	} elseif ( 'beside' === newspack_featured_image_position() ) {
+		$classes[] = 'single-featured-image-beside';
+	} elseif ( is_single() ) {
+		$classes[] = 'single-featured-image-default';
 	}
 
 	// Adds a class if singular post has a large featured image

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -19,7 +19,7 @@ get_header();
 				the_post();
 
 				// Template part for large featured images.
-				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) && is_singular( 'post' ) ) :
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -37,7 +37,7 @@ get_header();
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( 'small' === newspack_featured_image_position() || ! is_singular( 'post' ) ) :
+					if ( 'small' === newspack_featured_image_position() ) :
 						newspack_post_thumbnail();
 					endif;
 

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -19,7 +19,7 @@ get_header();
 				the_post();
 
 				// Template part for large featured images.
-				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) && is_singular( 'post' ) ) :
 					get_template_part( 'template-parts/post/large-featured-image' );
 				else :
 				?>
@@ -37,7 +37,7 @@ get_header();
 					}
 
 					// Place smaller featured images inside of 'content' area.
-					if ( 'small' === newspack_featured_image_position() ) :
+					if ( 'small' === newspack_featured_image_position() || ! is_singular( 'post' ) ) :
 						newspack_post_thumbnail();
 					endif;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, if you set a default featured image placement in the Customizer, it will be applied to all CPTs, not just posts. 

This PR adds a check to apply the 'small' image size to any CPTs. 

Closes #1119.

### How to test the changes in this Pull Request:

1. Set up the Newspack Listings plugin (currently in dev; ping for a link), and set up a listing with a larger featured image.
2. Set up a regular post with a large featured image.
3. Navigate to Customizer > Template Settings, and set the default featured image placement to 'behind'.
4. View both of your posts on the front-end; note that the behind image placement is also picked up by the listing, but can't be turned off because it's not a CPT option:

Listing CPT:
![image](https://user-images.githubusercontent.com/177561/96754165-c284e700-1385-11eb-86f6-35f4533a1329.png)

Regular post: 
![image](https://user-images.githubusercontent.com/177561/96754094-aed98080-1385-11eb-9fdd-5469c4f6718c.png)

5. Apply the PR.
6. Confirm that the featured image is now displaying as 'small' on your CPT:

![image](https://user-images.githubusercontent.com/177561/96754062-9ff2ce00-1385-11eb-895e-4f6fc81f4bc4.png)

7. Confirm that the 'behind' image placement is still being applied to your regular post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
