### PR TITLE
Avoid error with AMP fallback for the search

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -7,33 +7,36 @@
 ( function() {
 	// Search toggle.
 	const headerContain = document.getElementById( 'masthead' ),
-		headerSearch = document.getElementById( 'header-search' ),
-		headerSearchInput = headerSearch.getElementsByTagName( 'input' )[ 0 ],
-		searchToggle = document.getElementById( 'search-toggle' ),
-		searchToggleTextContain = searchToggle.getElementsByTagName( 'span' )[ 0 ],
-		searchToggleTextDefault = searchToggleTextContain.innerText;
+		searchToggle = document.getElementById( 'search-toggle' );
 
-	searchToggle.addEventListener(
-		'click',
-		function() {
-			// Toggle the search visibility.
-			headerContain.classList.toggle( 'hide-header-search' );
+	if ( null !== searchToggle ) {
+		const headerSearch = document.getElementById( 'header-search' ),
+			headerSearchInput = headerSearch.getElementsByTagName( 'input' )[ 0 ],
+			searchToggleTextContain = searchToggle.getElementsByTagName( 'span' )[ 0 ],
+			searchToggleTextDefault = searchToggleTextContain.innerText;
 
-			// Toggle screen reader text label and aria settings.
-			if ( searchToggleTextDefault === searchToggleTextContain.innerText ) {
-				searchToggleTextContain.innerText = newspackScreenReaderText.close_search;
-				headerSearch.setAttribute( 'aria-expanded', 'true' );
-				searchToggle.setAttribute( 'aria-expanded', 'true' );
-				headerSearchInput.focus();
-			} else {
-				searchToggleTextContain.innerText = searchToggleTextDefault;
-				headerSearch.setAttribute( 'aria-expanded', 'false' );
-				searchToggle.setAttribute( 'aria-expanded', 'false' );
-				searchToggle.focus();
-			}
-		},
-		false
-	);
+		searchToggle.addEventListener(
+			'click',
+			function() {
+				// Toggle the search visibility.
+				headerContain.classList.toggle( 'hide-header-search' );
+
+				// Toggle screen reader text label and aria settings.
+				if ( searchToggleTextDefault === searchToggleTextContain.innerText ) {
+					searchToggleTextContain.innerText = newspackScreenReaderText.close_search;
+					headerSearch.setAttribute( 'aria-expanded', 'true' );
+					searchToggle.setAttribute( 'aria-expanded', 'true' );
+					headerSearchInput.focus();
+				} else {
+					searchToggleTextContain.innerText = searchToggleTextDefault;
+					headerSearch.setAttribute( 'aria-expanded', 'false' );
+					searchToggle.setAttribute( 'aria-expanded', 'false' );
+					searchToggle.focus();
+				}
+			},
+			false
+		);
+	}
 
 	// Menu toggle variables.
 	const mobileToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you set up a header with the standard height, and no primary menu, when AMP is disabled it will throw a JavaScript error for the search toggle fallback. It's not a super-common configuration, but it would be good to fix, as it can be a red herring for other issues.

### How to test the changes in this Pull Request:

1. Navigate to the Customizer > Header Settings > Appearance, and uncheck if Short Header is checked; navigate to Menus and disable the Primary menu.
2. View the non-AMP version of the site on the front-end and check the console log; note the error:

![image](https://user-images.githubusercontent.com/177561/97026165-e83cf800-150d-11eb-844d-6f82388d0c3f.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the error is now gone.
5. Add a menu to the Primary Menu again.
6. Confirm that the search toggle still works when AMP is disabled. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
