### PR TITLE
Feature: Add featured image position options for pages

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -749,7 +749,7 @@ function newspack_sanitize_avatars() {
  * @return array Array of post type slugs.
  */
 function newspack_get_featured_image_post_types() {
-	return apply_filters( 'newspack_theme_featured_image_post_types', [ 'post' ] );
+	return apply_filters( 'newspack_theme_featured_image_post_types', array( 'post', 'page' ) );
 }
 
 /**

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -636,10 +636,21 @@ function newspack_customize_register( $wp_customize ) {
 	/**
 	 * Template Settings
 	 */
+	$wp_customize->add_panel(
+		'newspack_template_settings',
+		array(
+			'title' => esc_html__( 'Template Settings', 'newspack' ),
+		)
+	);
+
+	/**
+	 * Post Template Settings
+	 */
 	$wp_customize->add_section(
 		'post_default_settings',
 		array(
-			'title' => esc_html__( 'Template Settings', 'newspack' ),
+			'title' => esc_html__( 'Post Settings', 'newspack' ),
+			'panel' => 'newspack_template_settings',
 		)
 	);
 
@@ -741,6 +752,41 @@ function newspack_customize_register( $wp_customize ) {
 			)
 		);
 	}
+
+	/**
+	 * Page Template Settings
+	 */
+	$wp_customize->add_section(
+		'page_default_settings',
+		array(
+			'title' => esc_html__( 'Page Settings', 'newspack' ),
+			'panel' => 'newspack_template_settings',
+		)
+	);
+
+	// Add option to set a featured image default.
+	$wp_customize->add_setting(
+		'page_featured_image_default',
+		array(
+			'default'           => 'small',
+			'sanitize_callback' => 'newspack_sanitize_feature_image_position',
+		)
+	);
+	$wp_customize->add_control(
+		'page_featured_image_default',
+		array(
+			'type'    => 'radio',
+			'label'   => __( 'Featured Image Default Position', 'newspack' ),
+			'choices' => array(
+				'large'  => esc_html__( 'Large', 'newspack' ),
+				'small'  => esc_html__( 'Small', 'newspack' ),
+				'behind' => esc_html__( 'Behind article title', 'newspack' ),
+				'beside' => esc_html__( 'Beside article title', 'newspack' ),
+				'hidden' => esc_html__( 'Hidden', 'newspack' ),
+			),
+			'section' => 'page_default_settings',
+		)
+	);
 
 	/**
 	 * Comments settings

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -41,7 +41,6 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			}
 		}
 
-		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large, or if not a featured image post post-type.
 		if ( ( 'large' === $position && 1200 > $img_width ) || ! in_array( get_post_type(), newspack_get_featured_image_post_types() ) ) {
 			$position = 'small';
 		}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 	 */
 	function newspack_featured_image_position() {
 		// If we're not on a single page, or if there's no thumbnail, return.
-		if ( ! is_single() || ! has_post_thumbnail() ) {
+		if ( ( ! is_single() && ! is_page() ) || ! has_post_thumbnail() ) {
 			return '';
 		}
 
@@ -24,9 +24,6 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 		// Get per-post image position setting.
 		$image_pos = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
 
-		// Get default image position setting from the Customizer.
-		$default_image_pos = get_theme_mod( 'featured_image_default', 'large' );
-
 		// Set a position value to return.
 		$position = '';
 
@@ -35,7 +32,13 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			$position = $image_pos;
 		// If this post doesn't have a setting, fall back to the default.
 		} else {
-			$position = $default_image_pos;
+			if ( is_single() ) {
+				// Set default if a post:
+				$position = get_theme_mod( 'featured_image_default', 'large' );
+			} elseif ( is_page() ) {
+				// Set default if a page:
+				$position = get_theme_mod( 'page_featured_image_default', 'small' );
+			}
 		}
 
 		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large, or if not a featured image post post-type.

--- a/newspack-theme/page.php
+++ b/newspack-theme/page.php
@@ -12,22 +12,32 @@ get_header();
 
 	<section id="primary" class="content-area">
 		<main id="main" class="site-main">
-
-
 			<?php
 
 			/* Start the Loop */
 			while ( have_posts() ) :
 				the_post();
+
+				// Template part for large featured images.
+				if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) :
+					get_template_part( 'template-parts/post/large-featured-image' );
+				else :
 				?>
 
-				<header class="entry-header">
-					<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
-				</header>
+					<header class="entry-header">
+						<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+					</header>
+
+				<?php endif; ?>
 
 				<div class="main-content">
-
 					<?php
+
+					// Place smaller featured images inside of 'content' area.
+					if ( 'small' === newspack_featured_image_position() ) :
+						newspack_post_thumbnail();
+					endif;
+
 					get_template_part( 'template-parts/content/content', 'page' );
 
 					// If comments are open or we have at least one comment, load up the comment template.

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -340,8 +340,11 @@ div.sharedaddy .sd-social h3.sd-title,
 	}
 }
 
-.page:not( .home ) article.page > .post-thumbnail {
-	margin-top: #{1.5 * $size__spacing-unit};
+.page {
+	.entry-header + .post-thumbnail,
+	.main-content > .post-thumbnail:first-child {
+		margin-top: #{1.5 * $size__spacing-unit};
+	}
 }
 
 .page.home .entry .entry-content {
@@ -582,6 +585,14 @@ div.sharedaddy .sd-social h3.sd-title,
 	.entry-meta .byline {
 		display: inline-block;
 		margin-right: $size__spacing-unit;
+	}
+}
+
+@include media( tablet ) {
+	.page .featured-image-behind {
+		.entry-header {
+			margin-bottom: #{3 * $size__spacing-unit};
+		}
 	}
 }
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -141,6 +141,10 @@
 	padding-top: calc( #{$size__spacing-unit} * 1.5 );
 }
 
+.page #secondary {
+	padding-top: $size__spacing-unit;
+}
+
 .above-content {
 	margin: $size__spacing-unit 0 0;
 }

--- a/newspack-theme/template-parts/content/content-page.php
+++ b/newspack-theme/template-parts/content/content-page.php
@@ -10,8 +10,6 @@
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php newspack_post_thumbnail(); ?>
-
 	<div class="entry-content">
 		<?php
 		the_content();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the same featured image options for pages as current exist for posts. This includes a page-specific Customizer setting for the default, and a per-page option for individual pages. 

Closes #751.

### How to test the changes in this Pull Request:

1. To make sure no new issues were introduced, navigate to Customizer > Template Settings, and change the post featured image default if not already changed away from 'Large'.
2. Create a page and add a featured image; it should use the 'small' placement (in the primary content column).
3. Apply the PR and run `npm run build`. 
4. Navigate back to Customizer > Template Settings; confirm that that panel is now split into a Post Settings and Page Settings panel:

![image](https://user-images.githubusercontent.com/177561/97211167-da8caa00-177b-11eb-9185-8397e984287b.png)

5. Under the Posts Settings panel, confirm that the original options are still there, and that anything set there (including your featured image default) are still set.
6. Under the Page Settings panel, confirm that there is a 'Featured Image Default Position' option there, too, and the default is set to "Small":

![image](https://user-images.githubusercontent.com/177561/97211295-0f98fc80-177c-11eb-8091-6b2ef0a86a1e.png)

7. View the page you created and confirm the featured image placement is the same:

![image](https://user-images.githubusercontent.com/177561/97212275-6521d900-177d-11eb-819b-4e1202de889b.png)

8. Edit the page and confirm that you have the Large, Small, Behind... options in the Featured Image section, with 'Default' as the ... default:

![image](https://user-images.githubusercontent.com/177561/97214704-aff12000-1780-11eb-90dc-0a21f420fb28.png)

9. Try cycling through the different options, and confirm they display as expected on the front-end:

![image](https://user-images.githubusercontent.com/177561/97214853-efb80780-1780-11eb-81a9-7c918199c2b6.png)

![image](https://user-images.githubusercontent.com/177561/97216956-cba9f580-1783-11eb-918b-33040e410634.png)

![image](https://user-images.githubusercontent.com/177561/97217227-2e02f600-1784-11eb-89d3-3a149d4f4396.png)

10. Navigate to Customize > Template Settings > Page Settings and change the default image placement.
11. Confirm that this does _not_ affect the page that has a different featured image placement set.
12. Confirm that it does affect pages that have the 'Default' featured image placement set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
