### PR TITLE
Captions: correct caption width issue

### DIFF
--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -23,3 +23,21 @@ figcaption,
 	font-family: $font__heading;
 	line-height: $font__line-height-pre;
 }
+
+.entry-content {
+	.wp-caption-text,
+	figcaption {
+		max-width: 780px;
+	}
+}
+
+.newspack-front-page,
+.post-template-single-wide,
+.page-template-single-wide {
+	.entry-content {
+		.wp-caption-text,
+		figcaption {
+			max-width: 1200px;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a caption width issue introduced in #1113: captions on wide and full-width image blocks are no longer matching the width of the content area, but instead running the full width of the image.

### How to test the changes in this Pull Request:

1. Set up a test post with a few image blocks; include regular width, wide and full. Add captions to all.
2. Switch the template to use the one-column template.
3. View on front-end; note the captions on the wide and full blocks match the width of the block:

![image](https://user-images.githubusercontent.com/177561/97610141-b9bd9200-19d1-11eb-8898-60bc473a5264.png)

4. Apply the PR and run `npm run build`.
5. Confirm the captions now match the width of the template's content width (a max-width of 780px):

![image](https://user-images.githubusercontent.com/177561/97609936-7f53f500-19d1-11eb-902e-3f7e7d8a1af4.png)

6. Switch to the one-column wide template.
7. Confirm the captions still match the width of the content area (a max-width of 1200px wide).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
