### PR TITLE
Header: Add seperate colour control for primary menu

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -19,8 +19,10 @@ function newspack_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+			$header_color                = get_theme_mod( 'header_color_hex', '#666666' );
+			$header_color_contrast       = newspack_get_color_contrast( $header_color );
+			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '#4a4a4a' );
+			$primary_menu_color_contrast = newspack_get_color_contrast( $primary_menu_color );
 		} else {
 			$header_color          = $primary_color;
 			$header_color_contrast = newspack_get_color_contrast( $primary_color );
@@ -242,6 +244,20 @@ function newspack_custom_colors_css() {
 					color: ' . esc_html( $header_color_contrast ) . ';
 				}
 			';
+
+			if ( isset( $primary_menu_color ) && '#4a4a4a' !== $primary_menu_color ) {
+				$theme_css .= '
+					.h-sb .bottom-header-contain {
+						background: ' . esc_html( $primary_menu_color ) . ';
+					}
+
+					.h-sb .bottom-header-contain .nav1 .main-menu > li,
+					.h-sb .bottom-header-contain .nav1 .main-menu > li > a,
+					.h-sb .bottom-header-contain #search-toggle {
+						color: ' . esc_html( $primary_menu_color_contrast ) . ';
+					}
+				';
+			}
 		}
 
 		if ( isset( $footer_color ) && '' !== $footer_color ) {

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -21,7 +21,7 @@ function newspack_custom_colors_css() {
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color                = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast       = newspack_get_color_contrast( $header_color );
-			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '#4a4a4a' );
+			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '' );
 			$primary_menu_color_contrast = newspack_get_color_contrast( $primary_menu_color );
 		} else {
 			$header_color          = $primary_color;
@@ -245,7 +245,7 @@ function newspack_custom_colors_css() {
 				}
 			';
 
-			if ( isset( $primary_menu_color ) && '#4a4a4a' !== $primary_menu_color ) {
+			if ( isset( $primary_menu_color ) && '' !== $primary_menu_color ) {
 				$theme_css .= '
 					.h-sb .bottom-header-contain {
 						background: ' . esc_html( $primary_menu_color ) . ';

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -465,6 +465,26 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add primary menu color hexidecimal setting and control.
+	$wp_customize->add_setting(
+		'header_primary_menu_color_hex',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'header_primary_menu_color_hex',
+			array(
+				'description' => __( 'Apply a background color to the primary menu.', 'newspack' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
 	/**
 	 * Footer background_color
 	 */
@@ -489,7 +509,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Add header color hexidecimal setting and control.
+	// Add footer color hexidecimal setting and control.
 	$wp_customize->add_setting(
 		'footer_color_hex',
 		array(

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -68,6 +68,25 @@
 				setting.bind( visibility );
 			} );
 
+			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						// Make sure the site is set to use a solid header background.
+						if (
+							true === wp.customize.value( 'header_solid_background' )() &&
+							false === wp.customize.value( 'header_simplified' )() &&
+							'custom' === wp.customize.value( 'header_color' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+
 			// Footer Color
 			wp.customize.control( 'footer_color', function( control ) {
 				const visibility = function() {
@@ -128,9 +147,64 @@
 				visibility();
 				setting.bind( visibility );
 			} );
+
+			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						if (
+							'custom' === wp.customize.value( 'header_color' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+
+			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						if (
+							'custom' === wp.customize.value( 'header_color' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
 		} );
 
-		// Controls to show/hide when the Solid Background is toggled.
+		// Controls to show/hide when Short Header is toggled
+		wp.customize( 'header_simplified', function( setting ) {
+			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
+				const visibility = function() {
+					if ( false === setting.get() ) {
+						if (
+							'custom' === wp.customize.value( 'header_color' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )() &&
+							true === wp.customize.value( 'header_solid_background' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
+		// Controls to show/hide when the Custom Header Color is toggled.
 		wp.customize( 'header_color', function( setting ) {
 			wp.customize.control( 'header_color_hex', function( control ) {
 				const visibility = function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a separate control to change the primary menu background when the 'solid header' option is selected. Right now, it defaults to slightly different things, depending on the theme (based on how the solid header was originally handled):

Newspack, Scott: medium grey
Katharine, Sacha: darker grey
Joseph: black
Nelson: transparent (uses header colour)

Rather than add an on/off toggle for setting for this option, like I did to the header, to work around the inconsistent default, I just left the default colour field blank. It does look grey until it's opened, then it's clearer no RGB value is applied:

![image](https://user-images.githubusercontent.com/177561/98408649-5f9e7b80-2026-11eb-896a-0af4766b7f2f.png)

This results in less convoluted code, but slightly less clear UI (though having to pick a solid header AND then opt out of the default to get to a colour picker is also not great). I would be interested to hear if anyone thinks this trade-off is problematic!

I've also left this so this option can be applied to Newspack Nelson, rather than having the child themes behave differently. Admittedly, it doesn't make a lot of visual sense in that theme, so I'd also be open to feedback about whether leaving it makes sense, or if the child theme should remove it. 

Closes #1097

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Navigate to Customizer > Header Settings > Appearance; enable the Solid Background and disable the Short Header.
3. Navigate to Customizer > Colors, and click 'Custom' for the Header Background Color.
4. Confirm that there is now an option to change the primary menu background colour:

![image](https://user-images.githubusercontent.com/177561/98409270-5a8dfc00-2027-11eb-8c69-d9c5129309fc.png)

5. Try changing the colour to both a light and darker colour; confirm your colour is applied, and that the links maintain correct contrast:

![image](https://user-images.githubusercontent.com/177561/98409666-1f3ffd00-2028-11eb-8613-d284dc9a24fc.png)

![image](https://user-images.githubusercontent.com/177561/98409760-45659d00-2028-11eb-9501-8f6a760784ce.png)

6. Cycle through the themes and confirm that your colour is applied.
7. Try changing the Customizer options a few times, and navigate back to the Colors panel; the "Apply a background color to the primary menu" should only be visible when:
    * Header Settings > Appearance > Solid Background is on.
    * Header Settings > Appearance > Short Header is off.
    * Colors > Header Background Color is Custom.
8. Click the "Clear" button for the primary menu background picker; confirm that the themes fall back to their default greys/black/transparent menu backgrounds:

![image](https://user-images.githubusercontent.com/177561/98409593-ffa8d480-2027-11eb-80dc-5d05f31c9078.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
