### PR TITLE
Footer: Add option to change footer background color

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -19,6 +19,11 @@ function newspack_joseph_custom_colors_css() {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -57,6 +62,21 @@ function newspack_joseph_custom_colors_css() {
 			.h-sb .top-header-contain,
 			.h-sb .middle-header-contain {
 				color: ' . esc_html( $header_color_contrast ) . ';
+			}
+		';
+	}
+
+	if ( isset( $footer_color ) && '' !== $footer_color ) {
+		$theme_css .= '
+			#colophon,
+			#colophon .widget-title,
+			#colophon .social-navigation a {
+				color: ' . esc_html( $footer_color_contrast ) . ';
+			}
+
+			#colophon .footer-branding .wrapper,
+			#colophon .footer-widgets:first-child {
+				border-top: 0;
 			}
 		';
 	}

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -19,6 +19,11 @@ function newspack_katharine_custom_colors_css() {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -109,6 +114,14 @@ function newspack_katharine_custom_colors_css() {
 				}
 			';
 		}
+	}
+
+	if ( isset( $footer_color ) && '' !== $footer_color ) {
+		$theme_css .= '
+			.footer-branding .wrapper {
+				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
+			}
+		';
 	}
 
 	$editor_css = '

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -22,6 +22,11 @@ function newspack_nelson_custom_colors_css() {
 			$header_color          = $primary_color;
 			$header_color_contrast = newspack_get_color_contrast( $primary_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -53,8 +58,7 @@ function newspack_nelson_custom_colors_css() {
 		$theme_css .= '
 			/* Header solid background */
 			.h-sb .site-header,
-			.h-sb .middle-header-contain,
-			.h-sb .site-footer {
+			.h-sb .middle-header-contain {
 				background-color: ' . esc_html( $header_color ) . ';
 			}
 
@@ -92,9 +96,36 @@ function newspack_nelson_custom_colors_css() {
 			.h-sb .site-header .highlight-menu a,
 			.h-sb .site-breadcrumb,
 			.h-sb .site-breadcrumb a,
-			.h-sb .site-breadcrumb .breadcrumb_last,
-			.h-sb .site-footer {
+			.h-sb .site-breadcrumb .breadcrumb_last {
 				color: ' . esc_html( $header_color_contrast ) . ';
+			}
+		';
+
+		if ( ! isset( $footer_color ) || ( isset( $footer_color ) && '' === $footer_color ) ) {
+			$theme_css .= '
+				.h-sb .site-footer {
+					background-color: ' . esc_html( $header_color ) . ';
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+			';
+		}
+	}
+
+	if ( isset( $footer_color ) && '' !== $footer_color ) {
+		$theme_css .= '
+			.h-sb .site-footer {
+				background-color ' . esc_html( $footer_color ) . ';
+			}
+
+			.h-sb .site-footer,
+			.site-footer .widget-title {
+				color: ' . esc_html( $footer_color_contrast ) . ';
+			}
+
+			#colophon .site-info,
+			#colophon .site-info .widget-title,
+			#colophon .site-info a {
+				color: #fff;
 			}
 		';
 	}

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -19,6 +19,11 @@ function newspack_sacha_custom_colors_css() {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -73,6 +78,19 @@ function newspack_sacha_custom_colors_css() {
 				}
 			';
 		}
+	}
+
+	if ( isset( $footer_color ) && '' !== $footer_color ) {
+		$theme_css .= '
+			.site-footer .widget .widget-title,
+			.site-info a:visited {
+				color: ' . esc_html( $footer_color_contrast ) . ';
+			}
+
+			.site-info {
+				background-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -10 ) ) . ';
+			}
+		';
 	}
 
 	$editor_css = '

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -22,6 +22,11 @@ function newspack_scott_custom_colors_css() {
 			$header_color          = $primary_color;
 			$header_color_contrast = newspack_get_color_contrast( $primary_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -76,6 +81,23 @@ function newspack_scott_custom_colors_css() {
 			}
 		';
 	}
+
+	if ( isset( $footer_color ) && '' !== $footer_color ) {
+		$theme_css .= '
+			#colophon,
+			#colophon .widget-title,
+			#colophon .social-navigation a {
+				color: ' . esc_html( $footer_color_contrast ) . ';
+			}
+
+			#colophon .footer-branding .wrapper,
+			#colophon .footer-widgets:first-child {
+				border: 0;
+			}
+		';
+	}
+
+
 
 	$editor_css = '
 		.block-editor-block-list__layout .block-editor-block-list__block.accent-header:before,

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -25,6 +25,11 @@ function newspack_custom_colors_css() {
 			$header_color          = $primary_color;
 			$header_color_contrast = newspack_get_color_contrast( $primary_color );
 		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
+			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
+		}
 	}
 
 	// Set colour contrasts.
@@ -239,6 +244,32 @@ function newspack_custom_colors_css() {
 			';
 		}
 
+		if ( isset( $footer_color ) && '' !== $footer_color ) {
+			$theme_css .= '
+				.site-footer {
+					background: ' . esc_html( $footer_color ) . ';
+				}
+
+				.site-footer,
+				.site-footer a,
+				.site-footer a:hover,
+				.site-footer .widget-title,
+				.site-info {
+					color: ' . esc_html( $footer_color_contrast ) . ';
+				}
+
+				.site-footer a:hover,
+				.site-footer .widget a:hover {
+					opacity: 0.7;
+				}
+
+				.site-info .widget-area .wrapper,
+				.site-info .site-info-contain:first-child {
+					border-top-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
+				}
+			';
+		}
+
 		if ( ! is_child_theme() ) {
 			$theme_css .= '
 				.mobile-sidebar .nav3 a {
@@ -275,6 +306,15 @@ function newspack_custom_colors_css() {
 					.h-sb .site-header .nav3 .menu-highlight a {
 						background-color: ' . $secondary_color . ';
 						color: ' . esc_html( $secondary_color_contrast ) . ';
+					}
+				';
+			}
+
+			if ( isset( $footer_color ) && '' !== $footer_color ) {
+				$theme_css .= '
+					.site-footer .footer-branding .wrapper,
+					.site-footer .footer-widgets:first-child .wrapper {
+						border-top: 0;
 					}
 				';
 			}

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -465,6 +465,50 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	/**
+	 * Footer background_color
+	 */
+	$wp_customize->add_setting(
+		'footer_color',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_color_option',
+		)
+	);
+
+	$wp_customize->add_control(
+		'footer_color',
+		array(
+			'type'    => 'radio',
+			'label'   => __( 'Footer Background Color', 'newspack' ),
+			'choices' => array(
+				'default' => _x( 'Default', 'footer background color', 'newspack' ),
+				'custom'  => _x( 'Custom', 'footer background color', 'newspack' ),
+			),
+			'section' => 'colors',
+		)
+	);
+
+	// Add header color hexidecimal setting and control.
+	$wp_customize->add_setting(
+		'footer_color_hex',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'footer_color_hex',
+			array(
+				'description' => __( 'Apply a background color to the footer.', 'newspack' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
 	// Header - add option to hide tagline.
 	$wp_customize->add_setting(
 		'header_display_tagline',

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -34,6 +34,8 @@
 				visibility();
 				setting.bind( visibility );
 			} );
+
+			// Header Color
 			wp.customize.control( 'header_color', function( control ) {
 				const visibility = function() {
 					if ( 'custom' === setting.get() ) {
@@ -56,6 +58,33 @@
 							true === wp.customize.value( 'header_solid_background' )() &&
 							'custom' === wp.customize.value( 'header_color' )()
 						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+
+			// Footer Color
+			wp.customize.control( 'footer_color', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						control.container.slideDown( 180 );
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+			wp.customize.control( 'footer_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						// Make sure the site is set to use a custom footer color.
+						if ( 'custom' === wp.customize.value( 'footer_color' )() ) {
 							control.container.slideDown( 180 );
 						}
 					} else {
@@ -110,6 +139,23 @@
 							true === wp.customize.value( 'header_solid_background' )() &&
 							'custom' === wp.customize.value( 'theme_colors' )()
 						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
+		// Controls to show/hide when the Footer Backround is toggled.
+		wp.customize( 'footer_color', function( setting ) {
+			wp.customize.control( 'footer_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						if ( 'custom' === wp.customize.value( 'theme_colors' )() ) {
 							control.container.slideDown( 180 );
 						}
 					} else {

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -5,6 +5,7 @@
 
 	a {
 		color: $color__text-light;
+		transition: opacity $link_transition ease-in-out;
 	}
 
 	.footer-branding {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to change the background colour of the theme footer. 

Similar to #1134, it leaves the default colour picker state as 'empty', since the themes treat the footer differently, but it also includes a toggle to better match how the header is treated.

Closes #1114

### How to test the changes in this Pull Request:

1. Start with the default Newspack theme; add a number of footer widgets so you have things like regular text and links.
2. Apply the PR and run `npm run build`
3. Navigate to Customizer > Colors; confirm that there's an option to change the footer background from default to custom:

![image](https://user-images.githubusercontent.com/177561/98486686-c9a85380-21d3-11eb-9f5b-5440bee941cc.png)

4. Enable the option and pick a new background colour. 
5. Confirm it's applied on the front end.
6. Cycle through all of the themes and apply a light and dark background colour; confirm that it's applied and that the text has sufficient contrast:

**Newspack - default**

![image](https://user-images.githubusercontent.com/177561/98486067-f3f81200-21cf-11eb-9849-d4fd504fc95b.png)

**Newspack - custom**
_On top of the background colour change, the top border should disappear_

![image](https://user-images.githubusercontent.com/177561/98486049-dd51bb00-21cf-11eb-8279-e699e5b157f2.png)

![image](https://user-images.githubusercontent.com/177561/98486091-27d33780-21d0-11eb-85e5-9c26a8135981.png)

**Newspack Joseph - default**

![image](https://user-images.githubusercontent.com/177561/98486159-8ac4ce80-21d0-11eb-98c7-8e2cd20b5b2e.png)

**Newspack Joseph - custom**
_On top of the background colour change, the top border should disappear_

![image](https://user-images.githubusercontent.com/177561/98486211-d9726880-21d0-11eb-802d-79b1365b83a4.png)

![image](https://user-images.githubusercontent.com/177561/98486265-2a825c80-21d1-11eb-9234-2a08a3ee97ad.png)

**Newspack Katharine - default**

![image](https://user-images.githubusercontent.com/177561/98486308-733a1580-21d1-11eb-97b8-efddc402efa1.png)

**Newspack Katharine - custom**

![image](https://user-images.githubusercontent.com/177561/98486359-b98f7480-21d1-11eb-9464-d47000bc60dc.png)

![image](https://user-images.githubusercontent.com/177561/98486398-eb084000-21d1-11eb-90da-57588edfbe1d.png)

**Newspack Nelson - default**
_By default, the footer will use the primary colour as a background_

![image](https://user-images.githubusercontent.com/177561/98486442-286ccd80-21d2-11eb-8f6e-c21c40fae188.png)

**Newspack Nelson - custom**
_On top of the background colour change, the very bottom section should remain black_

![image](https://user-images.githubusercontent.com/177561/98486536-af21aa80-21d2-11eb-8530-aa72cbc25830.png)

![image](https://user-images.githubusercontent.com/177561/98486551-cf516980-21d2-11eb-9d55-32f5fa471f79.png)

**Newspack Sacha - default**

![image](https://user-images.githubusercontent.com/177561/98486605-235c4e00-21d3-11eb-99ac-194b48379b9c.png)

**Newspack Sacha - custom**
_On top of the background colour change, the very bottom section should be slightly darker, and the widget titles either white or black_

![image](https://user-images.githubusercontent.com/177561/98486648-71715180-21d3-11eb-86b3-646c7a944600.png)

![image](https://user-images.githubusercontent.com/177561/98486675-ad0c1b80-21d3-11eb-9e02-9467177eb5cf.png)

**Newspack Scott - default**

![image](https://user-images.githubusercontent.com/177561/98486789-302d7180-21d4-11eb-8020-29fe492da461.png)

**Newspack Scott - custom**
_On top of the background colour change, the top border should disappear_

![image](https://user-images.githubusercontent.com/177561/98486845-94e8cc00-21d4-11eb-81fb-214825ca4f30.png)

![image](https://user-images.githubusercontent.com/177561/98486908-e002df00-21d4-11eb-9a1a-77f30421d19d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
