### PR TITLE
Use featured img post types function to preserve backwards compatibility

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -38,8 +38,8 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			$position = $default_image_pos;
 		}
 
-		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large, or if not a post post-type.
-		if ( ( 'large' === $position && 1200 > $img_width ) || ! is_singular( 'post' ) ) {
+		// Fallback to the small inline posiiton if the image isn't large enough to be, uh, large, or if not a featured image post post-type.
+		if ( ( 'large' === $position && 1200 > $img_width ) || ! in_array( get_post_type(), newspack_get_featured_image_post_types() ) ) {
 			$position = 'small';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes a backwards-compatibility issue introduced in in #1120, where custom post types don't have their featured image settings applied to them. The `newspack_get_featured_image_post_types` helper function should be used for the featured image post type check to preserve backwards compatibility of any CPTs using the featured image feature.

### How to test the changes in this Pull Request:

1. Before testing this PR, add the following code somewhere (also visit Settings > Permalinks to flush the rewrite rules after adding):

```
add_action( 'init', function(){
		$labels = array(
			'name'               => 'Test CPT',
			'singular_name'      => 'Test CPT',
			'menu_name'          => 'Test CPT',
			'name_admin_bar'     => 'Test CPT',
			'add_new'            => 'Add New',
			'add_new_item'       => 'Add New Test CPT',
			'new_item'           => 'New Test CPT',
			'edit_item'          => 'Edit Test CPT',
			'view_item'          => 'View Test CPT',
			'all_items'          => 'All Test CPTs',
			'search_items'       => 'Search Test CPT',
			'parent_item_colon'  => 'Parent Test CPT:',
			'not_found'          => 'No Test CPT found.',
			'not_found_in_trash' => 'No Test CPT found in Trash.',
			'item_published'     => 'Test CPT published',
			'item_updated'       => 'Test CPT updated',
		);

		$args = array(
			'labels'              => $labels,
			'description'         => '',
			'public'              => true,
			'exclude_from_search' => true,
			'publicly_queryable'  => true,
			'show_ui'             => true,
			'show_in_menu'        => true,
			'menu_icon'           => 'dashicons-yes',
			'query_var'           => true,
			'capability_type'     => 'post',
			'has_archive'         => true,
			'hierarchical'        => false,
			'menu_position'       => null,
			'supports'            => [ 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'custom-fields', 'revisions' ],
			'show_in_rest'        => true,
			'rewrite'             => [ 'slug' => 'test-cpt' ],
			'show_in_admin_bar'   => false,
			'taxonomies'          => [ 'category', 'post_tag' ],
		);

		register_post_type( 'test-cpt', $args );
});

add_filter( 'newspack_theme_featured_image_post_types', function( $post_types ) {
	$post_types[] = 'test-cpt';
	return $post_types;
} );
```

2. Create a new Test CPT post and assign it a featured image with a non-small size:

<img width="1327" alt="Screen Shot 2020-11-10 at 8 08 30 AM" src="https://user-images.githubusercontent.com/7317227/98699874-6e3da900-232c-11eb-8bc8-3619e8f2a0bf.png">

3. Visit the post on the frontend. Observe the image is small:

<img width="1302" alt="Screen Shot 2020-11-10 at 8 09 14 AM" src="https://user-images.githubusercontent.com/7317227/98699887-70a00300-232c-11eb-813f-5c1bbe7b0451.png">

4. Apply this patch. Visit the post on the frontend. Observe the image is correctly laid out:

<img width="1490" alt="Screen Shot 2020-11-10 at 8 09 32 AM" src="https://user-images.githubusercontent.com/7317227/98699915-78f83e00-232c-11eb-9708-e9c2369a6b6a.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
