### PR TITLE
feat: optimize sponsors queries; fix phpcs lint rules

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -51,7 +51,7 @@ $underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 				<?php
 				if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) {
 					// Get label for native archive sponsors.
-					newspack_sponsor_label( $native_sponsors );
+					newspack_sponsor_label( $native_sponsors, null, true );
 				}
 				?>
 

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -7,6 +7,11 @@
  * @package Newspack
  */
 get_header();
+
+// Get sponsors for this taxonomy archive.
+$all_sponsors         = newspack_get_all_sponsors( get_queried_object_id() );
+$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 ?>
 
 	<section id="primary" class="content-area">
@@ -44,28 +49,31 @@ get_header();
 			<span>
 
 				<?php
-					if ( ( is_category() || is_tag() ) && function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id() ) ) {
-						newspack_sponsor_label( get_queried_object_id(), true, 'native', 'archive' );
-					}
+				if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) {
+					// Get label for native archive sponsors.
+					newspack_sponsor_label( $native_sponsors );
+				}
 				?>
 
 				<?php the_archive_title( '<h1 class="page-title">', '</h1>' ); ?>
 
 				<?php do_action( 'newspack_theme_below_archive_title' ); ?>
 
-				<?php if ( ( is_category() || is_tag() ) && function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id(), 'native' ) ) : ?>
-					<?php newspack_sponsor_archive_description( get_queried_object_id(), 'native', 'archive' ); ?>
-				<?php elseif ( '' !== get_the_archive_description() ) : ?>
-					<div class="taxonomy-description">
-						<?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?>
-					</div>
+				<?php
+				if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) :
+					// Get description for native archive sponsors.
+					newspack_sponsor_archive_description( $native_sponsors );
+				elseif ( '' !== get_the_archive_description() ) :
+					?>
+				<div class="taxonomy-description">
+					<?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?>
+				</div>
 				<?php endif; ?>
 
 				<?php
-				if ( is_category() || is_tag() ) {
-					if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_queried_object_id(), 'underwritten', 'archive' ) ) {
-						newspack_sponsored_underwriters_info( get_queried_object_id(), 'underwritten', 'archive' );
-					}
+				if ( ( is_category() || is_tag() ) && ! empty( $underwriter_sponsors ) ) {
+					// Get info for underwriter archive sponsors.
+					newspack_sponsored_underwriters_info( $underwriter_sponsors );
 				}
 			?>
 

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -6,30 +6,35 @@
  *
  * @package Newspack
  */
-?>
 
+// Get sponsors for this post.
+$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
+$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<?php newspack_post_thumbnail(); ?>
 
 	<div class="entry-container">
 		<?php
-			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) :
-				newspack_sponsor_label( get_the_id() );
-			endif;
+		if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) {
+			// Get label for native post sponsors.
+			newspack_sponsor_label( $native_sponsors );
+		}
 		?>
 		<header class="entry-header">
 			<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 		</header><!-- .entry-header -->
 
 		<?php if ( ! is_page() ) : ?>
-			<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) : ?>
+			<?php if ( ! empty( $native_sponsors ) ) : ?>
 				<div class="entry-meta entry-sponsor">
-					<?php newspack_sponsor_logo_list( get_the_id() ); ?>
+					<?php newspack_sponsor_logo_list( $native_sponsors ); ?>
 					<span>
 						<?php
-							newspack_sponsor_byline( get_the_id() );
-							newspack_posted_on();
+						newspack_sponsor_byline( $native_sponsors );
+						newspack_posted_on();
 						?>
 					</span>
 				</div>
@@ -44,4 +49,3 @@
 		<?php endif; ?>
 	</div><!-- .entry-container -->
 </article><!-- #post-${ID} -->
-

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -18,7 +18,7 @@ $underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 
 	<div class="entry-container">
 		<?php
-		if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) {
+		if ( ! empty( $native_sponsors ) ) {
 			// Get label for native post sponsors.
 			newspack_sponsor_label( $native_sponsors );
 		}

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -6,6 +6,11 @@
  *
  * @package Newspack
  */
+
+// Get sponsors for this post.
+$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
+$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -14,8 +19,9 @@
 	<div class="entry-container">
 		<?php
 		if ( 'page' !== get_post_type() ) :
-			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) :
-				newspack_sponsor_label( get_the_id() );
+			if ( ! empty( $native_sponsors ) ) :
+				// Get label for native post sponsors.
+				newspack_sponsor_label( $native_sponsors );
 			elseif ( ! is_archive() ) :
 				newspack_categories();
 			endif;
@@ -26,12 +32,12 @@
 		</header><!-- .entry-header -->
 
 		<?php if ( 'page' !== get_post_type() ) : ?>
-			<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native', 'post' ) ) : ?>
+			<?php if ( ! empty( $native_sponsors ) ) : ?>
 				<div class="entry-meta entry-sponsor">
-					<?php newspack_sponsor_logo_list( get_the_id() ); ?>
+					<?php newspack_sponsor_logo_list( $native_sponsors ); ?>
 					<span>
 						<?php
-							newspack_sponsor_byline( get_the_id() );
+							newspack_sponsor_byline( $native_sponsors );
 							newspack_posted_on();
 							do_action( 'newspack_theme_entry_meta' );
 						?>
@@ -53,4 +59,3 @@
 		</div><!-- .entry-content -->
 	</div><!-- .entry-container -->
 </article><!-- #post-${ID} -->
-

--- a/newspack-theme/template-parts/content/content-single.php
+++ b/newspack-theme/template-parts/content/content-single.php
@@ -6,15 +6,28 @@
  *
  * @package Newspack
  */
+
+// Get sponsors for this taxonomy archive.
+$all_sponsors         = newspack_get_all_sponsors(
+	get_the_id(),
+	null,
+	'post',
+	[
+		'maxwidth'  => 150,
+		'maxheight' => 100,
+	]
+);
+$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<div class="entry-content">
 
 		<?php
-			if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'underwritten' ) ) :
-				newspack_sponsored_underwriters_info( get_the_id(), 'underwritten' );
-			endif;
+		if ( ! empty( $underwriter_sponsors ) ) :
+			newspack_sponsored_underwriters_info( $underwriter_sponsors );
+		endif;
 		?>
 
 		<?php
@@ -51,8 +64,8 @@
 	</footer><!-- .entry-footer -->
 
 	<?php
-	if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native' ) ) :
-		newspack_sponsor_footer_bio( get_the_id() );
+	if ( ! empty( $native_sponsors ) ) :
+		newspack_sponsor_footer_bio( $native_sponsors );
 	elseif ( ! is_singular( 'attachment' ) ) :
 		get_template_part( 'template-parts/post/author', 'bio' );
 	endif;

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -7,13 +7,17 @@
 
 $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_discussion_data() : null;
 
+// Get sponsors for this post.
+$all_sponsors         = newspack_get_all_sponsors( get_the_id() );
+$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 ?>
 
 <?php if ( is_singular() ) : ?>
 	<?php
 	if ( ! is_page() ) :
-		if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id() ) ) {
-			newspack_sponsor_label( get_the_id(), true );
+		if ( ! empty( $all_sponsors ) ) {
+			newspack_sponsor_label( $all_sponsors );
 		} else {
 			newspack_categories();
 		}
@@ -41,12 +45,12 @@ $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_d
 
 <?php if ( ! is_page() ) : ?>
 	<div class="entry-subhead">
-		<?php if ( function_exists( 'newspack_get_all_sponsors' ) && newspack_get_all_sponsors( get_the_id(), 'native' ) ) : ?>
+		<?php if ( ! empty( $native_sponsors ) ) : ?>
 			<div class="entry-meta entry-sponsor">
-				<?php newspack_sponsor_logo_list( get_the_id() ); ?>
+				<?php newspack_sponsor_logo_list( $native_sponsors ); ?>
 				<span>
 					<?php
-						newspack_sponsor_byline( get_the_id() );
+						newspack_sponsor_byline( $native_sponsors );
 						newspack_posted_on();
 						do_action( 'newspack_theme_entry_meta' );
 					?>

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -16,8 +16,8 @@ $underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 <?php if ( is_singular() ) : ?>
 	<?php
 	if ( ! is_page() ) :
-		if ( ! empty( $all_sponsors ) ) {
-			newspack_sponsor_label( $all_sponsors, null, true );
+		if ( ! empty( $native_sponsors ) ) {
+			newspack_sponsor_label( $native_sponsors, null, true );
 		} else {
 			newspack_categories();
 		}

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -17,7 +17,7 @@ $underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 	<?php
 	if ( ! is_page() ) :
 		if ( ! empty( $all_sponsors ) ) {
-			newspack_sponsor_label( $all_sponsors );
+			newspack_sponsor_label( $all_sponsors, null, true );
 		} else {
 			newspack_categories();
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Extra" />
+	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress-VIP-Go" />
+
+	<rule ref="WordPress">
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
+
+	<rule ref="PHPCompatibilityWP"/>
+	<config name="testVersion" value="7.2"/>
+
+	<arg name="extensions" value="php"/>
+
+	<!-- Show sniff codes in all reports -->
+	<arg value="s"/>
+
+	<!-- Allow invoking just `phpcs` on command line without assuming STDIN for file input. -->
+	<file>.</file>
+
+	<exclude-pattern>*/dev-lib/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I opened [this issue](https://github.com/Automattic/newspack-theme/issues/1127) after the systems team informed us that the sponsors plugin was executing a large number of queries per page. This PR attempts to minimize the number of queries executed by the sponsors plugin to at most once per template part.

I also added a phpcs.xml config file which should update the linting behavior to more recent WP standards (now matches other Newspack repos).

If all looks good to you, I'll do the same updates to the Blocks repo.

Closes #1127.

### How to test the changes in this Pull Request:

Front-end behavior shouldn't be any different. Testing instructions for sponsors are [here](https://github.com/Automattic/newspack-theme/pull/1008).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
