### PR TITLE
Fix fatals if sponsors plugin is inactive

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -9,9 +9,11 @@
 get_header();
 
 // Get sponsors for this taxonomy archive.
-$all_sponsors         = newspack_get_all_sponsors( get_queried_object_id() );
-$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
-$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+if ( function_exists( 'newspack_get_all_sponsors' ) ) {
+	$all_sponsors         = newspack_get_all_sponsors( get_queried_object_id() );
+	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+}
 ?>
 
 	<section id="primary" class="content-area">

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -8,9 +8,11 @@
  */
 
 // Get sponsors for this post.
-$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
-$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
-$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+if ( function_exists( 'newspack_get_all_sponsors' ) ) {
+	$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
+	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+}
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -8,9 +8,11 @@
  */
 
 // Get sponsors for this post.
-$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
-$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
-$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+if ( function_exists( 'newspack_get_all_sponsors' ) ) {
+	$all_sponsors         = newspack_get_all_sponsors( get_the_id(), null, 'post' );
+	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+}
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/newspack-theme/template-parts/content/content-single.php
+++ b/newspack-theme/template-parts/content/content-single.php
@@ -8,17 +8,19 @@
  */
 
 // Get sponsors for this taxonomy archive.
-$all_sponsors         = newspack_get_all_sponsors(
-	get_the_id(),
-	null,
-	'post',
-	[
-		'maxwidth'  => 150,
-		'maxheight' => 100,
-	]
-);
-$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
-$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+if ( function_exists( 'newspack_get_all_sponsors' ) ) {
+	$all_sponsors         = newspack_get_all_sponsors(
+		get_the_id(),
+		null,
+		'post',
+		[
+			'maxwidth'  => 150,
+			'maxheight' => 100,
+		]
+	);
+	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+}
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -8,9 +8,14 @@
 $discussion = ! is_page() && newspack_can_show_post_thumbnail() ? newspack_get_discussion_data() : null;
 
 // Get sponsors for this post.
-$all_sponsors         = newspack_get_all_sponsors( get_the_id() );
-$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
-$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+if ( function_exists( 'newspack_get_all_sponsors' ) ) {
+	$all_sponsors         = newspack_get_all_sponsors( get_the_id() );
+	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
+	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
+}
+
+// Filter for Newspack Listings plugin.
+$listing_hide_author = apply_filters( 'newspack_listings_hide_author', false );
 ?>
 
 <?php if ( is_singular() ) : ?>
@@ -43,7 +48,7 @@ $underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 <?php endif; ?>
 
 
-<?php if ( ! is_page() ) : ?>
+<?php if ( ! is_page() && ! $listing_hide_author ) : ?>
 	<div class="entry-subhead">
 		<?php if ( ! empty( $native_sponsors ) ) : ?>
 			<div class="entry-meta entry-sponsor">

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -13,9 +13,6 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
 	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 }
-
-// Filter for Newspack Listings plugin.
-$listing_hide_author = apply_filters( 'newspack_listings_hide_author', false );
 ?>
 
 <?php if ( is_singular() ) : ?>
@@ -48,7 +45,7 @@ $listing_hide_author = apply_filters( 'newspack_listings_hide_author', false );
 <?php endif; ?>
 
 
-<?php if ( ! is_page() && ! $listing_hide_author ) : ?>
+<?php if ( ! is_page() ) : ?>
 	<div class="entry-subhead">
 		<?php if ( ! empty( $native_sponsors ) ) : ?>
 			<div class="entry-meta entry-sponsor">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error that happens if the Newspack Sponsors plugin is not activated.

### How to test the changes in this Pull Request:

1. On `master`, deactivate the Newspack Sponsors plugin and view the site front-end (homepage, taxonomy archive, author archive, and single posts).
2. Note a fatal error like this that prevents those pages from rendering:

```
PHP Fatal error:  Uncaught Error: Call to undefined function newspack_get_native_sponsors() in /Users/dkoo/Local Sites/newspack/app/public/wp-content/themes/repo/newspack-theme/template-parts/header/entry-header.php:12
```

3. Check out this branch and refresh those pages.
4. Confirm that the fatal is no longer thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
