### PR TITLE
Feature: Add option to display 'updated' date

### DIFF
--- a/newspack-katharine/inc/child-typography.php
+++ b/newspack-katharine/inc/child-typography.php
@@ -36,6 +36,7 @@ function newspack_katharine_custom_typography_css() {
 			.author-bio h2 span,
 			.entry-meta .byline a,
 			.entry-meta .entry-date,
+			.entry-meta .updated,
 			.site-footer .widget-title,
 			.site-info {
 				text-transform: uppercase;

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -747,7 +747,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'checkbox',
 			'label'       => esc_html__( 'Show "last updated" date', 'newspack' ),
-			'description' => esc_html__( 'When paired with the "time ago" date format, the cut off for that format will automatically be switched to one day on posts that are updated.', 'newspack' ),
+			'description' => esc_html__( 'When paired with the "time ago" date format, the cut off for that format will automatically be switched to one day.', 'newspack' ),
 			'section'     => 'post_default_settings',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -734,6 +734,23 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to display updated date.
+	$wp_customize->add_setting(
+		'post_updated_date',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'post_updated_date',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Show "last updated" date', 'newspack' ),
+			'section' => 'post_default_settings',
+		)
+	);
+
 	// Add option to turn off Yoast's Primary Category functionality.
 	if ( class_exists( 'WPSEO_Primary_Term' ) ) {
 		$wp_customize->add_setting(

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -745,9 +745,10 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'post_updated_date',
 		array(
-			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Show "last updated" date', 'newspack' ),
-			'section' => 'post_default_settings',
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Show "last updated" date', 'newspack' ),
+			'description' => esc_html__( 'When paired with the "time ago" date format, the cut off for that format will automatically be switched to one day on posts that are updated.', 'newspack' ),
+			'section'     => 'post_default_settings',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -746,7 +746,7 @@ function newspack_customize_register( $wp_customize ) {
 		'post_updated_date',
 		array(
 			'type'        => 'checkbox',
-			'label'       => esc_html__( 'Show "last updated" date', 'newspack' ),
+			'label'       => esc_html__( 'Show "last updated" date on single posts', 'newspack' ),
 			'description' => esc_html__( 'When paired with the "time ago" date format, the cut off for that format will automatically be switched to one day.', 'newspack' ),
 			'section'     => 'post_default_settings',
 		)

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -605,20 +605,14 @@ function newspack_should_display_updated_date() {
 		return false;
 	}
 
-	$post = get_post();
-
+	$post          = get_post();
 	$publish_date  = $post->post_date;
 	$modified_date = $post->post_modified;
 
-	// Exclude posts updated during launch.
-	// if ( 0 === strpos( $modified_date, '2020-06-23' ) ) {
-	// return false;
-	// }
-
 	$publish_timestamp  = strtotime( $publish_date );
 	$modified_timestamp = strtotime( $modified_date );
+	$modified_cutoff    = strtotime( 'tomorrow midnight', $publish_timestamp );
 
-	$modified_cutoff = strtotime( 'tomorrow midnight', $publish_timestamp );
 	if ( $modified_timestamp > $modified_cutoff ) {
 		return true;
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -566,6 +566,7 @@ function newspack_math_to_time_ago( $post_time, $format, $post, $updated ) {
 		$cut_off_seconds = $cut_off * 86400;
 
 		if ( true === newspack_should_display_updated_date() ) {
+			// Switch cut off to one day if updated date is displayed.
 			$cut_off_seconds = 86400;
 		}
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -565,8 +565,8 @@ function newspack_math_to_time_ago( $post_time, $format, $post, $updated ) {
 		// Transform cut off from days to seconds.
 		$cut_off_seconds = $cut_off * 86400;
 
-		if ( true === newspack_should_display_updated_date() ) {
-			// Switch cut off to one day if updated date is displayed.
+		if ( true === get_theme_mod( 'post_updated_date', false ) ) {
+			// Switch cut off to 24 hours.
 			$cut_off_seconds = 86400;
 		}
 
@@ -602,21 +602,20 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
  * Check whether updated date should be displayed.
  */
 function newspack_should_display_updated_date() {
-	if ( ! is_single() ) {
-		return false;
+	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) ) {
+		$post          = get_post();
+		$publish_date  = $post->post_date;
+		$modified_date = $post->post_modified;
+
+		$publish_timestamp  = strtotime( $publish_date );
+		$modified_timestamp = strtotime( $modified_date );
+		$modified_cutoff    = strtotime( 'tomorrow midnight', $publish_timestamp );
+
+		if ( $modified_timestamp > $modified_cutoff ) {
+			return true;
+		} else {
+			return false;
+		}
 	}
-
-	$post          = get_post();
-	$publish_date  = $post->post_date;
-	$modified_date = $post->post_modified;
-
-	$publish_timestamp  = strtotime( $publish_date );
-	$modified_timestamp = strtotime( $modified_date );
-	$modified_cutoff    = strtotime( 'tomorrow midnight', $publish_timestamp );
-
-	if ( $modified_timestamp > $modified_cutoff ) {
-		return true;
-	}
-
 	return false;
 }

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -160,6 +160,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'no-sidebar';
 	}
 
+	// Add a class if updated date should display
+	if ( is_single() && newspack_should_display_updated_date() ) {
+		$classes[] = 'show-updated';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );
@@ -539,17 +544,23 @@ function newspack_the_custom_logo() {
 	}
 }
 
+// post_modified
+
 /**
  * Change date to 'time ago' format if enabled in the Customizer.
  */
-function newspack_convert_to_time_ago( $post_time, $format, $post ) {
+function newspack_math_to_time_ago( $post_time, $format, $post, $updated ) {
 	$use_time_ago = get_theme_mod( 'post_time_ago', false );
 
 	// Only filter time when $use_time_ago is enabled, and it's not using a machine-readable format (for datetime).
 	if ( true === $use_time_ago && 'Y-m-d\TH:i:sP' !== $format ) {
 		$current_time = current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
-		$org_time     = strtotime( $post->post_date );
 		$cut_off      = get_theme_mod( 'post_time_ago_cut_off', '14' );
+		$org_time     = strtotime( $post->post_date );
+
+		if ( true === $updated ) {
+			$org_time = strtotime( $post->post_modified );
+		}
 
 		// Transform cut off from days to seconds.
 		$cut_off_seconds = $cut_off * 86400;
@@ -562,9 +573,25 @@ function newspack_convert_to_time_ago( $post_time, $format, $post ) {
 			);
 		}
 	}
+
 	return $post_time;
 }
+
+/**
+ * Apply time ago format to publish dates if enabled.
+ */
+function newspack_convert_to_time_ago( $post_time, $format, $post ) {
+	return newspack_math_to_time_ago( $post_time, $format, $post, false );
+}
 add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 3 );
+
+/**
+ * Apply time ago format to modified dates if enabled.
+ */
+function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
+	return newspack_math_to_time_ago( $post_time, $format, $post, true );
+}
+
 
 /**
  * Check whether updated date should be displayed.
@@ -575,7 +602,7 @@ function newspack_should_display_updated_date() {
 	$publish_date  = $post->post_date;
 	$modified_date = $post->post_modified;
 
-	// Exclude posts updated during Calmatters Newspack launch.
+	// Exclude posts updated during launch.
 	// if ( 0 === strpos( $modified_date, '2020-06-23' ) ) {
 	// return false;
 	// }

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -161,7 +161,7 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Add a class if updated date should display
-	if ( is_single() && newspack_should_display_updated_date() ) {
+	if ( newspack_should_display_updated_date() ) {
 		$classes[] = 'show-updated';
 	}
 
@@ -565,6 +565,10 @@ function newspack_math_to_time_ago( $post_time, $format, $post, $updated ) {
 		// Transform cut off from days to seconds.
 		$cut_off_seconds = $cut_off * 86400;
 
+		if ( true === newspack_should_display_updated_date() ) {
+			$cut_off_seconds = 86400;
+		}
+
 		if ( $cut_off_seconds >= ( $current_time - $org_time ) ) {
 			$post_time = sprintf(
 				/* translators: %s: Time ago date format */
@@ -597,6 +601,10 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
  * Check whether updated date should be displayed.
  */
 function newspack_should_display_updated_date() {
+	if ( ! is_single() ) {
+		return false;
+	}
+
 	$post = get_post();
 
 	$publish_date  = $post->post_date;

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -565,3 +565,28 @@ function newspack_convert_to_time_ago( $post_time, $format, $post ) {
 	return $post_time;
 }
 add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 3 );
+
+/**
+ * Check whether updated date should be displayed.
+ */
+function newspack_should_display_updated_date() {
+	$post = get_post();
+
+	$publish_date  = $post->post_date;
+	$modified_date = $post->post_modified;
+
+	// Exclude posts updated during Calmatters Newspack launch.
+	// if ( 0 === strpos( $modified_date, '2020-06-23' ) ) {
+	// return false;
+	// }
+
+	$publish_timestamp  = strtotime( $publish_date );
+	$modified_timestamp = strtotime( $modified_date );
+
+	$modified_cutoff = strtotime( 'tomorrow midnight', $publish_timestamp );
+	if ( $modified_timestamp > $modified_cutoff ) {
+		return true;
+	}
+
+	return false;
+}

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 				$time_string,
 				esc_attr( get_the_date( DATE_W3C ) ),
 				esc_html( get_the_date() ),
-				'<span>' . esc_html__( 'Updated', 'newspack' ) . '</span>',
+				'<span class="updated-label">' . esc_html__( 'Updated', 'newspack' ) . ' </span>',
 				esc_attr( get_the_modified_date( DATE_W3C ) ),
 				esc_html( get_the_modified_date() )
 			);
@@ -50,7 +50,9 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 							'class'    => array(),
 							'datetime' => array(),
 						),
-						'span' => array(),
+						'span' => array(
+							'class' => array(),
+						),
 					)
 				)
 			);

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -12,19 +12,33 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 	function newspack_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
 
-		if ( newspack_should_display_updated_date() ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>' . esc_html__( 'Updated', 'newspack' ) . '<time datetime="%3$s">%4$s</time>';
-		} elseif ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>%3$s<time class="updated" datetime="%4$s">%5$s</time>';
 		}
 
-		$time_string = sprintf(
+		if ( newspack_should_display_updated_date() ) {
+			add_filter( 'get_the_modified_date', 'newspack_convert_modified_to_time_ago', 10, 3 );
+
+			$time_string = sprintf(
+				$time_string,
+				esc_attr( get_the_date( DATE_W3C ) ),
+				esc_html( get_the_date() ),
+				'<span>' . esc_html__( 'Updated', 'newspack' ) . '</span>',
+				esc_attr( get_the_modified_date( DATE_W3C ) ),
+				esc_html( get_the_modified_date() )
+			);
+
+			remove_filter( 'get_the_modified_date', 'newspack_convert_modified_to_time_ago', 10, 3 );
+		} else {
+			$time_string = sprintf(
 			$time_string,
 			esc_attr( get_the_date( DATE_W3C ) ),
 			esc_html( get_the_date() ),
+			'',
 			esc_attr( get_the_modified_date( DATE_W3C ) ),
 			esc_html( get_the_modified_date() )
 		);
+		}
 
 		if ( is_single() ) {
 			printf(
@@ -36,6 +50,7 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 							'class'    => array(),
 							'datetime' => array(),
 						),
+						'span' => array(),
 					)
 				)
 			);
@@ -50,6 +65,7 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 							'class'    => array(),
 							'datetime' => array(),
 						),
+						'span' => array(),
 					)
 				)
 			);

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -11,7 +11,10 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 	 */
 	function newspack_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+
+		if ( newspack_should_display_updated_date() ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>' . esc_html__( 'Updated', 'newspack' ) . '<time datetime="%3$s">%4$s</time>';
+		} elseif ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 		}
 

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -229,7 +229,7 @@
 			} );
 		} );
 
-		// Diable 'time ago cutoff' when post updated date is enabled.
+		// Disable 'time ago cutoff' when post updated date is enabled.
 		wp.customize( 'post_updated_date', function( setting ) {
 			wp.customize.control( 'post_time_ago_cut_off', function( control ) {
 				const visibility = function() {

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -229,6 +229,21 @@
 			} );
 		} );
 
+		// Diable 'time ago cutoff' when post updated date is enabled.
+		wp.customize( 'post_updated_date', function( setting ) {
+			wp.customize.control( 'post_time_ago_cut_off', function( control ) {
+				const visibility = function() {
+					if ( true === setting.get() ) {
+						$( 'input', control.selector ).prop( 'disabled', true );
+					} else {
+						$( 'input', control.selector ).prop( 'disabled', false );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
 		// Lets you jump to specific sections in the Customizer
 		$( [ 'control', 'section', 'panel' ] ).each( function( i, type ) {
 			$( 'a[rel="goto-' + type + '"]' ).click( function( e ) {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -129,6 +129,10 @@ amp-script .cat-links {
 			color: $color__text-light;
 		}
 	}
+
+	.updated-label {
+		margin-left: 1em;
+	}
 }
 
 .entry-footer {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -6,6 +6,10 @@
 	display: none;
 }
 
+.show-updated .entry-header .updated:not( .published ) {
+	display: inline-block;
+}
+
 .page-links {
 	clear: both;
 	margin: 0 0 calc( 1.5 * #{$size__spacing-unit} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to the customizer to display each post's last updated date, if it has been updated more than a full day after its published.

When paired with the 'time ago' date format, it will automatically override the 'cut off' time for the time ago format, and switch it to 1 day. This is to serve two purposes: 1. Make sure you don't end up with a somewhat unclear date, like "November 20th Updated 2 days ago", and 2. to avoid having both use the time ago format without too many code acrobatics (5 days ago Update 2 days ago").

**Questions** 

* Do we need some kind of override for changes that happen during migration/launch? I noticed this in the CalMatters code I was working from.
* Right now, the updated dates only display on single posts; would it make sense to add them to other locations, too, like the archives, search, or blocks (which would, in part, need a separate PR at least to add the Updated string)? 
* Does the 'Time ago' override behaviour make sense, or would it be better to honour their settings and let them decide if it seems weird or not?

See #598

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Start with a mix of posts that have been published recently, updated recently, and published and updated again in the same 24 hour period. 
3. Navigate to Customizer > Template Settings > Post Settings and check the 'Show "Last updated" date' checkbox.
4. Confirm that on posts that have been published and updated more than 24 hours later, a second 'Updated' date is displaying:

![image](https://user-images.githubusercontent.com/177561/100296881-2af55400-2f42-11eb-9676-678040e610bc.png)

5. Confirm that on posts that have been updated less than 24 hours after publishing, the updated date does not show up.
6. Navigate back to Customizer > Template Settings > Post settings, and check 'Use "time ago" date format'; note that the 'Cut off' field is greyed out.
7. Try toggling on and off the 'Show "last updated" date' to make sure the cut off field is enabled/disabled. Leave both options checked and click 'Publish'.
8. Confirm that the time-ago date is only applied to the updated date, even when the normal 'cut-off' would apply it to both dates:

![image](https://user-images.githubusercontent.com/177561/100297071-b66ee500-2f42-11eb-8641-a5a0906be18c.png)

9. Confirm that posts that don't display the updated date (either because they haven't been updated, or that were updated in the 24 hours after publishing), don't show the updated date, and show the 'time ago' format:

![image](https://user-images.githubusercontent.com/177561/100297217-077ed900-2f43-11eb-99d8-7951c4ba6658.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
