### PR TITLE
fix: center sponsor flag in Newspack Sacha

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -194,10 +194,6 @@ cite {
 }
 
 .single {
-	.cat-links {
-		text-align: center;
-	}
-
 	.featured-image-behind {
 		.entry-subhead {
 			border: 0;
@@ -216,10 +212,8 @@ cite {
 	}
 
 	.entry-header {
-		.entry-title,
-		.newspack-post-subtitle {
-			text-align: center;
-		}
+		text-align: center;
+
 		.entry-title {
 			margin-bottom: #{1.5 * $size__spacing-unit};
 			margin-top: $size__spacing-unit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an alignment issue with the sponsor flag on Newspack Sacha; it should be centred but it's aligned left.

Closes #1155.

### How to test the changes in this Pull Request:

1. Start with a test site running Newspack Sacha, and set up a sponsor and apply it to a post.
2. View on the front end and note the alignment:

![image](https://user-images.githubusercontent.com/177561/100479406-f9e06500-30a2-11eb-9a0b-f6f84b1b0200.png)

3. Apply the PR and run `npm run build`.
4. Refresh the post and confirm the flag is now centred:

![image](https://user-images.githubusercontent.com/177561/100479525-593e7500-30a3-11eb-9c1d-bbf36fceeab4.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
