### PR TITLE
feat: add option to show excerpts on archives

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -116,7 +116,7 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 				$post_count++;
 				the_post();
 
-				if ( 1 === $post_count ) {
+				if ( 1 === $post_count || true === get_theme_mod( 'archive_show_excerpt', false ) ) {
 					get_template_part( 'template-parts/content/content', 'excerpt' );
 				} else {
 					get_template_part( 'template-parts/content/content', 'archive' );

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -789,6 +789,34 @@ function newspack_customize_register( $wp_customize ) {
 	);
 
 	/**
+	 * Archive settings
+	 */
+	$wp_customize->add_section(
+		'archive_options',
+		array(
+			'title' => esc_html__( 'Archive Settings', 'newspack' ),
+			'panel' => 'newspack_template_settings',
+		)
+	);
+
+	// Add option to show excerpts for all archives.
+	$wp_customize->add_setting(
+		'archive_show_excerpt',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'archive_show_excerpt',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Show excerpts for all archives', 'newspack' ),
+			'section' => 'archive_options',
+		)
+	);
+
+	/**
 	 * Comments settings
 	 */
 	$wp_customize->add_section(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, the archive pages only show the excerpt for the very first post, and titles for the rest.

This PR adds an option to display the excerpt for all posts in the archive.

Closes #779.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. View a category, tag or author archive.
3. Navigate to Customize > Template Settings > Archive Settings, and check "Show excerpts for all archives"
4. Refresh the archive and confirm all display the excerpt.
5. Navigate back to the Archive Settings and uncheck "Show excerpts for all archives".
6. Refresh the archive and confirm only the first post displays the archive again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
