### PR TITLE
fix: correct video width preview in editor

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -372,6 +372,10 @@ figcaption,
 	text-align: left;
 }
 
+.wp-block-video video {
+	width: 100%;
+}
+
 /** === Group === */
 .wp-block[data-align='left'] .wp-block-group,
 .wp-block[data-align='right'] .wp-block-group {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the wide/full alignment preview for the video block in the editor.

Closes #1146.

### How to test the changes in this Pull Request:

1. Add a video block to the editor.
2. Set the width to wide and full; note that the container gets wider, but the video does not -- it just moves to the left.
3. Apply the PR and run `npm run build`.
4. Confirm that the video previews at the correct width.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
