### PR TITLE
WooCommerce: add coupon information to simplified checkout

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -405,6 +405,10 @@ dl.variation,
  * Single product
  */
 .single-product {
+	&.has-sidebar #main {
+		display: block;
+	}
+
 	div.product {
 		position: relative;
 	}
@@ -1547,6 +1551,11 @@ table.woocommerce-table--order-details.shop_table,
 			color: $color__text-light;
 			display: block;
 		}
+	}
+
+	.woocommerce-remove-coupon {
+		font-size: 0.9em;
+		margin-left: 0.5em;
 	}
 }
 

--- a/newspack-theme/woocommerce/checkout/form-checkout.php
+++ b/newspack-theme/woocommerce/checkout/form-checkout.php
@@ -42,31 +42,39 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 <?php if ( 'display' !== $order_details_display ) : ?>
 	<div class="order-details-summary">
-	<?php
-	// Simplified output of order
-	foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-		$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+		<?php
+		// Simplified output of order.
+		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
-		if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
-		?>
-			<h4>
-				<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' ' . sprintf( '%s&nbsp;&times;', $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				<strong>
-					<?php
-						echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					?>
-				</strong>
-				<span>
-				<?php
-					echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_checkout_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
 				?>
-				</span>
-			</h4>
-			<?php
+				<h4>
+					<?php echo apply_filters( 'woocommerce_checkout_cart_item_quantity', ' ' . sprintf( '%s&nbsp;&times;', $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<strong>
+						<?php
+							echo apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
+					</strong>
+					<span>
+					<?php
+						echo apply_filters( 'woocommerce_cart_item_subtotal', WC()->cart->get_product_subtotal( $_product, $cart_item['quantity'] ), $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
+					</span>
+				</h4>
+				<?php
+			}
 		}
-	}
-	?>
+		?>
+
+		<?php foreach ( WC()->cart->get_coupons() as $code => $coupon ) : ?>
+			<h4>
+				<strong><?php wc_cart_totals_coupon_label( $coupon ); ?></strong>
+				<span><?php wc_cart_totals_coupon_html( $coupon ); ?></span>
+			</h4>
+		<?php endforeach; ?>
+
 	</div><!-- .order-details-summary -->
 <?php endif; ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds coupon information to the simplified checkout info at the top.

I opted to keep this simple, in hopes that it'll be enough, but I'm open to feedback about it! I don't want to try to fully replace the full details table that you can still opt to display, behind a toggle or not, but I also get that this still may not be totally clear. 

Closes #1124.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > WooCommerce > Order Details, and pick "Hide, with ability to toggle open"
2. On your test site, set up a coupon and run the checkout with it. 
3. On the simplified checkout page, note that your product(s) are at the top, but with no coupon in the summary:

![image](https://user-images.githubusercontent.com/177561/100490399-0333f680-30d0-11eb-8adc-d1bf199a320b.png)

4. Click "Show Details" and note that the coupon is incorporated into the total:

![image](https://user-images.githubusercontent.com/177561/100490410-1941b700-30d0-11eb-83a5-358ea5b5b54b.png)

5. Apply the PR and run `npm run build`.
6. Refresh the checkout; note that the coupon now appears in the summary:

![image](https://user-images.githubusercontent.com/177561/100490458-6c1b6e80-30d0-11eb-9bd1-92aba124d85b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
