### PR TITLE
Columns block: fix wide alignment width

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1066,6 +1066,7 @@
 				margin-left: calc( 25% - 25vw );
 				margin-right: calc( 25% - 25vw );
 				max-width: 100vw;
+				width: auto;
 			}
 		}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1066,7 +1066,31 @@
 				margin-left: calc( 25% - 25vw );
 				margin-right: calc( 25% - 25vw );
 				max-width: 100vw;
-				width: auto;
+			}
+
+			@include media( tablet ) {
+				&.wp-block-columns {
+					margin-left: calc( 25% - 25vw - 16px );
+					margin-right: calc( 25% - 25vw - 16px );
+					max-width: calc( 100vw + 32px );
+					width: auto;
+
+					&.is-style-borders {
+						margin-left: calc( 25% - 25vw - 24px );
+						margin-right: calc( 25% - 25vw - 24px );
+						max-width: calc( 100vw + 48px );
+					}
+				}
+			}
+
+			@include media( desktop ) {
+				&.wp-block-columns {
+					&.is-style-borders {
+						margin-left: calc( 25% - 25vw - 32px );
+						margin-right: calc( 25% - 25vw - 32px );
+						max-width: calc( 100vw + 64px );
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #1063.

### How to test the changes in this Pull Request:

1. Create a new post or page and select the 'One Column' template.
2. Add a column block, and give it the wide alignment.
3. View on the front-end.
4. Note that the block doesn't fill the available space -- it hangs to the left:

![image](https://user-images.githubusercontent.com/177561/100657147-ac623300-3302-11eb-89e2-329400548a36.png)

5. Apply the PR and run 'npm run build'
6. Confirm that the column block now fills the available 'wide' width:

![image](https://user-images.githubusercontent.com/177561/100656696-f0086d00-3301-11eb-8767-accaa8e412fd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
