### PR TITLE
fix: correct issue with primary menu background control

### DIFF
--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -153,24 +153,8 @@
 					if ( true === setting.get() ) {
 						if (
 							'custom' === wp.customize.value( 'header_color' )() &&
-							'custom' === wp.customize.value( 'theme_colors' )()
-						) {
-							control.container.slideDown( 180 );
-						}
-					} else {
-						control.container.slideUp( 180 );
-					}
-				};
-				visibility();
-				setting.bind( visibility );
-			} );
-
-			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
-				const visibility = function() {
-					if ( true === setting.get() ) {
-						if (
-							'custom' === wp.customize.value( 'header_color' )() &&
-							'custom' === wp.customize.value( 'theme_colors' )()
+							'custom' === wp.customize.value( 'theme_colors' )() &&
+							false === wp.customize.value( 'header_simplified' )()
 						) {
 							control.container.slideDown( 180 );
 						}
@@ -212,6 +196,24 @@
 						if (
 							true === wp.customize.value( 'header_solid_background' )() &&
 							'custom' === wp.customize.value( 'theme_colors' )()
+						) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+
+			wp.customize.control( 'header_primary_menu_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						if (
+							true === wp.customize.value( 'header_solid_background' )() &&
+							'custom' === wp.customize.value( 'theme_colors' )() &&
+							false === wp.customize.value( 'header_simplified' )()
 						) {
 							control.container.slideDown( 180 );
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes issue where primary colour background control wasn't showing when expected.

### How to test the changes in this Pull Request:

1. Apply the PR and run`npm run build`
2. Try Header Settings > Appearance > Solid Background - toggle on and off the Header Background Colour and the primary background colour option should appear with the regular header background option.
3. Disable Header Settings > Appearance > Solid Background  - primary background colour should be gone
4. Enable Header Settings > Appearance > Solid Background - it should be back 
5. Enable Header Settings > Appearance > Short Header - it should be gone
6. Try toggling on and off Colors > Header Background Colour and make sure the primary menu option stays hidden. 
7. Turn Colors > Header Background Colour off. 
8. Turn Header Settings > Appearance > Short Header off.
9. Turn Colors > Header Background Colour on -- the primary menu option should be back. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
