### PR TITLE
fix: override semi-transparent styles for separator block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -799,6 +799,7 @@ hr {
 	height: 1px;
 	margin: ( 2 * $size__spacing-unit ) auto;
 	max-width: #{5 * $size__spacing-unit};
+	opacity: 1;
 
 	&.is-style-wide {
 		max-width: 100%;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -604,6 +604,7 @@ figcaption,
 /** === Separator === */
 
 .wp-block-separator {
+	opacity: 1;
 	&:not( .is-style-dots ) {
 		border: 0;
 		border-top: 1px solid $color__border;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As of WordPress 5.6. the separator block has a opacity of `0.4`. This is having some unintended effects on Newspack sites, so this PR overrides that opacity change.

### How to test the changes in this Pull Request:

1. Add the seperator block to a post, using its different styles (short, wide, dotted).
2. View in the editor and on the front-end -- it will be a _very_ light grey in most cases (instead of a light -- but easy to see -- grey), or for Newspack Nelson or Joseph, a middle grey (it should be black):

![image](https://user-images.githubusercontent.com/177561/101804566-9274dd00-3ac6-11eb-80ff-d4ee8bf117aa.png)


3. Apply the PR and run `npm run build`.
4. Confirm that the block is now using the correct colour:

![image](https://user-images.githubusercontent.com/177561/101804309-4c1f7e00-3ac6-11eb-880a-819de3bd54cd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
