### PR TITLE
Add per-post toggle for updated date

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -435,6 +435,9 @@ function newspack_enqueue_scripts() {
 	if ( 'post' === get_current_screen()->post_type ) {
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', get_parent_theme_file_path( '/languages' ) );
+
+		wp_enqueue_script( 'newspack-post-date-updated', get_theme_file_uri( '/js/dist/post-date-updated.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+		wp_set_script_translations( 'newspack-post-date-updated', 'newspack', get_parent_theme_file_path( '/languages' ) );
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
@@ -610,6 +613,16 @@ function newspack_register_meta() {
 			'show_in_rest' => true,
 			'single'       => true,
 			'type'         => 'string',
+		)
+	);
+
+	register_post_meta(
+		'post',
+		'newspack_show_updated_date',
+		array(
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'boolean',
 		)
 	);
 }

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -436,8 +436,10 @@ function newspack_enqueue_scripts() {
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', get_parent_theme_file_path( '/languages' ) );
 
-		wp_enqueue_script( 'newspack-post-date-updated', get_theme_file_uri( '/js/dist/post-date-updated.js' ), array(), wp_get_theme()->get( 'Version' ), true );
-		wp_set_script_translations( 'newspack-post-date-updated', 'newspack', get_parent_theme_file_path( '/languages' ) );
+		if ( true === get_theme_mod( 'post_updated_date', false ) ) {
+			wp_enqueue_script( 'newspack-post-date-updated', get_theme_file_uri( '/js/dist/post-date-updated.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+			wp_set_script_translations( 'newspack-post-date-updated', 'newspack', get_parent_theme_file_path( '/languages' ) );
+		}
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
@@ -618,7 +620,7 @@ function newspack_register_meta() {
 
 	register_post_meta(
 		'post',
-		'newspack_show_updated_date',
+		'newspack_hide_updated_date',
 		array(
 			'show_in_rest' => true,
 			'single'       => true,

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -604,7 +604,7 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
  * Check whether updated date should be displayed.
  */
 function newspack_should_display_updated_date() {
-	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) ) {
+	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) && get_post_meta( get_the_ID(), 'newspack_show_updated_date', true ) ) {
 		$post          = get_post();
 		$publish_date  = $post->post_date;
 		$modified_date = $post->post_modified;

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -604,7 +604,7 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
  * Check whether updated date should be displayed.
  */
 function newspack_should_display_updated_date() {
-	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) && get_post_meta( get_the_ID(), 'newspack_show_updated_date', true ) ) {
+	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) && ! get_post_meta( get_the_ID(), 'newspack_hide_updated_date', true ) ) {
 		$post          = get_post();
 		$publish_date  = $post->post_date;
 		$modified_date = $post->post_modified;

--- a/newspack-theme/js/src/post-date-updated.js
+++ b/newspack-theme/js/src/post-date-updated.js
@@ -14,7 +14,7 @@ const updatedDateToggle = ( { meta, updateMetaValue } ) => {
 	return (
 		<PluginPostStatusInfo>
 			<ToggleControl
-				label={ __( 'Show updated date', 'newspack' ) }
+				label={ __( 'Hide updated date', 'newspack' ) }
 				checked={ newspack_show_updated_date }
 				onChange={ value => updateMetaValue( 'newspack_show_updated_date', value ) }
 			/>

--- a/newspack-theme/js/src/post-date-updated.js
+++ b/newspack-theme/js/src/post-date-updated.js
@@ -1,0 +1,46 @@
+'use strict';
+
+import { ToggleControl } from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+const updatedDateToggle = ( { meta, updateMetaValue } ) => {
+	const { newspack_show_updated_date } = meta;
+
+	return (
+		<PluginPostStatusInfo>
+			<ToggleControl
+				label={ __( 'Show updated date', 'newspack' ) }
+				checked={ newspack_show_updated_date }
+				onChange={ value => updateMetaValue( 'newspack_show_updated_date', value ) }
+			/>
+		</PluginPostStatusInfo>
+	);
+};
+
+const mapStateToProps = select => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+
+	return {
+		meta: getEditedPostAttribute( 'meta' ),
+	};
+};
+
+const mapDispatchToProps = dispatch => {
+	const { editPost } = dispatch( 'core/editor' );
+
+	return {
+		updateMetaValue: ( key, value ) => editPost( { meta: { [ key ]: value } } ),
+	};
+};
+
+const showUpdatedDate = compose( [
+	withSelect( mapStateToProps ),
+	withDispatch( mapDispatchToProps ),
+] )( updatedDateToggle );
+
+registerPlugin( 'show-updated-date', { render: showUpdatedDate } );

--- a/newspack-theme/js/src/post-date-updated.js
+++ b/newspack-theme/js/src/post-date-updated.js
@@ -9,14 +9,14 @@ import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 const updatedDateToggle = ( { meta, updateMetaValue } ) => {
-	const { newspack_show_updated_date } = meta;
+	const { newspack_hide_updated_date } = meta;
 
 	return (
 		<PluginPostStatusInfo>
 			<ToggleControl
 				label={ __( 'Hide updated date', 'newspack' ) }
-				checked={ newspack_show_updated_date }
-				onChange={ value => updateMetaValue( 'newspack_show_updated_date', value ) }
+				checked={ newspack_hide_updated_date }
+				onChange={ value => updateMetaValue( 'newspack_hide_updated_date', value ) }
 			/>
 		</PluginPostStatusInfo>
 	);
@@ -38,9 +38,9 @@ const mapDispatchToProps = dispatch => {
 	};
 };
 
-const showUpdatedDate = compose( [
+const hideUpdatedDate = compose( [
 	withSelect( mapStateToProps ),
 	withDispatch( mapDispatchToProps ),
 ] )( updatedDateToggle );
 
-registerPlugin( 'show-updated-date', { render: showUpdatedDate } );
+registerPlugin( 'hide-updated-date', { render: hideUpdatedDate } );

--- a/newspack-theme/js/src/post-date-updated.js
+++ b/newspack-theme/js/src/post-date-updated.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { ToggleControl } from '@wordpress/components';
+import { FormToggle } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 import { registerPlugin } from '@wordpress/plugins';
@@ -13,10 +13,13 @@ const updatedDateToggle = ( { meta, updateMetaValue } ) => {
 
 	return (
 		<PluginPostStatusInfo>
-			<ToggleControl
-				label={ __( 'Hide updated date', 'newspack' ) }
+			<label htmlFor="hide_updated_date">{ __( 'Hide updated date', 'newspack' ) }</label>
+			<FormToggle
 				checked={ newspack_hide_updated_date }
-				onChange={ value => updateMetaValue( 'newspack_hide_updated_date', value ) }
+				onChange={ () =>
+					updateMetaValue( 'newspack_hide_updated_date', ! newspack_hide_updated_date )
+				}
+				id="hide_updated_date"
 			/>
 		</PluginPostStatusInfo>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a per-post option to override showing the 'updated date' on individual posts.

Closes #1162 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Template Settings > Post Settings, and check "Show "last updated" date on single posts"
3. Edit a post so it has an updated date. 
4. In the editor, verify that the post is showing a toggle for "Hide updated date" under "Status & visibility", and confirm that it's off by default:

![image](https://user-images.githubusercontent.com/177561/102656317-8624fb80-4128-11eb-9735-8ccc8a677624.png)

5. Toggle the option on and publish the post; view on the front-end and confirm that the updated date is now gone.
6. Toggle the option back off, and confirm that the updated date is now showing again.
7. Navigate back to Customize > Template Settings > Post Settings, and uncheck "Show "last updated" date on single posts"
8. Edit your post again and confirm the "Hide updated date" toggle is now gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
