### PR TITLE
feat: add fr-BR JSON files for the editor

### DIFF
--- a/newspack-theme/languages/newspack-fr_BE-newspack-extend-featured-image-script.json
+++ b/newspack-theme/languages/newspack-fr_BE-newspack-extend-featured-image-script.json
@@ -1,0 +1,17 @@
+{
+	"translation-revision-date": "2020-12-18 15:45+0000",
+	"generator": "WP-CLI/2.4.0",
+	"source": "js/src/extend-featured-image-editor.js",
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": { "domain": "messages", "lang": "fr_BE", "plural-forms": "nplurals=2; plural=(n > 1);" },
+			"Small": ["Petit"],
+			"Large": ["Large"],
+			"Behind article title": ["Derri\u00e8re le titre de l\u2019article"],
+			"Beside article title": ["\u00c0 c\u00f4t\u00e9 du titre de l\u2019article"],
+			"Hidden": ["Masqu\u00e9"],
+			"Default (set in Customizer)": ["Par d\u00e9faut (d\u00e9fini dans le personnalisateur)"]
+		}
+	}
+}

--- a/newspack-theme/languages/newspack-fr_BE-newspack-post-subtitle.json
+++ b/newspack-theme/languages/newspack-fr_BE-newspack-post-subtitle.json
@@ -1,0 +1,13 @@
+{
+	"translation-revision-date": "2020-12-18 15:45+0000",
+	"generator": "WP-CLI/2.4.0",
+	"source": "js/src/post-subtitle/index.js",
+	"domain": "messages",
+	"locale_data": {
+		"messages": {
+			"": { "domain": "messages", "lang": "fr_BE", "plural-forms": "nplurals=2; plural=(n > 1);" },
+			"Article Subtitle": ["Sous-titre de l\u2019article"],
+			"Set a Subtitle for the Article": ["D\u00e9finir un sous-titre pour l\u2019article"]
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR pairs with #1188, to add the corresponding JSON files with the fr_BE translation.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Switch your admin language to French (Belgique)
3. Edit a post; confirm that the Article Subtitle and Featured Image placement options are en français.

Note: it looks like the POT file is already a bit out of date so the 'Above post title' image placement is not translated, but thankfully for these files it's just in the editor. We'll need to do another update of all files, probably in the new year. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
