### PR TITLE
feat: add styles for the block 'read more' links

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -481,6 +481,7 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */
+		.block-editor-block-list__layout .block-editor-block-list__block a.more-link,
 		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a,
 		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a:hover,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color a,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -179,6 +179,10 @@ p.has-background {
 		max-width: 100%;
 	}
 
+	.more-link + .entry-meta {
+		margin-top: #{0.75 * $size__spacing-unit};
+	}
+
 	article.format-aside {
 		.entry-meta > a,
 		.entry-meta .byline {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -192,19 +192,19 @@ amp-script .cat-links {
 	}
 
 	.more-link {
-		@include link-transition;
-		display: inline;
 		color: inherit;
+		font-size: 0.8em;
+		@include link-transition;
+		text-decoration: none;
 
 		&::after {
 			content: '\02192';
 			display: inline-block;
-			margin-left: 0.5em;
+			margin-left: 0.25em;
 		}
 
 		&:hover {
-			color: $color__primary-variation;
-			text-decoration: none;
+			text-decoration: underline;
 		}
 	}
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -193,15 +193,11 @@ amp-script .cat-links {
 
 	.more-link {
 		color: inherit;
+		display: block;
 		font-size: 0.8em;
 		@include link-transition;
+		margin: 0.5em 0;
 		text-decoration: none;
-
-		&::after {
-			content: '\02192';
-			display: inline-block;
-			margin-left: 0.25em;
-		}
 
 		&:hover {
 			text-decoration: underline;

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -197,11 +197,6 @@ amp-script .cat-links {
 		font-size: 0.8em;
 		@include link-transition;
 		margin: 0.5em 0;
-		text-decoration: none;
-
-		&:hover {
-			text-decoration: underline;
-		}
 	}
 
 	a {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -101,12 +101,6 @@ a {
 	font-size: 0.8em;
 	@include link-transition;
 	margin: 0.5em 0;
-	text-decoration: none;
-
-	&:hover {
-		color: $color__primary-variation;
-		text-decoration: underline;
-	}
 }
 
 table td,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -96,6 +96,24 @@ a {
 	}
 }
 
+.more-link {
+	color: inherit;
+	font-size: 0.9em;
+	@include link-transition;
+	text-decoration: none;
+
+	&::after {
+		content: '\02192';
+		display: inline-block;
+		margin-left: 0.25em;
+	}
+
+	&:hover {
+		color: $color__primary-variation;
+		text-decoration: underline;
+	}
+}
+
 table td,
 table th {
 	font-family: $font__body;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -98,15 +98,10 @@ a {
 
 .more-link {
 	color: inherit;
-	font-size: 0.9em;
+	font-size: 0.8em;
 	@include link-transition;
+	margin: 0.5em 0;
 	text-decoration: none;
-
-	&::after {
-		content: '\02192';
-		display: inline-block;
-		margin-left: 0.25em;
-	}
 
 	&:hover {
 		color: $color__primary-variation;
@@ -192,6 +187,10 @@ figcaption,
 /** === Homepage Posts === */
 
 .wpnbha {
+	.more-link + .entry-meta {
+		margin-top: #{0.75 * $size__spacing-unit};
+	}
+
 	article.format-aside {
 		.entry-meta > a,
 		.entry-meta .byline,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some styles to the new 'Read More' link added to the Homepage Posts block. It needs to be tested with https://github.com/Automattic/newspack-blocks/pull/656 applied.

Edited to add: I'm still waffling a bit about how opinionated this is, so I'd definitely appreciate feedback on this either way; it's pretty subtle now, but could also be bolded, or have some kind of icon -- like an arrow -- to help it stand out more. 

### How to test the changes in this Pull Request:

1. Set your test site to use the default font and colours.
2. Apply this PR to the theme, and https://github.com/Automattic/newspack-blocks/pull/656 to the Newspack Blocks, and run `npm run build` for each. 
3. Add some homepage posts blocks with the Read More link enabled. 
4. View on the front-end and in the editor; confirm that the link is the same colour as the text, and doesn't have an underline unless hovered over. When the block type scale is 4 and higher, the link font size should be slightly smaller; for the type scale 1-3, the link should be the same font size:

![image](https://user-images.githubusercontent.com/177561/103567467-bda9dc80-4e78-11eb-8548-ef28e59c9487.png)

![image](https://user-images.githubusercontent.com/177561/103567480-c39fbd80-4e78-11eb-9de8-76aa77c245a1.png)

5. Try changing the block text colour and confirm that the link picks it up:

![image](https://user-images.githubusercontent.com/177561/103567509-d0bcac80-4e78-11eb-8bf7-d07a07c591f8.png)

6. Try changing the site's custom colours and fonts; confirm they're picked up as expected (with the link picking up the body font, and still the same colour as the text):

![image](https://user-images.githubusercontent.com/177561/103567582-ed58e480-4e78-11eb-885f-39e31c16a206.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
