### PR TITLE
Pullquote Block: Make sure italics are working

### DIFF
--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -53,13 +53,25 @@ Newspack Sacha Editor Styles
 	font-style: normal;
 	font-weight: bold;
 
+	p {
+		font-style: inherit;
+
+		em {
+			font-style: italic;
+		}
+
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
+	&.is-style-solid-color {
+		border: 0;
+	}
+
 	blockquote {
 		border-color: inherit;
 		text-align: center;
-	}
-
-	p {
-		font-style: normal;
 	}
 
 	&.is-style-solid-color {

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -1,5 +1,5 @@
 /*!
-Newspack Sacha Editor Styles
+Newspack Joseph Editor Styles
 */
 
 /** === Includes === */
@@ -59,9 +59,6 @@ Newspack Sacha Editor Styles
 		em {
 			font-style: italic;
 		}
-
-		@include media( tablet ) {
-			font-size: $font__size-xl;
 	}
 
 	&.is-style-solid-color {
@@ -71,10 +68,6 @@ Newspack Sacha Editor Styles
 	blockquote {
 		border-color: inherit;
 		text-align: center;
-	}
-
-	&.is-style-solid-color {
-		border: 0;
 	}
 
 	.wp-block-pullquote__citation {

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -62,7 +62,6 @@ Newspack Sacha Editor Styles
 
 		@include media( tablet ) {
 			font-size: $font__size-xl;
-		}
 	}
 
 	&.is-style-solid-color {

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -345,6 +345,10 @@ textarea {
 	p {
 		font-style: inherit;
 
+		em {
+			font-style: italic;
+		}
+
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -348,10 +348,6 @@ textarea {
 		em {
 			font-style: italic;
 		}
-
-		@include media( tablet ) {
-			font-size: $font__size-xl;
-		}
 	}
 
 	blockquote {

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -101,6 +101,10 @@ figure.wp-block-pullquote {
 	&.is-style-solid-color blockquote p {
 		font-size: $font__size-lg;
 
+		em {
+			font-style: italic;
+		}
+
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -101,10 +101,6 @@ figure.wp-block-pullquote {
 	&.is-style-solid-color blockquote p {
 		font-size: $font__size-lg;
 
-		em {
-			font-style: italic;
-		}
-
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
@@ -113,6 +109,10 @@ figure.wp-block-pullquote {
 	p {
 		font-style: normal;
 		font-weight: bold;
+	}
+
+	em {
+		font-style: italic;
 	}
 
 	.wp-block-pullquote__citation {

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -265,6 +265,15 @@ figcaption,
 		font-weight: bold;
 		p {
 			font-style: normal;
+			font-size: $font__size-lg;
+
+			em {
+				font-style: italic;
+			}
+
+			@include media( tablet ) {
+				font-size: $font__size-xl;
+			}
 		}
 	}
 

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -88,6 +88,10 @@ blockquote {
 	blockquote p {
 		font-size: $font__size-lg;
 
+		em {
+			font-style: italic;
+		}
+
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -88,10 +88,6 @@ blockquote {
 	blockquote p {
 		font-size: $font__size-lg;
 
-		em {
-			font-style: italic;
-		}
-
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
@@ -100,6 +96,10 @@ blockquote {
 	p {
 		font-style: normal;
 		font-weight: bold;
+	}
+
+	em {
+		font-style: italic;
 	}
 
 	.wp-block-pullquote__citation {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -366,6 +366,14 @@ blockquote {
 
 		p {
 			font-style: normal;
+
+			em {
+				font-style: italic;
+			}
+
+			@include media( tablet ) {
+				font-size: $font__size-xl;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the Newspack theme, the default, Sacha and Scott all italicize the pullquote block, so when you apply italics to part of the block, it switches it to non-italics instead.

However, Nelson, Katharine and Joseph do not italicize the pullquote by default, but the italicized styles aren't working. This PR fixes that.

Closes #1187

### How to test the changes in this Pull Request:

1. Start with the theme Newspack Katharine.
2. Create a Pullquote block and italicize part of it.
3. Note that your italics aren't being applied:

![image](https://user-images.githubusercontent.com/177561/103718494-b5869580-4f7b-11eb-84f1-5dfe39046013.png)

4. Apply the PR and run `npm run build`.
5. Confirm that your italics are now being applied in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/103718449-9ee03e80-4f7b-11eb-8953-713c6c589d91.png)

6. Check Newspack Nelson and Joseph, and confirm the italics working there, too. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
