### PR TITLE
Pullquote Block: remove hyphenation styles from pullquote blocks

### DIFF
--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -153,8 +153,7 @@ h6 {
 }
 
 .entry-title,
-.comments-title,
-blockquote {
+.comments-title {
 	hyphens: auto;
 	word-break: break-word;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the pullquote block has styles that break longer words and add hyphenations, which can act a bit aggressively for the block. This PR removes that style from the pullquote block, so words wrap rather than having odd breakpoints.

Closes #1047

### How to test the changes in this Pull Request:

1. Set up a pullquote block with some longer-ish words; align it left or right to give it less space (note: the left and right alignment preview in the editor is incorrect; I'll tackle that in a separate PR). 
2. View on the front-end and note the hyphenation (note: it may take a few tries to get the right word combo to recreate). In this example, it doesn't make sense that 'hyphenate' is hyphenated -- it should fully wrap to a new line:
![image](https://user-images.githubusercontent.com/177561/103719127-37c38980-4f7d-11eb-8758-117ec04668db.png)

3. Apply the PR and run `npm run build`.
4. Confirm the pullquotes are no longer oddly hyphenated:

![image](https://user-images.githubusercontent.com/177561/103719188-54f85800-4f7d-11eb-88b5-7091ef770da9.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
