### PR TITLE
Pullquote Block: fix font size with solid backgrounds

### DIFF
--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -254,15 +254,17 @@ figcaption,
 	border-width: 0;
 	position: relative;
 
+	blockquote p,
+	&.is-style-solid-color blockquote p {
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
 	blockquote {
 		font-weight: bold;
 		p {
 			font-style: normal;
-			font-size: $font__size-lg;
-
-			@include media( tablet ) {
-				font-size: $font__size-xl;
-			}
 		}
 	}
 

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -354,16 +354,18 @@ blockquote {
 .wp-block-pullquote {
 	border-width: 16px 0 4px;
 
+	blockquote p,
+	&.is-style-solid-color blockquote p {
+		@include media( tablet ) {
+			font-size: $font__size-xl;
+		}
+	}
+
 	blockquote {
 		margin: #{2 * $size__spacing-unit} 0;
 
 		p {
-			font-size: $font__size-lg;
 			font-style: normal;
-
-			@include media( tablet ) {
-				font-size: $font__size-xl;
-			}
 		}
 	}
 
@@ -386,7 +388,8 @@ blockquote {
 		margin-bottom: #{1.5 * $size__spacing-unit};
 
 		@include media( tablet ) {
-			p {
+			blockquote p,
+			&.is-style-solid-color blockquote p {
 				font-size: $font__size-lg;
 			}
 		}

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -158,13 +158,10 @@ cite {
 .wp-block-pullquote {
 	border-width: 2px 0;
 
-	blockquote {
-		p {
-			font-size: $font__size-lg;
-
-			@include media( tablet ) {
-				font-size: $font__size-xl;
-			}
+	blockquote p,
+	&.is-style-solid-color blockquote p {
+		@include media( tablet ) {
+			font-size: $font__size-xl;
 		}
 	}
 
@@ -186,7 +183,8 @@ cite {
 		}
 
 		@include media( tablet ) {
-			p {
+			blockquote p,
+			&.is-style-solid-color blockquote p {
 				font-size: $font__size-lg;
 			}
 		}

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -148,7 +148,8 @@ div.wpnbha .article-section-title {
 	padding-top: #{4 * $size__spacing-unit};
 	position: relative;
 
-	p {
+	&.is-style-solid-color blockquote p,
+	blockquote p {
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
@@ -242,20 +243,21 @@ div.wpnbha .article-section-title {
 			}
 		}
 
+		&.is-style-solid-color blockquote p,
+		blockquote p {
+			font-size: $font__size-md;
+		}
+
 		&,
 		&.is-style-solid-color {
 			padding-top: #{3 * $size__spacing-unit};
 		}
 
-		p {
-			font-size: $font__size-md;
-
-			&:first-of-type::before {
-				font-size: calc( 1rem * 5 );
-				left: 0;
-				text-align: left;
-				width: 0.5em;
-			}
+		p:first-of-type::before {
+			font-size: calc( 1rem * 5 );
+			left: 0;
+			text-align: left;
+			width: 0.5em;
 		}
 
 		&.is-style-solid-color {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -346,8 +346,12 @@ p.has-background {
 		padding-left: 0;
 	}
 
+	blockquote p,
+	&.is-style-solid-color blockquote p {
+		font-size: $font__size-lg;
+	}
+
 	p {
-		font-size: $font__size-md;
 		font-style: italic;
 		line-height: 1.3;
 		margin-bottom: 0.5em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I'm not sure if this is related to a Gutenberg style update, or something that changed in the theme, but I noticed when pullquotes have a solid background, they're not using the correct font sizes. This PR fixes that. 

### How to test the changes in this Pull Request:

1. Start with the default Newspack theme.
2. Create a post and set it up with pullquote blocks with various settings -- should at least include the following; you can also copy-paste [this test content](https://cloudup.com/cc_CZZ2-MsG) into the code editor (note: there are some editor preview issues that will be addressed in a separate PR):
* A pullquote block with default settings
* A pullquote block with a solid background
* A left-aligned pullquote block with no background
* A left-aligned pullquote block with a solid background
* A right-aligned pullquote block with no background
* A right-aligned pullquote block with a solid background
3. View on the front-end; note that the font size on the pullquote block with a solid background is larger than the others:

![image](https://user-images.githubusercontent.com/177561/103929273-ebd62900-50d1-11eb-987b-e1e9505a17ec.png)

4. Apply the PR and run `npm run build`.
5. Refresh the page and confirm that the font size matches:

![image](https://user-images.githubusercontent.com/177561/103929455-348de200-50d2-11eb-8b78-392f9550edb6.png)

6. Cycle through the child themes and confirm that the font size is consistent when there is a solid background; also check the left and right aligned pullquotes and confirm they are consistent with each other when the PR is applied:

**Newspack Default:**

![image](https://user-images.githubusercontent.com/177561/103929542-525b4700-50d2-11eb-8fb1-77c184803f0f.png)

**Newspack Joseph**

![image](https://user-images.githubusercontent.com/177561/103930092-107ed080-50d3-11eb-823c-fa300cee3957.png)

![image](https://user-images.githubusercontent.com/177561/103930101-14aaee00-50d3-11eb-8689-be6fbc2194e2.png)

**Newspack Katharine**

![image](https://user-images.githubusercontent.com/177561/103930148-27bdbe00-50d3-11eb-8cf0-a77b0f76a79e.png)

![image](https://user-images.githubusercontent.com/177561/103930220-42903280-50d3-11eb-8905-061d763a0903.png)

**Newspack Nelson**

![image](https://user-images.githubusercontent.com/177561/103932189-52f5dc80-50d6-11eb-9168-ea7dcfe196a9.png)

![image](https://user-images.githubusercontent.com/177561/103932203-58ebbd80-50d6-11eb-807e-c56dd0b12d7b.png)

**Newspack Sacha**

![image](https://user-images.githubusercontent.com/177561/103932256-6c972400-50d6-11eb-8be4-36309e276daf.png)

![image](https://user-images.githubusercontent.com/177561/103932266-70c34180-50d6-11eb-94e7-d4ac30e0a8ae.png)

**Newspack Scott**

![image](https://user-images.githubusercontent.com/177561/103932322-86d10200-50d6-11eb-95de-942537e57303.png)

![image](https://user-images.githubusercontent.com/177561/103932343-8c2e4c80-50d6-11eb-8569-c8ab56a57100.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
