### PR TITLE
Pullquote Block: Correct preview in editor

### DIFF
--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -45,45 +45,25 @@ Newspack Sacha Editor Styles
 }
 
 /* Pullquote */
-.wp-block[data-type='core/pullquote'] {
-	.wp-block-pullquote {
-		border: 0;
-		border-bottom: 2px solid;
-		border-top: 1px solid;
-		font-family: $font__heading;
-		font-style: normal;
-		font-weight: bold;
-
-		p {
-			font-style: inherit;
-
-			@include media( tablet ) {
-				font-size: $font__size-xl;
-			}
-		}
-
-		&.is-style-solid-color {
-			border: 0;
-		}
-	}
+.wp-block-pullquote {
+	border: 0;
+	border-bottom: 2px solid;
+	border-top: 1px solid;
+	font-family: $font__heading;
+	font-style: normal;
+	font-weight: bold;
 
 	blockquote {
 		border-color: inherit;
 		text-align: center;
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
 	p {
-		font-family: $font__heading;
-		font-size: $font__size-lg;
-		font-weight: bold;
+		font-style: normal;
+	}
 
-		@include media( tablet ) {
-			font-size: $font__size-xl;
-		}
+	&.is-style-solid-color {
+		border: 0;
 	}
 
 	.wp-block-pullquote__citation {
@@ -91,17 +71,17 @@ Newspack Sacha Editor Styles
 		font-size: $font__size-base;
 		font-weight: normal;
 	}
+}
 
-	&[data-align='left'],
-	&[data-align='right'] {
-		blockquote {
-			text-align: left;
-		}
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	blockquote {
+		text-align: left;
+	}
 
-		@include media( tablet ) {
-			.wp-block-pullquote p {
-				font-size: $font__size-md;
-			}
+	@include media( tablet ) {
+		p {
+			font-size: $font__size-md;
 		}
 	}
 }

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -71,43 +71,44 @@ Newspack Katharine Editor Styles
 	}
 }
 
-.wp-block[data-type='core/pullquote'] {
-	.wp-block-pullquote {
-		border-width: 0;
-		position: relative;
+figure.wp-block-pullquote {
+	border-width: 0;
+}
 
-		&:not( .is-style-solid-color ) {
-			blockquote {
-				padding-left: #{2 * $size__spacing-unit};
-			}
+.wp-block-pullquote {
+	position: relative;
 
-			&::before {
-				border-top: 8px solid;
-				border-left: 8px solid;
-				border-color: inherit;
-				content: '';
-				display: block;
-				height: 40px;
-				left: 0;
-				position: absolute;
-				top: 0;
-				width: 40px;
-			}
+	&:not( .is-style-solid-color ) {
+		blockquote {
+			padding-left: #{2 * $size__spacing-unit};
+		}
+
+		&::before {
+			border-top: 8px solid;
+			border-left: 8px solid;
+			border-color: inherit;
+			content: '';
+			display: block;
+			height: 40px;
+			left: 0;
+			position: absolute;
+			top: 0;
+			width: 40px;
 		}
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
-	p {
+	blockquote p,
+	&.is-style-solid-color blockquote p {
 		font-size: $font__size-lg;
-		font-style: normal;
-		font-weight: bold;
 
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
+	}
+
+	p {
+		font-style: normal;
+		font-weight: bold;
 	}
 
 	.wp-block-pullquote__citation {
@@ -115,22 +116,18 @@ Newspack Katharine Editor Styles
 		opacity: 0.6;
 		text-transform: uppercase;
 	}
+}
 
-	&[data-align='left'],
-	&[data-align='right'] {
-		@include media( tablet ) {
-			.wp-block-pullquote blockquote p {
-				font-size: $font__size-lg;
-			}
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	@include media( tablet ) {
+		blockquote p,
+		&.is-style-solid-color blockquote p {
+			font-size: $font__size-lg;
 		}
 	}
 
-	&[data-align='left']
-		.editor-block-list__block-edit
-		.wp-block-pullquote:not( .is-style-solid-color ),
-	&[data-align='right']
-		.editor-block-list__block-edit
-		.wp-block-pullquote:not( .is-style-solid-color ) {
+	&:not( .is-style-solid-color ) {
 		padding-top: $size__spacing-unit;
 
 		blockquote {

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -77,27 +77,25 @@ blockquote {
 	border-color: currentColor;
 }
 
-.wp-block[data-type='core/pullquote'] {
-	.wp-block-pullquote {
-		border-width: 16px 0 4px;
-	}
+.wp-block-pullquote {
+	border-width: 16px 0 4px;
 
 	blockquote {
 		margin: #{2 * $size__spacing-unit} 0;
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
-	p {
+	&.is-style-solid-color blockquote p,
+	blockquote p {
 		font-size: $font__size-lg;
-		font-style: normal;
-		font-weight: bold;
 
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
+	}
+
+	p {
+		font-style: normal;
+		font-weight: bold;
 	}
 
 	.wp-block-pullquote__citation {
@@ -106,35 +104,32 @@ blockquote {
 		opacity: 0.9;
 		text-transform: uppercase;
 	}
+}
 
-	&[data-align='left'] .wp-block-pullquote,
-	&[data-align='right'] .wp-block-pullquote {
-		border-width: 0;
-		position: relative;
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	border-width: 0;
+	position: relative;
 
-		blockquote {
-			margin-top: #{1.5 * $size__spacing-unit};
-			margin-bottom: #{1.5 * $size__spacing-unit};
+	blockquote {
+		margin-top: #{1.5 * $size__spacing-unit};
+		margin-bottom: #{1.5 * $size__spacing-unit};
+	}
+
+	@include media( tablet ) {
+		&.is-style-solid-color blockquote p,
+		blockquote p {
+			font-size: $font__size-lg;
 		}
+	}
 
-		@include media( tablet ) {
-			blockquote
-				> .block-library-pullquote__content
-				.editor-rich-text__tinymce[data-is-empty='true']::before,
-			blockquote > .editor-rich-text p,
-			p {
-				font-size: $font__size-md;
-			}
-		}
-
-		&::before {
-			border-color: inherit;
-			border-width: 10px 0 0;
-			border-style: solid;
-			content: '';
-			display: block;
-			width: 75%;
-		}
+	&::before {
+		border-color: inherit;
+		border-width: 10px 0 0;
+		border-style: solid;
+		content: '';
+		display: block;
+		width: 75%;
 	}
 }
 

--- a/newspack-sacha/sass/style-editor.scss
+++ b/newspack-sacha/sass/style-editor.scss
@@ -69,27 +69,25 @@ cite {
 	}
 }
 
-.wp-block[data-type='core/pullquote'] {
-	.wp-block-pullquote {
-		border-width: 2px 0;
-	}
+.wp-block-pullquote {
+	border-width: 2px 0;
 
 	blockquote {
 		margin: #{2 * $size__spacing-unit} 0;
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
-	p {
+	&.is-style-solid-color blockquote p,
+	blockquote p {
 		font-size: $font__size-lg;
-		font-family: $font__heading;
-		text-align: center;
 
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
+	}
+
+	p {
+		font-family: $font__heading;
+		text-align: center;
 	}
 
 	.wp-block-pullquote__citation {
@@ -102,26 +100,23 @@ cite {
 			font-style: normal;
 		}
 	}
+}
 
-	&[data-align='left'] .wp-block-pullquote,
-	&[data-align='right'] .wp-block-pullquote {
-		margin-top: #{1.5 * $size__spacing-unit};
-		margin-bottom: #{1.5 * $size__spacing-unit};
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	margin-top: #{1.5 * $size__spacing-unit};
+	margin-bottom: #{1.5 * $size__spacing-unit};
 
-		@include media( tablet ) {
-			blockquote
-				> .block-library-pullquote__content
-				.editor-rich-text__tinymce[data-is-empty='true']::before,
-			blockquote > .editor-rich-text p,
-			p {
-				font-size: $font__size-md;
-				text-align: left;
-			}
+	@include media( tablet ) {
+		&.is-style-solid-color blockquote p,
+		blockquote p {
+			font-size: $font__size-lg;
 		}
+	}
 
-		.wp-block-pullquote__citation {
-			text-align: left;
-		}
+	p,
+	.wp-block-pullquote__citation {
+		text-align: left;
 	}
 }
 

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -108,8 +108,12 @@ function newspack_scott_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
-		.editor-styles-wrapper .wp-block[data-type="core/pullquote"] .wp-block-pullquote:not(.is-style-solid-color) blockquote > .editor-rich-text__editable:first-child:before {
+		.editor-styles-wrapper .wp-block-pullquote:not(.is-style-solid-color) blockquote p:first-of-type::before {
 			color: ' . esc_html( $primary_color ) . ';
+		}
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]) blockquote::before,
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]) blockquote::after {
+			border-top-color: ' . esc_html( $primary_color ) . ';
 		}
 	';
 

--- a/newspack-scott/inc/child-typography.php
+++ b/newspack-scott/inc/child-typography.php
@@ -28,7 +28,7 @@ function newspack_scott_custom_typography_css() {
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] p,
 			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] .wp-block-pullquote__citation,
-			.block-editor-block-list__layout .block-editor-block-list__block.wp-block[data-type="core/pullquote"] blockquote > .editor-rich-text__editable:first-child::before {
+			.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote blockquote p:first-of-type::before {
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}
 		';

--- a/newspack-scott/sass/style-editor.scss
+++ b/newspack-scott/sass/style-editor.scss
@@ -49,16 +49,14 @@ Newspack Scott Editor Styles
 	}
 }
 
-.wp-block[data-type='core/pullquote'] {
-	.wp-block-pullquote {
-		border-width: 0;
-		padding-top: #{3 * $size__spacing-unit};
-		position: relative;
+.wp-block-pullquote {
+	border-width: 0;
+	padding-top: #{3 * $size__spacing-unit};
+	position: relative;
 
-		.block-library-pullquote__content {
-			position: relative;
-			z-index: 1;
-		}
+	.block-library-pullquote__content {
+		position: relative;
+		z-index: 1;
 	}
 
 	blockquote {
@@ -69,7 +67,7 @@ Newspack Scott Editor Styles
 		&::before,
 		&::after {
 			border-top: 2px solid;
-			border-top-color: inherit;
+			border-top-color: $color__primary;
 			content: '';
 			display: block;
 			position: absolute;
@@ -88,14 +86,25 @@ Newspack Scott Editor Styles
 		}
 	}
 
-	.wp-block-pullquote.is-style-solid-color {
+	&[style*='border-color'] blockquote {
+		&::before,
+		&::after {
+			border-top-color: inherit;
+		}
+	}
+
+	&.is-style-solid-color {
 		blockquote::before,
 		blockquote::after {
 			border-top-color: currentColor;
 		}
+
+		blockquote {
+			padding-top: #{2 * $size__spacing-unit};
+		}
 	}
 
-	blockquote > .editor-rich-text__editable:first-child::before {
+	blockquote p:first-of-type::before {
 		color: $color__primary;
 		content: '\201C';
 		display: inline-block;
@@ -116,24 +125,22 @@ Newspack Scott Editor Styles
 		}
 	}
 
-	.wp-block-pullquote.is-style-solid-color
-		blockquote
-		> .editor-rich-text__editable:first-child::before {
+	&.is-style-solid-color blockquote p:first-of-type::before {
 		color: inherit;
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
-	p {
-		font-family: $font__heading;
+	&.is-style-solid-color blockquote p,
+	blockquote p {
 		font-size: $font__size-lg;
-		font-weight: bold;
 
 		@include media( tablet ) {
 			font-size: $font__size-xl;
 		}
+	}
+
+	p {
+		font-family: $font__heading;
+		font-weight: bold;
 	}
 
 	.wp-block-pullquote__citation {
@@ -141,52 +148,49 @@ Newspack Scott Editor Styles
 		font-weight: normal;
 		text-transform: uppercase;
 	}
+}
 
-	&[data-align='left'] .wp-block-pullquote,
-	&[data-align='right'] .wp-block-pullquote {
-		border-width: 0;
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	border-width: 0;
 
-		blockquote {
-			padding-top: #{3.5 * $size__spacing-unit};
-			text-align: left;
+	blockquote {
+		padding-top: #{1.5 * $size__spacing-unit};
+		text-align: left;
 
-			&::before {
-				left: 3em;
-				right: 0;
-			}
-
-			&::after {
-				display: none;
-			}
+		&::before {
+			left: 3em;
+			right: 0;
 		}
 
-		blockquote > .editor-rich-text__editable:first-child::before {
-			font-size: calc( 1rem * 6 );
-			left: 0;
-			text-align: left;
-			top: 0.3em;
-			width: 0.5em;
+		&::after {
+			display: none;
+		}
+	}
+
+	blockquote p:first-of-type::before {
+		font-size: calc( 1rem * 6 );
+		left: 0;
+		text-align: left;
+		top: 0.3em;
+		width: 0.5em;
+	}
+
+	&.is-style-solid-color blockquote {
+		padding-top: #{1.5 * $size__spacing-unit};
+
+		&::before {
+			left: #{5 * $size__spacing-unit};
+			right: #{2 * $size__spacing-unit};
 		}
 
-		&.is-style-solid-color blockquote {
-			padding-top: #{0.25 * $size__spacing-unit};
-
-			&::before {
-				left: #{5 * $size__spacing-unit};
-				right: #{2 * $size__spacing-unit};
-			}
-
-			> .editor-rich-text__editable:first-child::before {
-				left: #{1.5 * $size__spacing-unit};
-			}
+		p:first-of-type::before {
+			left: #{1.5 * $size__spacing-unit};
 		}
+	}
 
-		blockquote
-			> .block-library-pullquote__content
-			.editor-rich-text__tinymce[data-is-empty='true']::before,
-		blockquote > .editor-rich-text p,
-		p {
-			font-size: $font__size-md;
-		}
+	&.is-style-solid-color blockquote p,
+	blockquote p {
+		font-size: $font__size-md;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -463,8 +463,44 @@ figcaption,
 	padding: $size__spacing-unit 0;
 	text-align: left;
 
+	&.is-style-solid-color blockquote p,
+	p {
+		font-size: $font__size-md;
+
+		@include media( tablet ) {
+			font-size: $font__size-lg;
+		}
+	}
+
 	blockquote {
 		margin: #{1.5 * $size__spacing-unit} 0;
+	}
+
+	p {
+		font-style: italic;
+		line-height: 1.3;
+		margin-bottom: 0.5em;
+		margin-top: 0.5em;
+	}
+
+	.wp-block-pullquote__citation {
+		font-family: $font__heading;
+		font-size: $font__size-xs;
+		line-height: 1.6;
+		text-transform: none;
+
+		&::before {
+			content: '\2014';
+			margin-right: #{0.25 * $size__spacing-unit};
+		}
+	}
+
+	div.wp-block-pullquote__citation {
+		opacity: 0.8;
+	}
+
+	em {
+		font-style: normal;
 	}
 
 	&.is-style-solid-color {
@@ -487,69 +523,24 @@ figcaption,
 	}
 }
 
-.wp-block[data-type='core/pullquote'] {
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
-	p {
-		font-size: $font__size-md;
-		font-style: italic;
-		line-height: 1.3;
-		margin-bottom: 0.5em;
-		margin-top: 0.5em;
+[data-align='left'] .wp-block-pullquote,
+[data-align='right'] .wp-block-pullquote {
+	max-width: 50%;
+	width: 50%;
 
-		@include media( tablet ) {
-			font-size: $font__size-lg;
-		}
+	@include media( tablet ) {
+		border-bottom: 0;
 	}
 
-	.wp-block-pullquote__citation {
-		font-family: $font__heading;
-		font-size: $font__size-xs;
-		line-height: 1.6;
-		text-transform: none;
-
-		&::before {
-			content: '\2014';
-			margin-right: #{0.25 * $size__spacing-unit};
-		}
-	}
-
-	div.wp-block-pullquote__citation {
-		opacity: 0.8;
-	}
-
-	em {
-		font-style: normal;
-	}
-}
-
-.wp-block[data-type='core/pullquote'][data-align='left'],
-.wp-block[data-type='core/pullquote'][data-align='right'] {
-	.is-block-content {
-		max-width: 50%;
-		width: 50%;
-	}
-
-	.wp-block-pullquote {
-		@include media( tablet ) {
-			border-bottom: 0;
-		}
-	}
-
-	.wp-block-pullquote:not( .is-style-solid-color ) {
+	&:not( .is-style-solid-color ) {
 		padding: 0;
 	}
 
-	.wp-block-pullquote.is-style-solid-color {
+	&.is-style-solid-color {
 		padding: $size__spacing-unit #{2 * $size__spacing-unit};
 	}
 
-	blockquote
-		> .block-library-pullquote__content
-		.editor-rich-text__tinymce[data-is-empty='true']::before,
-	blockquote > .editor-rich-text p,
+	&.is-style-solid-color blockquote p,
 	p {
 		font-size: 1rem;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There have been some markup changes to the Pullquote block in the editor, causing the preview to be pretty incorrect.

This PR updates the styles to work with the new markup.

_Note: it's best to test this against the front-end version of the pullquotes, but there are a couple smaller PRs fixing issues there (#1194, #1195); if those aren't merged when this is tested, the front-end and editor may not be 1:1, specifically font sizes and the solid background pullquotes._

### How to test the changes in this Pull Request:

1. Start with the default Newspack theme.
2. Copy-paste this [test content](https://cloudup.com/cc_CZZ2-MsG) into a post, or add some pullquot blocks to a post; make sure to use the 'Main' color, the solid background, and left and right alignments in your options.
3. View in the editor; note that the left and right aligned blocks are full-width (rather than maxing out at half the width), and not using the correct italics styles:

![image](https://user-images.githubusercontent.com/177561/103933086-addc0380-50d7-11eb-9e89-7dec51c2ac47.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the editor preview is now correct:

![image](https://user-images.githubusercontent.com/177561/103933371-22af3d80-50d8-11eb-9d6d-021816598bd3.png)

6. Cycle through the other themes and confirm that the front-end view of the pullquotes matches the editor preview. Main concerns are font size, font style and weight, and the left and right alignments.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
