### PR TITLE
Print styles: Make sure header elements, campaigns are hidden

### DIFF
--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -143,6 +143,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.entry-footer,
 	.widget-area,
 	.comments-area .comments-title-wrap,
+	.comment-reply,
 	#respond,
 	.comment .comment-metadata .edit-link,
 	.newspack_global_ad,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -107,20 +107,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 		background: transparent;
 	}
 
-	/* Featured Image Behind */
-
-	.featured-image-behind {
-		background: transparent;
-		display: block;
-		margin: 0;
-		min-height: 0;
-		width: auto;
-	}
-
-	.featured-image-behind .wp-post-image {
-		position: static;
-	}
-
 	/* Hide */
 
 	.nav1,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -22,6 +22,10 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 		margin: 2cm;
 	}
 
+	#primary {
+		padding: 0;
+	}
+
 	.entry {
 		margin-top: 1em;
 	}
@@ -29,6 +33,13 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.entry .entry-header,
 	.site-footer .site-info {
 		margin: 0;
+	}
+
+	/* Borders */
+
+	#page .site-header,
+	#primary {
+		border: 0;
 	}
 
 	/* Fonts */
@@ -134,7 +145,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.footer-branding,
 	.site-info a.privacy-policy-link,
 	.wc-memberships-frontend-banner,
-	#atomic-proxy-bar {
+	#atomic-proxy-bar,
+	.newspack-lightbox,
+	.newspack-inline-popup {
 		display: none;
 	}
 

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -118,6 +118,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 		background: transparent;
 	}
 
+	/* Footer */
+	.site-info {
+		background: #fff;
+		color: #000;
+	}
+
 	/* Hide */
 
 	.nav1,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -143,6 +143,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.entry-footer,
 	.widget-area,
 	.comments-area .comments-title-wrap,
+	.comment-form-flex,
 	.comment-reply,
 	#respond,
 	.comment .comment-metadata .edit-link,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -34,10 +34,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	/* Fonts */
 
 	body {
-		font: 13pt Georgia, 'Times New Roman', Times, serif;
-		line-height: 1.3;
+		font: 13pt 'Times New Roman', Times, Georgia, serif;
+		line-height: 1.4;
 		background: #fff;
 		color: #000;
+		outline: 0;
+		padding: 0;
 	}
 
 	h1 {
@@ -57,7 +59,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	}
 
 	/* Page breaks */
-
 	a,
 	blockquote {
 		page-break-inside: avoid;
@@ -91,33 +92,72 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
 	/* Links */
 
-	a:link,
-	a:visited,
-	a {
+	.entry-content a:link,
+	.entry-content a:visited,
+	.entry-content a {
 		background: transparent;
 		font-weight: bold;
 		text-decoration: underline;
 		text-align: left;
 	}
 
-	/* Visibility */
-	.nav1,
-	.site-title + .nav1,
-	.social-navigation,
-	.site-branding-container::before,
-	.entry .entry-title::before,
-	.entry-footer,
-	.author-description::before,
-	.widget-area,
-	.comment-form-flex,
-	.comment-reply,
-	.comment .comment-metadata .edit-link {
-		display: none;
-	}
-
 	.entry .entry-content .wp-block-button .wp-block-button__link,
 	.entry .entry-content .button {
 		color: #000;
-		background: none;
+		background: transparent;
 	}
+
+	/* Featured Image Behind */
+
+	.featured-image-behind {
+		background: transparent;
+		display: block;
+		margin: 0;
+		min-height: 0;
+		width: auto;
+	}
+
+	.featured-image-behind .wp-post-image {
+		position: static;
+	}
+
+	/* Hide */
+
+	.nav1,
+	.nav2,
+	.nav3,
+	.mobile-menu-toggle,
+	.desktop-menu-toggle,
+	.jp-relatedposts-i2,
+	.social-navigation,
+	.subpage-toggle-contain,
+	.header-search-contain,
+	.top-header-contain,
+	.bottom-header-contain,
+	.button.mb-cta,
+	.sharedaddy,
+	.entry-footer,
+	.widget-area,
+	.comments-area .comments-title-wrap,
+	#respond,
+	.comment .comment-metadata .edit-link,
+	.newspack_global_ad,
+	.widget_newspack-ads-widget,
+	.above-content.widget,
+	.below-content.widget,
+	.footer-branding,
+	.site-info a.privacy-policy-link,
+	.wc-memberships-frontend-banner,
+	#atomic-proxy-bar {
+		display: none;
+	}
+
+	/* AMP */
+
+	/* stylelint-disable selector-type-no-unknown  */
+	amp-ads,
+	amp-next-page {
+		display: none;
+	}
+	/* stylelint-enable */
 }

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -123,6 +123,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.nav1,
 	.nav2,
 	.nav3,
+	.highlight-menu-contain,
 	.mobile-menu-toggle,
 	.desktop-menu-toggle,
 	.jp-relatedposts-i2,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates the print styles to make sure all header navigation, footer, advertising and campaign elements are hidden.

Further work is still needed to make sure all content options print well, but this should at least make sure we're not displaying things like popups and menus. 

See #516.

### How to test the changes in this Pull Request:

1. Set up a test site with all available menus (primary, secondary, tertiary, highlight, social); and with the slide-out sidebar and mobile CTA.
2. Enable campaigns
3. Add footer widgets (so your site branding also appears in the footer).
4. Preview the print version of the page; note what's showing (some menus; footer branding, share links, your campaign if displaying already when you printed):

Firefox (previewing PDF in Preview app) - with and without the campaign: 

![image](https://user-images.githubusercontent.com/177561/103946069-05379f00-50eb-11eb-8a2d-9e74f8a2d2de.png)

![image](https://user-images.githubusercontent.com/177561/103946410-67909f80-50eb-11eb-960d-c41e6bcc0473.png)

Chrome, with and without the campaign: 

![image](https://user-images.githubusercontent.com/177561/103946162-2dbf9900-50eb-11eb-813f-ad8ec761ed97.png)

![image](https://user-images.githubusercontent.com/177561/103946361-59db1a00-50eb-11eb-8d07-48ffaa4ab4dc.png)

5. Apply the PR and run `npm run build`.
6. Refresh the page and try the print preview again; confirm that the menus and campaigns are now hidden:

Firefox:

![image](https://user-images.githubusercontent.com/177561/103947954-ca833600-50ed-11eb-8060-818107c73623.png)

Chrome:

![image](https://user-images.githubusercontent.com/177561/103947912-b6d7cf80-50ed-11eb-92d0-069f6df5f9d2.png)

7. Switch your test campaign from overlay to inline, or vis versa, and confirm it's still not displaying when printing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
