### PR TITLE
Fix editor width issue

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -8,12 +8,6 @@ body {
 	background-color: $color__background-body;
 }
 
-/** === Content Width === */
-
-.wp-block {
-	max-width: 810px; // 780px + 30px to offset padding
-}
-
 /** === Base Typography === */
 
 // stylelint-disable-next-line no-duplicate-selectors


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Partial fix of https://github.com/Automattic/newspack-blocks/issues/666. This fix will make the sidebar less clipped, but there is still clipping caused by the editor itself, reported here: https://github.com/WordPress/gutenberg/issues/28140

### How to test the changes in this Pull Request:

1. Observe https://github.com/Automattic/newspack-blocks/issues/666 is not reproducible

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
