### PR TITLE
Comments: Add optional space for a comment policy 

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -951,7 +951,7 @@ function newspack_customize_register( $wp_customize ) {
 		'comment_policy',
 		array(
 			'default'           => '',
-			'sanitize_callback' => 'wp_kses_post',
+			'sanitize_callback' => 'newspack_sanitize_textarea_balance',
 		)
 	);
 	$wp_customize->add_control(
@@ -1384,6 +1384,19 @@ function newspack_sanitize_radio( $input, $setting ) {
 
 	// If the input is a valid key, return it; otherwise, return the default.
 	return ( array_key_exists( $input, $choices ) ? $input : $setting->default );
+}
+
+/**
+ * Sanitize and balance tags in textareas.
+ *
+ * @param string $input Value of textarea.
+ *
+ * @return string The textarea value, sanitized and with HTML tags balanced.
+ */
+function newspack_sanitize_textarea_balance( $input ) {
+	$input = wp_kses_post( force_balance_tags( $input ) );
+
+	return $input;
 }
 
 /**

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -928,6 +928,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to collapse the comments.
+	$wp_customize->add_setting(
+		'display_comment_policy',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'display_comment_policy',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Display comment policy', 'newspack' ),
+			'description' => esc_html__( 'Allows you to add an optional comment policy above the comment form when using WordPress\'s default comments.', 'newspack' ),
+			'section'     => 'comments_options',
+		)
+	);
+
 	// Add option to display comment policy.
 	$wp_customize->add_setting(
 		'comment_policy',
@@ -939,10 +957,9 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'comment_policy',
 		array(
-			'type'        => 'textarea',
-			'label'       => esc_html__( 'Commenting policy', 'newspack' ),
-			'description' => esc_html__( 'Allows you to add an optional comment policy above the comment form when using WordPress\'s default comments.', 'newspack' ),
-			'section'     => 'comments_options',
+			'type'    => 'textarea',
+			'label'   => esc_html__( 'Comment policy text', 'newspack' ),
+			'section' => 'comments_options',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -928,6 +928,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to display comment policy.
+	$wp_customize->add_setting(
+		'comment_policy',
+		array(
+			'default'           => '',
+			'sanitize_callback' => 'wp_kses_post',
+		)
+	);
+	$wp_customize->add_control(
+		'comment_policy',
+		array(
+			'type'        => 'textarea',
+			'label'       => esc_html__( 'Commenting policy', 'newspack' ),
+			'description' => esc_html__( 'Allows you to add an optional comment policy above the comment form when using WordPress\'s default comments.', 'newspack' ),
+			'section'     => 'comments_options',
+		)
+	);
+
 	/**
 	 * Footer settings
 	 */

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -380,9 +380,10 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 			);
 
 			$comment_policy = get_theme_mod( 'comment_policy', '' );
+			$display_policy = get_theme_mod( 'display_comment_policy', false );
 
 			// Check if there's a comment policy set in the Customizer.
-			if ( '' !== $comment_policy ) {
+			if ( $display_policy && '' !== $comment_policy ) {
 				$comment_attributes['title_reply_before'] = '<span class="comment-policy">' . wp_kses_post( $comment_policy ) . '</span>';
 			}
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -384,7 +384,7 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 
 			// Check if there's a comment policy set in the Customizer.
 			if ( $display_policy && '' !== $comment_policy ) {
-				$comment_attributes['title_reply_before'] = '<span class="comment-policy">' . wp_kses_post( $comment_policy ) . '</span>';
+				$comment_attributes['title_reply_before'] = '<div class="comment-policy">' . wp_kses_post( $comment_policy ) . '</div>';
 			}
 
 			comment_form( $comment_attributes );

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -383,7 +383,7 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 			$display_policy = get_theme_mod( 'display_comment_policy', false );
 
 			// Check if there's a comment policy set in the Customizer.
-			if ( $display_policy && '' !== $comment_policy ) {
+			if ( $display_policy && '' !== trim( $comment_policy ) ) {
 				$comment_attributes['title_reply_before'] = '<div class="comment-policy">' . wp_kses_post( $comment_policy ) . '</div>';
 			}
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -374,12 +374,19 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 	function newspack_comment_form( $order ) {
 		if ( true === $order || strtolower( $order ) === strtolower( get_option( 'comment_order', 'asc' ) ) ) {
 
-			comment_form(
-				array(
-					'logged_in_as' => null,
-					'title_reply'  => null,
-				)
+			$comment_attributes = array(
+				'logged_in_as' => null,
+				'title_reply'  => null,
 			);
+
+			$comment_policy = get_theme_mod( 'comment_policy', '' );
+
+			// Check if there's a comment policy set in the Customizer.
+			if ( '' !== $comment_policy ) {
+				$comment_attributes['title_reply_before'] = '<span class="comment-policy">' . wp_kses_post( $comment_policy ) . '</span>';
+			}
+
+			comment_form( $comment_attributes );
 		}
 	}
 endif;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -107,6 +107,7 @@
 
 .comment-policy {
 	font-size: $font__size-sm;
+	margin: #{0.5 * $size__spacing-unit} 0 $size__spacing-unit;
 
 	a {
 		text-decoration: underline;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -105,6 +105,10 @@
 	}
 }
 
+.comment-policy {
+	font-size: $font__size-sm;
+}
+
 .comment-list {
 	list-style: none;
 	padding: 0;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -107,6 +107,10 @@
 
 .comment-policy {
 	font-size: $font__size-sm;
+
+	a {
+		text-decoration: underline;
+	}
 }
 
 .comment-list {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds the ability to add a comment policy above the WordPress comment form. 

Closes #1102

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Navigate to Customize > Comment Settings
3. Confirm that you now have a checkbox to display the Comment Policy, and a text field below that for the actual policy text: 
4. 
![image](https://user-images.githubusercontent.com/177561/104383595-f2570d00-54e4-11eb-846d-9ffd0538fc4d.png)

4. Enable the checkbox, and add some text to the Comment Policy field, including some simple HTML (like bolding and links).
5. Click Update.
6. Navigate to a post with comments open, and confirm that your text is appearing between the Comment Form title and fields:

![image](https://user-images.githubusercontent.com/177561/104384177-df910800-54e5-11eb-8e3a-1394e4639b4f.png)

7. Navigate back to the customizer and uncheck the option to display the comment policy.
8. Confirm that the comment policy is now hidden. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
