### PR TITLE
Single Articles: Add previous/next links

### DIFF
--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -244,7 +244,8 @@ figcaption,
 
 //! Columns Block
 .wp-block-columns.is-style-borders .wp-block-column::after,
-.wp-block-group.is-style-border {
+.wp-block-group.is-style-border,
+.post-navigation {
 	border-style: dotted;
 	border-color: $color__text-main;
 }

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -312,6 +312,11 @@ div.wpnbha .article-section-title {
 	}
 }
 
+.post-navigation {
+	border-color: $color__text-main;
+	border-top-width: 4px;
+}
+
 // Blocks
 
 blockquote {

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -836,6 +836,23 @@ function newspack_customize_register( $wp_customize ) {
 		);
 	}
 
+	// Add option to display previous and next links on single posts.
+	$wp_customize->add_setting(
+		'post_previous_next',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'post_previous_next',
+		array(
+			'type'    => 'checkbox',
+			'label'   => __( 'Display previous and next links at the bottom of each post.', 'newspack' ),
+			'section' => 'post_default_settings',
+		)
+	);
+
 	/**
 	 * Page Template Settings
 	 */

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -257,14 +257,18 @@ if ( ! function_exists( 'newspack_previous_next' ) ) :
 	 * Prints previous and next links for single posts.
 	 */
 	function newspack_previous_next() {
-		the_post_navigation(
-			array(
-				'next_text' => '<span class="meta-nav">' . __( 'Next', 'newspack' ) . '</span> ' .
-					'<span class="post-title">%title</span>',
-				'prev_text' => '<span class="meta-nav">' . __( 'Previous', 'newspack' ) . '</span> ' .
-					'<span class="post-title">%title</span>',
-			)
-		);
+		$show_prev_next_links = get_theme_mod( 'post_previous_next', false );
+
+		if ( true === $show_prev_next_links && is_singular( 'post' ) ) {
+			the_post_navigation(
+				array(
+					'next_text' => '<span class="meta-nav">' . __( 'Next', 'newspack' ) . '</span> ' .
+						'<span class="post-title">%title</span>',
+					'prev_text' => '<span class="meta-nav">' . __( 'Previous', 'newspack' ) . '</span> ' .
+						'<span class="post-title">%title</span>',
+				)
+			);
+		}
 	}
 endif;
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -252,6 +252,22 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'newspack_previous_next' ) ) :
+	/**
+	 * Prints previous and next links for single posts.
+	 */
+	function newspack_previous_next() {
+		the_post_navigation(
+			array(
+				'next_text' => '<span class="meta-nav">' . __( 'Next', 'newspack' ) . '</span> ' .
+					'<span class="post-title">%title</span>',
+				'prev_text' => '<span class="meta-nav">' . __( 'Previous', 'newspack' ) . '</span> ' .
+					'<span class="post-title">%title</span>',
+			)
+		);
+	}
+endif;
+
 if ( ! function_exists( 'newspack_entry_footer' ) ) :
 	/**
 	 * Prints HTML with meta information for the tags and comments.

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -92,6 +92,7 @@ function newspack_custom_typography_css() {
 		/* _next_previous.scss */
 		.comment-navigation .nav-previous,
 		.comment-navigation .nav-next,
+		.post-navigation,
 
 		/* _comments.scss */
 		.comment-list .pingback .comment-body,

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -334,6 +334,52 @@ div.sharedaddy .sd-social h3.sd-title,
 	}
 }
 
+.post-navigation {
+	border-width: 1px 0;
+	border-style: solid;
+	border-color: $color__border;
+	margin: #{2 * $size__spacing-unit} 0 $size__spacing-unit;
+
+	a {
+		color: #111;
+
+		&:focus {
+			text-decoration: none;
+		}
+	}
+
+	.nav-previous,
+	.nav-next {
+		margin: #{1.5 * $size__spacing-unit} 0;
+	}
+
+	.meta-nav {
+		color: $color__text-light;
+		display: block;
+		margin: 0 0 #{0.25 * $size__spacing-unit};
+	}
+
+	@include media( tablet ) {
+		.nav-links {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+		}
+
+		.nav-previous,
+		.nav-next {
+			margin: #{2 * $size__spacing-unit} 0;
+			width: calc( 50% - #{2 * $size__spacing-unit} );
+		}
+
+		.nav-next {
+			text-align: right;
+		}
+	}
+}
+
+/* Page */
+
 .page {
 	.entry-header + .post-thumbnail,
 	.main-content > .post-thumbnail:first-child {

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -18,6 +18,7 @@
 .page-links,
 .page-description,
 .pagination .nav-links,
+.post-navigation,
 .site-title,
 .site-description,
 .site-info,
@@ -48,6 +49,7 @@ amp-script .cat-links {
 .comment-author .fn,
 .no-comments,
 .site-title,
+.post-navigation .post-title,
 h1,
 h2,
 h3,
@@ -111,6 +113,7 @@ h3 {
 .no-comments,
 h2.author-title,
 p.author-bio,
+.post-navigation .post-title,
 h4 {
 	font-size: $font__size-md;
 }

--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -50,9 +50,7 @@ get_header();
 						get_template_part( 'template-parts/content/content', 'single' );
 					}
 
-					if ( is_singular( 'post' ) ) {
-						newspack_previous_next();
-					}
+					newspack_previous_next();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {

--- a/newspack-theme/single-feature.php
+++ b/newspack-theme/single-feature.php
@@ -50,6 +50,10 @@ get_header();
 						get_template_part( 'template-parts/content/content', 'single' );
 					}
 
+					if ( is_singular( 'post' ) ) {
+						newspack_previous_next();
+					}
+
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
 						newspack_comments_template();

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -50,9 +50,7 @@ get_header();
 						get_template_part( 'template-parts/content/content', 'single' );
 					}
 
-					if ( is_singular( 'post' ) ) {
-						newspack_previous_next();
-					}
+					newspack_previous_next();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {

--- a/newspack-theme/single-wide.php
+++ b/newspack-theme/single-wide.php
@@ -50,6 +50,10 @@ get_header();
 						get_template_part( 'template-parts/content/content', 'single' );
 					}
 
+					if ( is_singular( 'post' ) ) {
+						newspack_previous_next();
+					}
+
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
 						newspack_comments_template();

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -43,6 +43,10 @@ get_header();
 
 					get_template_part( 'template-parts/content/content-single', 'single' );
 
+					if ( is_singular( 'post' ) ) {
+						newspack_previous_next();
+					}
+
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {
 						newspack_comments_template();

--- a/newspack-theme/single.php
+++ b/newspack-theme/single.php
@@ -43,9 +43,7 @@ get_header();
 
 					get_template_part( 'template-parts/content/content-single', 'single' );
 
-					if ( is_singular( 'post' ) ) {
-						newspack_previous_next();
-					}
+					newspack_previous_next();
 
 					// If comments are open or we have at least one comment, load up the comment template.
 					if ( comments_open() || get_comments_number() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to show previous and next links at the bottom of single posts.

Closes #1160.

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Navigate to Customize > Template Settings > Post Settings, and confirm there's an option at the bottom to display previous and next links:

![image](https://user-images.githubusercontent.com/177561/104395557-ceec8c00-54fd-11eb-9bfc-d17b7a843ec9.png)

3. Check that option, and click "Update".
4. View the single posts on the front-end and confirm that a set of 'previous/next' links appears at the bottom:

![image](https://user-images.githubusercontent.com/177561/104395603-e7f53d00-54fd-11eb-8e16-84651c4ef6fb.png)

5. Confirm that the links stack on smaller screens:

![image](https://user-images.githubusercontent.com/177561/104395638-fb080d00-54fd-11eb-8aee-70c8a0fa4efa.png)

6. Cycle through the default, one column and one-column wide templates, and confirm that the previous and next links appear on all three. 
7. Navigate to Customize > Typography and change the Header font; confirm that the previous/next links pick it up:

![image](https://user-images.githubusercontent.com/177561/104395748-43bfc600-54fe-11eb-8861-f69a263d4dc7.png)

8. Test with really long titles, and make sure each link doesn't exceed half of the available width. 
9. Cycle through the different child themes, and confirm that the styles match each theme (Newspack Joseph should have a darker border; Newspack Nelson a thicker top border, and Newpsack Katharine a dotted border):

**Newspack Joseph:**

![image](https://user-images.githubusercontent.com/177561/104395891-8c777f00-54fe-11eb-9223-2536ffe3dbde.png)

**Newspack Nelson:**

![image](https://user-images.githubusercontent.com/177561/104395909-97caaa80-54fe-11eb-8763-1dca62936db0.png)

**Newspack Katharine:**

![image](https://user-images.githubusercontent.com/177561/104395944-a3b66c80-54fe-11eb-8b2b-c57e01641522.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
