### PR TITLE
Custom HTML Block: Apply font styles in editor

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -754,6 +754,17 @@ ul.wp-block-archives,
 	}
 }
 
+// Custom HTML
+.wp-block[data-type='core/html'] {
+	font-family: $font__code;
+	font-size: $font__size-sm;
+
+	textarea {
+		border: 1px solid $color__border;
+		padding: #{0.5 * $size__spacing-unit};
+	}
+}
+
 /** === Jetpack Blocks === */
 
 // Related Posts


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I've noticed recently that the Custom HTML block is using the body font styles in the editor, which is a bit disconcerting -- at a glance you can't tell if you're publishing actual HTML, or a paragraph block that has HTML style writing in it.

This PR switches the editor preview to use a monospaced font, and adds a border.

### How to test the changes in this Pull Request:

1. Add a Custom HTML block to the editor, and add some text.
2. Note its appearance:

![image](https://user-images.githubusercontent.com/177561/104668629-50beef80-568d-11eb-98e2-c223d1b38e86.png)

3. Apply the PR and run `npm run build`
4. Confirm your HTML block now looks like it is actual HTML, and not a paragraph block with HTML in it:

![image](https://user-images.githubusercontent.com/177561/104668550-28cf8c00-568d-11eb-9819-741bc0991439.png)

5. Toggle on the "Preview" option in the block's toolbar, and confirm you have a 'normal' looking preview (no border, non-monospaced fonts):

![image](https://user-images.githubusercontent.com/177561/104668564-2ff69a00-568d-11eb-9bc1-6ea9578491e2.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
