### PR TITLE
Button Block: Fix issue where primary background colour not applied

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -53,6 +53,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"] .has-primary-background-color,
 			*[class^="wp-block-"].is-style-solid-color,
 			*[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
+			.is-style-outline .wp-block-button__link.has-primary-background-color:not( :hover ),
 			.wp-block-file .wp-block-file__button,
 			.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
 			.comment .comment-author .post-author-badge {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Button block, when using the 'outline' style, will apply the custom primary colour as a background on the front-end; right now there's a bug where it's using the default blue colour. 

### How to test the changes in this Pull Request:

1. If you haven't already, under Customize > Colors, pick a custom primary colour.
2. Add a button block to the editor; pick the outline style, and give it the primary colour as a background.
3. Publish the post; view on the front end and note it's using the blue (in my screenshot, the buttons are using the primary, primary variation, secondary, and secondary-variation as backgrounds):

![image](https://user-images.githubusercontent.com/177561/104770240-20c32b00-5725-11eb-9006-5c612a229318.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the button is now using your selected primary colour:

![image](https://user-images.githubusercontent.com/177561/104770008-0426f300-5725-11eb-9d59-3fcee21b981e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
