### PR TITLE
Add Article Hat

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -433,6 +433,9 @@ function newspack_enqueue_scripts() {
 	wp_enqueue_script( 'newspack-extend-featured-image-script' );
 
 	if ( 'post' === get_current_screen()->post_type ) {
+		wp_enqueue_script( 'newspack-post-hat', get_theme_file_uri( '/js/dist/post-hat.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+		wp_set_script_translations( 'newspack-post-hat', 'newspack', get_parent_theme_file_path( '/languages' ) );
+
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', get_parent_theme_file_path( '/languages' ) );
 
@@ -611,6 +614,16 @@ function newspack_register_meta() {
 	register_post_meta(
 		'post',
 		'newspack_post_subtitle',
+		array(
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		)
+	);
+
+	register_post_meta(
+		'post',
+		'newspack_post_hat',
 		array(
 			'show_in_rest' => true,
 			'single'       => true,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -220,6 +220,7 @@ function newspack_custom_typography_css() {
 		';
 
 		$editor_css_blocks .= '
+			#newspack-post-hat-element,
 			#newspack-post-subtitle-element,
 			.block-editor-block-list__layout,
 			.editor-default-block-appender .editor-default-block-appender__content

--- a/newspack-theme/js/src/post-hat/HatEditor.js
+++ b/newspack-theme/js/src/post-hat/HatEditor.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { connectWithSelect, META_FIELD_NAME } from './utils';
+
+const decorate = compose(
+	connectWithSelect,
+	withDispatch( dispatch => ( {
+		saveHat: hat => {
+			dispatch( 'core/editor' ).editPost( {
+				meta: {
+					[ META_FIELD_NAME ]: hat,
+				},
+			} );
+		},
+	} ) )
+);
+
+const HatEditor = ( { hat, saveHat } ) => {
+	const [ value, setValue ] = useState( hat );
+
+	useEffect( () => {
+		saveHat( value );
+	}, [ value ] );
+
+	return (
+		<TextareaControl
+			value={ value }
+			onChange={ setValue }
+			style={ { marginTop: '10px', width: '100%' } }
+		/>
+	);
+};
+
+export default decorate( HatEditor );

--- a/newspack-theme/js/src/post-hat/index.js
+++ b/newspack-theme/js/src/post-hat/index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import HatEditor from './HatEditor';
+import { appendHatToTitleDOMElement, connectWithSelect } from './utils';
+
+/**
+ * Component to be used as a panel in the Document tab of the Editor.
+ *
+ * https://developer.wordpress.org/block-editor/developers/slotfills/plugin-document-setting-panel/
+ */
+const NewspackHatPanel = ( { hat, mode } ) => {
+	// Update the DOM when hat value changes or editor mode is switched
+	useEffect( () => {
+		appendHatToTitleDOMElement( hat, mode === 'text' );
+	}, [ hat, mode ] );
+
+	return (
+		<PluginDocumentSettingPanel
+			name="newspack-hat"
+			title={ __( 'Article Hat', 'newspack' ) }
+			className="newspack-hat"
+		>
+			{ __( 'Set a Hat for the Article', 'newspack' ) }
+			<HatEditor />
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'plugin-document-setting-panel-newspack-hat', {
+	render: connectWithSelect( NewspackHatPanel ),
+	icon: null,
+} );

--- a/newspack-theme/js/src/post-hat/utils.js
+++ b/newspack-theme/js/src/post-hat/utils.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+const HAT_ID = 'newspack-post-hat-element';
+export const META_FIELD_NAME = 'newspack_post_hat';
+
+/**
+ * Appends hat to DOM, above the Title in the Editor.
+ *
+ * @param  {string} hat Hat text
+ */
+export const appendHatToTitleDOMElement = ( hat, isInCodeEditor ) => {
+	const titleEl = document.querySelector( '.editor-post-title__block' );
+	if ( titleEl && typeof hat === 'string' ) {
+		let hatEl = document.getElementById( HAT_ID );
+		if ( ! hatEl ) {
+			hatEl = document.createElement( 'div' );
+			hatEl.id = HAT_ID;
+			// special style for the code (raw text) editor
+			if ( isInCodeEditor ) {
+				hatEl.style.paddingLeft = '14px';
+				hatEl.style.marginBottom = '4px';
+			}
+			titleEl.prepend( hatEl );
+		}
+		hatEl.innerText = hat;
+	}
+};
+
+export const connectWithSelect = withSelect( select => ( {
+	hat: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ META_FIELD_NAME ],
+	mode: select( 'core/edit-post' ).getEditorMode(),
+} ) );

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -45,6 +45,15 @@
 	}
 }
 
+.newspack-post-hat {
+	margin-bottom: 1.3em;
+	text-transform: uppercase;
+    font-size: small;
+	@include media( mobile ) {
+		margin-bottom: 0;
+	}
+}
+
 .newspack-post-subtitle {
 	margin-bottom: 1.3em;
 	font-style: italic;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -877,6 +877,12 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Post Hat === */
+
+#newspack-post-hat-element {
+	font-style: italic;
+}
+
 /** === Post Subtitle === */
 
 #newspack-post-subtitle-element {

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -26,8 +26,14 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 	endif;
 	?>
 	<?php
+		$hat = get_post_meta( $post->ID, 'newspack_post_hat', true );
 		$subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
 	?>
+	<?php if ( $hat ) : ?>
+		<div class="newspack-post-hat">
+			<?php echo esc_html( $hat ); ?>
+		</div>
+	<?php endif; ?>
 	<h1 class="entry-title <?php echo $subtitle ? 'entry-title--with-subtitle' : ''; ?>">
 		<?php echo wp_kses_post( get_the_title() ); ?>
 	</h1>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?



### Changes proposed in this Pull Request:

This enables adding a hat to a post. Here's how it looks like:
![image](https://user-images.githubusercontent.com/4308648/105389888-c62b4280-5bee-11eb-908b-d4e62feadd49.png)


Closes #1106 .

### How to test the changes in this Pull Request:

1.  Visit post editor
2. Open "Article Hat" panel in the sidebar
3. Edit the hat - it should appear in above the title in the editor
4. Save the post
5. The hat should appear above title
