### PR TITLE
Archives: Add option to change archive layout

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -135,7 +135,12 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 		endif;
 		?>
 		</main><!-- #main -->
-		<?php get_sidebar(); ?>
+		<?php
+		$archive_layout = get_theme_mod( 'archive_layout', 'default' );
+		if ( 'default' === $archive_layout ) {
+			get_sidebar();
+		}
+		?>
 	</section><!-- #primary -->
 
 <?php

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -64,6 +64,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 
 		add_image_size( 'newspack-featured-image', 1200, 9999 );
 		add_image_size( 'newspack-archive-image', 800, 600, true );
+		add_image_size( 'newspack-archive-image-large', 1200, 900, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999, true );
 
 		// This theme uses wp_nav_menu() in two locations.

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -917,6 +917,28 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to change archive layouts.
+	$wp_customize->add_setting(
+		'archive_layout',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_radio',
+		)
+	);
+	$wp_customize->add_control(
+		'archive_layout',
+		array(
+			'type'    => 'radio',
+			'label'   => esc_html__( 'Archive Layout', 'newspack' ),
+			'choices' => array(
+				'default'         => esc_html__( 'Default', 'newspack' ),
+				'one-column'      => esc_html__( 'One column', 'newspack' ),
+				'one-column-wide' => esc_html__( 'One column wide', 'newspack' ),
+			),
+			'section' => 'archive_options',
+		)
+	);
+
 	/**
 	 * Comments settings
 	 */

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -175,6 +175,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'show-updated';
 	}
 
+	// Adds a class for the archive page layout.
+	$archive_layout = get_theme_mod( 'archive_layout', 'default' );
+	if ( is_archive() && 'default' !== $archive_layout ) {
+		$classes[] = 'archive-' . esc_attr( $archive_layout );
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -318,7 +318,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 	 * Wraps the post thumbnail in an anchor element on index views, or a div
 	 * element when on single views.
 	 */
-	function newspack_post_thumbnail() {
+	function newspack_post_thumbnail( $size = 'newspack-featured-image' ) {
 		if ( ! newspack_can_show_post_thumbnail() ) {
 			return;
 		}
@@ -333,7 +333,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 				if ( in_array( newspack_featured_image_position(), array( 'behind', 'beside' ) ) ) :
 
 					the_post_thumbnail(
-						'newspack-featured-image',
+						$size,
 						array(
 							'object-fit' => 'cover',
 						)
@@ -342,13 +342,13 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 					if ( 'above' === newspack_featured_image_position() ) :
 						the_post_thumbnail(
-							'newspack-featured-image',
+							$size,
 							array(
 								'layout' => 'responsive',
 							)
 						);
 					else :
-						the_post_thumbnail( 'newspack-featured-image' );
+						the_post_thumbnail( $size );
 					endif;
 
 					$caption = get_the_excerpt( get_post_thumbnail_id() );
@@ -377,7 +377,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 			<figure class="post-thumbnail">
 				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-					<?php the_post_thumbnail( 'newspack-archive-image' ); ?>
+					<?php the_post_thumbnail( $size ); ?>
 				</a>
 			</figure>
 

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -99,13 +99,12 @@
 }
 
 @include media( tablet ) {
-	.page-template-single-feature {
-		.entry-header {
-			margin-left: auto;
-			margin-right: auto;
-			max-width: 780px;
-			width: 100%;
-		}
+	.page-template-single-feature .entry-header,
+	.archive.archive-one-column .page-header {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 780px;
+		width: 100%;
 	}
 }
 

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -90,6 +90,7 @@
 // Single-column layouts
 .post-template-single-feature .main-content,
 .page-template-single-feature .main-content,
+.archive-one-column #main,
 .newspack-front-page.page-template-single-feature .site-main {
 	margin-left: auto;
 	margin-right: auto;
@@ -97,8 +98,8 @@
 	width: 100%;
 }
 
-.page-template-single-feature {
-	@include media( tablet ) {
+@include media( tablet ) {
+	.page-template-single-feature {
 		.entry-header {
 			margin-left: auto;
 			margin-right: auto;
@@ -106,6 +107,10 @@
 			width: 100%;
 		}
 	}
+}
+
+.archive-one-column-wide #main {
+	width: 100%;
 }
 
 .newspack-front-page,

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -16,7 +16,7 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php newspack_post_thumbnail(); ?>
+	<?php newspack_post_thumbnail( 'newspack-archive-image' ); ?>
 
 	<div class="entry-container">
 		<?php

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -16,7 +16,7 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-	<?php newspack_post_thumbnail(); ?>
+	<?php newspack_post_thumbnail( 'newspack-archive-image-large' ); ?>
 
 	<div class="entry-container">
 		<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some layout options for the archive pages that mirror the templates available for single posts and pages.

Closes #1192

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customize > Template Settings > Archive Settings, and confirm there's now a select dropdown for the Archive Layout:

![image](https://user-images.githubusercontent.com/177561/105787107-2db8f900-5f33-11eb-91e3-ee5a0424b4eb.png)

3. Try changing the option to One Column, and view a category, tag or date archive; confirm that the layout is one-column, and centered:

![image](https://user-images.githubusercontent.com/177561/105787210-60fb8800-5f33-11eb-99b6-18e7681a0628.png)

4. Navigate back to Customize > Template Settings > Archive Settings, and change the template to One Column Wide; view an archive page and confirm it displays as full width (note: I added a new image size for this option; if your test site is not running Jetpack's Image Acceleration, you may need to run Regenerate Thumbnails to see a large enough image on the first post): 

![image](https://user-images.githubusercontent.com/177561/105787629-b9328a00-5f33-11eb-9b2d-78c7e6ef4b74.png)

5. Return the Archive Layout option to Default and confirm the sidebar displays. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
