### PR TITLE
Archives: add option to change first archive layout

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -14,6 +14,10 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 	$native_sponsors      = newspack_get_native_sponsors( $all_sponsors );
 	$underwriter_sponsors = newspack_get_underwriter_sponsors( $all_sponsors );
 }
+
+$feature_latest_post = get_theme_mod( 'archive_feature_latest_post', true );
+$show_excerpt        = get_theme_mod( 'archive_show_excerpt', false );
+
 ?>
 
 	<section id="primary" class="content-area">
@@ -108,15 +112,13 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 		<?php
 		if ( have_posts() ) :
 			$post_count = 0;
-			?>
 
-			<?php
 			// Start the Loop.
 			while ( have_posts() ) :
 				$post_count++;
 				the_post();
 
-				if ( 1 === $post_count || true === get_theme_mod( 'archive_show_excerpt', false ) ) {
+				if ( ( 1 === $post_count && true === $feature_latest_post ) || true === $show_excerpt ) {
 					get_template_part( 'template-parts/content/content', 'excerpt' );
 				} else {
 					get_template_part( 'template-parts/content/content', 'archive' );

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -118,7 +118,8 @@ $show_excerpt        = get_theme_mod( 'archive_show_excerpt', false );
 				$post_count++;
 				the_post();
 
-				if ( ( 1 === $post_count && true === $feature_latest_post ) || true === $show_excerpt ) {
+				// Check if you're on the first post of the first page and if it should be styled differently, or if excerpts are enabled.
+				if ( ( 1 === $post_count && 0 === get_query_var( 'paged' ) && true === $feature_latest_post ) || true === $show_excerpt ) {
 					get_template_part( 'template-parts/content/content', 'excerpt' );
 				} else {
 					get_template_part( 'template-parts/content/content', 'archive' );

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -939,6 +939,25 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+
+	// Add option to change the first archive's layout.
+	$wp_customize->add_setting(
+		'archive_feature_latest_post',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+
+	$wp_customize->add_control(
+		'archive_feature_latest_post',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Use a large, featured display for the latest post in the archives', 'newspack' ),
+			'section' => 'archive_options',
+		)
+	);
+
 	/**
 	 * Comments settings
 	 */

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -181,6 +181,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'archive-' . esc_attr( $archive_layout );
 	}
 
+	// Add a class when using the 'featured latest' archive layout.
+	$feature_latest_post = get_theme_mod( 'archive_feature_latest_post', true );
+	if ( is_archive() && true === $feature_latest_post ) {
+		$classes[] = 'feature-latest';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -76,7 +76,7 @@
 	}
 
 	@include media( tablet ) {
-		&:not( .paged ) article.has-post-thumbnail:first-of-type {
+		&:not( .paged ).feature-latest article.has-post-thumbnail:first-of-type {
 			display: block;
 
 			.post-thumbnail {

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -88,7 +88,7 @@ h1,
 .not-found .page-title,
 .error-404 .page-title,
 .has-larger-font-size,
-.archive:not( .paged ) article.entry:first-of-type .entry-title,
+.archive:not( .paged ).feature-latest article.entry:first-of-type .entry-title,
 h2 {
 	font-size: $font__size-lg;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option disable the styles used for the latest post in the archives, so rather than giving it a larger image, it places the featured image next to the text, like on the other archives. 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Navigate to Customizer > Template Settings > Archive Settings, and confirm you now have a checkbox for using a different display on the latest post in the archive, and that it's checked by default:

![image](https://user-images.githubusercontent.com/177561/105788841-1d564d80-5f36-11eb-9312-1c928694d8ce.png)

3. Uncheck it and publish; confirm that the first post looks like the rest:

![image](https://user-images.githubusercontent.com/177561/105789008-6efed800-5f36-11eb-8e1b-bc5084dc8414.png)

4. Navigate to Customizer > Template Settings > Archive Settings, and check 'Show excerpts for all archives'; confirm this works for the first post, too:

![image](https://user-images.githubusercontent.com/177561/105788967-5e4e6200-5f36-11eb-9643-e743ed726e0d.png)

5. Navigate to Customizer > Template Settings > Archive Settings and check "Use a large, featured display for the latest post in the archives"; confirm it returns to the default layout. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
