### PR TITLE
Archives: make hidden categories on archives more flexible

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -193,7 +193,8 @@ input[type='submit'] {
 
 /* Posts & Pages */
 .search,
-.blog {
+.blog,
+.archive {
 	.cat-links::before {
 		display: none;
 	}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -78,11 +78,15 @@ div.wpnbha .article-section-title,
 	font-size: $font__size-xs;
 }
 
-.search .cat-links {
-	margin-bottom: #{0.5 * $size__spacing-unit};
+.blog,
+.search,
+.archive {
+	.cat-links {
+		margin-bottom: #{0.5 * $size__spacing-unit};
 
-	&::before {
-		display: none;
+		&::before {
+			display: none;
+		}
 	}
 }
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -114,7 +114,8 @@ div.wpnbha .article-section-title,
 }
 
 .blog,
-.search {
+.search,
+.archive {
 	.cat-links {
 		text-align: left;
 	}

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -77,7 +77,8 @@ div.wpnbha .article-section-title {
 }
 
 .search,
-.blog {
+.blog,
+.archive {
 	.cat-links::before {
 		display: none;
 	}

--- a/newspack-theme/sass/plugins/newspack-sponsors.scss
+++ b/newspack-theme/sass/plugins/newspack-sponsors.scss
@@ -176,6 +176,7 @@ amp-script .sponsor-label {
 		}
 
 		.sponsor-label {
+			display: flex;
 			font-size: 65%;
 		}
 	}

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -111,6 +111,10 @@
 			}
 		}
 	}
+
+	.cat-links:not( .sponsor-label ) {
+		display: none;
+	}
 }
 
 .page-description {

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -161,10 +161,13 @@
 /* Archives */
 
 .blog,
-.search {
+.search,
+.archive {
 	.cat-links {
 		margin-bottom: #{0.5 * $size__spacing-unit};
 		a {
+			font-size: 0.65rem;
+			margin-bottom: 0;
 			padding: 0.25em 0.5em;
 		}
 	}

--- a/newspack-theme/template-parts/content/content-archive.php
+++ b/newspack-theme/template-parts/content/content-archive.php
@@ -20,10 +20,14 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 
 	<div class="entry-container">
 		<?php
-		if ( ! empty( $native_sponsors ) ) {
-			// Get label for native post sponsors.
-			newspack_sponsor_label( $native_sponsors );
-		}
+		if ( 'page' !== get_post_type() ) :
+			if ( ! empty( $native_sponsors ) ) :
+				// Get label for native post sponsors.
+				newspack_sponsor_label( $native_sponsors );
+			else :
+				newspack_categories();
+			endif;
+		endif;
 		?>
 		<header class="entry-header">
 			<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>

--- a/newspack-theme/template-parts/content/content-excerpt.php
+++ b/newspack-theme/template-parts/content/content-excerpt.php
@@ -24,7 +24,7 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 			if ( ! empty( $native_sponsors ) ) :
 				// Get label for native post sponsors.
 				newspack_sponsor_label( $native_sponsors );
-			elseif ( ! is_archive() ) :
+			else :
 				newspack_categories();
 			endif;
 		endif;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, in the archive templates, the post categories aren't output at all. This PR switches the categories to be output, but hidden in the CSS instead; this is to allow them to be made visible with flexibility (being able to target all archives; post type archives or specific types of archives, like author or tag), without adding multiple toggles.

The categories were originally hidden on the archive pages because they didn't make sense on the category archives; however, there have been really specific cases -- like Reveal's podcast CPT archive -- where it would be handy to show them.  A styles-only approach seemed to be the most flexible -- especially as we get into some site-specific CPTs -- but I'm open to feedback on other approaches!

### How to test the changes in this Pull Request:

1. Start with a site with a few sponsored posts. 
2. Apply the PR and run `npm run build`. 
3. View an archive page; note that the sponsor labels are still showing for the appropriate posts, but the categories are not. 
4. Edit the custom CSS and add the following (or some variation of it, targeting a specific archive type):

```
.archive .cat-links:not(.sponsor-label) {
    display: block;
}
```

5. Confirm that the categories are now displaying on the appropriate archive page. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
