### PR TITLE
fix: add check for meta and post types before loading toggles

### DIFF
--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -12,6 +12,9 @@ import { __ } from '@wordpress/i18n';
  * Hide updated date
  */
 const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
+	if ( ! meta ) {
+		return null;
+	}
 	const { newspack_hide_page_title, newspack_hide_updated_date } = meta;
 	const { hide_date = [], hide_title = [] } = window.newspack_post_meta_post_types;
 	const hideDate = 0 <= hide_date.indexOf( postType );
@@ -20,10 +23,9 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 	if ( ! hideDate && ! hideTitle ) {
 		return null;
 	}
-
 	return (
 		<PluginPostStatusInfo>
-			{ hideDate && (
+			{ hideDate && 'post' === postType && (
 				<>
 					<label htmlFor="hide_updated_date">{ __( 'Hide updated date', 'newspack' ) }</label>
 					<FormToggle
@@ -35,7 +37,7 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 					/>
 				</>
 			) }
-			{ hideTitle && (
+			{ hideTitle && 'post' === postType && (
 				<>
 					<label htmlFor="hide_page_title">{ __( 'Hide page title', 'newspack' ) }</label>
 					<FormToggle

--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -37,7 +37,7 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 					/>
 				</>
 			) }
-			{ hideTitle && 'post' === postType && (
+			{ hideTitle && 'page' === postType && (
 				<>
 					<label htmlFor="hide_page_title">{ __( 'Hide page title', 'newspack' ) }</label>
 					<FormToggle


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a check for post meta, post type, before loading editor toggle options, to prevent errors with reusable blocks. 

### How to test the changes in this Pull Request:

1. Navigate to [yourtestsite]/wp-admin/edit.php?post_type=wp_block and edit one of your reusable blocks.
2. Note the error.
3. Apply the PR and run `npm run build`.
4. Confirm that your reusable block now loads correctly.
5. Edit a page, and confirm you have a toggle under Status & visibility to "Hide Page title".
6. Under Customizer > Template Settings > Post settings, turn on the option to display the last updated date, if it's not already on.
7. Edit a post and confirm you have an option to hide the updated date on a per-post basis under Status & visibility.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
