### PR TITLE
Fix author hover colour

### DIFF
--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -34,7 +34,6 @@ function newspack_katharine_custom_colors_css() {
 		.archive .page-title,
 		.entry-meta .byline a,
 		.entry-meta .byline a:visited,
-		.entry .entry-meta a:hover,
 		.cat-links,
 		.cat-links a,
 		.cat-links a:visited,
@@ -44,6 +43,8 @@ function newspack_katharine_custom_colors_css() {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
+		.entry-meta .byline a:hover,
+		.entry-meta .byline a:hover:visited,
 		.cat-links a:hover {
 			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 		}

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -44,6 +44,11 @@ function newspack_sacha_custom_colors_css() {
 			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
 		}
 
+		.entry-meta .byline a:hover,
+		.entry-meta .byline a:hover:visited {
+			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
+		}
+
 		.has-drop-cap:not(:focus)::first-letter {
 			background-color: ' . esc_html( $primary_color ) . ';
 			color: ' . esc_html( $primary_color_contrast ) . ';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -363,7 +363,7 @@ function newspack_custom_colors_css() {
 
 				.entry-meta .byline a:hover,
 				.entry-meta .byline a:visited:hover {
-					color: ' . esc_html( newspack_color_with_contrast( newspack_adjust_brightness( $primary_color, -20 ) ) ) . ';
+					color: ' . esc_html( newspack_color_with_contrast( newspack_adjust_brightness( $primary_color, -40 ) ) ) . ';
 				}
 			';
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -356,9 +356,14 @@ function newspack_custom_colors_css() {
 		if ( ! is_child_theme() ) {
 			$theme_css .= '
 				.archive .page-title,
-				.entry-meta .byline a, .entry-meta .byline a:visited,
-				.entry .entry-meta a:hover {
+				.entry-meta .byline a,
+				.entry-meta .byline a:visited {
 					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+				}
+
+				.entry-meta .byline a:hover,
+				.entry-meta .byline a:visited:hover {
+					color: ' . esc_html( newspack_color_with_contrast( newspack_adjust_brightness( $primary_color, -20 ) ) ) . ';
 				}
 			';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the Newspack default theme, Newspack Katharine and Newspack Sacha, the author hover colour wasn't correctly picking up the primary colour (either completely, like with the main Newspack theme, or after being visited, like with Katharine and Sacha). 

Closes #1230

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Change your custom colours to use a darker primary colour (so it doesn't fall back to grey for text for lighter colours).
3. Cycle through the Newspack default, Katharine and Sacha themes; confirm that the author names are using a darker version of your primary colour on hover. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
