### PR TITLE
Update footer credit to mention WordPress.com

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -38,7 +38,7 @@
 				<?php endif; ?>
 
 				<a href="<?php echo esc_url( __( 'https://newspack.pub/', 'newspack' ) ); ?>" class="imprint">
-					<?php echo esc_html__( 'Proudly powered by Newspack by Automattic', 'newspack' ); ?>
+					<?php echo esc_html__( 'Proudly powered by Newspack, a service of WordPress.com', 'newspack' ); ?>
 				</a>
 
 				<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the current footer credit language to mention "WordPress.com" rather than "Automattic"; this better matches the Newspack credits elsewhere, like the plugin.

Closes #1237 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. View the footer; confirm that the credit now reads, "Proudly powered by Newspack, a service of WordPress.com"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
