### PR TITLE
Make sure the updated date is still output in the HTML

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -11,11 +11,11 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 	 */
 	function newspack_posted_on() {
 		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>%3$s<time class="updated" datetime="%4$s">%5$s</time>';
+		}
 
 		if ( newspack_should_display_updated_date() ) {
-			if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-				$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>%3$s<time class="updated" datetime="%4$s">%5$s</time>';
-			}
 			add_filter( 'get_the_modified_date', 'newspack_convert_modified_to_time_ago', 10, 3 );
 
 			$time_string = sprintf(
@@ -29,6 +29,7 @@ if ( ! function_exists( 'newspack_posted_on' ) ) :
 
 			remove_filter( 'get_the_modified_date', 'newspack_convert_modified_to_time_ago', 10, 3 );
 		} else {
+
 			$time_string = sprintf(
 				$time_string,
 				esc_attr( get_the_date( DATE_W3C ) ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When the option was added to 'Show updated date' on single posts in #1154, the theme's original behaviour -- always outputting and hiding the updated date -- stopped working. 

This is because the check for whether the published date matched the modified date got moved into the `newspack_should_display_updated_date()` check, so it was only run when the post would display the updated date when `Show "last updated" date on single posts` was enabled. 

This PR makes sure that functionality still works, while also allowing the 'updated date' option.

This came up when digging into #1247

### How to test the changes in this Pull Request:

1. Make sure `Show "last updated" date on single posts` is turned off under Customizer > Template Settings > Post Settings.
2. Update an older post, and publish a brand new post.
3. Inspect the published dates for both; you should just have one `<time>` in the source in both cases:

![image](https://user-images.githubusercontent.com/177561/108241591-db699300-7100-11eb-89ca-b9ff35bc17c1.png)

4. Apply the PR.
5. Confirm that the new post still has one `<time>` in the source, while the updated one now has two:

![image](https://user-images.githubusercontent.com/177561/108241708-f9cf8e80-7100-11eb-9320-66561a00058a.png)

6. Confirm that this is the case wherever the posts appear from the theme -- a single post, archives, search results.
7. Navigate to Customizer > Template Settings > Post Settings and enable  `Show "last updated" date on single posts`.
8. Confirm that your updated date is now displaying on single posts. 
9. Confirm that nothing funky happened to the date in the archives or search, which should not have changed. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
