### PR TITLE
fix: only show sticky ad at mobile viewports

### DIFF
--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -57,6 +57,12 @@
 }
 
 .newspack_amp_sticky_ad {
+	&__container {
+		@include media( mobile ) {
+			display: none;
+		}
+	}
+
 	* {
 		margin: auto;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/873, ensures that sticky ads only get shown at mobile viewports (less than 600px). Since the `amp-sticky-ad` element doesn't currently support responsive units, only the smallest sizes can get shown, which looks weird at larger viewports.

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run build`. Also make sure your main plugin is on https://github.com/Automattic/newspack-plugin/pull/873.
2. Set up an ad unit via GAM and set it to the Sticky predefined placement.
3. View the site front-end. Confirm that the sticky ad is shown only when the viewport is smaller than 600px.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
