### PR TITLE
fix: correct link color in the gallery block captions

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -793,7 +793,8 @@ p.has-background {
 		margin-bottom: 16px;
 	}
 
-	figcaption a {
+	figcaption a,
+	figcaption a:hover {
 		color: #fff;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -372,8 +372,15 @@ figcaption,
 
 /** === Gallery === */
 
-.wp-block-gallery figcaption {
-	margin-bottom: 0;
+.wp-block-gallery {
+	figcaption {
+		margin-bottom: 0;
+
+		a,
+		a:hover {
+			color: #fff;
+		}
+	}
 }
 
 /** === Audio & Video === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure links in the gallery block captions don't accidentally pick up the regular link colour on hover, or in the editor. 

Closes #1252

### How to test the changes in this Pull Request:

1. Add a gallery block; add at least one caption with a link in it.
2. Note the appearance both on the front-end and in the editor; on the front-end, the colour changes on hover and is often unreadable; in the editor, the link is always a custom colour:

_Front-end - on hover:_ 

![image](https://user-images.githubusercontent.com/177561/108939319-5f8eaf80-7606-11eb-966a-399bb5455065.png)

_In the editor:_

![image](https://user-images.githubusercontent.com/177561/108939349-687f8100-7606-11eb-8f7f-a8b96ec02dc9.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the link is now white in the editor, and on hover on the front-end:

_Front-end - on hover:_

![image](https://user-images.githubusercontent.com/177561/108939485-a2508780-7606-11eb-8a21-01d8628ee75f.png)

_In the editor:_

![image](https://user-images.githubusercontent.com/177561/108939526-b300fd80-7606-11eb-9b89-2c382326d069.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
