### PR TITLE
fix: do not show sticky ads at larger viewports in non-amp

### DIFF
--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -25,7 +25,9 @@
 		z-index: 1;
 
 		&.active {
-			display: flex;
+			@include media( mobileonly ) {
+				display: flex;
+			}
 		}
 
 		button {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hides the sticky ad at viewports 600px or larger. Couples with https://github.com/Automattic/newspack-ads/pull/113 which ensures that ad unit sizes larger 600px or larger are not rendered at all for sticky ads.

### How to test the changes in this Pull Request:

1. Create a sticky ad unit with multiple sizes, including at least one set of sizes with a width larger than 600px.
2. Load a page in non-AMP mode. On `master`, observe that the ad unit gets displayed at all viewport sizes.
3. Switch to this branch, run `npm run build`
4. Refresh the non-AMP page, confirm that the ad unit is hidden via CSS at viewports 600px or larger.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
