### PR TITLE
WooCommerce: Improve checkout page appearance and simplify

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -224,7 +224,8 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].has-secondary-variation-ackground-color,
 			*[class^="wp-block-"] .has-secondary-variation-background-color,
 			*[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color,
-			.is-style-outline .wp-block-button__link.has-secondary-variation-background-color:not( :hover ) {
+			.is-style-outline .wp-block-button__link.has-secondary-variation-background-color:not( :hover ),
+			#ship-to-different-address label input[type="checkbox"]:checked + span::before {
 				background-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
 			}
 
@@ -241,6 +242,11 @@ function newspack_custom_colors_css() {
 			.is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
 				color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+			}
+
+			/* Set secondary border */
+			#ship-to-different-address label input[type="checkbox"]:checked + span::before {
+				border-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ';
 			}
 
 			/* Set gradients */

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -208,15 +208,15 @@ function newspack_checkout_fields_styling( $fields ) {
 	unset( $fields['billing']['billing_phone'] );
 
 	// Check to see if there are only virtual items in the cart.
-	$only_virtual = true;
+	$needs_shipping = false;
 	foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-		if ( ! $cart_item['data']->is_virtual() ) {
-			$only_virtual = false;
+		if ( $cart_item['data']->needs_shipping() ) {
+			$needs_shipping = true;
 		}
 	}
 
 	// If the cart only has virtual products, simplify checkout further.
-	if ( $only_virtual ) {
+	if ( ! $needs_shipping ) {
 		unset( $fields['billing']['billing_address_1'] );
 		unset( $fields['billing']['billing_city'] );
 		unset( $fields['billing']['billing_postcode'] );
@@ -226,7 +226,7 @@ function newspack_checkout_fields_styling( $fields ) {
 	}
 
 	// If the cart has physical items, replace .form-row-wide classes with classes to style fields narrower.
-	if ( ! $only_virtual ) {
+	if ( $needs_shipping ) {
 		$fields['billing']['billing_email']['class'] = array( 'form-row-last' );
 	}
 

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -76,6 +76,10 @@ a.button {
 
 		&.form-row-first {
 			clear: left;
+
+			&:last-child {
+				width: 100%;
+			}
 		}
 	}
 }
@@ -1184,10 +1188,10 @@ table.variations {
 		cursor: pointer;
 
 		span {
-			position: relative;
-			display: block;
-			text-align: right;
+			font-weight: bold;
+			display: inline-block;
 			padding-right: 45px;
+			position: relative;
 
 			&::before {
 				content: '';
@@ -1200,7 +1204,7 @@ table.variations {
 				box-sizing: content-box;
 				transition: all ease-in-out 0.3s;
 				position: absolute;
-				top: 4px;
+				top: 2px;
 				right: 0;
 			}
 
@@ -1211,7 +1215,7 @@ table.variations {
 				height: 14px;
 				background: white;
 				position: absolute;
-				top: 7px;
+				top: 5px;
 				right: 17px;
 				border-radius: 13rem;
 				transition: all ease-in-out 0.3s;
@@ -1227,8 +1231,8 @@ table.variations {
 		}
 
 		input[type='checkbox']:checked + span::before {
-			border-color: #000;
-			background: #000;
+			border-color: $color__secondary-variation;
+			background: $color__secondary-variation;
 		}
 	}
 }
@@ -1306,7 +1310,8 @@ table.variations {
 
 	.woocommerce-billing-fields,
 	.woocommerce-account-fields,
-	.woocommerce-shipping-fields {
+	.woocommerce-shipping-fields,
+	.woocommerce-additional-fields {
 		label {
 			font-size: $font__size-sm;
 		}

--- a/newspack-theme/woocommerce/checkout/form-checkout.php
+++ b/newspack-theme/woocommerce/checkout/form-checkout.php
@@ -95,13 +95,13 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 	<?php do_action( 'woocommerce_checkout_before_customer_details' ); ?>
 
-	<div class="col2-set" id="customer_details">
-		<?php if ( wc_shipping_enabled() && WC()->cart->get_shipping_total() > 0 ) : ?>
-			<div class="col-1">
+	<div id="customer_details">
+		<?php if ( newspack_checkout_needs_shipping() ) : ?>
+			<div>
 				<?php do_action( 'woocommerce_checkout_billing' ); ?>
 			</div>
 
-			<div class="col-2">
+			<div>
 				<?php do_action( 'woocommerce_checkout_shipping' ); ?>
 			</div>
 		<?php else : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR improves the appearance of the WooCommerce checkout page by correcting some field alignments, and removing a couple redundant fields (company, address line 2, and phone). When you only have items in your cart that don't require shipping, it strips the form down to just first and last name, and email address [Edited to add: let me know if this would make more sense as an _option_ to do, so a publication can also choose to collect billing address information, for whatever reason. I'm not sure if it would ever be necessary but it might be?].

When shipping is required, the potential shipping address is moved under the billing address, and the same field simplification (removing company, address line 2, and phone) is applied. 

**Note:** best I can tell, [this check for whether or not a product requires shipping](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-cart.php#L1517) checks whether or not products are virtual. It looks like the Newspack product [does create them this way](https://github.com/Automattic/newspack-plugin/blob/b82bd0a52d44c1afaf0808ba200bcdd28cda763b/includes/class-donations.php#L242), but I wanted to flag just in case we should double-check existing sites. 

Closes #943.

### How to test the changes in this Pull Request:

1. Add a digital and product that requires shipping to your cart. To test the original appearance of the shipping address, you'll need a product that has a shipping price.
2. View the Checkout page:

<details>
<summary><strong>Checkout without shipping</strong></summary>

![screencapture-build-newspack-test-checkout-2021-02-27-11_52_23](https://user-images.githubusercontent.com/177561/109398805-ef2caa80-78f3-11eb-9001-23a2a7724b81.png)

</details>

<details>
<summary><strong>Checkout with shipping</strong></summary>

![screencapture-build-newspack-test-checkout-2021-02-27-12_06_10](https://user-images.githubusercontent.com/177561/109398859-331faf80-78f4-11eb-8017-a121fbde00ff.png)

![screencapture-build-newspack-test-checkout-2021-02-27-12_06_45](https://user-images.githubusercontent.com/177561/109398882-50ed1480-78f4-11eb-8244-033f83f66f6d.png)

</details>

3. Apply the PR and run `npm run build`.
4. View the cart; note the simplified form:

<details>
<summary><strong>Checkout with shipping closed</strong></summary>

![screencapture-build-newspack-test-checkout-2021-02-27-11_51_10 (1)](https://user-images.githubusercontent.com/177561/109399263-a88c7f80-78f6-11eb-972d-42d1d998d988.png)

</details>

5. Toggle open the "Ship to a different address?" option on; confirm that the background is using the secondary colour, and that the shipping form displays well underneath it:
<details>
<summary><strong>Checkout with shipping open</strong></summary>

![screencapture-build-newspack-test-checkout-2021-02-27-12_11_49](https://user-images.githubusercontent.com/177561/109399258-9dd1ea80-78f6-11eb-90b3-6d06e60a7047.png)

</details>

6. Remove the physical product from your cart; make sure you only have a virtual item (like a donation).
7. View the checkout page again; confirm that the form is now simplified down to the First Name, Last Name and Email address fields: 
<details>
<summary><strong>Checkout with a virtual product</strong></summary>

![screencapture-build-newspack-test-checkout-2021-02-27-12_32_19](https://user-images.githubusercontent.com/177561/109399481-eb9b2280-78f7-11eb-99e3-8f1143a4f7d4.png)

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
