### PR TITLE
Add Display and Monospace to the font fallback stack

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -322,7 +322,7 @@ function newspack_custom_typography_link( $theme_mod ) {
 function newspack_get_font_stacks() {
 	return array(
 		'serif'      => array(
-			'name'  => __( 'Serif' ),
+			'name'  => __( 'Serif', 'newspack' ),
 			'fonts' => array(
 				'Georgia',
 				'Garamond',
@@ -331,7 +331,7 @@ function newspack_get_font_stacks() {
 			),
 		),
 		'sans_serif' => array(
-			'name'  => __( 'Sans Serif' ),
+			'name'  => __( 'Sans Serif', 'newspack' ),
 			'fonts' => array(
 				'-apple-system',
 				'BlinkMacSystemFont',
@@ -344,6 +344,37 @@ function newspack_get_font_stacks() {
 				'Droid Sans',
 				'Helvetica Neue',
 				'sans-serif',
+			),
+		),
+		'display'    => array(
+			'name'  => __( 'Display', 'newspack' ),
+			'fonts' => array(
+				'Impact',
+				'Haettenschweiler',
+				'Franklin Gothic Bold',
+				'Charcoal',
+				'Helvetica Inserat',
+				'Bitstream Vera Sans Bold',
+				'Arial Black',
+				'sans-serif',
+			),
+		),
+		'monospace'  => array(
+			'name'  => __( 'Monospace', 'newspack' ),
+			'fonts' => array(
+				'Consolas',
+				'Andale Mono WT',
+				'Andale Mono',
+				'Lucida Console',
+				'Lucida Sans Typewriter',
+				'DejaVu Sans Mono',
+				'Bitstream Vera Sans Mono',
+				'Liberation Mono',
+				'Nimbus Mono L',
+				'Monaco',
+				'Courier New',
+				'Courier',
+				'monospace'
 			),
 		),
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds 2 new types of fallback: Display and Monospace. It's going to be useful for the onboarding since users will be able to select Display or Monospace fonts 😊

See https://github.com/Automattic/newspack-plugin/pull/892

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add a non-existing Google Font to the customizer (this will return a 404 so you will see the fallback font)
3. Change the fallback fonts to Display and Monospace
4. Check if you see the changes in the customizer
5. Save
6. Check the front-end to see the changes

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
