### PR TITLE
fix: add presentation role to buttons in the menu dropdowns

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -406,7 +406,7 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		$icon = newspack_get_icon_svg( 'keyboard_arrow_down', 24 );
 
 		$output .= sprintf(
-			'<button class="submenu-expand" tabindex="-1">%s</button>',
+			'<button class="submenu-expand" tabindex="-1" role="presentation">%s</button>',
 			$icon
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds `role="presentation"` to the buttons used in the dropdown menu markup.

This is a recommendation we got from one of our publishers' review.

Closes #1279

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Set up a menu with multiple levels of dropdowns.
3. Inspect the menu and confirm that the buttons have the attribute `role="presentation"`. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
