### PR TITLE
feat: add category class to single post body

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -144,6 +144,13 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
+	// Add a class for each category assigned to a single post.
+	if ( is_single() ) {
+		foreach ( ( get_the_category( $page_id ) ) as $category ) {
+			$classes[] = 'cat-' . $category->category_nicename;
+		}
+	}
+
 	// Adds class if singular post or page has a featured image.
 	if ( is_singular() && has_post_thumbnail() && 'hidden' !== newspack_featured_image_position() ) {
 		$classes[] = 'has-featured-image';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a CSS class to the `<body>` tag of single posts for each category assigned to the post, in the format `cat-[category-slug]`.

Closes #1201

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Example a number of single posts; confirm that they body tag now includes a CSS class for each assigned category. 
3. Test posts with multiple categories, and categories that contain multiple words; confirm all categories are added as classes, and that the classes are correctly formed (dashes instead of spaces). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
