### PR TITLE
Add logo resizer to footer logo

### DIFF
--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -403,6 +403,7 @@ hr {
 
 	.wrapper {
 		border-bottom: 1px solid rgba( 255, 255, 255, 0.25 );
+		padding-bottom: $size__spacing-unit;
 	}
 }
 

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -514,6 +514,7 @@ blockquote {
 
 	.wrapper {
 		border-bottom: 1px solid currentColor;
+		padding-bottom: $size__spacing-unit;
 	}
 }
 

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -41,30 +41,58 @@ function newspack_logo_resizer_customize_register( $wp_customize ) {
 			),
 		)
 	);
+
+	$wp_customize->add_setting(
+		'footer_logo_size',
+		array(
+			'default'              => 50,
+			'type'                 => 'theme_mod',
+			'theme_supports'       => 'custom-logo',
+			'transport'            => 'postMessage',
+			'sanitize_callback'    => 'absint',
+			'sanitize_js_callback' => 'absint',
+		)
+	);
+
+	$wp_customize->add_control(
+		'footer_logo_size',
+		array(
+			'label'       => esc_html__( 'Footer Logo Size', 'newspack' ),
+			'section'     => 'title_tagline',
+			'priority'    => 9,
+			'type'        => 'range',
+			'settings'    => 'footer_logo_size',
+			'input_attrs' => array(
+				'step'             => 5,
+				'min'              => 0,
+				'max'              => 100,
+				'aria-valuemin'    => 0,
+				'aria-valuemax'    => 100,
+				'aria-valuenow'    => 50,
+				'aria-orientation' => 'horizontal',
+			),
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_logo_resizer_customize_register' );
 
 /**
  * Add support for logo resizing by filtering `get_custom_logo`.
  */
-function newspack_customize_logo_resize( $html ) {
-	$size           = get_theme_mod( 'logo_size' );
-	$custom_logo_id = get_theme_mod( 'custom_logo' );
-	// set the short side minimum
-	$min = 48;
+function newspack_return_logo_sizes( $set_size, $set_logo_id, $min = 48 ) {
+	$size         = get_theme_mod( $set_size );
+	$logo_id      = get_theme_mod( $set_logo_id );
+	$custom_sizes = '';
 
-	// don't use empty() because we can still use a 0
-	if ( is_numeric( $size ) && is_numeric( $custom_logo_id ) ) {
-
+	if ( is_numeric( $size ) && is_numeric( $logo_id ) ) {
 		// we're looking for $img['width'] and $img['height'] of original image
-		$logo = wp_get_attachment_metadata( $custom_logo_id );
+		$logo = wp_get_attachment_metadata( $logo_id );
 		if ( ! $logo ) {
-			return $html;
+			return;
 		}
 
 		// get the logo support size
-		$sizes = get_theme_support( 'custom-logo' );
-
+		$sizes          = get_theme_support( 'custom-logo' );
 		$logo_max_width = ( $logo['width'] > 600 ) ? 600 : $logo['width'];
 
 		// Check for max height and width, default to image sizes if none set in theme
@@ -94,46 +122,109 @@ function newspack_customize_logo_resize( $html ) {
 			);
 		}
 
-		$mobile_max_width  = 175;
-		$mobile_max_height = 65;
+		$custom_sizes = array(
+			'height'    => $img['height'],
+			'maxheight' => $max['height'],
+			'maxwidth'  => $max['width'],
+			'width'     => $img['width'],
+		);
+	}
 
-		$subhead_max_width  = 200;
-		$subhead_max_height = 60;
+	return $custom_sizes;
+}
 
-		$mobile  = newspack_logo_small_sizes( $img['width'], $img['height'], $mobile_max_width, $mobile_max_height );
-		$subhead = newspack_logo_small_sizes( $img['width'], $img['height'], $subhead_max_width, $subhead_max_height );
+/**
+ * Puts together CSS from logo sizes and max-widths.
+ *
+ * @param string $html original HTML for the site logo.
+ *
+ * @return string Returns the logo's HTML with the resizer styles.
+ */
+function newspack_return_logo_css( $html ) {
+	// Get sizes of the header logo.
+	$logo_sizes = newspack_return_logo_sizes( 'logo_size', 'custom_logo' );
+	// Get sizes of the footer logo.
+	$footer_sizes = newspack_return_logo_sizes( 'footer_logo_size', newspack_get_footer_logo() );
 
-		// add the CSS
-		$css = '
-		<style>
+	// Make sure at least one is populated before proceeding.
+	if ( empty( $logo_sizes ) && empty( $footer_sizes ) ) {
+		return $html;
+	}
+
+	// Set a mobile max-width, and subheader max-width.
+	$mobile_max_width  = 175;
+	$mobile_max_height = 65;
+
+	$subhead_max_width  = 200;
+	$subhead_max_height = 60;
+
+	$mobile  = newspack_logo_small_sizes( $logo_sizes['width'], $logo_sizes['height'], $mobile_max_width, $mobile_max_height );
+	$subhead = newspack_logo_small_sizes( $logo_sizes['width'], $logo_sizes['height'], $subhead_max_width, $subhead_max_height );
+
+	// Add the CSS.
+	$css = '
+	.site-header .custom-logo {
+		height: ' . $logo_sizes['height'] . 'px;
+		max-height: ' . $logo_sizes['maxheight'] . 'px;
+		max-width: ' . $logo_sizes['maxwidth'] . 'px;
+		width: ' . $logo_sizes['width'] . 'px;
+	}
+
+	@media (max-width: 781px) {
 		.site-header .custom-logo {
-			height: ' . $img['height'] . 'px;
-			max-height: ' . $max['height'] . 'px;
-			max-width: ' . $max['width'] . 'px;
-			width: ' . $img['width'] . 'px;
+			max-width: ' . $mobile['width'] . 'px;
+			max-height: ' . $mobile['height'] . 'px;
+		}
+	}
+
+	@media (min-width: 782px) {
+		.h-sub .site-header .custom-logo {
+			max-width: ' . $subhead['width'] . 'px;
+			max-height: ' . $subhead['height'] . 'px;
+		}
+	}';
+
+	if ( '' !== newspack_get_footer_logo() ) {
+		$css .= '
+		.site-footer .footer-logo,
+		.site-footer .custom-logo {
+			height: ' . $footer_sizes['height'] . 'px;
+			max-height: ' . $footer_sizes['maxheight'] . 'px;
+			max-width: ' . $footer_sizes['maxwidth'] . 'px;
+			width: ' . $footer_sizes['width'] . 'px;
 		}
 
 		@media (max-width: 781px) {
-			.site-header .custom-logo {
+			.site-footer .footer-logo,
+			.site-footer .custom-logo {
 				max-width: ' . $mobile['width'] . 'px;
 				max-height: ' . $mobile['height'] . 'px;
 			}
-		}
-
-		@media (min-width: 782px) {
-			.h-sub .site-header .custom-logo {
-				max-width: ' . $subhead['width'] . 'px;
-				max-height: ' . $subhead['height'] . 'px;
-			}
-		}
-		</style>';
-
-		$html = $css . $html;
+		}';
 	}
+
+	$html = '<style>' . $css . '</style>' . $html;
 
 	return $html;
 }
-add_filter( 'get_custom_logo', 'newspack_customize_logo_resize' );
+
+add_filter( 'get_custom_logo', 'newspack_return_logo_css' );
+
+/**
+ * Checks to see if the footer uses the footer logo option, or falls back to the custom logo, or none.
+ *
+ * TODO: Remove/replace is_active_sidebar once we remove that condition from the theme.
+ */
+function newspack_get_footer_logo() {
+	$footer_logo = '';
+	if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) {
+		$footer_logo = 'newspack_footer_logo';
+	} elseif ( '' !== get_theme_mod( 'custom_logo', '' ) && 0 !== get_theme_mod( 'custom_logo', '' ) && is_active_sidebar( 'footer-2' ) ) {
+		$footer_logo = 'custom_logo';
+	}
+
+	return $footer_logo;
+}
 
 /**
  * Helper function to determine the max size of the logo
@@ -188,6 +279,6 @@ add_action( 'customize_controls_enqueue_scripts', 'newspack_logo_resizer_customi
  * Adds CSS to the Customizer controls.
  */
 function newspack_logo_resizer_customize_css() {
-	wp_add_inline_style( 'customize-controls', '#customize-control-logo_size input[type="range"] { width: 100%; }' );
+	wp_add_inline_style( 'customize-controls', '#customize-control-logo_size input[type="range"], #customize-control-footer_logo_size input[type="range"] { width: 100%; }' );
 }
 add_action( 'customize_controls_enqueue_scripts', 'newspack_logo_resizer_customize_css' );

--- a/newspack-theme/js/src/logo-customize-controls.js
+++ b/newspack-theme/js/src/logo-customize-controls.js
@@ -14,6 +14,10 @@
 		$( window ).load( function() {
 			if ( false === api.control( 'custom_logo' ).setting() ) {
 				$( '#customize-control-logo_size' ).hide();
+
+				if ( false === api.control( 'newspack_footer_logo' ).setting() ) {
+					$( '#customize-control-footer_logo_size' ).hide();
+				}
 			}
 		} );
 	} );
@@ -28,6 +32,20 @@
 				api.control( 'logo_size' ).activate();
 				api.control( 'logo_size' ).setting( 50 );
 				api.control( 'logo_size' ).setting.preview();
+			}
+		} );
+	} );
+
+	// Check logo changes
+	api( 'newspack_footer_logo', function( value ) {
+		value.bind( function( to ) {
+			if ( '' === to ) {
+				api.control( 'footer_logo_size' ).deactivate();
+			} else {
+				$( '#customize-control-footer_logo_size' ).show();
+				api.control( 'footer_logo_size' ).activate();
+				api.control( 'footer_logo_size' ).setting( 50 );
+				api.control( 'footer_logo_size' ).setting.preview();
 			}
 		} );
 	} );

--- a/newspack-theme/js/src/logo-customize-preview.js
+++ b/newspack-theme/js/src/logo-customize-preview.js
@@ -8,7 +8,10 @@
 ( function( $ ) {
 	const api = wp.customize;
 	const Logo = new NewspackLogo( '.site-header .custom-logo' );
-	const FooterLogo = new NewspackLogo( '.site-footer .footer-logo, .site-footer .custom-logo' );
+	const FooterLogo = new NewspackLogo(
+		'.site-footer .footer-logo, .site-footer .custom-logo',
+		400
+	);
 
 	let resizeTimer;
 
@@ -33,7 +36,7 @@
 	} );
 
 	/**
-	 *
+	 * Make changes to the header logo.
 	 */
 	function handleLogoDetection( to, initial ) {
 		if ( '' === to ) {
@@ -46,6 +49,9 @@
 		initial = to;
 	}
 
+	/**
+	 * Make changes to the footer logo.
+	 */
 	function handleLogoFooterDetection( to, initial ) {
 		if ( '' === to ) {
 			FooterLogo.remove();
@@ -58,11 +64,10 @@
 	}
 
 	/**
-	 *
+	 * Figure out the size the logo should update to.
 	 */
-	function NewspackLogo( logo_class ) {
+	function NewspackLogo( logo_class, setMax = 600, setMin = 48 ) {
 		let hasLogo = null;
-		const min = 48;
 
 		const self = {
 			resize( to ) {
@@ -81,7 +86,7 @@
 					};
 
 					const max = new Object();
-					max.width = $.isNumeric( cssMax.width ) ? cssMax.width : 600;
+					max.width = $.isNumeric( cssMax.width ) ? cssMax.width : setMax;
 					max.height = $.isNumeric( cssMax.height ) ? cssMax.height : size.height;
 
 					img.onload = function() {
@@ -89,14 +94,14 @@
 
 						if ( size.width >= size.height ) {
 							// landscape or square, calculate height as short side
-							output = logo_min_max( size.height, size.width, max.height, max.width, to, min );
+							output = logo_min_max( size.height, size.width, max.height, max.width, to, setMin );
 							size = {
 								height: output.a,
 								width: output.b,
 							};
 						} else if ( size.width < size.height ) {
 							// portrait, calculate height as long side
-							output = logo_min_max( size.width, size.height, max.width, max.height, to, min );
+							output = logo_min_max( size.width, size.height, max.width, max.height, to, setMin );
 							size = {
 								height: output.b,
 								width: output.a,

--- a/newspack-theme/js/src/logo-customize-preview.js
+++ b/newspack-theme/js/src/logo-customize-preview.js
@@ -7,7 +7,9 @@
  */
 ( function( $ ) {
 	const api = wp.customize;
-	const Logo = new NewspackLogo();
+	const Logo = new NewspackLogo( '.site-header .custom-logo' );
+	const FooterLogo = new NewspackLogo( '.site-footer .footer-logo, .site-footer .custom-logo' );
+
 	let resizeTimer;
 
 	api( 'custom_logo', function( value ) {
@@ -18,6 +20,16 @@
 	api( 'logo_size', function( value ) {
 		Logo.resize( value() );
 		value.bind( Logo.resize );
+	} );
+
+	api( 'newspack_footer_logo', function( value ) {
+		handleLogoFooterDetection( value() );
+		value.bind( handleLogoFooterDetection );
+	} );
+
+	api( 'footer_logo_size', function( value ) {
+		FooterLogo.resize( value() );
+		value.bind( FooterLogo.resize );
 	} );
 
 	/**
@@ -34,10 +46,21 @@
 		initial = to;
 	}
 
+	function handleLogoFooterDetection( to, initial ) {
+		if ( '' === to ) {
+			FooterLogo.remove();
+		} else if ( undefined === initial ) {
+			FooterLogo.add();
+		} else {
+			FooterLogo.change();
+		}
+		initial = to;
+	}
+
 	/**
 	 *
 	 */
-	function NewspackLogo() {
+	function NewspackLogo( logo_class ) {
 		let hasLogo = null;
 		const min = 48;
 
@@ -45,7 +68,7 @@
 			resize( to ) {
 				if ( hasLogo ) {
 					const img = new Image();
-					const logo = $( '.custom-logo' );
+					const logo = $( logo_class );
 
 					let size = {
 						width: parseInt( logo.attr( 'width' ), 10 ),
@@ -97,7 +120,7 @@
 
 			add() {
 				const intId = setInterval( function() {
-					const logo = $( '.custom-logo[src]' );
+					const logo = $( logo_class + '[src]' );
 					if ( logo.length ) {
 						clearInterval( intId );
 						hasLogo = true;
@@ -106,9 +129,9 @@
 			},
 
 			change() {
-				const oldlogo = $( '.custom-logo' ).attr( 'src' );
+				const oldlogo = $( logo_class ).attr( 'src' );
 				const intId = setInterval( function() {
-					const logo = $( '.custom-logo' ).attr( 'src' );
+					const logo = $( logo_class ).attr( 'src' );
 					if ( logo !== oldlogo ) {
 						clearInterval( intId );
 						hasLogo = true;

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -16,6 +16,7 @@
 
 	.custom-logo,
 	.footer-logo {
+		margin-bottom: $size__spacing-unit;
 		max-height: 75px;
 		max-width: 200px;
 	}

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -16,7 +16,6 @@
 
 	.custom-logo,
 	.footer-logo {
-		margin-bottom: $size__spacing-unit;
 		max-height: 75px;
 		max-width: 200px;
 	}

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -15,14 +15,14 @@
 
 		.custom-logo-link,
 		.footer-logo-link {
-			margin-bottom: $size__spacing-unit;
-			max-height: 75px;
-			max-width: 200px;
+			//margin-bottom: $size__spacing-unit;
+			//max-height: 75px;
+			//max-width: 200px;
 
-			img {
-				max-height: inherit;
-				width: auto;
-			}
+			//img {
+			//	max-height: inherit;
+			//	width: auto;
+			//}
 		}
 	}
 

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -12,18 +12,12 @@
 		.wrapper {
 			padding-top: $size__spacing-unit;
 		}
+	}
 
-		.custom-logo-link,
-		.footer-logo-link {
-			//margin-bottom: $size__spacing-unit;
-			//max-height: 75px;
-			//max-width: 200px;
-
-			//img {
-			//	max-height: inherit;
-			//	width: auto;
-			//}
-		}
+	.custom-logo,
+	.footer-logo {
+		max-height: 75px;
+		max-width: 200px;
 	}
 
 	.footer-widgets {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a logo resizer for the footer logo, similar to the one available for the main logo. It will let you set a size for the footer logo independent of the header logo, even if they're using the same graphic. 

Closes #1218

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`
2. Navigate to Customizer > Site Identity and confirm you have a logo resizer for both the main site logo, and the footer logo.
3. Set up the site so it has just the Custom Logo, and footer widgets; in this case, the footer logo space will use the main custom logo as a fallback.
4. Confirm that the footer logo can be resized independent of the on in the header, using the two different sliders:

![logo-resizer-1 2021-03-07 13_56_37](https://user-images.githubusercontent.com/177561/110256314-018a9200-7f4d-11eb-93c2-3aee7542ea96.gif)

5. View on the front-end and confirm that your changes are reflected there.
6. Upload a different footer logo; make sure that each logo size can still be controlled independently in the Customizer, and that your changes are reflected on the front-end.
7. Remove the main header logo; confirm that you can still resize the remaining footer logo in the Customizer and that the changes are reflected on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
