### PR TITLE
fix: correct style selectors for inline text colours

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -442,13 +442,15 @@ function newspack_custom_colors_css() {
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color,
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color, /* legacy */
+		.edit-post-visual-editor .editor-styles-wrapper .has-primary-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-color {
 			color: ' . esc_html( $primary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color,
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color, /* legacy */
+		.edit-post-visual-editor .editor-styles-wrapper .has-primary-variation-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-color {
 			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
@@ -504,13 +506,15 @@ function newspack_custom_colors_css() {
 			color: inherit;
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-color,
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-color, /* legacy */
+		.edit-post-visual-editor .editor-styles-wrapper .has-secondary-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-color {
 			color: ' . esc_html( $secondary_color ) . ';
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color,
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color, /* legacy */
+		.edit-post-visual-editor .editor-styles-wrapper .has-secondary-variation-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-color {
 			color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.gihub/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The 'inline' text colour options in the editor are not previewing the primary and secondary colours --  I think this was introduced with WP 5.7 (or at least was reported immediately afterwards)

### How to test the changes in this Pull Request:

1. Start on a test site with a non-default colour palette.
2. Set up a couple blocks, like a paragraph and pullquote, and try adding inline text colours using the available palette (it's good to mix-and-match with the full block colour options on the right, too, to make sure there aren't any clashes):

![image](https://user-images.githubusercontent.com/177561/110816625-5b86a280-8240-11eb-9ebf-c939c6f4f10c.png)

3. Note that if you pick the primary colour, you get Newspack Blue, and if you pick the secondary colour, you get the default #666 grey, regardless what your current colour palette is. Here are two pullquote blocks, one with the default overall colour, and one with a pink overall colour, to help the inline text colour sections stand out:

![image](https://user-images.githubusercontent.com/177561/110817179-e071bc00-8240-11eb-8c12-7dab18ee238c.png)

4. Apply the PR.
5. Refresh the editor; confirm that your colours are now being applied as expected:

![image](https://user-images.githubusercontent.com/177561/110818481-2418f580-8242-11eb-8650-8c8390df19b5.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
