### PR TITLE
fix: remove spacing from first block in campaign

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -47,6 +47,10 @@
 	}
 }
 
+.newspack-inline-popup > *:first-child {
+	margin-top: 0;
+}
+
 // Wide and full widths need adjustment for the wider templates
 .newspack-front-page,
 .post-template-single-wide,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme currently removes the bottom margin from the last block in the inline campaigns, but it doesn't do the same with the top margin on the first block -- this can leave a pretty sizeable space at the top.

### How to test the changes in this Pull Request:

1. Set up an inline campaign with 1 block.
2. Preview your campaign - note the space at the top:

![image](https://user-images.githubusercontent.com/177561/110841184-6fd79900-825a-11eb-9b04-ce3065f68ce8.png)

3. Apply the PR and run `npm run build`.
4. Confirm that there is less space at the top:

![image](https://user-images.githubusercontent.com/177561/110840887-1b341e00-825a-11eb-95e2-1dad88bdb6dd.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
