### PR TITLE
feat: add support for custom excerpts on pages

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -67,6 +67,11 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_image_size( 'newspack-archive-image-large', 1200, 900, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999 );
 
+		/**
+		 * Enable feature support for specific post types.
+		 */
+		add_post_type_support( 'page', 'excerpt' ); // Custom excerpts for pages, normally restricted to posts.
+
 		// This theme uses wp_nav_menu() in two locations.
 		register_nav_menus(
 			array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A small change to add support for custom excerpts on pages. Pages mainly display excerpts when shown in search results or archive pages. Can't think of any reason why we wouldn't want to enable this, but paging @sonjaleix in case there's a reason I'm not thinking of.

### How to test the changes in this Pull Request:

1. Execute a site search with a term that you know will show a page.
2. Observe that the page is shown in the results with an auto-generated excerpt.
3. Check out this branch and edit the page.
4. Confirm that there's now an "Excerpt" sidebar panel in the editor. Add a custom excerpt and update.
5. Refresh the search and confirm that the custom excerpt is now shown in the results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
