### PR TITLE
fix: remove filtering of WooCommerce checkout fields

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -213,39 +213,6 @@ function newspack_checkout_needs_shipping() {
 }
 
 /**
- * Improve appearance of WooCommerce checkout
- *
- * @param array $fields Array of WooCommerce billing fields.
- */
-function newspack_checkout_fields_styling( $fields ) {
-	// Remove some unneeded fields from the checkout.
-	unset( $fields['billing']['billing_company'] );
-	unset( $fields['billing']['billing_address_2'] );
-	unset( $fields['billing']['billing_phone'] );
-	unset( $fields['shipping']['shipping_company'] );
-	unset( $fields['shipping']['shipping_address_2'] );
-	unset( $fields['shipping']['shipping_phone'] );
-
-	// If the cart only has virtual products, simplify checkout further.
-	if ( ! newspack_checkout_needs_shipping() ) {
-		unset( $fields['billing']['billing_address_1'] );
-		unset( $fields['billing']['billing_city'] );
-		unset( $fields['billing']['billing_postcode'] );
-		unset( $fields['billing']['billing_country'] );
-		unset( $fields['billing']['billing_state'] );
-		add_filter( 'woocommerce_enable_order_notes_field', '__return_false' );
-	}
-
-	// If the cart has physical items, replace .form-row-wide classes with classes to style fields narrower.
-	if ( newspack_checkout_needs_shipping() ) {
-		$fields['billing']['billing_email']['class'] = array( 'form-row-last' );
-	}
-	return $fields;
-}
-add_filter( 'woocommerce_checkout_fields', 'newspack_checkout_fields_styling', 9999 );
-
-
-/**
  * Improve appearance of WooCommerce checkout.
  *
  * @param array $fields Array of WooCommerce address fields.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes filtering of WooCommerce checkout fields that was added in #1275. We shouldn't be messing with these fields because:

- We don't know which fields might be required by certain payment gateways (e.g. billing address is required by credit card companies even for virtual products)
- There's an existing plugin called [WooCommerce Checkout Editor](https://docs.woocommerce.com/document/checkout-field-editor/) which allows publishers to edit checkout fields without code.

### How to test the changes in this Pull Request:

1. On `master`, make sure your donation platform is set to Newspack and WooCommerce plugins and pages are set up to process test donations.
2. As a non-logged-in user, submit a donation to get to the checkout page.
3. Observe that the only billing fields shown are First Name, Last Name, and email address.
4. Check out this branch and refresh the checkout page.
5. Confirm that billing fields now include address and phone number fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
