### PR TITLE
Update footer logo sizes and rename choices

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -600,7 +600,7 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_setting(
 		'footer_logo_size',
 		array(
-			'default'           => 'small',
+			'default'           => 'medium',
 			'sanitize_callback' => 'newspack_sanitize_footer_logo_size',
 		)
 	);
@@ -614,8 +614,8 @@ function newspack_customize_register( $wp_customize ) {
 			'type'     => 'select',
 			'settings' => 'footer_logo_size',
 			'choices'  => array(
-				'xsmall' => esc_html__( 'Extra Small', 'newspack' ),
 				'small'  => esc_html__( 'Small', 'newspack' ),
+				'medium' => esc_html__( 'Medium', 'newspack' ),
 				'large'  => esc_html__( 'Large', 'newspack' ),
 				'xlarge' => esc_html__( 'Extra Large', 'newspack' ),
 			),
@@ -1364,8 +1364,8 @@ add_action( 'customize_controls_enqueue_scripts', 'newspack_panels_js' );
  */
 function newspack_sanitize_footer_logo_size( $choice ) {
 	$valid = array(
-		'xsmall',
 		'small',
+		'medium',
 		'large',
 		'xlarge',
 	);
@@ -1374,7 +1374,7 @@ function newspack_sanitize_footer_logo_size( $choice ) {
 		return $choice;
 	}
 
-	return 'small';
+	return 'medium';
 }
 
 /**

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -195,8 +195,8 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Add a class for the footer logo size.
-	$footer_logo_size = get_theme_mod( 'footer_logo_size', 'small' );
-	if ( 'small' !== $footer_logo_size ) {
+	$footer_logo_size = get_theme_mod( 'footer_logo_size', 'medium' );
+	if ( 'medium' !== $footer_logo_size ) {
 		$classes[] = 'footer-logo-' . esc_attr( $footer_logo_size );
 	}
 

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -64,7 +64,7 @@
 		/* stylelint-enable */
 	}
 
-	.footer-logo-xsmall & {
+	.footer-logo-small & {
 		.custom-logo-link,
 		.footer-logo-link {
 			max-height: 48px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Medium size was missing. We previously had: XS, S, L, XL... This PR fixes it.

* Rename: Extra Small -> Small
* Rename Small -> Medium
* Set default to `medium`

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Site Identity
2. Check the Footer Logo Size dropdown
3. Switch to this branch
4. You should see the new choices

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
