### PR TITLE
Don't override specifically requested date/time formats

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -621,7 +621,11 @@ function newspack_math_to_time_ago( $post_time, $format, $post, $updated ) {
  * Apply time ago format to publish dates if enabled.
  */
 function newspack_convert_to_time_ago( $post_time, $format, $post ) {
-	return newspack_math_to_time_ago( $post_time, $format, $post, false );
+	// Don't override specifically requested formats.
+	if ( empty( $format ) ) {
+		$post_time = newspack_math_to_time_ago( $post_time, $format, $post, false );
+	}
+	return $post_time;
 }
 add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 3 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduces a check in `newspack_convert_to_time_ago()` that prevents the theme from overriding WordPress and plugins when they use `get_the_date()` to request a particular format.

Closes #1312.

### How to test the changes in this Pull Request:

1. Make sure there are recent posts
2. Turn on the "relative date" feature in Customiser
3. Observe that the relative dates are used
4. Add a small plugin with the following code: `add_filter( 'the_content', function( $c ) { $c .= get_the_date( 'U' ); return $c; } );`
5. Load any recently published post and observe that the date printed at the end of the post will be something like "X hours ago" when it should show a Unix time
6. Apply this PR
7. Observe that the relative time is replaced with a unix time in the content, but other dates use the relative format

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
