### PR TITLE
Add custom style to subscribe block and patterns

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -966,25 +966,35 @@ hr {
 
 	.newspack-pattern.subscribe__style-5 &,
 	.newspack-pattern.subscribe__style-6 & {
-		form {
-			align-items: center;
-			display: flex;
-			flex-wrap: wrap;
+		.wp-block-button__link {
+			width: 100%;
 
-			> * {
-				flex: 0 0 100%;
+			@include media( mobile ) {
+				width: auto;
 			}
+		}
 
-			> p:first-child {
-				flex: 1 1 auto;
-				margin-bottom: $size__spacing-unit / 2;
-				margin-right: $size__spacing-unit / 2;
-			}
+		@include media( tablet ) {
+			form {
+				align-items: center;
+				display: flex;
+				flex-wrap: wrap;
 
-			> .wp-block-jetpack-button.wp-block-button {
-				flex: 0 0 auto;
-				margin-left: auto;
-				margin-top: 0;
+				> * {
+					flex: 0 0 100%;
+				}
+
+				> p:first-child {
+					flex: 1 1 auto;
+					margin-bottom: $size__spacing-unit / 2;
+					margin-right: $size__spacing-unit / 2;
+				}
+
+				> .wp-block-jetpack-button.wp-block-button {
+					flex: 0 0 auto;
+					margin-left: auto;
+					margin-top: 0;
+				}
 			}
 		}
 	}
@@ -997,7 +1007,8 @@ hr {
 				max-width: 65%;
 			}
 
-			p {
+			p,
+			.wp-block-jetpack-button {
 				text-align: center;
 			}
 		}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -939,8 +939,72 @@ hr {
 		width: 100%;
 	}
 
-	p[id^='wp-block-jetpack-mailchimp'] {
+	p {
+		margin: 0;
+
+		&[id^='wp-block-jetpack-mailchimp'] {
+			font-size: $font__size-sm;
+		}
+	}
+
+	.wp-block-jetpack-button.wp-block-button {
+		margin: $size__spacing-unit / 2 0;
+	}
+
+	.wp-block-jetpack-mailchimp_notification {
 		font-size: $font__size-sm;
+		margin-top: $size__spacing-unit / 2;
+
+		&.is-visible {
+			margin-bottom: 0;
+		}
+
+		&.wp-block-jetpack-mailchimp__is-amp {
+			margin: 0;
+		}
+	}
+
+	.newspack-pattern.subscribe__style-5 &,
+	.newspack-pattern.subscribe__style-6 & {
+		form {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+
+			> * {
+				flex: 0 0 100%;
+			}
+
+			> p:first-child {
+				flex: 1 1 auto;
+				margin-bottom: $size__spacing-unit / 2;
+				margin-right: $size__spacing-unit / 2;
+			}
+
+			> .wp-block-jetpack-button.wp-block-button {
+				flex: 0 0 auto;
+				margin-left: auto;
+				margin-top: 0;
+			}
+		}
+	}
+
+	.newspack-pattern.subscribe__style-5 & {
+		form {
+			@include media( tablet ) {
+				margin-left: auto;
+				margin-right: auto;
+				max-width: 65%;
+			}
+
+			p {
+				text-align: center;
+			}
+		}
+
+		.wp-block-jetpack-mailchimp_notification {
+			text-align: center;
+		}
 	}
 }
 

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -862,6 +862,47 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Subscribe Patterns === */
+.wp-block-group.newspack-pattern {
+	&.subscribe__style-5,
+	&.subscribe__style-6 {
+		.wp-block-jetpack-mailchimp {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+
+			.wp-block-jetpack-mailchimp_text-input {
+				flex: 1 1 auto;
+
+				.components-base-control__field {
+					margin-bottom: 0;
+				}
+			}
+
+			.block-editor-inner-blocks {
+				flex: 1 1 100%;
+
+				@include media( mobile ) {
+					flex: 0 0 auto;
+					margin-left: $size__spacing-unit / 2;
+				}
+
+				.wp-block-button__link {
+					width: 100%;
+
+					@include media( mobile ) {
+						width: auto;
+					}
+				}
+			}
+
+			.block-editor-rich-text__editable {
+				flex: 0 0 100%;
+			}
+		}
+	}
+}
+
 /** === Donate Block === */
 .wpbnbd .freq-label,
 .wpbnbd .tier-label,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -792,6 +792,12 @@ ul.wp-block-archives,
 	.block-editor-rich-text__editable {
 		font-size: $font__size-sm;
 	}
+
+	.newspack-pattern.subscribe__style-5 & {
+		p {
+			text-align: center;
+		}
+	}
 }
 
 /** === Organic Profile Block === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Test this along side https://github.com/Automattic/newspack-blocks/pull/730

This PR slightly tweaks the CSS of the Mailchimp block and add custom CSS specific to Newspack Pattern styles 5 and 6. 

### How to test the changes in this Pull Request:

1. Switch to this branch (make sure you also have https://github.com/Automattic/newspack-blocks/pull/730)
2. Add style 5 and/or 6 to your page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
