### PR TITLE
Add ads background color theme option

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -690,7 +690,7 @@ add_action( 'after_switch_theme', 'newspack_migrate_settings', 10, 2 );
 function newspack_colors_css_wrap() {
 
 	// Only bother if we haven't customized the color.
-	if ( ( ! is_customize_preview() && ( 'default' === get_theme_mod( 'theme_colors', 'default' ) && newspack_get_mobile_cta_color() === get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() ) ) ) || is_admin() ) {
+	if ( ( ! is_customize_preview() && ( 'default' === get_theme_mod( 'theme_colors', 'default' ) && newspack_get_mobile_cta_color() === get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() ) && 'default' === get_theme_mod( 'ads_color', 'default' ) ) ) || is_admin() ) {
 		return;
 	}
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -425,7 +425,7 @@ function newspack_custom_colors_css() {
 			.newspack_global_ad.global_above_header,
 			.widget_newspack-ads-widget,
 			div[class*="newspack-ads-blocks-ad-unit"] {
-				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '' ) ) . ';
+				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
 			}
 			.single-featured-image-behind .newspack_global_ad.global_below_header,
 			.newspack_global_ad.global_above_footer {
@@ -580,6 +580,15 @@ function newspack_custom_colors_css() {
 			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block.accent-header {
 				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+			}
+		';
+	}
+
+	if ( 'default' !== get_theme_mod( 'ads_color', 'default' ) ) {
+		$editor_css .= '
+			.wp-block-newspack-ads-blocks-ad-unit > div {
+				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
+				padding: 8px;
 			}
 		';
 	}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -418,6 +418,32 @@ function newspack_custom_colors_css() {
 		';
 	}
 
+	// Set ads background color
+	if ( 'default' !== get_theme_mod( 'ads_color', 'default' ) ) {
+		$theme_css .= '
+			.newspack_global_ad,
+			.newspack_global_ad.global_above_header,
+			.widget_newspack-ads-widget,
+			div[class*="newspack-ads-blocks-ad-unit"] {
+				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '' ) ) . ';
+			}
+			.single-featured-image-behind .newspack_global_ad.global_below_header,
+			.newspack_global_ad.global_above_footer {
+				margin-bottom: -2rem;
+			}
+			.newspack_global_ad.global_above_footer {
+				margin-top: 2rem;
+			}
+			.newspack_global_ad > * {
+				margin-bottom: 8px;
+				margin-top: 8px;
+			}
+			.widget_newspack-ads-widget .textwidget,
+			div[class*="newspack-ads-blocks-ad-unit"] {
+				padding: 8px;
+			}
+		';
+	}
 
 	$editor_css = '
 		/*

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -529,6 +529,50 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	/**
+	 * Ads background_color
+	 */
+	$wp_customize->add_setting(
+		'ads_color',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_color_option',
+		)
+	);
+
+	$wp_customize->add_control(
+		'ads_color',
+		array(
+			'type'    => 'radio',
+			'label'   => __( 'Ads Background Color', 'newspack' ),
+			'choices'   => array(
+				'default' => _x( 'Default', 'primary color', 'newspack' ),
+				'custom'  => _x( 'Custom', 'primary color', 'newspack' ),
+			),
+			'section' => 'colors',
+		)
+	);
+
+	// Add ads color hexidecimal setting and control.
+	$wp_customize->add_setting(
+		'ads_color_hex',
+		array(
+			'default'           => '#ffffff',
+			'sanitize_callback' => 'sanitize_hex_color',
+		)
+	);
+
+	$wp_customize->add_control(
+		new WP_Customize_Color_Control(
+			$wp_customize,
+			'ads_color_hex',
+			array(
+				'description' => __( 'Apply a background color to the ads.', 'newspack' ),
+				'section'     => 'colors',
+			)
+		)
+	);
+
 	// Header - add option to hide tagline.
 	$wp_customize->add_setting(
 		'header_display_tagline',

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -243,6 +243,23 @@
 			} );
 		} );
 
+		// Controls to show/hide when the Ads Backround is toggled.
+		wp.customize( 'ads_color', function( setting ) {
+			wp.customize.control( 'ads_color_hex', function( control ) {
+				const visibility = function() {
+					if ( 'custom' === setting.get() ) {
+						if ( 'custom' === wp.customize.value( 'ads_color' )() ) {
+							control.container.slideDown( 180 );
+						}
+					} else {
+						control.container.slideUp( 180 );
+					}
+				};
+				visibility();
+				setting.bind( visibility );
+			} );
+		} );
+
 		// Only show the rest of the author controls when the bio is visible.
 		wp.customize( 'show_author_bio', function( setting ) {
 			wp.customize.control( 'show_author_email', function( control ) {

--- a/newspack-theme/js/src/customize-controls.js
+++ b/newspack-theme/js/src/customize-controls.js
@@ -395,5 +395,10 @@
 				}
 			} );
 		} );
+
+		// Update the default color palettes
+		$( '.wp-color-picker' ).iris( {
+			palettes: [ '#f6f7f7', '#c3c4c7', '#646970', '#3c434a', '#d63638', '#008a20', '#0675c4' ],
+		} );
 	} );
 } )( jQuery );

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -7,8 +7,8 @@
 	align-items: center;
 
 	> * {
-		margin-top: $size__spacing-unit;
-		margin-bottom: $size__spacing-unit;
+		margin-top: $size__vertical-rhythm * 2;
+		margin-bottom: $size__vertical-rhythm * 2;
 	}
 
 	&.global_above_header {
@@ -54,6 +54,10 @@
 			max-height: 100px;
 		}
 	}
+
+	amp-ad {
+		vertical-align: bottom;
+	}
 }
 
 .newspack_amp_sticky_ad {
@@ -91,6 +95,13 @@
 			background-color: inherit;
 		}
 	}
+}
+
+.widget_newspack-ads-widget .textwidget,
+div[class*='newspack-ads-blocks-ad-unit'] {
+	align-items: center;
+	display: flex;
+	justify-content: center;
 }
 
 body {

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -55,6 +55,7 @@
 		}
 	}
 
+	/* stylelint-disable selector-type-no-unknown  */
 	amp-ad {
 		vertical-align: bottom;
 	}

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -863,6 +863,15 @@ ul.wp-block-archives,
 	font-family: $font__heading;
 }
 
+/** === Ad Unit Block === */
+.wp-block-newspack-ads-blocks-ad-unit {
+	> div {
+		align-items: center;
+		display: flex;
+		justify-content: center;
+	}
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */

--- a/newspack-theme/sass/variables-site/_structure.scss
+++ b/newspack-theme/sass/variables-site/_structure.scss
@@ -6,6 +6,7 @@ $size__site-sidebar: 25%;
 $size__site-margins: calc( 10% + 60px );
 $size__site-tablet-content: 65%;
 $size__site-desktop-content: 65%;
+$size__vertical-rhythm: 8px;
 
 // Responsive widths.
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a new theme option to control the background color of the Ads in the Customizer (Colors > Ads Background Color)

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Colors > Ads Background Color
2. By default, the radio should be on Default
3. Switch to Custom, you should have access to a color picker
4. Select a background color and Save.
5. Check all the ads around your site to see if they have the new background color, and some padding.

__Note: make sure you test all the different solutions to display a ad on a Newspack site, including the widget, the ad units block...__

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
