### PR TITLE
Fix sticky ad initialisation on non-AMP pages

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -210,25 +210,28 @@
 	const stickyAdClose = document.querySelector( '.newspack_sticky_ad__close' );
 	const stickyAd = document.querySelector( '.newspack_global_ad.sticky' );
 
-	if ( stickyAdClose && stickyAd && window.googletag ) {
-		const initialBodyPadding = body.style.paddingBottom;
+	if ( stickyAdClose && stickyAd ) {
+		window.googletag = window.googletag || { cmd: [] };
+		window.googletag.cmd.push( function() {
+			const initialBodyPadding = body.style.paddingBottom;
 
-		// Add padding to body to accommodate the sticky ad.
-		window.googletag.pubads().addEventListener( 'slotRenderEnded', event => {
-			const renderedSlotId = event.slot.getSlotElementId();
-			const stickyAdSlot = stickyAd.querySelector( '#' + renderedSlotId );
+			// Add padding to body to accommodate the sticky ad.
+			window.googletag.pubads().addEventListener( 'slotRenderEnded', event => {
+				const renderedSlotId = event.slot.getSlotElementId();
+				const stickyAdSlot = stickyAd.querySelector( '#' + renderedSlotId );
 
-			if ( stickyAdSlot ) {
-				stickyAd.classList.add( 'active' );
-				body.style.paddingBottom = stickyAd.clientHeight + 'px';
-			}
-		} );
+				if ( stickyAdSlot ) {
+					stickyAd.classList.add( 'active' );
+					body.style.paddingBottom = stickyAd.clientHeight + 'px';
+				}
+			} );
 
-		stickyAdClose.addEventListener( 'click', () => {
-			stickyAd.parentElement.removeChild( stickyAd );
+			stickyAdClose.addEventListener( 'click', () => {
+				stickyAd.parentElement.removeChild( stickyAd );
 
-			// Reset body padding.
-			body.style.paddingBottom = initialBodyPadding;
+				// Reset body padding.
+				body.style.paddingBottom = initialBodyPadding;
+			} );
 		} );
 	}
 } )();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1304

You might find #1304 not reproducible (don't know what that depends on), but the `googletag.cmd.push` way of interacting with GPT [is the recommended one](https://developers.google.com/publisher-tag/guides/get-started?hl=en) anyway.

### How to test the changes in this Pull Request:

1. Set up a sticky ad by assigning one of the ad units to the "Sticky" position in Advertising wizard, Global Settings view
2. Set the site to AMP transitional mode (or turn off AMP plugin)
3. Observe the sticky ad rendered

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->