### PR TITLE
Fix sticky ad layer

### DIFF
--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -22,7 +22,7 @@
 		display: none;
 		position: fixed;
 		width: 100%;
-		z-index: 1;
+		z-index: 11;
 
 		&.active {
 			@include media( mobileonly ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a CSS layering issue:

![image](https://user-images.githubusercontent.com/7383192/116883773-4289e480-ac26-11eb-98de-28eb4a83dec9.png)

### How to test the changes in this Pull Request:

1. On `master`, visit a non-AMP version of a post, with a featured image, and a sticky ad set up 
2. Observe the `.entry-header` content is on top of the sticky ad (when the screen is small enough)
3. Switch to this branch, rebuild, observe the problem gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->