### PR TITLE
feat: allow limited text-formatting html elements in subtitles

### DIFF
--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -25,7 +25,7 @@ export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
 			}
 			titleEl.appendChild( subtitleEl );
 		}
-		subtitleEl.innerText = subtitle;
+		subtitleEl.innerHTML = subtitle;
 	}
 };
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -51,6 +51,11 @@
 	@include media( mobile ) {
 		margin-bottom: 2.3em;
 	}
+
+	em,
+	i {
+		font-style: normal;
+	}
 }
 
 body.page {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -946,6 +946,11 @@ ul.wp-block-archives,
 
 #newspack-post-subtitle-element {
 	font-style: italic;
+
+	em,
+	i {
+		font-style: normal;
+	}
 }
 
 /** === Custom Colors === */

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -38,7 +38,22 @@ $subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
 	<?php endif; ?>
 	<?php if ( $subtitle ) : ?>
 		<div class="newspack-post-subtitle">
-			<?php echo esc_html( $subtitle ); ?>
+			<?php
+			echo wp_kses(
+				$subtitle,
+				[
+					'b'      => true,
+					'strong' => true,
+					'i'      => true,
+					'em'     => true,
+					'mark'   => true,
+					'u'      => true,
+					'small'  => true,
+					'sub'    => true,
+					'sup'    => true,
+				]
+			);
+			?>
 		</div>
 	<?php endif; ?>
 <?php else : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows a limited set of text formatting HTML elements in post subtitles. The list of allowed tags is swiped from [this reference](https://www.w3schools.com/html/html_formatting.asp), plus `u` tags for underlining.

Some potential improvements:

* Use a `RichText` field instead of a simple `TextAreaControl` field to edit the subtitle. I couldn't get the `RichText` component to render with a formatting toolbar outside of a block context, though, so I'm not sure this would be supported by Gutenberg.
* Sanitize the HTML string in the editor preview before rendering as `innerHTML`, so that the output matches the front-end output more exactly. See step 3 below for more details.

Note that `em` and `i` tags are rendered with _non-italic_ styling because the subtitle as a whole is italicized. This is the generally accepted way to handle italics-within-italics in written English, but noting here just in case.

Closes #1136.

### How to test the changes in this Pull Request:

1. Edit a post, expand the "Article Subtitle" sidebar panel.
2. Enter a string with some of the allowed HTML tags, plus some disallowed tags. Example string you could use:

```
Regular text <b>bold</b> <i>italic</i> <small>small</small> <mark>marked</mark> <del>deleted</del> <sup>superscript</sup> <sub>subscript</sub> <u>underlined</u> <div>disallowed (appears as regular text)</div>
```

3. Confirm that the editor preview updates and renders the string with HTML formatting. **Note** that the editor preview will render _all_ HTML, not just the allowed ones—not sure the best way to prevent this without some very complicated regex-ing and am open to suggestions on this!
4. Save the post, view on the front-end. Confirm that the subtitle is rendered with the allowed HTML formatting, with any disallowed tags stripped.

<img width="1087" alt="Screen Shot 2021-05-14 at 4 40 13 PM" src="https://user-images.githubusercontent.com/2230142/118338317-12b6c880-b4d3-11eb-9af5-7602c66a372c.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
