### PR TITLE
Fix: Web Stories default customizer options display

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1027,6 +1027,4 @@ if ( function_exists( '\Newspack_Sponsors\get_sponsors_for_post' ) ) {
 /**
  * Load Web Stories compatibility file.
  */
-if ( class_exists( 'Google\Web_Stories\Customizer' ) ) {
-	require get_template_directory() . '/inc/web-stories.php';
-}
+require get_template_directory() . '/inc/web-stories.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the web stories plugin version 1.7.1, the code was refactored and plugin structure got changed. So customizer option for web stories disappeared. This PR fixes it. See https://github.com/google/web-stories-wp/pull/7266/files

This PR removes `class_exists` check as the web-stories plugin classes, functions are available only after `init` hook. See https://github.com/google/web-stories-wp/blob/8024de410bb7522eeffa6e6896ab28974973adf1/includes/namespace.php#L204

### How to test the changes in this Pull Request:

1. Add some web stories using web-stories plugin.
2. Enable `Web Stories > Display stories` from Customizer settings. 
3. Web Stories should display above the header of any newspack theme as shown in screenshot below.

![Screenshot 2021-05-19 at 8 12 31 PM](https://user-images.githubusercontent.com/1139853/118833081-cc040c80-b8de-11eb-863a-7d7808b28ae1.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
