### PR TITLE
fix: style of sponsor logo in footer blurb if no link

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -270,13 +270,15 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 
 					<?php
 					if ( ! empty( $sponsor['sponsor_logo'] ) ) {
+						echo '<figure class="avatar">';
 						if ( '' !== $sponsor['sponsor_url'] ) {
-							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" class="avatar" target="_blank">';
+							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
 						}
 						echo '<img src="' . esc_url( $sponsor['sponsor_logo']['src'] ) . '" width="' . esc_attr( $sponsor['sponsor_logo']['img_width'] ) . '" height="' . esc_attr( $sponsor['sponsor_logo']['img_height'] ) . '">';
 						if ( '' !== $sponsor['sponsor_url'] ) {
 							echo '</a>';
 						}
+						echo '</figure>';
 					}
 					?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

_(Not to be read until after 6/14)_

Welcome back, @laurelfulford! Here's a hopefully straightforward PR to ease you back into things. 😄  

Fixes a style bug for sponsor footer blurbs with a specific combination of conditions. If a sponsor has a logo and a relatively long blurb/content, but no link, the logo image is rendered as a first-level child of the `.sponsor-bio` element, which is a flex element, so the image ends up getting stretched to fill the available space. This PR nests the logo image in a `figure` element whether or not there's a link, so that the same styles are applied regardless of whether there's a link.

### How to test the changes in this Pull Request:

1. On `master`, create a native sponsor with a logo image and a blurb at least a paragraph or two long, with no Sponsor URL. Apply the sponsor to a post.
2. On the front-end, observe that the logo in the footer logo image is stretched to match the height of the blurb text content, and without a gutter to separate it from the text:

<img width="786" alt="Screen Shot 2021-06-09 at 3 12 16 PM" src="https://user-images.githubusercontent.com/2230142/121430927-fbce8f00-c935-11eb-9dd4-5c4d994151c6.png">

3. Check out this branch, rebuild, and refresh the page. Confirm that the image now renders at an appropriate height with gutter, both with and without a Sponsor URL defined in the sponsor editor page:

<img width="787" alt="Screen Shot 2021-06-09 at 3 19 42 PM" src="https://user-images.githubusercontent.com/2230142/121431046-20c30200-c936-11eb-9f7c-29b23090854c.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
