### PR TITLE
Make sure mobile menu displays when it only contains widgets

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -478,7 +478,9 @@ endif;
  * Check if any header menus are applied; used to show menu toggle on smaller screens.
  */
 function newspack_has_menus() {
-	if ( has_nav_menu( 'primary-menu' ) || has_nav_menu( 'secondary-menu' ) || has_nav_menu( 'tertiary-menu' ) ) {
+	// check if primary, secondary or tertiary menus are populated, or if slideout sidebar widget is populated & should show on mobile.
+	if ( ( has_nav_menu( 'primary-menu' ) || has_nav_menu( 'secondary-menu' ) || has_nav_menu( 'tertiary-menu' ) ) ||
+		( true === get_theme_mod( 'header_show_slideout', false ) && true === get_theme_mod( 'slideout_widget_mobile', false ) && is_active_sidebar( 'header-1' ) ) ) {
 		return true;
 	} else {
 		return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally, the theme's mobile menu would check for the presence of either the primary, secondary or tertiary menu before being written to the screen. 

However, there are some cases where a publisher might want to put their navigation, via widget, entirely inside of the 'slide out sidebar' and set it to display on mobile -- when it's set up this way, with no other menus assigned, the mobile menu doesn't display despite the fact it would be populated with widgets if it did.

This PR adds a check for the slide out sidebar widgets being turned on, assigned, and set to show on mobile to the mobile menu as well, so you can set it up to be only populated by widgets and have it display.

Closes #1343 

### How to test the changes in this Pull Request:

1. Remove the primary, secondary and tertiary menu.
2. Under Header Settings, enable the Slide-out sidebar, and check `Add slide-out widgets to mobile menu`. Add some widgets to this widget area.
3. View the site on a mobile sized screen; note there is no mobile menu toggle.
4. Apply the PR and run `npm run build`.
5. Confirm that there's now a mobile menu toggle on smaller screens.
6. Remove the widgets from the slide out sidebar space and confirm the mobile menu toggle disappears.
7. Add a menu - primary, secondary or tertiary - and confirm the mobile menu toggle reappears. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
