### PR TITLE
fix: figcaption rendering bug in Safari

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -769,14 +769,6 @@ p.has-background {
 	}
 
 	@include media( mobileonly ) {
-		.alignleft,
-		.aligncenter,
-		.alignright {
-			figcaption {
-				display: block;
-			}
-		}
-
 		.aligncenter {
 			display: block;
 			img {

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -24,8 +24,11 @@ figcaption,
 	line-height: $font__line-height-pre;
 }
 
-.wp-block-image [class^='align'] > figcaption {
-	display: block;
+/* Hack to address a bug that affects caption positioning in Safari only. Targets Safari 9+ only. */
+@supports ( -webkit-hyphens: none ) {
+	.wp-block-image [class^='align'] > figcaption {
+		display: block;
+	}
 }
 
 .entry-content {

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -24,6 +24,10 @@ figcaption,
 	line-height: $font__line-height-pre;
 }
 
+.wp-block-image [class^='align'] > figcaption {
+	display: block;
+}
+
 .entry-content {
 	.wp-caption-text,
 	figcaption {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an [obscure Safari rendering bug](https://github.com/ampproject/amp-wp/issues/6035) which causes captions inside image blocks with an alignment set to render in the wrong position.

Closes #1132

### How to test the changes in this Pull Request:

1. Add an image block to a post and choose an image that has a caption. Set an alignment on the block (left, center, or right).
2. On `master`, view the post in Safari. Observe that the caption appears in the wrong place (if you don't see the bug, try hard-refreshing the post):

<img width="854" alt="Screen Shot 2021-06-23 at 3 44 30 PM" src="https://user-images.githubusercontent.com/2230142/123172150-f135ee80-d439-11eb-8ed9-a857efdbabc0.png">

3. Check out this branch and hard-refresh the post. Confirm that the caption now renders as expected.
4. Re-test with all alignment options and no alignment options, and in another browser to ensure that the fix doesn't change anything outside Safari.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
