### PR TITLE
Newspack Sacha: make accent header styles more specific in Newspack Sacha

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -78,7 +78,7 @@ div.wpnbha .article-section-title,
 }
 
 .accent-header,
-.article-section-title span {
+.article-section-title > span {
 	align-items: center;
 	display: flex;
 	width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a minor irritation but: when you use Newspack Sacha, and add a custom inline colour to the section header in the Homepage Posts block, you get a weird double line on the front end. This is because the inline colour adds a second `span` that the CSS is not expecting; this PR makes the styles for the section header more specific, to prevent this issue.

Closes #1285

### How to test the changes in this Pull Request:

1. Switch your site to Newspack Sacha.
2. Add two homepage posts blocks; give them each a section header, and change the colour of one of the section headers using the option in the block toolbar.
3. View on the front-end; note the block with the custom colour has an odd doubled border on the edges:

![image](https://user-images.githubusercontent.com/177561/123471601-ddf66080-d5aa-11eb-97e9-a509f6588166.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the odd double border is gone, and that the block without a custom colour still displays normally:

![image](https://user-images.githubusercontent.com/177561/123471547-cd45ea80-d5aa-11eb-8eea-f0746ef78871.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
