### PR TITLE
Newspack Sacha: correct alignment for sponsor bio in Newspack Sacha

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -547,3 +547,13 @@ cite {
 	left: 50%;
 	margin-left: -150px;
 }
+
+.sponsor-bio {
+	.avatar {
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.author-bio-header h2 {
+		text-align: center;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects an alignment issue in Newspack Sacha with the sponsor bios at the bottom of single posts. 

Closes #1369 

### How to test the changes in this Pull Request:

1. Switch your site to use Newspack Sacha.
2. Set up a sponsor using Newspack Sponsors; give them a bio and assign them to at least one post.
3. View the single post on the front-end; note that the sponsor logo and name are aligned left in the bio at the bottom of the post:

![image](https://user-images.githubusercontent.com/177561/123472589-32e6a680-d5ac-11eb-88ca-757e5981f1dd.png)

4. Apply PR and run `npm run build`.
5. Revisit the sponsor bio; confirm that their name and logo are aligned centre:

![image](https://user-images.githubusercontent.com/177561/123472531-23fff400-d5ac-11eb-836b-bf69a3a975ba.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
