### PR TITLE
WordPress 5.8: Prevent white screen and errors on Widget Screen

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -427,6 +427,7 @@ function newspack_enqueue_scripts() {
 	$languages_path = get_parent_theme_file_path( '/languages' );
 	$theme_version  = wp_get_theme()->get( 'Version' );
 	$post_type      = get_post_type();
+	$current_screen = get_current_screen();
 
 	// Featured Image options.
 	wp_register_script(
@@ -449,21 +450,24 @@ function newspack_enqueue_scripts() {
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', $languages_path );
 	}
 
-	// Post meta options.
-	wp_register_script(
-		'newspack-post-meta-toggles',
-		get_theme_file_uri( '/js/dist/post-meta-toggles.js' ),
-		array(),
-		$theme_version,
-		true
-	);
-	wp_set_script_translations( 'newspack-post-meta-toggles', 'newspack', $languages_path );
-	wp_localize_script(
-		'newspack-post-meta-toggles',
-		'newspack_post_meta_post_types',
-		newspack_get_post_toggle_post_types()
-	);
-	wp_enqueue_script( 'newspack-post-meta-toggles' );
+	// Add check to see if currently on the widgets screen; this file should not be loaded there, but is as of WordPress 5.8.
+	// See: https://github.com/WordPress/gutenberg/issues/28538.
+	if ( 'widgets' !== $current_screen->id ) {
+		wp_register_script(
+			'newspack-post-meta-toggles',
+			get_theme_file_uri( '/js/dist/post-meta-toggles.js' ),
+			array(),
+			$theme_version,
+			true
+		);
+		wp_set_script_translations( 'newspack-post-meta-toggles', 'newspack', $languages_path );
+		wp_localize_script(
+			'newspack-post-meta-toggles',
+			'newspack_post_meta_post_types',
+			newspack_get_post_toggle_post_types()
+		);
+		wp_enqueue_script( 'newspack-post-meta-toggles' );
+	}
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -429,6 +429,12 @@ function newspack_enqueue_scripts() {
 	$post_type      = get_post_type();
 	$current_screen = get_current_screen();
 
+	// Add check to see if currently on the widgets screen; none of these files are needed there, but are loaded as of WP 5.8.
+	// See: https://github.com/WordPress/gutenberg/issues/28538.
+	if ( 'widgets' === $current_screen->id ) {
+		return;
+	}
+
 	// Featured Image options.
 	wp_register_script(
 		'newspack-extend-featured-image-script',
@@ -450,24 +456,20 @@ function newspack_enqueue_scripts() {
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', $languages_path );
 	}
 
-	// Add check to see if currently on the widgets screen; this file should not be loaded there, but is as of WordPress 5.8.
-	// See: https://github.com/WordPress/gutenberg/issues/28538.
-	if ( 'widgets' !== $current_screen->id ) {
-		wp_register_script(
-			'newspack-post-meta-toggles',
-			get_theme_file_uri( '/js/dist/post-meta-toggles.js' ),
-			array(),
-			$theme_version,
-			true
-		);
-		wp_set_script_translations( 'newspack-post-meta-toggles', 'newspack', $languages_path );
-		wp_localize_script(
-			'newspack-post-meta-toggles',
-			'newspack_post_meta_post_types',
-			newspack_get_post_toggle_post_types()
-		);
-		wp_enqueue_script( 'newspack-post-meta-toggles' );
-	}
+	wp_register_script(
+		'newspack-post-meta-toggles',
+		get_theme_file_uri( '/js/dist/post-meta-toggles.js' ),
+		array(),
+		$theme_version,
+		true
+	);
+	wp_set_script_translations( 'newspack-post-meta-toggles', 'newspack', $languages_path );
+	wp_localize_script(
+		'newspack-post-meta-toggles',
+		'newspack_post_meta_post_types',
+		newspack_get_post_toggle_post_types()
+	);
+	wp_enqueue_script( 'newspack-post-meta-toggles' );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -456,6 +456,7 @@ function newspack_enqueue_scripts() {
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', $languages_path );
 	}
 
+	// Post meta options.
 	wp_register_script(
 		'newspack-post-meta-toggles',
 		get_theme_file_uri( '/js/dist/post-meta-toggles.js' ),

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -40,7 +40,7 @@
 
 	// Menu toggle variables.
 	const mobileToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
-		body = document.getElementsByTagName( 'body' )[ 0 ],
+		body = document.body,
 		mobileSidebar = document.getElementById( 'mobile-sidebar-fallback' ),
 		desktopToggle = document.getElementsByClassName( 'desktop-menu-toggle' ),
 		desktopSidebar = document.getElementById( 'desktop-sidebar-fallback' ),
@@ -92,8 +92,8 @@
 
 	// Mobile menu fallback.
 	for ( let i = 0; i < mobileToggle.length; i++ ) {
-		const mobileOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
-			mobileCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ];
+		const mobileOpenButton = headerContain.querySelector( '.mobile-menu-toggle' ),
+			mobileCloseButton = mobileSidebar.querySelector( '.mobile-menu-toggle' );
 
 		mobileToggle[ i ].addEventListener(
 			'click',
@@ -110,8 +110,8 @@
 
 	// Desktop menu (AKA slide-out sidebar) fallback.
 	for ( let i = 0; i < desktopToggle.length; i++ ) {
-		const desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
-			desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ];
+		const desktopOpenButton = headerContain.querySelector( '.desktop-menu-toggle' ),
+			desktopCloseButton = desktopSidebar.querySelector( '.desktop-menu-toggle' );
 
 		desktopToggle[ i ].addEventListener(
 			'click',
@@ -129,8 +129,8 @@
 	// 'Subpage' menu fallback.
 	if ( 0 < subpageToggle.length ) {
 		const subpageSidebar = document.getElementById( 'subpage-sidebar-fallback' ),
-			subpageOpenButton = headerContain.getElementsByClassName( 'subpage-toggle' )[ 0 ],
-			subpageCloseButton = subpageSidebar.getElementsByClassName( 'subpage-toggle' )[ 0 ];
+			subpageOpenButton = headerContain.querySelector( '.subpage-toggle' ),
+			subpageCloseButton = subpageSidebar.querySelector( '.subpage-toggle' );
 
 		for ( let i = 0; i < subpageToggle.length; i++ ) {
 			subpageToggle[ i ].addEventListener(

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -42,12 +42,8 @@
 	const mobileToggle = document.getElementsByClassName( 'mobile-menu-toggle' ),
 		body = document.getElementsByTagName( 'body' )[ 0 ],
 		mobileSidebar = document.getElementById( 'mobile-sidebar-fallback' ),
-		mobileOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
-		mobileCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
 		desktopToggle = document.getElementsByClassName( 'desktop-menu-toggle' ),
 		desktopSidebar = document.getElementById( 'desktop-sidebar-fallback' ),
-		desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
-		desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
 		subpageToggle = document.getElementsByClassName( 'subpage-toggle' );
 
 	/**
@@ -96,6 +92,9 @@
 
 	// Mobile menu fallback.
 	for ( let i = 0; i < mobileToggle.length; i++ ) {
+		const mobileOpenButton = headerContain.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ],
+			mobileCloseButton = mobileSidebar.getElementsByClassName( 'mobile-menu-toggle' )[ 0 ];
+
 		mobileToggle[ i ].addEventListener(
 			'click',
 			function() {
@@ -111,6 +110,9 @@
 
 	// Desktop menu (AKA slide-out sidebar) fallback.
 	for ( let i = 0; i < desktopToggle.length; i++ ) {
+		const desktopOpenButton = headerContain.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ],
+			desktopCloseButton = desktopSidebar.getElementsByClassName( 'desktop-menu-toggle' )[ 0 ];
+
 		desktopToggle[ i ].addEventListener(
 			'click',
 			function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With WordPress 5.8's introduction of Widget Blocks, `enqueue_block_editor_assets` is now also being used on the Appearance > Widgets screen, to make sure all of the block assets are loaded. In the theme we have a number of JS files we're loading into the editor using this hook that are strictly for posts/pages: featured image placements, hiding page titles and updated dates, and article subtitles. In particular, the post-meta-toggle.js is causing an error on the Widgets screen that makes it unusable. This PR adds a check for the current screen before enqueuing any of these assets. 

In one related issue in the Gutenberg repo (https://github.com/WordPress/gutenberg/issues/28538), there's a suggestion for possibly adding screen-specific hooks (`enqueue_block_editor_assets-$screen`) on top of what's there now; if that happens down the road, it should be easy to switch the current approach to use the new hook. 

In WP 5.8, some front-end scripts and styles are also being loaded into the Widgets screen; the amp-fallback.js is currently firing errors because it can't find specific HTML elements. Rather than totally blocking this script (I want to try to let WordPress do it's own thing on these updated screens as much as possible!), I increased the checks for different elements so if they're not found, the code doesn't try to run. 

Notes: 

* I was able to consistently recreate the "white screen" issue on my local test sites, but not a Jurassic Ninja one; so it's possible this won't be as catastrophic on live sites, but we still should probably not be loading unnecessary files on the widgets screen. 
* This PR pulls double-duty, fixing two completely unrelated issues on the Appearance > Widgets screen. If it's less confusing to handle them separately, let me know!
* I'm open to feedback on either approach here; I'm especially unsure about the first one. I also tried adding checks to the post-meta-toggle.js because it's the problem file, but I can't actually see needing any of these files on the Widget screen as it works now. 

Closes #1386 

### How to test the changes in this Pull Request:

_Note: I've outlined the steps to test using two different test sites, since it saves you from having to upgrade, then downgrade, a site, but it all can be tested on one site if desired._ 

If you haven't already, set up a test site to run the latest WordPress 5.8 Beta (beta 4):

1. On a test site, install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Navigate to Tools > Beta Testing WordPress, and under `Select the update channel you would like this website to use:` pick `Bleeding Edge`; click 'Save'.
3. The screen will update on save to add new options; under `Select one of the stream options below:` pick `Beta/RC Only` and click 'Save'.
4. Navigate to Dashboard > Updates; you should have the option to update to version 5.8-beta4. Click that, and go grab a coffee! 

Steps to test the PR:

1. Disable AMP, so the site is always loading the AMP fallback script.
2. Navigate to WP Admin > Widgets.
3. Note that the page doesn't load:

![image](https://user-images.githubusercontent.com/177561/123848945-1e1c5280-d8cd-11eb-8ec8-50fc6d513776.png)

4. Apply the PR and run `npm run build`, then reload the page; confirm that it's now loading:

![image](https://user-images.githubusercontent.com/177561/123849058-3be9b780-d8cd-11eb-8778-26533cc97045.png)

5. There are still a number of errors in the console, at least on my localhost; double-check that none are coming from the AMP fallback JS. (Some of the errors seem to be related to the Newspack Blocks plugin -- or at least they disappear when I disable it -- but I need to do more testing to confirm before filing an issue). 
6. Just a precaution, make sure the per-page/post options (hide page title, featured image position, etc...) are still loading when you edit a page or post. 
7. Confirm that the mobile menu/search/slide-out sidebar toggles still work on the front end.
8. Test this PR on a site running WP 5.7.2 and confirm that the per-page/post options (hide page title, featured image position, etc...), and AMP fallback JavaScript still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
