### PR TITLE
Donate Block: improve donate block appearance for WP 5.8

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -55,7 +55,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 			.is-style-outline .wp-block-button__link.has-primary-background-color:not( :hover ),
 			.wp-block-file .wp-block-file__button,
-			.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
+			div.wpbnbd.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
 			.comment .comment-author .post-author-badge,
 			.woocommerce .onsale,
 			.woocommerce-store-notice {
@@ -105,7 +105,7 @@ function newspack_custom_colors_css() {
 			/* Header default background; default height */
 			body.h-db.h-dh .site-header .nav3 .menu-highlight a,
 			.comment .comment-author .post-author-badge,
-			.site-content .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
+			div.wpbnbd.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
 			.woocommerce .onsale,
 			.woocommerce-store-notice {
 				color: ' . esc_html( $primary_color_contrast ) . ';

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -232,6 +232,21 @@ p.has-background {
 	}
 }
 
+//! Newspack Donate Block
+#secondary .wpbnbd,
+.desktop-sidebar .wpbnbd,
+.mobile-sidebar .wpbnbd {
+	&.tiered .tiers {
+		margin-left: #{0.5 * $size__spacing-unit};
+		margin-right: #{0.5 * $size__spacing-unit};
+	}
+	.thanks,
+	button {
+		margin-left: $size__spacing-unit;
+		margin-right: $size__spacing-unit;
+	}
+}
+
 //! Columns
 .wp-block-columns {
 	.wp-block-cover,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -233,17 +233,23 @@ p.has-background {
 }
 
 //! Newspack Donate Block
-#secondary .wpbnbd,
-.desktop-sidebar .wpbnbd,
-.mobile-sidebar .wpbnbd {
-	&.tiered .tiers {
-		margin-left: #{0.5 * $size__spacing-unit};
-		margin-right: #{0.5 * $size__spacing-unit};
+#secondary,
+.desktop-sidebar,
+.mobile-sidebar {
+	.wpbnbd.tiered .tiers {
+		margin-left: #{0.62 * $size__spacing-unit};
+		margin-right: #{0.62 * $size__spacing-unit};
 	}
-	.thanks,
-	button {
+	.wpbnbd .thanks,
+	.wpbnbd button {
 		margin-left: $size__spacing-unit;
 		margin-right: $size__spacing-unit;
+	}
+}
+
+.site-info .widget .wpbnbd {
+	.thanks {
+		margin: 0.5rem 1.5rem;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR cleans up some small issues in the Donate Block when placed in the widget block spaces in WordPress 5.8, specifically making sure it's still picking up the custom colours, and reducing the padding a bit when it's in narrower spaces.

See #1372

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WordPress 5.8 RC; you can do this using the [Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Enable the slide-out sidebar, and set those widgets to also appear in the mobile menu.
3. Set up your site to use custom colours and fonts; set the footer to use a darker custom footer colour - this will help us test contrast, and that the block is picking up the custom colours when appropriate. 
4. Add the Donate widget to every widget space: sidebar, footer, slide-out sidebar, above copyright, and above and below the content area. 
5. View on the front end; note that the block is not always picking up the custom colours, and in some cases there's a bit more padding than needed:

Sidebar - spacing:
![image](https://user-images.githubusercontent.com/177561/124315573-faeddf00-db28-11eb-8ba0-c9719c57deac.png)

Slide-out Sidebar - spacing and colour:
![image](https://user-images.githubusercontent.com/177561/124315610-050fdd80-db29-11eb-8d0e-62e454d83580.png)

Slide-out Sidebar widgets in the mobile area - spacing and colour:
![image](https://user-images.githubusercontent.com/177561/124315643-15c05380-db29-11eb-8124-23928a475dbe.png)

Footer and Above Copyright - colour; weird 'thank you' spacing:
![image](https://user-images.githubusercontent.com/177561/124315541-ec9fc300-db28-11eb-9fc7-25f4234cd258.png)

6. Apply the PR and run `npm run build`.
7. Confirm that the above issues are resolved:

Sidebar:

![image](https://user-images.githubusercontent.com/177561/124316440-74d29800-db2a-11eb-8fa8-af5c3fe57c03.png)

Slide-out Sidebar: 

![image](https://user-images.githubusercontent.com/177561/124316462-7bf9a600-db2a-11eb-9b01-e6fc4d657709.png)

Slide-out Sidebar widgets in the mobile area:

![image](https://user-images.githubusercontent.com/177561/124316518-8ddb4900-db2a-11eb-9969-e79758319cfe.png)

Footer and Above Copyright:

![image](https://user-images.githubusercontent.com/177561/124317319-d34c4600-db2b-11eb-905a-c7625630c977.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
