### PR TITLE
Block Widgets: Correct font previews

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -161,18 +161,12 @@ function newspack_custom_typography_css() {
 		}';
 
 		$editor_css_blocks .= '
-		.edit-post-visual-editor.editor-styles-wrapper h1, /* legacy */
-		.edit-post-visual-editor.editor-styles-wrapper h2,
-		.edit-post-visual-editor.editor-styles-wrapper h3,
-		.edit-post-visual-editor.editor-styles-wrapper h4,
-		.edit-post-visual-editor.editor-styles-wrapper h5,
-		.edit-post-visual-editor.editor-styles-wrapper h6,
-		.edit-post-visual-editor .editor-styles-wrapper h1,
-		.edit-post-visual-editor .editor-styles-wrapper h2,
-		.edit-post-visual-editor .editor-styles-wrapper h3,
-		.edit-post-visual-editor .editor-styles-wrapper h4,
-		.edit-post-visual-editor .editor-styles-wrapper h5,
-		.edit-post-visual-editor .editor-styles-wrapper h6,
+		.editor-styles-wrapper .block-editor-block-list__layout h1,
+		.editor-styles-wrapper .block-editor-block-list__layout h2,
+		.editor-styles-wrapper .block-editor-block-list__layout h3,
+		.editor-styles-wrapper .block-editor-block-list__layout h4,
+		.editor-styles-wrapper .block-editor-block-list__layout h5,
+		.editor-styles-wrapper .block-editor-block-list__layout h6,
 		.block-editor-block-list__layout .block-editor-block-list__block figcaption,
 		.block-editor-block-list__layout .block-editor-block-list__block .gallery-caption,
 		.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
@@ -182,8 +176,8 @@ function newspack_custom_typography_css() {
 		.edit-post-visual-editor .editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
 
 		/* Homepage Posts Block */
-		.block-editor-block-list__layout .wpnbha .entry-title,
-		.block-editor-block-list__layout .wpnbha .entry-meta,
+		.block-editor-block-list__layout .wp-block .entry-title,
+		.block-editor-block-list__layout .wp-block .entry-meta,
 
 		/* Table Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th, /* legacy */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates some of the custom typography selectors, to make sure the blocks are picking them up on the Widgets screen.

Closes #1394

### How to test the changes in this Pull Request:

1. Start with a  test site running the latest WP 5.8 release candidate. 
2. In the Customizer, set a custom header and body font. 
3. Navigate to WP Admin > Appearance > Widgets; add a Homepage Posts block, Heading block, Author block and Post Carousel block.
4. Note that all but the Homepage Posts block aren't picking up your custom header font. In this case, the headers should be Montserrat (like the Homepage Posts block), but many are picking up the child theme's Fira Sans Condensed:

![image](https://user-images.githubusercontent.com/177561/124336742-099dbb80-db54-11eb-96c5-36b2792fea0e.png)

5. Apply the PR.
6. Refresh the page; confirm that the blocks are now picking up your custom fonts:

![image](https://user-images.githubusercontent.com/177561/124336542-4321f700-db53-11eb-9333-7a8e89a94841.png)


7. Test the same blocks in the post/page editor and confirm that they're still using your custom header fonts.
8. Test on a site running 5.7, and add the same blocks to the post/page editor and confirm that they're still using your custom header fonts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
