### PR TITLE
fix: ads media queries

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -856,7 +856,7 @@ function newspack_theme_newspack_ads_media_queries( $media_queries, $placement, 
 						$media_query['max_width'] = null;
 					} else {
 						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.9 );
-						if ( $next_media_query['width'] && $next_media_query['width'] <= 1200 ) {
+						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 1200 ) {
 							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.9 - 1 );
 						} else {
 							$media_query['max_width'] = null;
@@ -873,14 +873,14 @@ function newspack_theme_newspack_ads_media_queries( $media_queries, $placement, 
 						$media_query['max_width'] = null;
 					} else if ( intval( $media_query['width'] ) > ceil( 782 * 0.585 ) ) {
 						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.585 );
-						if ( $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
+						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
 							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.585 - 1 );
 						} else {
 							$media_query['max_width'] = null;
 						}
 					} else {
 						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.9 );
-						if ( $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
+						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
 							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.585 - 1 );
 						} else {
 							$media_query['max_width'] = null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue.

### How to test the changes in this Pull Request:

1. On `master`,
1. Create an ad unit with only mobile (<780) sizes
2. Insert it in a post using an ad block or SCAIP
3. Observe a PHP notice logged when viewing the post on desktop screen size: `PHP Notice:  Trying to access array offset on value of type null`
4. Switch to this branch, refresh the page, observe no PHP notice logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->