### PR TITLE
Homepage Posts Block: Style adjustments for widget block areas

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -119,7 +119,7 @@ input[type='submit'] {
 /* Accent headers */
 .accent-header,
 .wp-block-columns .wp-block-column > .accent-header,
-.site-content .wpnbha .article-section-title,
+div.wpnbha .article-section-title,
 .cat-links {
 	font-size: $font__size-base;
 	margin-bottom: $size__spacing-unit;

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -59,6 +59,14 @@ function newspack_katharine_custom_colors_css() {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
 
+		.mobile-sidebar .accent-header:before,
+		.mobile-sidebar div.wpnbha .article-section-title:before,
+		.mobile-sidebar .cat-links:before,
+		.mobile-sidebar figcaption:after,
+		.mobile-sidebar .wp-caption-text:after {
+			background-color: ' . esc_html( $primary_color_contrast ) . ';
+		}
+
 		@media only screen and (min-width: 782px) {
 			.featured-image-beside a,
 			.featured-image-beside a:visited,

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -18,6 +18,9 @@ function newspack_katharine_custom_colors_css() {
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color          = $primary_color;
+			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -65,6 +68,11 @@ function newspack_katharine_custom_colors_css() {
 		.mobile-sidebar figcaption:after,
 		.mobile-sidebar .wp-caption-text:after {
 			background-color: ' . esc_html( $primary_color_contrast ) . ';
+		}
+
+		.mobile-sidebar div.wpnbha .article-section-title::before,
+		.mobile-sidebar .accent-header::before {
+			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
 		}
 
 		@media only screen and (min-width: 782px) {
@@ -129,6 +137,11 @@ function newspack_katharine_custom_colors_css() {
 		$theme_css .= '
 			.footer-branding .wrapper {
 				border-bottom-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
+			}
+
+			.site-footer div.wpnbha .article-section-title::before,
+			.site-footer .accent-header::before {
+				background-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
 			}
 		';
 	}

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -72,7 +72,7 @@ function newspack_katharine_custom_colors_css() {
 
 		.mobile-sidebar div.wpnbha .article-section-title::before,
 		.mobile-sidebar .accent-header::before {
-			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
 		}
 
 		@media only screen and (min-width: 782px) {

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -18,9 +18,6 @@ function newspack_katharine_custom_colors_css() {
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
-		} else {
-			$header_color          = $primary_color;
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -72,7 +69,7 @@ function newspack_katharine_custom_colors_css() {
 
 		.mobile-sidebar div.wpnbha .article-section-title::before,
 		.mobile-sidebar .accent-header::before {
-			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
+			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 		}
 
 		@media only screen and (min-width: 782px) {
@@ -128,6 +125,11 @@ function newspack_katharine_custom_colors_css() {
 				.h-sb .top-header-contain,
 				.h-sb .middle-header-contain {
 					color: ' . esc_html( $header_color_contrast ) . ';
+				}
+
+				.mobile-sidebar div.wpnbha .article-section-title::before,
+				.mobile-sidebar .accent-header::before {
+					background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
 				}
 			';
 		}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -64,6 +64,14 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
+.widget {
+	.accent-header,
+	.article-section-title,
+	.cat-links {
+		color: inherit;
+	}
+}
+
 .accent-header,
 .wp-block-columns .wp-block-column > .accent-header,
 div.wpnbha .article-section-title,
@@ -137,6 +145,17 @@ div.wpnbha .article-section-title,
 	.sponsor-label + .entry-title {
 		margin-top: 0;
 		padding: 0;
+	}
+}
+
+.widget
+	.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category )
+	.post-has-image {
+	.entry-title {
+		background: transparent;
+		margin-top: inherit;
+		padding: inherit;
+		width: auto;
 	}
 }
 

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -64,7 +64,8 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-.widget {
+.mobile-sidebar,
+.site-footer {
 	.accent-header,
 	.article-section-title,
 	.cat-links {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -243,7 +243,7 @@ div.wpnbha .article-section-title {
 	}
 }
 
-#secondary .accent-header {
+#secondary .widget-title {
 	color: inherit;
 	font-size: $font__size-lg;
 
@@ -486,6 +486,15 @@ blockquote {
 .taxonomy-description {
 	font-family: $font__heading;
 	font-style: normal;
+}
+
+// Widgets
+.mobile-sidebar,
+.site-footer {
+	.accent-header,
+	div.wpnbha .article-section-title {
+		color: inherit;
+	}
 }
 
 // Footer

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -85,7 +85,7 @@ div.wpnbha .article-section-title,
 
 	&::before,
 	&::after {
-		background: $color__border;
+		border-top: 1px solid $color__border;
 		content: '';
 		flex: 1 0 0.5rem;
 		height: 1px;
@@ -97,6 +97,19 @@ div.wpnbha .article-section-title,
 
 	&::after {
 		margin-left: #{0.5 * $size__spacing-unit};
+	}
+}
+
+.mobile-sidebar,
+.site-footer {
+	.accent-header,
+	.article-section-title {
+		color: inherit;
+
+		&::before,
+		&::after {
+			border-color: currentColor;
+		}
 	}
 }
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -105,10 +105,14 @@ div.wpnbha .article-section-title,
 	.accent-header,
 	.article-section-title {
 		color: inherit;
+	}
 
+	.accent-header,
+	.article-section-title > span {
 		&::before,
 		&::after {
 			border-color: currentColor;
+			opacity: 0.2;
 		}
 	}
 }

--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -42,7 +42,6 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 						<div>
 							<h2 class="accent-header">
 								<?php echo esc_html( esc_html( $author->display_name ) ); ?>
-								<span><?php // TODO: Add Job title ?></span>
 							</h2>
 							<?php if ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) : ?>
 								<div class="author-meta">
@@ -103,7 +102,6 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			<div>
 				<h2 class="accent-header">
 					<?php echo esc_html( get_the_author() ); ?>
-					<span><?php // TODO: Add Job title ?></span>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) ) : ?>

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -50,6 +50,16 @@ function newspack_scott_custom_colors_css() {
 			border-color: ' . esc_html( $primary_color ) . ';
 		}
 
+		.mobile-sidebar .article-section-title,
+		.mobile-sidebar .accent-header {
+			color: ' . esc_html( $primary_color_contrast ) . ';
+		}
+
+		.mobile-sidebar .article-section-title::before,
+		.mobile-sidebar .accent-header::before {
+			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+		}
+
 		@media only screen and (min-width: 782px) {
 			/* Header default background */
 			.h-db .featured-image-beside .cat-links:before {
@@ -97,6 +107,11 @@ function newspack_scott_custom_colors_css() {
 			#colophon .footer-branding .wrapper,
 			#colophon .footer-widgets:first-child {
 				border: 0;
+			}
+
+			.site-footer .accent-header::before,
+			.site-footer .article-section-title::before {
+				background-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
 			}
 		';
 	}

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -57,7 +57,7 @@ function newspack_scott_custom_colors_css() {
 
 		.mobile-sidebar .article-section-title::before,
 		.mobile-sidebar .accent-header::before {
-			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
 		}
 
 		@media only screen and (min-width: 782px) {

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -286,9 +286,17 @@ div.wpnbha .article-section-title {
 }
 
 // Archive
-
 .archive .page-title {
 	color: $color__text-light;
+}
+
+// Widgets
+.mobile-sidebar,
+.site-footer {
+	.article-section-title,
+	.accent-header {
+		color: inherit;
+	}
 }
 
 /* Footer */

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -72,7 +72,9 @@ function newspack_custom_colors_css() {
 			/* Set primary color that contrasts against white */
 			.more-link:hover,
 			.nav1 .main-menu > li > a + svg,
-			.search-form button:active, .search-form button:hover, .search-form button:focus,
+			form.search-form button:active,
+			form.search-form button:hover,
+			form.search-form button:focus,
 			.entry-footer a,
 			.comment .comment-metadata > a:hover,
 			.comment .comment-metadata .comment-edit-link:hover,
@@ -323,6 +325,11 @@ function newspack_custom_colors_css() {
 				.mobile-sidebar .nav3 .menu-highlight a {
 					background: ' . esc_html( newspack_adjust_brightness( $primary_color, -20 ) ) . ';
 				}
+				.mobile-sidebar .accent-header,
+				.mobile-sidebar .article-section-title {
+					border-color: ' . newspack_adjust_brightness( $header_color, -20 ) . ';
+					color: ' . esc_html( $header_color_contrast ) . ';
+				}
 				.cat-links a,
 				.cat-links a:visited,
 				.site-header .nav3 .menu-highlight a {
@@ -360,6 +367,16 @@ function newspack_custom_colors_css() {
 					.site-footer .footer-branding .wrapper,
 					.site-footer .footer-widgets:first-child .wrapper {
 						border-top: 0;
+					}
+
+					.site-footer .accent-header,
+					.site-footer .article-section-title {
+						border-color: ' . newspack_adjust_brightness( $footer_color, -20 ) . ';
+					}
+
+					.site-footer .accent-header,
+					.site-footer .article-section-title {
+						color: ' . esc_html( $footer_color_contrast ) . ';
 					}
 				';
 			}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -220,21 +220,24 @@ p.has-background {
 	}
 }
 
-.widget .wpnbha {
-	.entry-meta,
-	.entry-meta a,
-	.entry-meta a:visited,
-	.entry-meta a:hover {
-		color: inherit;
-	}
-}
-
 .mobile-sidebar,
 .desktop-sidebar,
 .subpage-sidebar {
 	@include media( desktop ) {
 		.wpnbha.image-alignbehind .post-has-image .entry-wrapper {
 			padding: 1.5em 1em;
+		}
+	}
+}
+
+.mobile-sidebar,
+.site-footer {
+	.wpnbha {
+		.entry-meta,
+		.entry-meta a,
+		.entry-meta a:visited,
+		.entry-meta a:hover {
+			color: inherit;
 		}
 	}
 }

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -227,6 +227,12 @@ p.has-background {
 	.entry-meta a:hover {
 		color: inherit;
 	}
+
+	@include media( desktop ) {
+		&.image-alignbehind .post-has-image .entry-wrapper {
+			padding: 1.5em 1em;
+		}
+	}
 }
 
 //! Newspack Carousel Block

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -227,9 +227,13 @@ p.has-background {
 	.entry-meta a:hover {
 		color: inherit;
 	}
+}
 
+.mobile-sidebar,
+.desktop-sidebar,
+.subpage-sidebar {
 	@include media( desktop ) {
-		&.image-alignbehind .post-has-image .entry-wrapper {
+		.wpnbha.image-alignbehind .post-has-image .entry-wrapper {
 			padding: 1.5em 1em;
 		}
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -220,6 +220,15 @@ p.has-background {
 	}
 }
 
+.widget .wpnbha {
+	.entry-meta,
+	.entry-meta a,
+	.entry-meta a:visited,
+	.entry-meta a:hover {
+		color: inherit;
+	}
+}
+
 //! Newspack Carousel Block
 .wp-block-newspack-blocks-carousel {
 	h3 a,

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -142,19 +142,23 @@
 .mobile-sidebar,
 .desktop-sidebar,
 .subpage-sidebar {
-	font-size: $font__size-sm;
 	padding: $size__spacing-unit;
 	width: 90vw;
 
 	> * {
 		clear: both;
-		margin-bottom: $size__spacing-unit;
+		margin-bottom: #{0.75 * $size__spacing-unit};
+	}
+
+	nav,
+	.widget:not( .widget_block ) {
+		font-size: $font__size-sm;
 	}
 
 	.mobile-menu-toggle,
 	.desktop-menu-toggle,
 	.subpage-toggle {
-		font-size: 1em;
+		font-size: $font__size-sm;
 		float: right;
 		margin: 0 0 $size__spacing-unit;
 		padding: 0;
@@ -177,6 +181,10 @@
 	a:hover {
 		background: transparent;
 		text-decoration: underline;
+	}
+
+	.social-links-menu li a {
+		display: block;
 	}
 
 	.widget-title {

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -160,10 +160,8 @@
 		padding: 0;
 	}
 
-	nav ul,
-	nav li,
-	.widget_nav_menu ul,
-	.widget_nav_menu li {
+	ul,
+	li {
 		list-style: none;
 		margin: 0;
 		padding: 0;

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -160,14 +160,17 @@
 		padding: 0;
 	}
 
-	ul,
-	li {
+	nav ul,
+	nav li,
+	.widget_nav_menu ul,
+	.widget_nav_menu li {
 		list-style: none;
 		margin: 0;
 		padding: 0;
 	}
 
-	a {
+	nav a,
+	.widget_nav_menu a {
 		display: inline-block;
 		margin: #{0.125 * $size__spacing-unit} 0;
 		padding: #{0.125 * $size__spacing-unit} #{0.25 * $size__spacing-unit};

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -168,12 +168,12 @@
 		}
 
 		a {
+			display: inline;
 			margin: 0;
 		}
 
 		@include media( mobile ) {
-			ul,
-			li a {
+			ul {
 				display: inline;
 			}
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -1,6 +1,5 @@
 .widget {
 	font-family: $font__heading;
-	font-size: $font__size-sm;
 	margin: 0 0 $size__spacing-unit;
 	word-wrap: break-word;
 
@@ -22,6 +21,10 @@
 			color: $color__primary-variation;
 		}
 	}
+}
+
+.widget:not( .widget_block ) {
+	font-size: $font__size-sm;
 }
 
 .widget_archive,

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -47,7 +47,6 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 						<div>
 							<h2 class="accent-header">
 								<?php echo esc_html( esc_html( $author->display_name ) ); ?>
-								<span><?php // TODO: Add Job title ?></span>
 							</h2>
 
 							<?php if ( ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -112,7 +111,6 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			<div>
 				<h2 class="accent-header">
 					<?php echo esc_html( get_the_author() ); ?>
-					<span><?php // TODO: Add Job title ?></span>
 				</h2>
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
 					<div class="author-meta">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is in advance of the Homepage Posts block being able to be added to widget areas in WordPress 5.8. It's to help make sure there are no major visual issues. 

Unfortunately this will be a tedious one to test, since it involves checking the different themes, with different custom colour settings. Apologies in advance, and please let me know if there's anything I can do to make testing this easier (like setting up the PR on a Jurassic Ninja site, to save some steps). 

See #1372

### How to test the changes in this Pull Request:

1. Start with a test site running the latest WordPress 5.8 release candidate, and the Newspack Default theme.
2. Navigate to Widgets > Appearance and add the following blocks Sidebar and Slide-out Sidebar widget areas:
    * Homepage Posts block - default settings, with the "Section Header" filled out
    * Homepage Posts block - image behind
    * Homepage Posts block - image beside
    * Add a Header block, and give it the CSS class `accent-header`. 
    * Add at least one Navigation Menu Widget (under 'Legacy widgets'), and assign a menu.
3. Navigate to the Customizer, and set the following settings:
     * Under Header > Slide-out Sidebar, turn on and check the option to show the widgets in the mobile menu.
     * Under Header > Subpage Header and enable the subpage header.
     * Change the colour palette away from the default, and pick some custom fonts. 
     * Assign menus to the primary, secondary, tertiary and social locations.
4. View the footer widget area, slide-out sidebar, subpage sidebar and mobile menu; note the appearance of existing things, like the menus; also note the appearance of the Homepage Posts block - 


<details>
<summary><strong>Slide-out Sidebar</strong></summary>

### Navigation Menu widget 
* displaying correctly

![image](https://user-images.githubusercontent.com/177561/124670489-e8e1a880-de68-11eb-92b5-4150b9f98f09.png)

### Homepage posts 
* fonts are very small

![image](https://user-images.githubusercontent.com/177561/124670465-e0896d80-de68-11eb-8a29-18d0d3b78981.png)

* image behind doesn't fill space, and there's almost a padding around the edge

![image](https://user-images.githubusercontent.com/177561/124670435-d7000580-de68-11eb-8362-999cbcd2dc2d.png)

</details>

<details>
<summary><strong>Mobile menu</strong></summary>

### Regular menus (Tertiary, primary, secondary, social)
* Displaying correctly

![image](https://user-images.githubusercontent.com/177561/124670273-97391e00-de68-11eb-86fc-0f5e31e1bbb7.png)

### Homepage Posts block 
* header, byline invisible; entry date hard to read against dark background

![image](https://user-images.githubusercontent.com/177561/124670316-a750fd80-de68-11eb-9261-ff7253a88dd4.png)

* image behind - padding around the image

![image](https://user-images.githubusercontent.com/177561/124670358-b9cb3700-de68-11eb-8f08-7d27cae225a0.png)
</details>

<details>
<summary><strong>Subpage slide-out menu</strong></summary>

### Regular menus
* There's an existing display issue with the Tertiary Menu that is filed here: #1406; otherwise it's displaying as expected.

![image](https://user-images.githubusercontent.com/177561/124671130-e6cc1980-de69-11eb-9ec8-8640c893ee1a.png)

### Homepage Posts
* fonts are very small
![image](https://user-images.githubusercontent.com/177561/124671182-f9465300-de69-11eb-825d-8a330639ee31.png)

* image-behind doesn't fill the available space: 
![image](https://user-images.githubusercontent.com/177561/124671214-0400e800-de6a-11eb-83cf-9905c2f01240.png)

### Navigation Widget

* displaying correctly 

![image](https://user-images.githubusercontent.com/177561/124671354-33175980-de6a-11eb-90a5-6d563da087ae.png)
</details>

<details>
<summary><strong>Footer widget area</strong></summary>

### Homepage Posts block
* fonts are very small

![image](https://user-images.githubusercontent.com/177561/124671467-5e9a4400-de6a-11eb-860e-6f591563d3ed.png)
</details>

<details>
<summary><strong>Above Copyright widget area</strong></summary>

Overall, this is a terrible location for anything but text or image widgets, but we should fix the worst of the visual issues with the homepage posts block.

### Homepage posts block

* Byline wraps to seperate line
* When image is set to behind, it doesn't fill the available space
![image](https://user-images.githubusercontent.com/177561/124671719-c2247180-de6a-11eb-9264-e42c2caac2ad.png)
</details>

5. Apply the PR and run `npm run build`.
6. Re-review the above widget areas; confirm the issues are fixed with the Homepage Posts block, but without affecting things like spacing or font sizes on the existing elements, like menus and Navigation widgets.

<details>
<summary><strong>Slide-out Sidebar</strong></summary>

### Navigation Menu widget 

### Homepage posts 
* Fonts are a bit larger

![image](https://user-images.githubusercontent.com/177561/124672410-dc128400-de6b-11eb-9f8e-6dc7c8cbcd25.png)

* image behind option fills the available space
![image](https://user-images.githubusercontent.com/177561/124672442-e6348280-de6b-11eb-81e4-47ecbf05afa9.png)

</details>

<details>
<summary><strong>Mobile menu</strong></summary>

### Homepage Posts block 
* Contrast issues are fixed against dark backgrounds:

![image](https://user-images.githubusercontent.com/177561/124672561-15e38a80-de6c-11eb-8da3-cf8ae5d8867d.png)

* When you switch the primary colour to a lighter colour, the contrast is still good: 
![image](https://user-images.githubusercontent.com/177561/124672719-5cd18000-de6c-11eb-9642-1c6c3084efe9.png)

* with the image behind setting, the image now fills the available space
</details>

<details>
<summary><strong>Subpage slide-out menu</strong></summary>

### Homepage Posts
* fonts are a more standard size

![image](https://user-images.githubusercontent.com/177561/124673413-a5d60400-de6d-11eb-9cf7-3c2fb0321cfa.png)

* with the image behind setting, the image now fills the available space

</details>

<details>
<summary><strong>Footer widget area</strong></summary>

### Homepage Posts block
* fonts are more representative to what they're set to in the block, and the image behind issues are gone:
![image](https://user-images.githubusercontent.com/177561/124673618-09603180-de6e-11eb-902c-7761d2ae7001.png)

If you set the footer background to different colours, the Homepage Posts block also remains legible:

![image](https://user-images.githubusercontent.com/177561/124673708-39a7d000-de6e-11eb-8f58-0181ceb389de.png)

... and it also should work well with a lighter colour:

![image](https://user-images.githubusercontent.com/177561/124673761-50e6bd80-de6e-11eb-89f0-f02d7bc5a42d.png)

</details>

<details>
<summary><strong>Above Copyright widget area</strong></summary>

### Homepage posts block
* byline, image behind issues are resolved: 
![image](https://user-images.githubusercontent.com/177561/124673795-5f34d980-de6e-11eb-9f8d-09418083f51a.png)

</details>

7. Switch to Newspack Joseph; double check that the homepage posts block header is picking up the correct border colour (the line next to the header should be the same colour).

<details>
<summary><strong>Newspack Joseph screenshots</strong></summary>

![image](https://user-images.githubusercontent.com/177561/124674227-2f3a0600-de6f-11eb-9aba-3e427624e53f.png)

![image](https://user-images.githubusercontent.com/177561/124674242-352fe700-de6f-11eb-9b82-f3720223abb7.png)

</details>

8. Switch to Newspack Katharine; double-check that the accent header is picking up the correct colour in different cases (the primary colour when against a white background; has sufficient contrast against a coloured background). 

<details>
<summary><strong>Newspack Katharine screenshots</strong></summary>
Slide-out sidebar - accent header should use the primary colour if it can; if the primary colour is really light the text should be grey:

![image](https://user-images.githubusercontent.com/177561/124674395-7fb16380-de6f-11eb-99a8-935fdaff50b0.png)

![image](https://user-images.githubusercontent.com/177561/124674480-b0919880-de6f-11eb-9ffc-14c58433871c.png)

Mobile and footer - accent header should contrast against dark backgrounds; the rectangle above should be darker than the background:

Mobile:
![image](https://user-images.githubusercontent.com/177561/124674938-8db3b400-de70-11eb-95c8-76300de8cbf9.png)
![image](https://user-images.githubusercontent.com/177561/124674595-e8004500-de6f-11eb-9709-f70d485ba1d0.png)

Footer:
![image](https://user-images.githubusercontent.com/177561/124674428-8d66e900-de6f-11eb-9884-cedf4db0f1cb.png)
![image](https://user-images.githubusercontent.com/177561/124674622-f0f11680-de6f-11eb-9a6e-bbf7c5ce1737.png)
</details>

9. Switch to Newspack Nelson; confirm that the accent header has sufficient contrast against the different backgrounds. 

<details>
<summary><strong>Newspack Nelson screenshots</strong></summary>

Slide-out sidebar:

![image](https://user-images.githubusercontent.com/177561/124675562-bb4d2d00-de71-11eb-8422-47a9810b5f92.png)

Mobile: 

![image](https://user-images.githubusercontent.com/177561/124675585-c56f2b80-de71-11eb-9103-501968e70d71.png)

![image](https://user-images.githubusercontent.com/177561/124675718-01a28c00-de72-11eb-950d-058991902814.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/124675730-08c99a00-de72-11eb-81c1-b7688277d046.png)

![image](https://user-images.githubusercontent.com/177561/124675604-cf912a00-de71-11eb-8772-f0e46e75b434.png)

</details>

10. Switch to Newspack Sacha and confirm that the accent headers use the primary colour when in the slide-out sidebar, and have sufficient contrast when in the mobile menu and footer.

<details><summary><strong>Newspack Sacha screenshots</strong></summary>

Slide-out sidebar:

![image](https://user-images.githubusercontent.com/177561/124678412-4f6dc300-de77-11eb-8ff3-b1d23eb043ab.png)

Mobile menu:

![image](https://user-images.githubusercontent.com/177561/124678526-8e9c1400-de77-11eb-9fdb-e754940ba981.png)

![image](https://user-images.githubusercontent.com/177561/124678429-58f72b00-de77-11eb-9a54-ae90b45abd50.png)

Footer:

![image](https://user-images.githubusercontent.com/177561/124678454-614f6600-de77-11eb-8180-cbe595a63798.png)

![image](https://user-images.githubusercontent.com/177561/124678515-87750600-de77-11eb-886e-2739a1c6239d.png)

</details>

11. Switch to Newspack Scott and confirm the accent headers use the right styles; in the slide-out sidebar, the little block should pick up the primary colour. In the mobile menu and footer, it should use a darker colour than the background.

<details>
<summary><strong>Newspack Scott screenshots</strong></summary>

Slide-out sidebar:

![image](https://user-images.githubusercontent.com/177561/124678893-521ce800-de78-11eb-854d-71856f92a95b.png)

Mobile menu:
![image](https://user-images.githubusercontent.com/177561/124679293-facb4780-de78-11eb-8814-1f60ea3bff59.png)
![image](https://user-images.githubusercontent.com/177561/124679433-39610200-de79-11eb-9a13-06f7949ec89e.png)

Footer:
![image](https://user-images.githubusercontent.com/177561/124679271-f43cd000-de78-11eb-82bc-3e894ea20e87.png)
![image](https://user-images.githubusercontent.com/177561/124679419-31a15d80-de79-11eb-9928-f6fd5cafc3be.png)

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
