### PR TITLE
Add option to change the footer layout

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1100,6 +1100,28 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to toggle off the default footer layout.
+	$wp_customize->add_setting(
+		'footer_widget_layout',
+		array(
+			'default'           => 'columns',
+			'sanitize_callback' => 'newspack_sanitize_radio',
+		)
+	);
+	$wp_customize->add_control(
+		'footer_widget_layout',
+		array(
+			'type'        => 'radio',
+			'label'       => esc_html__( 'Footer widget layout', 'newspack' ),
+			'description' => esc_html__( 'Stack the footer widgets, or have them automatically divide into even columns.', 'newspack' ),
+			'choices'     => array(
+				'columns' => esc_html__( 'Columns', 'newspack' ),
+				'stacked' => esc_html__( 'Stacked', 'newspack' ),
+			),
+			'section'     => 'footer_options',
+		)
+	);
+
 	// Add option to collapse the comments.
 	$wp_customize->add_setting(
 		'footer_copyright',

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1112,7 +1112,7 @@ function newspack_customize_register( $wp_customize ) {
 		'footer_widget_layout',
 		array(
 			'type'        => 'radio',
-			'label'       => esc_html__( 'Footer widget layout', 'newspack' ),
+			'label'       => esc_html__( 'Footer Widget Layout', 'newspack' ),
 			'description' => esc_html__( 'Stack the footer widgets, or have them automatically divide into even columns.', 'newspack' ),
 			'choices'     => array(
 				'columns' => esc_html__( 'Columns', 'newspack' ),

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -200,6 +200,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'footer-logo-' . esc_attr( $footer_logo_size );
 	}
 
+	// Add a class for the footer widget layout.
+	$footer_widget_layout = get_theme_mod( 'footer_widget_layout', 'columns' );
+	if ( 'stacked' === $footer_widget_layout ) {
+		$classes[] = 'fw-stacked';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -41,6 +41,11 @@
 	}
 }
 
+/* When the Customizer option is enabled, override the footer columns layout */
+.fw-stacked .footer-widgets .wrapper {
+	display: block;
+}
+
 .footer-branding {
 	.wrapper {
 		padding-top: $size__spacing-unit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, the Newspack theme uses flexbox for the footer widgets, dividing them into up to four columns automatically.

With WordPress 5.8's widget blocks, this isn't a necessary tool for layouts -- the columns block is available, on top of other blocks that you may want to stack or have behave a different way than the default.

One work around is to wrap everything in the widget area in a single block, like a group or column block. Since that might be a bit unintuitive -- and a bit fragile, since you always have to remember to add new widgets inside of that containing block -- I've also added a toggle to the Customizer so the column behaviour can be 'turned off'. 

The CSS it uses is a bit clunky - it adds a class when you chose to stack the columns, and then uses that to override the flexbox styles. This is to avoid introducing more specific styles to create the current layout, since some Newspack sites already use Custom CSS to override that, and I don't want to break those sites. 

Closes #1393.

### How to test the changes in this Pull Request:

1. Add 2-4 widgets to the footer area; note that they sort into columns.
2. Navigate to Customizer > Footer Settings, and confirm there is now two radio options for the Footer layouts, either Columns (default) or Stacked. (I went with radio buttons instead of a single checkbox option, on the off-off-off chance we need to add a third layout down the road). 

![image](https://user-images.githubusercontent.com/177561/125356671-60a54c80-e31b-11eb-956f-3d6c72e343dd.png)

3. Switch the Footer Layout to 'Stacked'. 
4. Confirm the widgets are now stacked on top of one another, and take up the full content width (1200px) of the widget area. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
