### PR TITLE
Post Carousel: Adjust styles when used in certain widget areas

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -254,6 +254,66 @@ p.has-background {
 	}
 }
 
+#secondary,
+.desktop-sidebar,
+.mobile-sidebar,
+.subpage-sidebar {
+	.wp-block-newspack-blocks-carousel {
+		article {
+			.entry-title {
+				font-size: 0.9rem;
+			}
+			.entry-meta {
+				font-size: $font__size-xs;
+			}
+			.entry-wrapper {
+				padding: 20px 36px;
+			}
+			.avatar {
+				height: 30px;
+				width: 30px;
+			}
+		}
+
+		.swiper-button,
+		.amp-carousel-button,
+		.wp-block-newspack-carousel__amp-carousel button {
+			width: 24px;
+			height: 24px;
+		}
+
+		.amp-carousel-button-next,
+		.swiper-button-next,
+		.amp-carousel-button-prev,
+		.swiper-button-prev,
+		.amp-carousel-button-pause,
+		.amp-carousel-button-play {
+			background-size: 20px 20px;
+		}
+
+		.amp-carousel-button-next,
+		.swiper-button-next,
+		.amp-carousel-button-pause,
+		.amp-carousel-button-play {
+			right: 4px;
+		}
+
+		.amp-carousel-button-pause,
+		.amp-carousel-button-play {
+			top: 4px;
+		}
+
+		.amp-carousel-button-prev,
+		.swiper-button-prev {
+			left: 4px;
+		}
+
+		.swiper-pagination-bullets {
+			height: 1em;
+		}
+	}
+}
+
 //! Newspack Donate Block
 #secondary,
 .desktop-sidebar,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -307,10 +307,6 @@ p.has-background {
 		.swiper-button-prev {
 			left: 4px;
 		}
-
-		.swiper-pagination-bullets {
-			height: 1em;
-		}
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -319,7 +319,7 @@
 	z-index: 999999;
 
 	> * {
-		display: none;
+		visibility: hidden;
 	}
 }
 
@@ -352,13 +352,7 @@
 .desktop-menu-opened #desktop-sidebar-fallback,
 .subpage-menu-opened #subpage-sidebar-fallback {
 	> * {
-		display: block;
-	}
-
-	> .desktop-menu-toggle,
-	> .mobile-menu-toggle,
-	> .subpage-toggle {
-		display: flex;
+		visibility: visible;
 	}
 }
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -1,5 +1,6 @@
 .widget {
 	font-family: $font__heading;
+	font-size: $font__size-sm;
 	margin: 0 0 $size__spacing-unit;
 	word-wrap: break-word;
 
@@ -21,10 +22,6 @@
 			color: $color__primary-variation;
 		}
 	}
-}
-
-.widget:not( .widget_block ) {
-	font-size: $font__size-sm;
 }
 
 .widget_archive,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adjusts the font sizing, padding and navigation size of the post carousel controls when it's used in the narrower widget spaces (sidebar, slide out sidebar, and in the mobile menu).

It also updates how we prevent the hidden fallback slide out menus from being tabbed into (`visibility: hidden` when they were originally `display: none`) -- this makes sure the hidden post carousel actually gets initialized when AMP is disabled. 

See #1372.

Note: this should be tested after #1407 because it kind of relies on the font size and link spacing fixes from that PR. 

### How to test the changes in this Pull Request:

1. Add the post carousel block to the sidebar and slide-out sidebar widget areas, and set the slide-out sidebar widgets to display in the mobile menu.
2. View on the front-end; note how the carousel is somewhat crowded, and the controls can overlap the text:

![image](https://user-images.githubusercontent.com/177561/125371481-aec74980-e335-11eb-94b5-8d663e92dc3a.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the spacing is improved:

![image](https://user-images.githubusercontent.com/177561/125371417-8b9c9a00-e335-11eb-8264-f028fe3040be.png)

5. Disable AMP.
6. Confirm that the post carousel still works in the hidden widget areas. 
7. Try to tab through the page and confirm that, when the slide-out sidebar isn't open, you can't accidentally tab into the links there. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
