### PR TITLE
Widgets: Remove link from Slide-out Sidebar description

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -295,11 +295,7 @@ function newspack_widgets_init() {
 		array(
 			'name'          => __( 'Slide-out Sidebar', 'newspack' ),
 			'id'            => 'header-1',
-			'description'   => sprintf(
-				/* translators: %s: link to Header Settings panel in Customizer. */
-				__( 'Add widgets here to appear in an off-screen sidebar when it is enabled under %s.', 'newspack' ),
-				'<a rel="goto-control" href="#header_show_slideout">' . __( 'Header Settings', 'newspack' ) . '</a>'
-			),
+			'description'   => esc_html__( 'Add widgets here to appear in an off-screen sidebar when it is enabled under Header Settings > Slide-out Sidebar.', 'newspack' ),
 			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -295,7 +295,7 @@ function newspack_widgets_init() {
 		array(
 			'name'          => __( 'Slide-out Sidebar', 'newspack' ),
 			'id'            => 'header-1',
-			'description'   => esc_html__( 'Add widgets here to appear in an off-screen sidebar when it is enabled under Header Settings > Slide-out Sidebar.', 'newspack' ),
+			'description'   => esc_html__( 'Add widgets here to appear in an off-screen sidebar when it is enabled under the Customizer Header Settings.', 'newspack' ),
 			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
 			'after_widget'  => '</section>',
 			'before_title'  => '<h2 class="widget-title">',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When the Slide-out sidebar was originally added, both the Header Settings panel and Widget area had links to each other in their descriptions, to make it easier to hop between the two in the Customizer. 

The widget descriptions are also shown on the Widget screen; with WP 5.8, we'll be directing more traffic there, so it's not great that there's an escaped link visible. On top of that, the widget descriptions are no longer visible in the Customizer, so the link is no longer useful.

This PR removes the link from the Slide-out sidebar widget description.

Closes #1403 

### How to test the changes in this Pull Request:

1. On a test site running the latest WordPress 5.8 RC, navigate to WP Admin > Appearance > Widgets. 
2. Add a widget to a widget area, and click the 'Move' button in that widget's toolbar (the squiggly arrow). Note the HTML visible in the slide-out sidebar widget's description:

![image](https://user-images.githubusercontent.com/177561/125671336-1d98f806-d76a-4cab-841d-ab9b40abadcd.png)

3. Apply the PR.
4. Confirm that the HTML is now gone:

![image](https://user-images.githubusercontent.com/177561/125671400-0481a602-d298-4cd5-a84a-02d0c4b18db9.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
