### PR TITLE
Add support for custom spacing

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -252,6 +252,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
+		// Add block custom spacing support.
+		add_theme_support( 'custom-spacing' );
+
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for Gutenberg's 'custom spacing', which will add an option to manually add padding or spacing around on a per block basis to blocks which have added support for spacing. 

In Core, these blocks include:

* Column
* Group
* Cover
* Verse
* Site Tagline (5.8+)
* Site Title (5.8+)
* Template Part (5.8+ - but won't appear in a site running the theme, since we need to opt-in to see it)

In WP 5.8, at least one of the example Query Loop patterns includes padding on a Group block, so without this control visible in the theme, it's not possible to remove that padding (without flipping to the code editor and picking the padding out of the block that way... not great). The option should work in 5.7.2 though. 

This control will be helpful for one-off block adjusting, but we should discourage publishers from using this to control padding _everywhere_ -- like, if they always want the column block to have more spacing site wide, or always want the group block with a background to have less, it's much better for us to add it to their Custom CSS. Otherwise, all of the lines of inline styles really add to the CSS page load, and can make it hit the AMP limit prematurely. 

Closes #1391

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Try adding each of the above blocks; and confirm a section labelled 'Spacing' appears on the right when you select each block. (Note: some blocks are 5.8 specific but they're also not ones that are really useful outside of FSE).

![image](https://user-images.githubusercontent.com/177561/125694384-0466b4ca-386e-4f37-b963-b6617c43f02b.png)

3. Try adjusting the block's padding; you should have the option to add padding evenly to all four sides by entering a pixel amount in the text field, or you can click the link icon to get fields for each the top right bottom and left.
4. Publish your post; confirm your changes appear on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
