### PR TITLE
feat: add support for custom units

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -252,6 +252,9 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			)
 		);
 
+		// Add block custom unit support.
+		add_theme_support( 'custom-units', 'px', 'rem', 'em' );
+
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for custom units in the Newspack theme for Gutenberg's block controls. 

By default the theme only uses px for font sizing, and the 'spacing' option to be added [in this PR](https://github.com/Automattic/newspack-theme/pull/1416). This change will make `em` and `rem` also available. Ideally it will be tested after #1416 is merged. 

See #1391

### How to test the changes in this Pull Request:

1. 
2. 
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
