### PR TITLE
Author Profile Block: reduce font sizing slightly in slide-out sidebars

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -84,7 +84,6 @@ function newspack_body_classes( $classes ) {
 	// Hide specific page title.
 	$page_id         = get_queried_object_id();
 	$page_hide_title = get_post_meta( $page_id, 'newspack_hide_page_title', true );
-
 	if ( $page_hide_title ) {
 		$classes[] = 'hide-page-title';
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -84,6 +84,7 @@ function newspack_body_classes( $classes ) {
 	// Hide specific page title.
 	$page_id         = get_queried_object_id();
 	$page_hide_title = get_post_meta( $page_id, 'newspack_hide_page_title', true );
+
 	if ( $page_hide_title ) {
 		$classes[] = 'hide-page-title';
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -221,16 +221,6 @@ p.has-background {
 }
 
 .mobile-sidebar,
-.desktop-sidebar,
-.subpage-sidebar {
-	@include media( desktop ) {
-		.wpnbha.image-alignbehind .post-has-image .entry-wrapper {
-			padding: 1.5em 1em;
-		}
-	}
-}
-
-.mobile-sidebar,
 .site-footer {
 	.wpnbha {
 		.entry-meta,
@@ -258,6 +248,7 @@ p.has-background {
 .desktop-sidebar,
 .mobile-sidebar,
 .subpage-sidebar {
+	//! Newspack Carousel Block
 	.wp-block-newspack-blocks-carousel {
 		article {
 			.entry-title {
@@ -308,12 +299,8 @@ p.has-background {
 			left: 4px;
 		}
 	}
-}
 
-//! Newspack Donate Block
-#secondary,
-.desktop-sidebar,
-.mobile-sidebar {
+	//! Newspack Donate Block
 	.wpbnbd.tiered .tiers {
 		margin-left: #{0.62 * $size__spacing-unit};
 		margin-right: #{0.62 * $size__spacing-unit};
@@ -328,6 +315,15 @@ p.has-background {
 .site-info .widget .wpbnbd {
 	.thanks {
 		margin: 0.5rem 1.5rem;
+	}
+}
+
+.desktop-sidebar,
+.subpage-sidebar,
+.mobile-sidebar {
+	//! Newspack Profile block
+	.wp-block-newspack-blocks-author-profile {
+		font-size: $font__size-sm;
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -289,9 +289,14 @@
 	color: #fff;
 
 	a,
-	a:visited,
 	.nav1 .sub-menu > li > a {
 		color: #fff;
+	}
+
+	a:hover,
+	a:visited,
+	.widget a:hover {
+		color: inherit;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Though these are all kind of weird spots for the profile block, this PR adjusts the styles so they're a bit smaller when it's used in the slide-out sidebar or mobile menu locations. 

It also fixes a contrast issue in the mobile sidebar, and reorganized this and the other block-widget CSS a bit, to get rid of duplicate selectors.

Closes #1372 (it's the last of the four blocks tested there). 

### How to test the changes in this Pull Request:

1. On a site running 5.8 or the 5.8 RC Add the Profile Block to the slide-out sidebar, sidebar, and footer area; check the box to show the slide-out sidebar widgets on mobile.
2. View on the front-end; note the font size of the profile block is a bit big in the mobile and slide-out sidebars:

![image](https://user-images.githubusercontent.com/177561/126366649-09cc4459-26e6-44f3-a698-2677b73872fa.png)

![image](https://user-images.githubusercontent.com/177561/126366685-016a01b5-befd-49da-9b7d-013f2f1bb190.png)

3. Apply the PR and run `npm run build`.
4. Confirm the font size is a bit smaller in the mobile and slide-out sidebar. 

![image](https://user-images.githubusercontent.com/177561/126366514-6d3eb068-711f-462c-a0ea-513646ec5e86.png)

![image](https://user-images.githubusercontent.com/177561/126366573-6d5080be-685e-42da-ba3b-65a9ee104e8d.png)



5. Try changing the background colours of the mobile menu and footer, and confirm that the block has adequate contrast with light and dark backgrounds. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
