### PR TITLE
fix: add simple styles for the login block

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -188,6 +188,9 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout .wp-block.wp-block-post-terms,
 		.block-editor-block-list__layout .wp-block.wp-block-query-pagination,
 
+		/* Login/out Block */
+		.block-editor-block-list__layout .wp-block.wp-block-loginout,
+
 		/* Table Block */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table th, /* legacy */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-table td, /* legacy */

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -48,6 +48,7 @@ function newspack_custom_typography_css() {
 		.wp-block-post-date,
 		.wp-block-post-terms,
 		.wp-block-query-pagination,
+		.wp-block-loginout,
 		h1,
 		h2,
 		h3,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1024,6 +1024,13 @@ hr {
 	}
 }
 
+//! Login/logout block
+.wp-block-loginout {
+	label {
+		display: block;
+	}
+}
+
 //! Mailchimp block
 .wp-block-jetpack-mailchimp {
 	input[type='email'] {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -856,6 +856,16 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Login/out block === */
+.wp-block-loginout {
+	font-family: $font__heading;
+
+	label,
+	a {
+		font-size: $font__size-sm;
+	}
+}
+
 /** === Organic Profile Block === */
 .wp-block-organic-profile-block {
 	box-shadow: none;

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -156,7 +156,8 @@ h4 {
 .wp-block-post-date,
 .wp-block-post-terms,
 .wp-block-query-pagination,
-.wp-block-loginout,
+.wp-block-loginout label,
+.wp-block-loginout a,
 .comment-content,
 h5 {
 	font-size: $font__size-sm;

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -47,6 +47,7 @@ ul.products .added_to_cart,
 .wp-block-post-date,
 .wp-block-post-terms,
 .wp-block-query-pagination,
+.wp-block-loginout,
 h1,
 h2,
 h3,
@@ -155,6 +156,7 @@ h4 {
 .wp-block-post-date,
 .wp-block-post-terms,
 .wp-block-query-pagination,
+.wp-block-loginout,
 .comment-content,
 h5 {
 	font-size: $font__size-sm;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some simple styles to the new Login/Logout block. 

The form outputs the same text as the /wp-login.php screen; since the labels can't be edited and shortened, I opted to style the form similar to how it appears on the /wp-login.php screen, with the labels stacked on top of the inputs. (In the content area, it would normally look better with them side by side, to take up more horizontal space, but the label widths are really different!). 

Closes #1374 (last item to fix in that ticket!)

### How to test the changes in this Pull Request:

1. Add the Login block to a page; in the sidebar, check the option labelled "Display login as form".
2. Apply the PR and run `npm run build`.
3. View on the front-end when not logged in; confirm that the block is picking up the header fonts, and button styles:

![image](https://user-images.githubusercontent.com/177561/126371927-d8ed3aee-6586-4d5d-b841-637b63b4f8cd.png)

4. In the editor and when logged in, confirm that you have a simple text link:

![image](https://user-images.githubusercontent.com/177561/126372003-de072e66-da23-46a9-b258-9374a0c5baec.png)

5. If you're not already using a custom typography option, try changing the custom fonts and make sure the block is picking them up. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
