### PR TITLE
fix: replace widget spacing for standard content spacing for blocks

### DIFF
--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -216,6 +216,12 @@
 		&:last-child {
 			margin-bottom: #{1.5 * $size__spacing-unit};
 		}
+
+		&.widget_block {
+			border-top: 0;
+			margin-bottom: 32px;
+			padding-top: 0;
+		}
 	}
 
 	.widget-title {
@@ -253,6 +259,12 @@
 	nav + .widget,
 	.widget + .widget {
 		padding-top: $size__spacing-unit;
+	}
+
+	nav + .widget_block,
+	.widget + .widget_block {
+		border-top: 0;
+		padding-top: 0;
 	}
 
 	.submenu-expand {

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -6,6 +6,10 @@
 
 	@include media( tablet ) {
 		margin: 0 0 #{$size__spacing-unit * 3};
+
+		&.widget_block {
+			margin: 0 0 32px;
+		}
 	}
 
 	&:last-child {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, widgets have 3rem spacing under them on desktop-sized screens. When they appear in the slide out or mobile sidebars, they also have borders between them. Though this works well with the standard widgets, which are more stand-alone elements, it starts to look weird when you mix in blocks, especially when they should be kind of together (like having a Heading block then a Paragraph block).

This PR makes the margin 32px between widget blocks, and keeps the default spacing for regular widgets. It also removes the borders; if needed, they can be recreated using the separator block.

Closes #1392

### How to test the changes in this Pull Request:

1. Add some blocks and at least one legacy widget to the sidebar widget area and slide-out sidebar; make sure the latter shows up on mobile.
2. View on the front-end; note the spacing, and in the sidebar, the borders:

Slide-out sidebar: 
![image](https://user-images.githubusercontent.com/177561/126402580-168045a3-4732-4639-846a-34d9816b2135.png)

Mobile menu: 
![image](https://user-images.githubusercontent.com/177561/126402613-0a60a679-645f-4310-9fee-48fe2e331474.png)

Sidebar: 
![image](https://user-images.githubusercontent.com/177561/126402554-03d701d9-734a-4cc2-b946-7704bd5ee62f.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the block widgets are now closer together and don't have the borders, but the legacy widgets still look the same (spacing; borders in the slide-out, mobile menus). 

Slide-out Sidebar:
![image](https://user-images.githubusercontent.com/177561/126392911-701cccf9-14d9-4d71-9489-489d79700d35.png)

Mobile menu:
![image](https://user-images.githubusercontent.com/177561/126392944-f0ecb858-4d38-49bd-9b40-958ac317a2af.png)

Sidebar:
![image](https://user-images.githubusercontent.com/177561/126402474-a8bb40ac-c027-4599-9f54-06d2f4b343de.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
