### PR TITLE
Search block: improve appearance

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -484,12 +484,14 @@ function newspack_custom_colors_css() {
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button, /* legacy */
 		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-file .wp-block-file__button,
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
 			color: ' . esc_html( $primary_color_contrast ) . ';
 		}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -54,6 +54,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color,
 			*[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 			.is-style-outline .wp-block-button__link.has-primary-background-color:not( :hover ),
+			.wp-block-search__button-outside .wp-block-search__button,
 			.wp-block-file .wp-block-file__button,
 			div.wpbnbd.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
 			.comment .comment-author .post-author-badge,
@@ -102,6 +103,7 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar a:visited,
 			.mobile-sidebar .nav1 .sub-menu > li > a,
 			.mobile-sidebar .nav1 ul.main-menu > li > a,
+			.wp-block-search__button-outside .wp-block-search__button,
 			.wp-block-file .wp-block-file__button,
 			.highlight-menu .menu-label,
 			/* Header default background; default height */

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -64,6 +64,7 @@ function newspack_custom_typography_css() {
 		input[type="button"],
 		input[type="reset"],
 		input[type="submit"],
+		.wp-block-search__button-outside .wp-block-search__button,
 
 		/* _blocks.scss */
 		.wp-block-button__link,

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -215,6 +215,9 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file, /* legacy */
 		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-file,
 
+		/* Search Block */
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search .wp-block-search__button,
+
 		/* Widget blocks */
 		.block-editor-block-list__layout .block-editor-block-list__block ul.wp-block-archives li,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-categories li, /* legacy */

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -983,6 +983,33 @@ hr {
 	}
 }
 
+//! Search
+.wp-block-search {
+	.search-icon {
+		height: 32px;
+		width: 32px;
+	}
+
+	.has-icon {
+		padding: #{0.25 * $size__spacing-unit} #{0.5 * $size__spacing-unit};
+	}
+
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper .wp-block-search__button {
+			padding: #{0.45 * $size__spacing-unit};
+
+			&.has-icon {
+				padding: #{0.15 * $size__spacing-unit} #{0.25 * $size__spacing-unit};
+			}
+		}
+
+		.has-icon {
+			background: transparent;
+			border: 0;
+		}
+	}
+}
+
 //! Code
 .wp-block-code {
 	border-radius: 0;

--- a/newspack-theme/sass/forms/_buttons.scss
+++ b/newspack-theme/sass/forms/_buttons.scss
@@ -2,7 +2,8 @@
 button,
 input[type='button'],
 input[type='reset'],
-input[type='submit'] {
+input[type='submit'],
+.wp-block-search__button-outside .wp-block-search__button {
 	@include button-transition;
 	background: $color__background-button;
 	border: none;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -604,6 +604,47 @@ figcaption,
 	padding: 0;
 }
 
+/** === Search === */
+
+.wp-block-search {
+	.wp-block-search__button {
+		border-radius: 5px;
+		line-height: 1.8;
+		font-family: $font__heading;
+		font-size: $font__size-sm;
+		font-weight: bold;
+		padding: ( 0.55 * $size__spacing-unit ) $size__spacing-unit !important; // !important to override style from Gutenberg.
+
+		svg {
+			height: 32px;
+			width: 32px;
+		}
+
+		&.has-icon {
+			padding: #{0.3 * $size__spacing-unit} #{0.5 * $size__spacing-unit} !important; // !important to override style from Gutenberg.
+		}
+	}
+
+	&.wp-block-search__button-outside .wp-block-search__button {
+		border: 0;
+	}
+
+	&.wp-block-search__button-inside {
+		.wp-block-search__inside-wrapper .wp-block-search__button {
+			padding: #{0.25 * $size__spacing-unit} #{0.5 * $size__spacing-unit} !important; // !important to override style from Gutenberg.
+
+			&.has-icon {
+				padding: #{0.125 * $size__spacing-unit} #{0.25 * $size__spacing-unit} !important; // !important to override style from Gutenberg.
+			}
+		}
+
+		.has-icon {
+			background: transparent;
+			border: 0;
+		}
+	}
+}
+
 /** === Code === */
 
 .wp-block-code {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the search block styles, to take advantage of the new options, get the button style matching the rest of the theme, and making it possible to nearly recreate how the old search widget used to look.

See #1373 

### How to test the changes in this Pull Request:

1. Add the search block to both the content area and a widget space; make sure to include the combos with a text button inside and outside of the search form, and an icon button inside and outside of the search form.
2. Note the appearance in the editor and on the front end: the button is light grey, and is picking up the body font rather than the correct header font in the editor:

![image](https://user-images.githubusercontent.com/177561/126413690-ec8325ac-2f06-40ab-aff5-a1bebf68aef0.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the search button is now picking up the custom colours and typography; when inside, the button should be grey, or have no background when it's just an icon. This last bit mimics how the search looks in the theme:

![image](https://user-images.githubusercontent.com/177561/126413525-a401ce59-5a5f-4c01-bec9-b994cba77ccd.png)

(Note: the preview in the customizer sidebar is not 1:1; I have some wider work to do to get the styles displaying there correctly, like #1409).

5. Try changing the custom colour to a light colour if it's dark, or a dark colour if it's light, and confirm that the button text contrast is correct.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
