### PR TITLE
Button block: fix outline style padding and colour

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -179,7 +179,8 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color,
 			*[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-color p,
 			.is-style-outline .wp-block-button__link.has-secondary-color:not(:hover), /* legacy styles */
-			.wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
+			.wp-block-button__link.is-style-outline.has-secondary-color:not(:hover),
+			.is-style-outline > .wp-block-button__link:not(.has-text-color):not(:hover) {
 				color:' . esc_html( $secondary_color ) . '; /* base: #666 */
 			}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -668,13 +668,18 @@ p.has-background {
 	@include button-all-transition;
 	border-width: 2px;
 	border-style: solid;
-	color: $color__background-button;
 	border-color: currentColor;
 	padding: calc( 0.76rem - 2px ) calc( 1rem - 2px );
 
 	&:not( .has-background ) {
 		background: transparent;
 	}
+}
+
+.is-style-outline .wp-block-button__link,
+.wp-block-button__link.is-style-outline,
+.is-style-outline > .wp-block-button__link:not( .has-text-color ) {
+	color: $color__background-button;
 }
 
 .wp-block-button {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -670,6 +670,7 @@ p.has-background {
 	border-style: solid;
 	color: $color__background-button;
 	border-color: currentColor;
+	padding: calc( 0.76rem - 2px ) calc( 1rem - 2px );
 
 	&:not( .has-background ) {
 		background: transparent;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the button block has consistent padding between the default and outline styles, and that it's picking up the correct default style; it looks like some styles may have been updated in 5.8 to make the padding look wrong, and the default colour not pick up the theme colours. 

See #1373.

### How to test the changes in this Pull Request:

1. Add the Buttons block to the content and widget areas; add two buttons to each, and make one outline style.
2. View on the front end - note the different vertical heights, and that the outline button is black on the front-end (even though it's picking up your secondary colour in the editor):

Content:
![image](https://user-images.githubusercontent.com/177561/126415038-8efa9df5-614d-45e2-bfb8-f81bdd4f4218.png)

Sidebar:
![image](https://user-images.githubusercontent.com/177561/126415054-e9f51e63-242c-4134-9c61-c346d8ee7b5c.png)

3. Apply PR and run `npm run build`.
4. Confirm that the two buttons appear to be the same height and that the outline button is picking up the secondary colour by default:

Content:
![image](https://user-images.githubusercontent.com/177561/126415795-6a36de98-40ef-4efe-913b-ca087bb7817f.png)

Sidebar:
![image](https://user-images.githubusercontent.com/177561/126415806-e65ceace-6fec-4c9b-bdff-4c57c0de7e4a.png)

5. Double-check that changing the outline button's text colour to a custom colour in the editor still works.
![image](https://user-images.githubusercontent.com/177561/126415817-54e8856b-fc01-4ab4-a2a6-d3111ecc9d88.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
