### PR TITLE
fix: make sure event archives don't pick up regular archive styles

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -190,7 +190,7 @@ function newspack_body_classes( $classes ) {
 
 	// Add a class when using the 'featured latest' archive layout.
 	$feature_latest_post = get_theme_mod( 'archive_feature_latest_post', true );
-	if ( is_archive() && true === $feature_latest_post ) {
+	if ( is_archive() && true === $feature_latest_post && ! is_post_type_archive( 'tribe_events' ) ) {
 		$classes[] = 'feature-latest';
 	}
 

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -76,7 +76,8 @@
 	}
 
 	@include media( tablet ) {
-		&:not( .paged ).feature-latest article.has-post-thumbnail:first-of-type {
+		&:not( .paged ):not( .post-type-archive-tribe_events ).feature-latest
+			article.has-post-thumbnail:first-of-type {
 			display: block;
 
 			.post-thumbnail {

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -76,8 +76,7 @@
 	}
 
 	@include media( tablet ) {
-		&:not( .paged ):not( .post-type-archive-tribe_events ).feature-latest
-			article.has-post-thumbnail:first-of-type {
+		&:not( .paged ).feature-latest article.has-post-thumbnail:first-of-type {
 			display: block;
 
 			.post-thumbnail {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some of the archive styles are a bit too specific, and are overriding styles coming from The Events Calendar v2 views. This PR makes sure the class driving the archive styles isn't applied to the Events archive pages.

Closes #1408

### How to test the changes in this Pull Request:
 
1. Set up the Events Calendar on a test site. If you already have it running, go to WP Admin > Events > Settings > Display tab and make sure `Enable updated designs for all calendar views` is checked (alternatively, you can go to the Upgrades tab and confirm it's not prompting you to upgrade your views).
2. Under Customize > Template Settings > Archive Settings, make sure "Use a large, featured display for the latest post in the archives" is checked.
3. Navigate to an archive page and note the first post's appearance -- it should have a large featured image:
![image](https://user-images.githubusercontent.com/177561/126540298-20139d71-1dd7-41fa-8312-4477c22942fc.png)

4. Now navigate to your Events page (by default, it's /events) and view your events in list view; the featured images should be aligned right, but they are stacked: 

![image](https://user-images.githubusercontent.com/177561/126540441-7e46e2eb-38be-49c5-81a6-6dd3babf1f5e.png)

5. Apply the PR.
6. Confirm your regular archive pages have not changed. 
7. Confirm your events landing page now has the images aligned right in the list view:

![image](https://user-images.githubusercontent.com/177561/126540550-275e3900-2768-4f7a-911c-8e1fed46aa7c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
