### PR TITLE
Get Custom Fonts loading with the Events Calendar new views

### DIFF
--- a/newspack-joseph/tribe-events/tribe-events.scss
+++ b/newspack-joseph/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-style/variables-style';
+
+// Import TEC baseline styles
+@import '../../newspack-theme/sass/plugins/the-events-calendar';

--- a/newspack-katharine/tribe-events/tribe-events.scss
+++ b/newspack-katharine/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-style/variables-style';
+
+// Import TEC baseline styles
+@import '../../newspack-theme/sass/plugins/the-events-calendar';

--- a/newspack-nelson/tribe-events/tribe-events.scss
+++ b/newspack-nelson/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-style/variables-style';
+
+// Import TEC baseline styles
+@import '../../newspack-theme/sass/plugins/the-events-calendar';

--- a/newspack-sacha/tribe-events/tribe-events.scss
+++ b/newspack-sacha/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-style/variables-style';
+
+// Import TEC baseline styles
+@import '../../newspack-theme/sass/plugins/the-events-calendar';

--- a/newspack-scott/tribe-events/tribe-events.scss
+++ b/newspack-scott/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-style/variables-style';
+
+// Import TEC baseline styles
+@import '../../newspack-theme/sass/plugins/the-events-calendar';

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -165,6 +165,77 @@ function newspack_custom_typography_css() {
 			font-family: ' . wp_kses( $font_header, null ) . ';
 		}';
 
+		if ( class_exists( 'Tribe__Main' ) ) {
+			$css_blocks .= '
+			/* The Events Calendar */
+			div.tribe-common .tribe-common-form-control-checkbox__label,
+			div.tribe-common .tribe-common-form-control-radio__label,
+			div.tribe-common .tribe-common-form-control-slider__label,
+			div.tribe-common--breakpoint-medium.tribe-common .tribe-common-form-control-text__input,
+			div.tribe-common .tribe-common-form-control-text__input,
+			div#top .main_color .tribe-common .tribe-common-form-control-text__input,
+			div#top.tribe-theme-enfold .tribe-common .tribe-common-form-control-text__input,
+			div#top .main_color .tribe-common.tribe-common--breakpoint-medium .tribe-common-form-control-text__input,
+			div#top.tribe-theme-enfold .tribe-common.tribe-common--breakpoint-medium .tribe-common-form-control-text__input,
+			div.tribe-common .tribe-common-form-control-toggle__label,
+			div.tribe-common .tribe-common-b1,
+			div.tribe-common .tribe-common-b2,
+			div.tribe-common .tribe-common-b3,
+			div.tribe-common .tribe-common-cta,
+			div.tribe-common .tribe-common-h1,
+			div.tribe-common .tribe-common-h2,
+			div.tribe-common .tribe-common-h3,
+			div.tribe-common .tribe-common-h4,
+			div.tribe-common .tribe-common-h5,
+			div.tribe-common .tribe-common-h6,
+			div.tribe-common .tribe-common-h7,
+			div.tribe-common .tribe-common-h8,
+			div.tribe-common .tribe-common-c-btn-border,
+			div.tribe-common a.tribe-common-c-btn-border,
+			div.tribe-common .tribe-common-c-btn-border-small,
+			div.tribe-common a.tribe-common-c-btn-border-small,
+			div.tribe-common .tribe-common-c-btn,
+			div.tribe-common a.tribe-common-c-btn,
+			div.tribe-events .tribe-events-c-breadcrumbs__list,
+			div.tribe-events .datepicker .datepicker-switch,
+			div.tribe-events .datepicker .day,
+			div.tribe-events .datepicker .dow,
+			div.tribe-events .datepicker .month,
+			div.tribe-events .datepicker .year,
+			div.tribe-common--breakpoint-medium.tribe-events .tribe-events-c-view-selector--labels .tribe-events-c-view-selector__button-text,
+			div.tribe-events .tribe-events-c-view-selector__list-item-text,
+			div.tribe-events .tribe-events-calendar-list__event-date-tag-weekday,
+			div.tribe-events .tribe-events-calendar-month__calendar-event-datetime,
+			div.tribe-events .tribe-events-calendar-month__calendar-event-tooltip-datetime,
+			div.tribe-events .tribe-events-calendar-latest-past__event-date-tag-month,
+			div.tribe-events .tribe-events-calendar-latest-past__event-date-tag-year,
+
+			/* TEC - single event view */
+			p.tribe-events-back a,
+			p.tribe-events-back a:visited,
+			div .tribe-events-single-event-title,
+			div.tribe-events-schedule .recurringinfo,
+			div.tribe-events-schedule h2,
+			div.tribe-related-event-info .recurringinfo,
+			div.tribe-events-schedule .tribe-events-cost,
+			div.tribe-events-content h2,
+			div.tribe-events-content h3,
+			div.tribe-events-content h4,
+			div.tribe-events-content h5,
+			div.tribe-events-content h6,
+			div.tribe-events-cal-links,
+			div.tribe-events-event-meta,
+			div.tribe-events-related-events-title,
+			div.tribe-events-single ul.tribe-related-events li,
+			div.tribe-events-single ul.tribe-related-events li .tribe-related-events-title,
+			div.tribe-events-single .tribe-events-sub-nav,
+			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-single-event-title,
+			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-schedule h3
+			{
+				font-family: ' . wp_kses( $font_header, null ) . ';
+			}';
+		}
+
 		$editor_css_blocks .= '
 		.editor-styles-wrapper .block-editor-block-list__layout h1,
 		.editor-styles-wrapper .block-editor-block-list__layout h2,
@@ -270,6 +341,16 @@ function newspack_custom_typography_css() {
 			font-family: ' . wp_kses( $font_body, null ) . ';
 		}
 		';
+
+		if ( class_exists( 'Tribe__Main' ) ) {
+			$css_blocks .= '
+			div.tribe-common p,
+			div.tribe-events-content
+			{
+				font-family: ' . wp_kses( $font_body, null ) . ';
+			}
+			';
+		}
 
 		$editor_css_blocks .= '
 			#newspack-post-subtitle-element,

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -1,0 +1,100 @@
+// The Events Calendar Styles
+// Is run through each child theme to update fonts
+// CSS file is generated in /tribe-events/tribe-events.css
+// See: https://theeventscalendar.com/knowledgebase/k/customizing-css/
+
+@import '../mixins/mixins-master';
+
+//! Layout tweaks
+
+#tribe-events-pg-template,
+.tribe-common--breakpoint-medium.tribe-events .tribe-events-l-container {
+	padding-top: 0;
+}
+
+.single-tribe_events {
+	.site-content {
+		margin-top: 0;
+
+		@include media( tablet ) {
+			margin-top: $size__spacing-unit;
+		}
+	}
+
+	.tribe_events {
+		margin-top: 0;
+	}
+}
+
+//! Fonts
+
+div.tribe-common p,
+div.tribe-events-content {
+	font-family: $font__body;
+}
+
+div.tribe-common .tribe-common-form-control-checkbox__label,
+div.tribe-common .tribe-common-form-control-radio__label,
+div.tribe-common .tribe-common-form-control-slider__label,
+div.tribe-common--breakpoint-medium.tribe-common .tribe-common-form-control-text__input,
+div.tribe-common .tribe-common-form-control-text__input,
+div#top .main_color .tribe-common .tribe-common-form-control-text__input,
+div#top.tribe-theme-enfold .tribe-common .tribe-common-form-control-text__input,
+div#top .main_color .tribe-common.tribe-common--breakpoint-medium .tribe-common-form-control-text__input,
+div#top.tribe-theme-enfold .tribe-common.tribe-common--breakpoint-medium .tribe-common-form-control-text__input,
+div.tribe-common .tribe-common-form-control-toggle__label,
+div.tribe-common .tribe-common-b1,
+div.tribe-common .tribe-common-b2,
+div.tribe-common .tribe-common-b3,
+div.tribe-common .tribe-common-cta,
+div.tribe-common .tribe-common-h1,
+div.tribe-common .tribe-common-h2,
+div.tribe-common .tribe-common-h3,
+div.tribe-common .tribe-common-h4,
+div.tribe-common .tribe-common-h5,
+div.tribe-common .tribe-common-h6,
+div.tribe-common .tribe-common-h7,
+div.tribe-common .tribe-common-h8,
+div.tribe-common .tribe-common-c-btn-border,
+div.tribe-common a.tribe-common-c-btn-border,
+div.tribe-common .tribe-common-c-btn-border-small,
+div.tribe-common a.tribe-common-c-btn-border-small,
+div.tribe-common .tribe-common-c-btn,
+div.tribe-common a.tribe-common-c-btn,
+div.tribe-events .tribe-events-c-breadcrumbs__list,
+div.tribe-events .datepicker .datepicker-switch,
+div.tribe-events .datepicker .day,
+div.tribe-events .datepicker .dow,
+div.tribe-events .datepicker .month,
+div.tribe-events .datepicker .year,
+div.tribe-common--breakpoint-medium.tribe-events .tribe-events-c-view-selector--labels .tribe-events-c-view-selector__button-text,
+div.tribe-events .tribe-events-c-view-selector__list-item-text,
+div.tribe-events .tribe-events-calendar-list__event-date-tag-weekday,
+div.tribe-events .tribe-events-calendar-month__calendar-event-datetime,
+div.tribe-events .tribe-events-calendar-month__calendar-event-tooltip-datetime,
+div.tribe-events .tribe-events-calendar-latest-past__event-date-tag-month,
+div.tribe-events .tribe-events-calendar-latest-past__event-date-tag-year,
+
+/* TEC - single event view */
+p.tribe-events-back a,
+p.tribe-events-back a:visited,
+div .tribe-events-single-event-title,
+div.tribe-events-schedule .recurringinfo,
+div.tribe-events-schedule h2,
+div.tribe-related-event-info .recurringinfo,
+div.tribe-events-schedule .tribe-events-cost,
+div.tribe-events-content h2,
+div.tribe-events-content h3,
+div.tribe-events-content h4,
+div.tribe-events-content h5,
+div.tribe-events-content h6,
+div.tribe-events-cal-links,
+div.tribe-events-event-meta,
+div.tribe-events-related-events-title,
+div.tribe-events-single ul.tribe-related-events li,
+div.tribe-events-single ul.tribe-related-events li .tribe-related-events-title,
+div.tribe-events-single .tribe-events-sub-nav,
+div#top.tribe-theme-enfold.single-tribe_events .tribe-events-single-event-title,
+div#top.tribe-theme-enfold.single-tribe_events .tribe-events-schedule h3 {
+	font-family: $font__heading;
+}

--- a/newspack-theme/tribe-events/tribe-events.scss
+++ b/newspack-theme/tribe-events/tribe-events.scss
@@ -1,0 +1,8 @@
+// The Event Calendar CSS override
+// See: https://theeventscalendar.com/knowledgebase/k/basic-font-and-color-changes-with-css/
+
+// Import theme variables
+@import '../sass/variables-site/variables-site';
+
+// Import TEC baseline styles
+@import '../sass/plugins/the-events-calendar';

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -118,6 +118,10 @@ const SASS_STYLESHEETS = [
 		outFile: 'newspack-theme/styles/newspack-sponsors-editor.css',
 		withRTL: true,
 	},
+	{
+		inFile: 'newspack-theme/tribe-events/tribe-events.scss',
+		outFile: 'newspack-theme/tribe-events/tribe-events.css',
+	},
 	{ inFile: 'newspack-theme/sass/print.scss', outFile: 'newspack-theme/styles/print.css' },
 	// Newspack Sacha Child theme
 	{
@@ -133,6 +137,10 @@ const SASS_STYLESHEETS = [
 		inFile: 'newspack-sacha/sass/child-style-editor-overrides.scss',
 		outFile: 'newspack-sacha/styles/child-style-editor-overrides.css',
 	},
+	{
+		inFile: 'newspack-sacha/tribe-events/tribe-events.scss',
+		outFile: 'newspack-sacha/tribe-events/tribe-events.css',
+	},
 	// Newspack Scott Child theme
 	{
 		inFile: 'newspack-scott/sass/style.scss',
@@ -142,6 +150,10 @@ const SASS_STYLESHEETS = [
 	{
 		inFile: 'newspack-scott/sass/style-editor.scss',
 		outFile: 'newspack-scott/styles/style-editor.css',
+	},
+	{
+		inFile: 'newspack-scott/tribe-events/tribe-events.scss',
+		outFile: 'newspack-scott/tribe-events/tribe-events.css',
 	},
 	// Newspack Nelson Child theme
 	{
@@ -153,6 +165,10 @@ const SASS_STYLESHEETS = [
 		inFile: 'newspack-nelson/sass/style-editor.scss',
 		outFile: 'newspack-nelson/styles/style-editor.css',
 	},
+	{
+		inFile: 'newspack-nelson/tribe-events/tribe-events.scss',
+		outFile: 'newspack-nelson/tribe-events/tribe-events.css',
+	},
 	// Newspack Katharine Child theme
 	{
 		inFile: 'newspack-katharine/sass/style.scss',
@@ -163,6 +179,10 @@ const SASS_STYLESHEETS = [
 		inFile: 'newspack-katharine/sass/style-editor.scss',
 		outFile: 'newspack-katharine/styles/style-editor.css',
 	},
+	{
+		inFile: 'newspack-katharine/tribe-events/tribe-events.scss',
+		outFile: 'newspack-katharine/tribe-events/tribe-events.css',
+	},
 	// Newspack Joseph Child theme
 	{
 		inFile: 'newspack-joseph/sass/style.scss',
@@ -172,6 +192,10 @@ const SASS_STYLESHEETS = [
 	{
 		inFile: 'newspack-joseph/sass/style-editor.scss',
 		outFile: 'newspack-joseph/styles/style-editor.css',
+	},
+	{
+		inFile: 'newspack-joseph/tribe-events/tribe-events.scss',
+		outFile: 'newspack-joseph/tribe-events/tribe-events.css',
 	},
 ];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Events Calendar new views have very specific styles; they make it so the events pages don't pick up the theme's fonts, or the per-site Custom fonts.

This PR addresses that, plus scales down a bit of the excess space at the top of the Events templates.

The Events Calendar plugin will automatically pick up any stylesheet that's in the tribe-events/tribe-events.css location of a theme, so I opted to set up these styles in that way, so the plugin does the work of enqueuing them. 

Closes #1431.

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar set up, and a few events added. Make sure under your settings that:
     * AMP is turned off for these pages
     * That you're running the v2 views (under WP Admin > Events > Settings > Display, the `Enable updated designs for all calendar views` option should be checked).
     * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
     * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Set your theme to use its default fonts.      
3. View the Events pages; see that they're all using Helvetica Neue, regardless what the rest of your site is using:

![image](https://user-images.githubusercontent.com/177561/126722936-171e3382-1087-4509-b6dc-571da62da2a1.png)

4. Apply the PR and run `npm run build`.
5. Confirm that your events pages are now picking up your theme's fonts:

![image](https://user-images.githubusercontent.com/177561/126722639-0776f8db-af33-4105-8867-3c8f8488a1bb.png)

6. Change the theme and confirm that the fonts update (don't need to cycle through all but check at least one other theme - note: Newspack Nelson has a display issue with the header overlap that also needs to be fixed). 
7. Try changing your custom fonts and confirm they're getting picked up:

![image](https://user-images.githubusercontent.com/177561/126722734-d01b1287-71a3-4730-94ef-3fe1e0dddd5c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
