### PR TITLE
Re-add default header styles in editor

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -34,6 +34,7 @@ h3,
 h4,
 h5,
 h6 {
+	font-family: $font__heading;
 	font-weight: 700;
 	line-height: $font__line-height-heading;
 	a {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For reasons I cannot fathom, [I removed the default header font from the editor styles](https://github.com/Automattic/newspack-theme/commit/00efaaa5e87445ceb0d937ba8fcdccd848044c78#diff-ba52aa3233bbd569bd0f6b6f991ef3ba0a9648824fc80b5516263fc49c36baee) as part of a PR to add styles for the query block. 😬 This PR re-adds it. 

### How to test the changes in this Pull Request:

1. Start with the default settings in the Typography panel of the Customizer; it's also best to test with any theme but Newspack Katharine, since the same font is used for both the body and header. 
2. Add a heading block and a homepage posts block to the editor; note it's using Georgia (or whatever your body font is)/
3. Apply the PR and run `npm run build`.
4. Confirm that the correct heading font is now used. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
