### PR TITLE
Events Calendar: Make sure archive styles aren't breaking photo view

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -26,6 +26,17 @@
 	}
 }
 
+//! Photo view
+.archive.post-type-archive-tribe_events {
+	.has-post-thumbnail {
+		display: block;
+	}
+
+	.tribe_events {
+		margin-top: 0;
+	}
+}
+
 //! Fonts
 
 div.tribe-common p,

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -27,7 +27,7 @@
 }
 
 //! Photo view
-.archive.post-type-archive-tribe_events {
+.archive .tribe-events-pro-photo {
 	.has-post-thumbnail {
 		display: block;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme's archive styles were breaking the "Photos" layout available in the Events Calendar PRO plugin. This PR makes sure that is no longer the case.

Closes #1436 

### How to test the changes in this Pull Request:

1. Start with a site running the Events Calendar PRO (ping me if I can help set this bit up).
2. Under WP Admin > Events > Display, check off the Photos as one of the views available, under "Enable event views".
3. View on the front-end; note the messed up layout:

![image](https://user-images.githubusercontent.com/177561/127070975-558bccab-4aed-488d-ba87-d95183ab6b7b.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the photo view now looks okay:

![image](https://user-images.githubusercontent.com/177561/127070917-9a2956b4-d8e4-4a9f-a1d8-29129d1dc43e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
