### PR TITLE
Make sure mobile CTA doesn't pick up Events Calendar: Community Events styles

### DIFF
--- a/newspack-joseph/tribe-events/tribe-events.scss
+++ b/newspack-joseph/tribe-events/tribe-events.scss
@@ -6,3 +6,8 @@
 
 // Import TEC baseline styles
 @import '../../newspack-theme/sass/plugins/the-events-calendar';
+
+// Theme-specific styles
+.tribe_community_edit .button.mb-cta {
+	border-radius: 0;
+}

--- a/newspack-katharine/tribe-events/tribe-events.scss
+++ b/newspack-katharine/tribe-events/tribe-events.scss
@@ -6,3 +6,8 @@
 
 // Import TEC baseline styles
 @import '../../newspack-theme/sass/plugins/the-events-calendar';
+
+// Theme-specific styles
+.tribe_community_edit .button.mb-cta {
+	border-radius: 0;
+}

--- a/newspack-nelson/tribe-events/tribe-events.scss
+++ b/newspack-nelson/tribe-events/tribe-events.scss
@@ -6,3 +6,8 @@
 
 // Import TEC baseline styles
 @import '../../newspack-theme/sass/plugins/the-events-calendar';
+
+// Theme-specific styles
+.tribe_community_edit .button.mb-cta {
+	border-radius: 0;
+}

--- a/newspack-sacha/tribe-events/tribe-events.scss
+++ b/newspack-sacha/tribe-events/tribe-events.scss
@@ -6,3 +6,8 @@
 
 // Import TEC baseline styles
 @import '../../newspack-theme/sass/plugins/the-events-calendar';
+
+// Theme-specific styles
+.tribe_community_edit .button.mb-cta {
+	border-radius: 0;
+}

--- a/newspack-scott/tribe-events/tribe-events.scss
+++ b/newspack-scott/tribe-events/tribe-events.scss
@@ -6,3 +6,8 @@
 
 // Import TEC baseline styles
 @import '../../newspack-theme/sass/plugins/the-events-calendar';
+
+// Theme-specific styles
+.tribe_community_edit .button.mb-cta {
+	border-radius: 0;
+}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -432,7 +432,7 @@ function newspack_custom_colors_css() {
 		$theme_css .= '
 			.button.mb-cta,
 			.button.mb-cta:not(:hover):visited,
-			.tribe_community_edit .mb-cta.button {
+			.tribe_community_edit .button.mb-cta {
 				background-color: ' . esc_html( $cta_color ) . ';
 				color: ' . esc_html( $cta_color_contrast ) . ';
 			}

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -431,7 +431,8 @@ function newspack_custom_colors_css() {
 	if ( newspack_get_mobile_cta_color() !== $cta_color ) {
 		$theme_css .= '
 			.button.mb-cta,
-			.button.mb-cta:not(:hover):visited {
+			.button.mb-cta:not(:hover):visited,
+			.tribe_community_edit .mb-cta.button {
 				background-color: ' . esc_html( $cta_color ) . ';
 				color: ' . esc_html( $cta_color_contrast ) . ';
 			}

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -233,7 +233,7 @@ function newspack_custom_typography_css() {
 			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-schedule h3,
 
 			/* Mobile CTA fix */
-			.tribe_community_edit .mb-cta.button
+			.tribe_community_edit .button.mb-cta
 			{
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}';

--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -230,7 +230,10 @@ function newspack_custom_typography_css() {
 			div.tribe-events-single ul.tribe-related-events li .tribe-related-events-title,
 			div.tribe-events-single .tribe-events-sub-nav,
 			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-single-event-title,
-			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-schedule h3
+			div#top.tribe-theme-enfold.single-tribe_events .tribe-events-schedule h3,
+
+			/* Mobile CTA fix */
+			.tribe_community_edit .mb-cta.button
 			{
 				font-family: ' . wp_kses( $font_header, null ) . ';
 			}';

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -44,7 +44,7 @@
 }
 
 // Mobile CTA
-.button.mb-cta {
+.site-header .mb-cta {
 	background: #d33;
 	color: #fff;
 	font-size: 0.7em;
@@ -113,7 +113,7 @@
 	// Mobile Menu toggle
 	.h-dh .site-header .mobile-menu-toggle,
 	.h-sub .site-header .mobile-menu-toggle,
-	.h-dh .mb-cta {
+	.h-dh .site-header .mb-cta {
 		display: none;
 	}
 
@@ -129,7 +129,7 @@
 
 	// Mobile Menu toggle
 	.h-sh .site-header .mobile-menu-toggle,
-	.h-sh .mb-cta {
+	.h-sh .site-header .mb-cta {
 		display: none;
 	}
 

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -75,7 +75,7 @@
 }
 
 //! Community Events plugin
-.tribe_community_edit .mb-cta.button {
+.tribe_community_edit .button.mb-cta {
 	background: #d33;
 	border-radius: 5px;
 	font-family: $font__heading;

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -74,6 +74,18 @@
 	}
 }
 
+//! Community Events plugin
+.tribe_community_edit .mb-cta.button {
+	background: #d33;
+	border-radius: 5px;
+	font-family: $font__heading;
+	font-size: 0.7em;
+	font-weight: bold;
+	letter-spacing: 0;
+	padding: 0.6rem 0.5rem;
+	text-transform: none;
+}
+
 //! Fonts
 
 div.tribe-common p,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Events Calendar: Community Events plugin uses the very generic `.button` class, and because they're pairing it with a body class, it's overriding styles in the Newspack theme -- specifically, the mobile call to action in the header. On the Community Events pages, it's visible on desktop, and using the wrong fonts, colours, padding, border radius... everything. 

This PR fixes that issue, hopefully in a way that's least disruptive; I tried to ride the line between avoiding duplication, and avoiding making too many styles more specific (in case that causes issues with sites using Custom CSS). 

Closes #1437

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar set up, and a few events added. Make sure under your settings that:
     * AMP is turned off for these pages
     * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
     * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Install and activate the Events Calendar: Community Events plugin.
3. Set up and activate the Mobile CTA; keep the default colour to start. 
4. View one of the pages added by the Community Events plugin, like [yourtestsite.com]/events/community/add. Note the Mobile CTA visible on desktop:

![image](https://user-images.githubusercontent.com/177561/127077900-99615459-1bc5-4c9e-b342-26b04e4489c1.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the mobile CTA is now hidden on larger screens, and uses red/the theme's header fonts on mobile:

![image](https://user-images.githubusercontent.com/177561/127078024-132f71d7-7a0f-4ad1-bf26-527033fcc1b7.png)

![image](https://user-images.githubusercontent.com/177561/127078037-d616b22a-c016-4a8e-8c5b-dd5090735bea.png)

7. Try changing your site's header font, and mobile CTA background colour, and confirm they're being picked up.
 
![image](https://user-images.githubusercontent.com/177561/127078247-454c0f35-bcd1-40c3-b0f5-cb172d1b7667.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
