### PR TITLE
Newspack Nelson: Add overlap styles for the Events Calendar

### DIFF
--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -41,8 +41,7 @@ function newspack_nelson_custom_colors_css() {
 		.h-sh.h-db .site-header,
 		.site-content #primary,
 		#page .site-header,
-		body.post-type-archive-tribe_events .tribe-events .tribe-events-l-container,
-		main#tribe-events-pg-template {
+		.tec-wrapper {
 			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 		}
 

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -40,7 +40,9 @@ function newspack_nelson_custom_colors_css() {
 		/* Header short height; default background */
 		.h-sh.h-db .site-header,
 		.site-content #primary,
-		#page .site-header {
+		#page .site-header,
+		body.post-type-archive-tribe_events .tribe-events .tribe-events-l-container,
+		main#tribe-events-pg-template {
 			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
 		}
 

--- a/newspack-nelson/tribe-events/tribe-events.scss
+++ b/newspack-nelson/tribe-events/tribe-events.scss
@@ -11,3 +11,30 @@
 .tribe_community_edit .button.mb-cta {
 	border-radius: 0;
 }
+
+// Overlap styles
+body.post-type-archive-tribe_events .tribe-events .tribe-events-l-container,
+main#tribe-events-pg-template {
+	background-color: $color__background-body;
+	padding-top: $size__spacing-unit 0;
+
+	@include media( tablet ) {
+		border-top: 4px solid $color__primary-variation;
+		padding: #{3 * $size__spacing-unit} #{2 * $size__spacing-unit} 0;
+	}
+
+	@include media( desktop ) {
+		padding-left: #{3 * $size__spacing-unit};
+		padding-right: #{3 * $size__spacing-unit};
+	}
+}
+
+.single-tribe_events .site-content {
+	@include media( tablet ) {
+		margin-top: #{-3.5 * $size__spacing-unit};
+	}
+
+	@include media( desktop ) {
+		margin-top: #{-6 * $size__spacing-unit};
+	}
+}

--- a/newspack-nelson/tribe-events/tribe-events.scss
+++ b/newspack-nelson/tribe-events/tribe-events.scss
@@ -31,6 +31,16 @@
 	.tribe-events-l-container {
 		padding: $size__spacing-unit 0 0;
 	}
+
+	@include media( tablet ) {
+		#tribe-events-pg-template {
+			padding: 0;
+		}
+
+		.tribe-events-back {
+			margin-top: 0;
+		}
+	}
 }
 
 .single-tribe_events {

--- a/newspack-nelson/tribe-events/tribe-events.scss
+++ b/newspack-nelson/tribe-events/tribe-events.scss
@@ -13,8 +13,7 @@
 }
 
 // Overlap styles
-body.post-type-archive-tribe_events .tribe-events .tribe-events-l-container,
-main#tribe-events-pg-template {
+.tec-wrapper {
 	background-color: $color__background-body;
 	padding-top: $size__spacing-unit 0;
 
@@ -27,14 +26,21 @@ main#tribe-events-pg-template {
 		padding-left: #{3 * $size__spacing-unit};
 		padding-right: #{3 * $size__spacing-unit};
 	}
+
+	#tribe-events-pg-template,
+	.tribe-events-l-container {
+		padding: $size__spacing-unit 0 0;
+	}
 }
 
-.single-tribe_events .site-content {
-	@include media( tablet ) {
-		margin-top: #{-3.5 * $size__spacing-unit};
-	}
+.single-tribe_events {
+	.site-content {
+		@include media( tablet ) {
+			margin-top: #{-3.5 * $size__spacing-unit};
+		}
 
-	@include media( desktop ) {
-		margin-top: #{-6 * $size__spacing-unit};
+		@include media( desktop ) {
+			margin-top: #{-6 * $size__spacing-unit};
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR dds the 'overlap' style to the Events Calendar pages when using Newspack Nelson.

Marking as draft until #1442 is merged, because it will change the exact selector being used.

Closes #1432.

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar set up, and a few events added. Make sure under your settings that:
   * AMP is turned off for these pages
   * That you're running the v2 views (under WP Admin > Events > Settings > Display, the Enable updated designs for all calendar views option should be checked).
   * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
   * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Switch your site to Newspack Nelson, and navigate to the /events pages. Note that they don't have the correct overlap:

![image](https://user-images.githubusercontent.com/177561/127215527-5f2dfc4e-e05c-4443-8674-f4a14e042019.png)

![image](https://user-images.githubusercontent.com/177561/127215542-c745dd2f-8a32-4261-b44a-7a9acc43cd4b.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the overlap styles are being applied, and that they look good on desktop and small screens:
![image](https://user-images.githubusercontent.com/177561/127215338-aaf6f78e-f6b0-4aad-95eb-88135ce6e588.png)

![image](https://user-images.githubusercontent.com/177561/127215382-c5e1f1a2-29dc-497b-bcb6-01fc837278cb.png)

![image](https://user-images.githubusercontent.com/177561/127215356-2b707ba9-2109-42ea-bc30-04658363c6fa.png)

![image](https://user-images.githubusercontent.com/177561/127215397-ebd93622-3461-4a31-99b2-0f508289e9bd.png)

5. If you don't have custom colours set, navigate to Customizer > Colours and change the Primary colour; confirm it's used for the top border (pink in the screenshot above).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
