### PR TITLE
fix: override event link styles on related posts

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -36,7 +36,7 @@
 	}
 }
 
-// Sidebar styles.
+//! Sidebar styles
 .tec-wrapper {
 	margin: auto;
 	max-width: 90%;
@@ -84,6 +84,16 @@
 	letter-spacing: 0;
 	padding: 0.6rem 0.5rem;
 	text-transform: none;
+}
+
+//! Jetpack Related Posts
+.tribe-events-content .jp-relatedposts-post-title a {
+	&,
+	&:active,
+	&:focus,
+	&:hover {
+		border: 0;
+	}
 }
 
 //! Fonts


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you're running both the Events Calendar and Jetpack's recent posts, you can end up with some bizarre double-underlines when hovering over the Related Posts titles.

This PR removes one set of borders.

Closes #1434.

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar set up, and a few events added. Make sure under your settings that:
* AMP is turned off for these pages
* That you're running the v2 views (under WP Admin > Events > Settings > Display, the Enable updated designs for all calendar views option should be checked).
* That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
* That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Navigate to Jetpack > Settings > Traffic and enable related post.
3. View a single event and note the appearance of the Related Posts titles, with and without hovering. (Note: if they don't show up immediately, you can start on a single event, then in the Admin Toolbar click Customizer > Related Posts -- the related posts are always visible in the Customizer view, whether or not the post you're viewing would show them):

Standard:
![image](https://user-images.githubusercontent.com/177561/127409775-f40098c5-1731-4907-b2e0-435ed0cda0e2.png)

Hover:

![image](https://user-images.githubusercontent.com/177561/127409782-49e9fe2d-bd84-4699-a20d-04cb93f3fc2d.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the second (blue) set of underlines is now gone:

Standard:

![image](https://user-images.githubusercontent.com/177561/127409629-8b04056a-7f2f-43b1-8ccc-c90ba2bfced4.png)

Hover:

![image](https://user-images.githubusercontent.com/177561/127409637-42570876-a140-4375-a5b4-6930c07eb334.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
