### PR TITLE
Events Calendar: correct spacing in the event calendar photo shortcode

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -74,6 +74,22 @@
 	}
 }
 
+//! tribe_events shortcode - photo view
+.entry .entry-content .entry {
+	&.tribe-events-pro-photo__event {
+		margin: 0 0 24px;
+
+		&.tribe-common .tribe-common-g-row--gutters > .tribe-common-g-col {
+			padding-left: 21px;
+			padding-right: 21px;
+		}
+
+		&.tribe-common.tribe-common-g-col {
+			min-width: 0;
+		}
+	}
+}
+
 //! Community Events plugin
 .tribe_community_edit .button.mb-cta {
 	background: #d33;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The photo view of the shortcode in The Events Calendar PRO plugin is picking up some styles from the theme that are messing up its spacing. This PR should fix that.

### How to test the changes in this Pull Request:


1. Start with a test site with the Events Calendar PRO plugin set up, and a few events added. Make sure under your settings that:
     * That you're running the v2 views (under WP Admin > Events > Settings > Display, the Enable updated designs for all calendar views option should be checked).
     * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
     * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Edit or add a new page; add the shortcode `[tribe_events view="photo"]` and turn off AMP. 
3. View on the front-end; note the overlaps and odd spacing -- everything kind of crowds to the left. Here's the shortcode in a narrower column, and at full-width:

![image](https://user-images.githubusercontent.com/177561/127718755-148c9c9d-15db-41e8-98a6-bac0858a49b2.png)

![image](https://user-images.githubusercontent.com/177561/127718783-5f7fa51b-22af-48dd-a3c5-0637894235eb.png)

4. Apply the PR and run `npm run build`.
5. View on the front-end again, confirm that the events are more evenly spaced out, and not off-centre:

![image](https://user-images.githubusercontent.com/177561/127718833-2272e7ea-ac9a-4d0a-80c6-46881307407c.png)

![image](https://user-images.githubusercontent.com/177561/127718842-3b78e96c-1864-4d53-8a33-1ac19cbe73a7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
