### PR TITLE
Events Calendar: correct spacing in event calendar map shortcode

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -74,8 +74,8 @@
 	}
 }
 
-//! tribe_events shortcode - photo view
 .entry .entry-content .entry {
+	//! tribe_events shortcode - photo view
 	&.tribe-events-pro-photo__event {
 		margin: 0 0 24px;
 
@@ -87,6 +87,12 @@
 		&.tribe-common.tribe-common-g-col {
 			min-width: 0;
 		}
+	}
+
+	//! tribe_events shortcode - map view
+	&.tribe-events-pro-map__event-card,
+	&.tribe-events-pro-map__event-card-spacer {
+		padding: 16px 12px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Events Calendar PRO's map shortcode is picking up some styles from the theme, causing display issues. This PR should fix that.

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar PRO set up, and a few events added. Make sure under your settings that:
     * That you're running the v2 views (under WP Admin > Events > Settings > Display, the Enable updated designs for all calendar views option should be checked).
     * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
     * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Edit a page; turn off AMP and add the following shortcode: `[tribe_events view="map"]`
3. View on the front end; note the funky piled up details:

![image](https://user-images.githubusercontent.com/177561/127722008-08d94f9c-305c-43e6-abb7-148adefca0e9.png)

4. Apply the PR and run `npm run build`.
5. View one the front end; confirm that the event info is no longer jumbled:

![image](https://user-images.githubusercontent.com/177561/127721956-eb7025d5-68ad-4051-a48c-46662411589f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
