### PR TITLE
WooCommerce: Add `wc_format_content()` to shop page output

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -166,7 +166,7 @@ function woocommerce_product_archive_description() {
 	if ( is_post_type_archive( 'product' ) && in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true ) ) {
 		$shop_page = get_post( wc_get_page_id( 'shop' ) );
 		if ( $shop_page ) {
-			echo $shop_page->post_content;
+			echo wp_kses_post( wc_format_content( $shop_page->post_content ) );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Newspack Theme overrides WooCommerce's default handling of the shop page content by adding its own `woocommerce_product_archive_description()` function. This function's output was missing the `wc_format_content()` function, which is used in the [plugin](https://github.com/Automattic/woocommerce/blob/19bdc1c35b06fd1ad41f94bd91d5047474a59c3c/includes/wc-template-functions.php#L1262) and helps apply WordPress's usual content filters. 

This hasn't been an issue... unless the content has dynamic blocks that need the [`do_blocks()`](https://developer.wordpress.org/reference/functions/do_blocks/) function to actually get rendered 😅 

This PR adds `wc_format_content()` (and `wp_kses_post()`) to our shop page content output.

Closes #1457.

### How to test the changes in this Pull Request:

1. On a site running the Newspack theme and WooCommerce, edit your Shop page and add a dynamic block (this could include the Homepage Posts block, or one of WooCommerce's, like the Featured Product block).
2. Save the page and view on the front end; note your dynamic block doesn't appear (though regular ones, like paragraphs, or even block buttons nested inside of the Featured Product block content, do). 

<img width="827" alt="image" src="https://user-images.githubusercontent.com/177561/128072157-14e10ede-cb20-434e-a778-fdaa6c4a6172.png">

3. Apply the PR.
4. Confirm your dynamic blocks now appear:

<img width="843" alt="image" src="https://user-images.githubusercontent.com/177561/128072102-22b6c340-3898-4fce-a16a-838bd060f0ed.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
