### PR TITLE
Default theme: fix tertiary menu appearance in slide-out sidebar

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -335,7 +335,8 @@ function newspack_custom_colors_css() {
 				}
 				.cat-links a,
 				.cat-links a:visited,
-				.site-header .nav3 .menu-highlight a {
+				.site-header .nav3 .menu-highlight a,
+				.subpage-sidebar .nav3 .menu-highlight a {
 					background-color: ' . esc_html( $primary_color ) . ';
 					color: ' . esc_html( $primary_color_contrast ) . ';
 				}

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-.h-sb .nav3 {
+.h-sb .site-header .nav3 {
 	a {
 		background-color: darken( $color__primary, 10% );
 		color: #fff;
@@ -68,6 +68,10 @@
 	.menu-highlight a {
 		background-color: darken( $color__primary, 10% );
 	}
+}
+
+.subpage-sidebar .nav3 a {
+	padding: #{$size__spacing-unit * 0.5} #{$size__spacing-unit * 0.75};
 }
 
 /* Posts and pages */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When using the default Newspack theme + slideout sidebar header option + tertiary menu, the correct styles (padding, colours) aren't being picked up in all cases. 

This PR fixes those styles.

Closes #1406

### How to test the changes in this Pull Request:

1. Start with a site running the Default Newspack theme.
2. Under Customizer > Header Settings > Subpage Header, turn on the Simplified Subpage Header
3. Add a menu and assign it to the Tertiary Menu location; add at least two links, and add the CSS class `menu-highlight` to one of them.
4. View on the front-end and check the appearance of this menu on the homepage and on a subpage (where it's inside of the slideout sidebar), both with a solid header background colour (Customizer > Header Settings > Appearance; check Solid Background), and without. Note the following issues:

**Homepage with default header background:**
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/177561/128082181-cd907b43-a928-4abf-836c-58d4ef314da5.png">
* Correctly uses primary colour for `menu-highlight` button

**Homepage with solid header background:**
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/177561/128082695-70a4d40b-88b8-4457-a9fb-2969f431d44a.png">

* Correctly uses secondary colour** for `menu-highlight` button, and a slightly darker version of the header colour for regular buttons

_** Note: this button switches to the secondary colour as a work-around for the original solid header bg option, which would always use the primary colour._

**Slide-out sidebar with default header background:**
<img width="389" alt="image" src="https://user-images.githubusercontent.com/177561/128082264-a1ef9d31-d22f-437b-ba17-82afee6463b7.png">
* Wrong button colour on the `menu-highlight` link (it should be using my custom primary colour but is using Newspack blue)
* Wrong padding on the standard link

**Slide-out sidebar with solid header background:**
<img width="399" alt="image" src="https://user-images.githubusercontent.com/177561/128082887-9d1ea596-8350-4a26-baa0-5a290dc46a5c.png">
* Wrong button colour on the `menu-highlight` link (it should be using the primary colour)
* Wrong button colour on the regular link (it should be using the regular grey)

5. Apply the PR and run `npm run build`.
6. Confirm the menu is now displaying as expected from the homepage and on subpages:

**Homepage with default header background:**
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/177561/128083833-4777621c-a4b3-4069-95f7-a1604f77a770.png">

**Homepage with solid header background:**
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/177561/128083702-9b160bda-b1e3-478c-83c0-d8f5c0ee14ec.png">

**Slide-out sidebar with default header background:**
<img width="395" alt="image" src="https://user-images.githubusercontent.com/177561/128083888-d8730aa6-0893-4518-8299-bd287e33fa9c.png">

**Slide-out sidebar with solid header background:**
<img width="397" alt="image" src="https://user-images.githubusercontent.com/177561/128083614-975f476a-2057-45d0-916c-d8e0b8fc1c64.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
