### PR TITLE
fix: add space between above content widget and featured image

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -187,6 +187,10 @@ amp-script .cat-links {
 	}
 }
 
+.widget + .post-thumbnail {
+	margin-top: 32px;
+}
+
 .entry-content {
 	p {
 		word-wrap: break-word;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a space at the top of the 'small' featured image placement, if you have added a widget to the above content widget area.

Note: this isn't possible to replicate with the widget blocks due to their styles (yay!) but can still affect some legacy widgets, including the ads widget. Because of that, I think fixing it still makes sense, if there are sites set up with older widgets in the wild that will be having issues. 

Closes #1379

### How to test the changes in this Pull Request:

1. Add a widget to the 'Above Content' widget location -- one that doesn't have space at the bottom already built in (like the Jetpack's Google Translate widget) is a good candidate for showing the issue, but you can also pick a legacy widget with little space (the Meta widget).
2. Create a post with a featured image, and set it to 'Small'
3. View on the front-end; note there is no space between the widget and featured images:

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/177561/128103993-a0adb333-ce9f-4103-b7d6-ab27031edc45.png">

4. Apply the PR and run `npm run build`.
5. View the post again, confirm that there's 32px of space between the widget and the featured image. (If you've used a widget with space already, like the Meta widget, it should still be only 32px):

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/177561/128104055-bb86141f-7e2d-4cb1-a778-d77195b14319.png">
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
