### PR TITLE
Add styles for the "zip" type input field

### DIFF
--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -12,6 +12,7 @@ input[type='week'],
 input[type='time'],
 input[type='datetime'],
 input[type='datetime-local'],
+input[type='zip'],
 input[type='color'],
 textarea {
 	-webkit-backface-visibility: hidden;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds styles for the `zip` input type, to go with the other text-like input styles in the theme.

Closes #1306 

### How to test the changes in this Pull Request:

1. Add a Custom HTML block to a post, and add this HTML:

```
<input type="text"><br>
<input type="zip">
```

2. View on front-end; note the different appearance of the fields:

<img width="425" alt="image" src="https://user-images.githubusercontent.com/177561/128107128-b8760346-9379-4698-a9fd-9fdc9a71d1a1.png">

3. Apply the PR and run `npm run build`.
4. Confirm that the zip field is now styled like the text field:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/177561/128107205-d7a843de-e616-4b17-abea-353f0f612693.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
