### PR TITLE
fix: correct spacing in Events Calendar month shortcode

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -94,6 +94,11 @@
 	&.tribe-events-pro-map__event-card-spacer {
 		padding: 16px 12px;
 	}
+
+	//! tribe_events shortcode - month view
+	&.tribe-events-calendar-month-mobile-events__mobile-event {
+		padding: 12px 0;
+	}
 }
 
 //! Community Events plugin


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-theme/pull/1454, this PR tries to make sure the theme's spacing styles aren't overriding the spacing styles for the Events Calendar PRO shortcodes. 

### How to test the changes in this Pull Request:

1. Start with a test site with the Events Calendar PRO set up, and a few upcoming events added for the current month. Make sure under your settings that:
     * That you're running the v2 views (under WP Admin > Events > Settings > Display, the Enable updated designs for all calendar views option should be checked).
     * That your site is set to use 'Tribe Events Styles' (under WP Admin > Events > Settings > Display)
     * That your site is set to use the 'Default Events Template' (under WP Admin > Events > Settings > Display).
2. Edit a page; add the shortcode `[tribe_mini_calendar]`, and turn off AMP. Publish. 
3. View on the front-end; note that the upcoming events listed under the calendar are kind of squished:

![image](https://user-images.githubusercontent.com/177561/128220310-3795fea4-c161-479d-9b3c-dcb3c502c218.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the events are now properly spaced out:

![image](https://user-images.githubusercontent.com/177561/128220067-f168a2a1-b483-4966-b91f-31cc4c75abf6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
