### PR TITLE
Related Posts: make display behaviour more consistent between AMP and non-AMP

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -889,18 +889,6 @@ div.sharedaddy .sd-social h3.sd-title,
 			width: 33.3%;
 		}
 
-		@include media( tabletonly ) {
-			> * {
-				margin-left: calc( 25% + 20px );
-			}
-
-			> .jp-relatedposts-post-a {
-				float: left;
-				margin-left: 0;
-				max-width: 25%;
-			}
-		}
-
 		.jp-relatedposts-post-img {
 			margin-bottom: #{0.5 * $size__spacing-unit};
 		}

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -883,6 +883,23 @@ div.sharedaddy .sd-social h3.sd-title,
 #jp-relatedposts.jp-relatedposts {
 	.jp-relatedposts-items-visual .jp-relatedposts-post {
 		opacity: 1;
+		width: 100%;
+
+		@include media( tablet ) {
+			width: 33.3%;
+		}
+
+		@include media( tabletonly ) {
+			> * {
+				margin-left: calc( 25% + 20px );
+			}
+
+			> .jp-relatedposts-post-a {
+				float: left;
+				margin-left: 0;
+				max-width: 25%;
+			}
+		}
 
 		.jp-relatedposts-post-img {
 			margin-bottom: #{0.5 * $size__spacing-unit};

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -864,8 +864,10 @@ div.sharedaddy .sd-social h3.sd-title,
 	color: $color__text-main;
 }
 
-.jp-related-posts-i2__row {
-	margin: 0 -10px;
+@include media( mobile ) {
+	.jp-related-posts-i2__row {
+		margin: 0 -10px;
+	}
 }
 
 .jp-relatedposts-i2,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When AMP is enabled, Jetpack's Related Posts go from 1/3 of the available width to 100% of the available width on smaller screens.

When AMP is disabled, they go from 1/3 to 1/2, causing kind of a weird display issue, with two related posts in one row, and one alone on the row underneath. 

Though the image don't always fill the available space, this PR makes the non-AMP version of the related posts behave more like the AMP version. (I was going to make it so the images also floated to the left on smaller screens, but the AMP version of the related posts is structured differently, with the post title technically first and reordered using CSS. It seemed much easier to use this approach!)

It also fixes a minor issue where the related posts are being pulled too far left on mobile when AMP is enabled. 

Closes #1290

### How to test the changes in this Pull Request:

1. Start on a test site with Related Posts enabled, and compare the AMP and non-AMP versions of the related posts layout on smaller screen:

AMP:

![image](https://user-images.githubusercontent.com/177561/128399393-eda85683-412a-4503-8494-ef82d0e871d3.png)


Non-AMP:

![image](https://user-images.githubusercontent.com/177561/128399240-1e6a3b18-69fd-4747-a204-ee8120bd4214.png)


2. Apply the PR and run `npm run build`. 
3. Re-review the AMP and non-AMP versions of related posts, and confirm that they appear similar:

AMP:

![image](https://user-images.githubusercontent.com/177561/128398860-d2e72fa1-d1c4-4a10-9291-28490e8e1cfd.png)

Non-AMP:

![image](https://user-images.githubusercontent.com/177561/128399035-d3472a1a-9337-4e76-b944-1c88e910725f.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
