### PR TITLE
Legacy Widgets: avoid too small font sizes when nesting

### DIFF
--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -12,6 +12,11 @@
 		}
 	}
 
+	.widget {
+		font-size: inherit;
+		margin-bottom: 32px;
+	}
+
 	&:last-child {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The theme has a blanked `font-size: 0.8em` font size on all legacy `.widget` elements, but now that you can nest widgets, this font size can be compounded. This PR makes sure the font size is not applied on the nested legacy widgets, too.

Closes #1448

### How to test the changes in this Pull Request:

1. Edit your widgets; add a legacy 'Meta' widget, then add a second one nested inside a group block.
2. View on the front-end; note the nested widget is smaller than the original (the titles are also styled differently, but that's related to an issue in Gutenberg itself changing the `.widget-title` class; I will address in a separate issue!):

![image](https://user-images.githubusercontent.com/177561/128408293-778673f4-7b72-4d36-9a4c-b804933fab06.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the font sizes of the two widgets is now the same: 

![image](https://user-images.githubusercontent.com/177561/128408157-155138eb-9f0b-4e8e-a718-a0f8e4143b80.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
