### PR TITLE
Hide "Cancel Reply" link when AMP is enabled

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -399,8 +399,10 @@ if ( ! function_exists( 'newspack_comment_form' ) ) :
 		if ( true === $order || strtolower( $order ) === strtolower( get_option( 'comment_order', 'asc' ) ) ) {
 
 			$comment_attributes = array(
-				'logged_in_as' => null,
-				'title_reply'  => null,
+				'logged_in_as'       => null,
+				'title_reply'        => null,
+				'title_reply_before' => null,
+				'title_reply_after'  => null,
 			);
 
 			$comment_policy = get_theme_mod( 'comment_policy', '' );

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -156,6 +156,10 @@
 			}
 		}
 	}
+
+	#respond .comment-reply-title {
+		font-size: $font__size_base;
+	}
 }
 
 .comment-reply {

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -61,6 +61,7 @@
 
 #respond {
 	position: relative;
+
 	.comment-user-avatar {
 		margin: $size__spacing-unit 0 -#{$size__spacing-unit};
 	}
@@ -72,7 +73,7 @@
 	> small {
 		bottom: 1em;
 		display: block;
-		font-size: 1em;
+		font-size: $font__size_base;
 		position: absolute;
 		right: 0;
 		white-space: nowrap;

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -61,7 +61,6 @@
 
 #respond {
 	position: relative;
-
 	.comment-user-avatar {
 		margin: $size__spacing-unit 0 -#{$size__spacing-unit};
 	}
@@ -71,12 +70,17 @@
 	}
 
 	> small {
+		bottom: 1em;
 		display: block;
-		font-size: $font__size_base;
+		font-size: 1em;
 		position: absolute;
-		left: calc( #{$size__spacing-unit} + 100% );
-		top: calc( -3.5 * #{$size__spacing-unit} );
-		width: calc( 100vw / 12 );
+		right: 0;
+		white-space: nowrap;
+
+		// hide link if AMP is enabled; it adds an 'on' attribute.
+		[on] {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the 'Cancel Reply' link in the comments section when AMP is enabled. 

It's a pretty heavy handed fix to an issue where the link would incorrectly show up when the Collapse Comments option was on and comments were disabled for logged-out users. However, the link doesn't appear to work the same as it does when AMP is disabled: 

Normally you would click "Reply" to a comment, and the comment field would appear below that comment; clicking "Cancel reply" would return it to the bottom.

When AMP is enabled, clicking "Reply" will make the page jump to the comment field at the bottom, but clicking "Cancel reply" doesn't do anything (I would assume it would bring you back to the comment you started on, but that's not the case). 

Closes #1429

### How to test the changes in this Pull Request:

1. Set up a test site with the following settings:
     * Comments only on for logged in visitors (under WP Admin > Settings > Discussion)
     * Comments are 'collapsed' (under Customizer > Comment Settings)
     * You have two posts with more than two comments (so the 'collapsing' actually happens); one with AMP enabled, and one without. 
2. In an incognito window, view the post with AMP enabled, and toggle open the comments. The 'Cancel reply' link should either be visible on page load, or after you toggle the comments open:

![image](https://user-images.githubusercontent.com/177561/128435726-0c2ce20d-09fa-4a3a-b15c-fb642f56d662.png)

3. Open the same post in a not-incognito window; click the 'Reply' link under one of the comments, and then 'Cancel reply'; confirm nothing happens. 
4. Apply the PR and run `npm run build`.
5. Confirm that the 'Cancel reply' link no longer appears on the AMP version of the page, whether correctly (you're logged in and trying to reply to a comment), or incorrectly (you're not logged in and it's just randomly appearing with the collapse toggle). 
6. Double check the non-AMP version of the page, and confirm the 'Cancel reply' link is still appearing when you click 'Reply' to a comment, and that it returns the comment form back to the bottom of the page when you click it. Here's how it should look (in line with the Post Comment button) when it's displaying:

![image](https://user-images.githubusercontent.com/177561/128435833-0a6047da-fb3a-41e6-906d-6b3b349942c4.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
