### PR TITLE
Newspack Sacha: Remove border when author & date are hidden

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -574,3 +574,12 @@ cite {
 		text-align: center;
 	}
 }
+
+// Listings
+.newspack-listings {
+	&.hide-date.hide-author {
+		.entry-subhead {
+			border-top: 0;
+		}
+	}
+}

--- a/newspack-theme/sass/plugins/newspack-listings.scss
+++ b/newspack-theme/sass/plugins/newspack-listings.scss
@@ -1,0 +1,8 @@
+// Listings
+.newspack-listings {
+	&.hide-date.hide-author {
+		.entry-subhead {
+			padding: 0;
+		}
+	}
+}

--- a/newspack-theme/sass/style-base.scss
+++ b/newspack-theme/sass/style-base.scss
@@ -54,7 +54,13 @@
 @import 'media/media';
 
 /* Newspack Ads support */
+
 @import 'plugins/newspack-ads';
 
 /* Yoast Breadcrumb support */
+
 @import 'plugins/yoast-breadcrumb';
+
+/* Newspack Listings support */
+
+@import 'plugins/newspack-listings';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a bit of padding, and most importantly, removes some unnecessary borders when you've hidden the author and date on the Newspack Listings when using Newspack Sacha.

Closes #1389

### How to test the changes in this Pull Request:

1. Start with a test site running Newspack Sacha; make sure you're running the latest Newspack Listings code as well, to make sure [this update ](https://github.com/Automattic/newspack-listings/pull/108) is included.
2. Add a Listing, and hide the author and date (either just on that listing, or site-wide under WP Admin > Listings > Settings).
3. View on the front-end; note the weird double-border that frames where the byline/date would normally go:

![image](https://user-images.githubusercontent.com/177561/128791407-e1dd7c98-da6b-4262-9bac-13f44e91c74b.png)

4. Apply the PR and run `npm run build`.
5. Confirm that you're just down to one border now:

![image](https://user-images.githubusercontent.com/177561/128791334-86c2b8c9-a40d-408e-9123-946245024c62.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
