### PR TITLE
Add 'above' and 'below' widget areas to the theme

### DIFF
--- a/newspack-nelson/functions.php
+++ b/newspack-nelson/functions.php
@@ -26,6 +26,15 @@ endif;
 add_action( 'after_setup_theme', 'newspack_nelson_setup', 12 );
 
 /**
+ * Function to remove the 'below header' widget area.
+ */
+function newspack_nelson_remove_widget() {
+	// Unregister the 'below header' widget area.
+	unregister_sidebar( 'header-3' );
+}
+add_action( 'widgets_init', 'newspack_nelson_remove_widget', 11 );
+
+/**
  * Function to load child theme's Google Fonts.
  */
 function newspack_nelson_fonts_url() {

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -308,6 +308,30 @@ function newspack_widgets_init() {
 
 	register_sidebar(
 		array(
+			'name'          => __( 'Above Header', 'newspack' ),
+			'id'            => 'header-2',
+			'description'   => esc_html__( 'Add widgets here to appear above the site header.', 'newspack' ),
+			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		)
+	);
+
+	register_sidebar(
+		array(
+			'name'          => __( 'Below Header', 'newspack' ),
+			'id'            => 'header-3',
+			'description'   => esc_html__( 'Add widgets here to appear below the site header.', 'newspack' ),
+			'before_widget' => '<section id="%1$s" class="below-content widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		)
+	);
+
+	register_sidebar(
+		array(
 			'name'          => __( 'Footer', 'newspack' ),
 			'id'            => 'footer-1',
 			'description'   => __( 'Add widgets here to appear in your footer.', 'newspack' ),

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -46,6 +46,14 @@ endif;
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
+	<?php if ( is_active_sidebar( 'header-2' ) ) : ?>
+		<div class="header-widget above-header-widgets">
+			<div class="wrapper">
+				<?php dynamic_sidebar( 'header-2' ); ?>
+			</div><!-- .wrapper -->
+		</div><!-- .above-header-widgets -->
+	<?php endif; ?>
+
 	<header id="masthead" class="site-header hide-header-search" [class]="searchVisible ? 'show-header-search site-header ' : 'hide-header-search site-header'">
 
 		<?php if ( true === $header_sub_simplified && ! is_front_page() ) : ?>
@@ -280,5 +288,13 @@ endif;
 	?>
 
 	<?php do_action( 'after_header' ); ?>
+
+	<?php if ( is_active_sidebar( 'header-3' ) ) : ?>
+		<div class="header-widget below-header-widgets">
+			<div class="wrapper">
+				<?php dynamic_sidebar( 'header-3' ); ?>
+			</div><!-- .wrapper -->
+		</div><!-- .above-header-widgets -->
+	<?php endif; ?>
 
 	<div id="content" class="site-content">

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -548,3 +548,26 @@
 		display: inherit;
 	}
 }
+
+// Header widgets
+.header-widget {
+	.wrapper {
+		display: block;
+	}
+
+	.widget:first-child {
+		margin-top: 0;
+	}
+
+	.alignfull {
+		margin-left: calc( 50% - 50vw );
+		margin-right: calc( 50% - 50vw );
+		max-width: 100vw;
+	}
+
+	.alignwide {
+		margin-left: calc( 25% - 25vw );
+		margin-right: calc( 25% - 25vw );
+		max-width: 100vw;
+	}
+}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -548,26 +548,3 @@
 		display: inherit;
 	}
 }
-
-// Header widgets
-.header-widget {
-	.wrapper {
-		display: block;
-	}
-
-	.widget:first-child {
-		margin-top: 0;
-	}
-
-	.alignfull {
-		margin-left: calc( 50% - 50vw );
-		margin-right: calc( 50% - 50vw );
-		max-width: 100vw;
-	}
-
-	.alignwide {
-		margin-left: calc( 25% - 25vw );
-		margin-right: calc( 25% - 25vw );
-		max-width: 100vw;
-	}
-}

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -189,8 +189,18 @@
 		margin: 0 auto;
 		max-width: 1200px;
 	}
+}
 
-	&.above-header-widgets {
-		border-bottom: 1px solid $color__border;
+.h-db .above-header-widgets {
+	border-bottom: 1px solid $color__border;
+}
+
+// The Subpage header + special featured image placements also can't really support an ad in this spot.
+.h-sub {
+	&.single-featured-image-beside,
+	&.single-featured-image-behind {
+		.below-header-widgets {
+			display: none;
+		}
 	}
 }

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -157,3 +157,40 @@
 .above-content {
 	margin: $size__spacing-unit 0 0;
 }
+
+// Header widgets
+.header-widget {
+	.wrapper {
+		display: block;
+	}
+
+	.widget:first-of-type {
+		margin-top: 0;
+	}
+
+	.widget:last-of-type {
+		margin-bottom: 0;
+	}
+
+	.alignfull {
+		margin-left: calc( 50% - 50vw );
+		margin-right: calc( 50% - 50vw );
+		max-width: 100vw;
+		width: auto;
+	}
+
+	.alignwide {
+		margin-left: calc( 25% - 25vw );
+		margin-right: calc( 25% - 25vw );
+		max-width: 100vw;
+	}
+
+	[class*='__inner-container'] {
+		margin: 0 auto;
+		max-width: 1200px;
+	}
+
+	&.above-header-widgets {
+		border-bottom: 1px solid $color__border;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new widget area above and below the header in the Newspack theme, with a couple exceptions:
* The 'below header' widget area is not included in Newspack Nelson. With the overlap, it's tricky to get the styles working nicely. I'm happy to revisit if we do see a lot of demand for it, but I until then, I'd like to keep things as simple as possible.
* Similar to the below header ads, if you use the simplified subpage header + the behind/beside image placements, the 'below header' widget is hidden via CSS, since the header overlaps the featured image.

For styles, I've tried to maximize the stuff we can do with the widget block editor, so I've done things like removed the top margin from the first width and bottom margin from the last widget - this way, it's easier to do things like add full-width group block with a background, and it will fill the space above the header. I would really appreciate some feedback whether or not this seems like a good idea, though, as it also means if you just add something like an ad block or image, you'll need to add spacer blocks, or a group block with a background as well, to make sure it doesn't touch the top/bottom of the screen. 😬 

**Note:** these widgets have different IDs than the ones added via plugin to a handful of Newspack sites. If we want to migrate folks off of that, we'll need to move the widget from the plugin-generated area to one of the theme areas, then deactivate the plugin. 

Closes #1419

### How to test the changes in this Pull Request:

1. Start with a theme other than Newspack Nelson. 
2. Apply the PR and run `npm run build`. 
3. Navigate to Customizer > Widgets, and confirm you now have two new widget areas: Above Header and Below Header. 
4. Try adding a widget to the 'Above Header' widget area; I'd recommend using an image, or starting with a group block with a background. 
5. Make sure you can align the group block wide and full, and that if you do it takes up all available space; an image or cover block should work the same way:

![image](https://user-images.githubusercontent.com/177561/129114128-ede497a3-295e-40d1-8245-1ee3aedb5ac3.png)

6. Add a widget to the 'Below Header' widget space; view and make sure things look good -- it should touch the header:

![image](https://user-images.githubusercontent.com/177561/129116213-2accd6a2-4a0b-4ff0-a5af-f82ea0f43f20.png)

7. Enable the subpage header  under Customizer > Header Settings > Simplified Subpage Header, and view posts with the featured image behind and beside; confirm that the below widget doesn't display:

![image](https://user-images.githubusercontent.com/177561/129116487-e0fbbebe-81cf-478d-b140-890c413ff5f7.png)

8. Disable the subpage header, and confirm the below header widget area does display on posts using the behind and beside featured image placement:

![image](https://user-images.githubusercontent.com/177561/129116833-4c8f513a-f8e1-43c0-9f3d-0fac54ac9703.png)

9. Switch to Newspack Nelson; make sure the 'Below Header' widget space is not displayed, and is not available in the Customizer, either. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
