### PR TITLE
fix: reduce padding on headings with backgrounds

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -177,6 +177,18 @@
 	}
 }
 
+//! Headings
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	&.has-background {
+		padding: 20px 30px;
+	}
+}
+
 //! Paragraphs
 .has-drop-cap:not( :focus )::first-letter {
 	font-size: 4em;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -26,6 +26,10 @@ body {
 
 p {
 	font-size: $font__size_base;
+
+	&.has-background {
+		padding: 20px 30px;
+	}
 }
 
 h1,
@@ -44,6 +48,10 @@ h6 {
 		&:visited {
 			color: $color__text-main;
 		}
+	}
+
+	&.has-background {
+		padding: 20px 30px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR reduces the padding that's added on the Heading block when you give it a background, to make it line up with the paragraph block.

It also fixes a preview issue with the paragraph block's padding in the editor.

Closes #1095; see #1373.

### How to test the changes in this Pull Request:

1. Add a Heading and Paragraph block, and give them both backgrounds.
2. View on the front-end; note the padding on the Heading block is a bit extreme, especially when comparing the two:

![image](https://user-images.githubusercontent.com/177561/129253207-9af329b8-54a1-43df-b360-29a8487bb3e0.png)

3. Apply the PR and run `npm run build`.
4. Confirm the padding is now more consistent, on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/129253137-37ab3b18-2837-4d27-abfe-e6324fa8cc0d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
