### PR TITLE
fix: style categories widget block to match legacy widget

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -767,6 +767,17 @@ p.has-background {
 	@include nestedSubMenuPadding();
 }
 
+.widget .wp-block-categories li {
+	font-weight: normal;
+	line-height: 1.6;
+	padding-bottom: 0;
+
+	a {
+		display: inline-block;
+		padding: #{0.125 * $size__spacing-unit} 0;
+	}
+}
+
 .wp-block-latest-posts {
 	li > a {
 		font-family: $font__heading;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Categories block, when placed in a widget area, still displays the same as the Categories Widget (with non-bolded text, and similar spacing). 

See #1373

### How to test the changes in this Pull Request:

1. Add a Categories Block to the sidebar widget area. 
2. Install and activate the [Classic Widgets](https://wordpress.org/plugins/classic-widgets/) plugin.
3. Add a Categories legacy widget to the sidebar.
4. Compare on the front-end; note that the block is bolded, and the links are spaced further apart:

![image](https://user-images.githubusercontent.com/177561/129257371-f65a207f-f074-4514-9a29-24972842da8e.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the font weight and spacing between the two widgets are now the same:

![image](https://user-images.githubusercontent.com/177561/129257387-b8fbc035-351d-4b0d-946c-430f38ae1ee5.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
