### PR TITLE
Make sure comments block doesn't wrongly inherit avatar sizes

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -299,13 +299,15 @@ amp-script .cat-links {
 		}
 	}
 
-	.avatar {
-		height: #{1.75 * $size__spacing-unit};
-		width: #{1.75 * $size__spacing-unit};
+	.entry-subhead {
+		.avatar {
+			height: #{1.75 * $size__spacing-unit};
+			width: #{1.75 * $size__spacing-unit};
 
-		@include media( tablet ) {
-			height: #{2.25 * $size__spacing-unit};
-			width: #{2.25 * $size__spacing-unit};
+			@include media( tablet ) {
+				height: #{2.25 * $size__spacing-unit};
+				width: #{2.25 * $size__spacing-unit};
+			}
 		}
 	}
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -299,18 +299,6 @@ amp-script .cat-links {
 		}
 	}
 
-	.entry-subhead {
-		.avatar {
-			height: #{1.75 * $size__spacing-unit};
-			width: #{1.75 * $size__spacing-unit};
-
-			@include media( tablet ) {
-				height: #{2.25 * $size__spacing-unit};
-				width: #{2.25 * $size__spacing-unit};
-			}
-		}
-	}
-
 	.main-content > .post-thumbnail:first-child {
 		margin-top: #{2 * $size__spacing-unit};
 	}
@@ -325,6 +313,19 @@ amp-script .cat-links {
 			.entry-meta {
 				flex-grow: 2;
 			}
+		}
+	}
+}
+
+.entry-subhead,
+.comment-list {
+	.avatar {
+		height: #{1.75 * $size__spacing-unit};
+		width: #{1.75 * $size__spacing-unit};
+
+		@include media( tablet ) {
+			height: #{2.25 * $size__spacing-unit};
+			width: #{2.25 * $size__spacing-unit};
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Comments Block is incorrectly picking up the avatar sizing applied to the single post byline and comments, causing the border radius to look wonky.

This PR makes the avatar styles more specific so they won't be picked up by other areas of the page. 

See 1373.

### How to test the changes in this Pull Request:

1. Add the Comments Block to the sidebar, or to a single post's content.
2. View on front end and note the wacky border radius - not quite a circle, definitely not a square:

![image](https://user-images.githubusercontent.com/177561/129261637-4e45ba61-7398-4be7-b00b-ce75a5dc1e5d.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the avatars are actually round (and also smaller):

![image](https://user-images.githubusercontent.com/177561/129261561-fafc2784-dab1-4302-a233-b303814b62e6.png)

5. Make sure the byline avatar and comments avatars are still picking up the styles -- the easiest way is to make sure they get slightly smaller for mobile-sized screens. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
