### PR TITLE
Make sure preformatted block doesn't get too small

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -809,7 +809,7 @@ p.has-background {
 }
 
 .widget .wp-block-preformatted {
-	font-size: $font__size-sm;
+	font-size: 0.9em;
 }
 
 //! Verse

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -808,6 +808,10 @@ p.has-background {
 	padding: $size__spacing-unit;
 }
 
+.widget .wp-block-preformatted {
+	font-size: $font__size-sm;
+}
+
 //! Verse
 .wp-block-verse {
 	font-family: $font__body;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -809,7 +809,7 @@ p.has-background {
 }
 
 .widget .wp-block-preformatted {
-	font-size: 0.9em;
+	font-size: $font__size-sm;
 }
 
 //! Verse


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The preformatted block is styled to be smaller than the regular text, but when added to a widget area, it gets even smaller. 

This PR bumps up the font size a little bit, so it's at least not difficult to read.

Closes #1373

### How to test the changes in this Pull Request:

1. Add the preformatted block to the sidebar and view on the front-end:

![image](https://user-images.githubusercontent.com/177561/129263331-d5ade6c6-0fff-4055-aa62-0e50df3b54b4.png)

2. Apply the PR and run` npm run build`.
3. Confirm that the block is a bit larger (though it is still pretty small, so it's still relatively sized to other widget blocks).

![image](https://user-images.githubusercontent.com/177561/129263142-12799e62-3bd8-46c7-8a98-061233918c9b.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
