### PR TITLE
Newspack Nelson: remove overlap when featured image is above

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -106,8 +106,7 @@ body:not( .h-sb ) .site-header {
 
 // Featured templates - Short header on subpages
 .single-featured-image-beside,
-.single-featured-image-behind,
-.single-featured-image-above {
+.single-featured-image-behind {
 	@include media( tablet ) {
 		&.h-sub.h-db,
 		&.h-sub.h-sb {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -106,7 +106,8 @@ body:not( .h-sb ) .site-header {
 
 // Featured templates - Short header on subpages
 .single-featured-image-beside,
-.single-featured-image-behind {
+.single-featured-image-behind,
+.single-featured-image-above {
 	@include media( tablet ) {
 		&.h-sub.h-db,
 		&.h-sub.h-sb {
@@ -178,7 +179,8 @@ body:not( .h-sb ) .site-header {
 	}
 }
 
-.single-featured-image-behind {
+.single-featured-image-behind,
+.single-featured-image-above {
 	#primary {
 		padding-top: 0;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newspack Nelson's overlap doesn't play well with the different featured image settings.

When the 'behind' or 'beside' option is selected, the overlap is essentially 'styled away' -- this PR does the same with the 'above' image placement, which was somehow missed before. 

Closes #1481

### How to test the changes in this Pull Request:

1. Switch your test site to Newspack Nelson.
2. Create a post; add a featured image and change the position to "Above"
3. View on the front-end and note the big weird gap:

![image](https://user-images.githubusercontent.com/177561/129425903-b321f07b-c88b-4133-8797-516773155ff9.png)

4. Apply the PR and run `npm run build`
5. Refresh the post and confirm that the weird gap is now gone! 

![image](https://user-images.githubusercontent.com/177561/129425857-22938cae-8ae3-46e9-954f-dc9912a85e32.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
