### PR TITLE
WooCommerce: Bump template version number

### DIFF
--- a/newspack-theme/woocommerce/order/order-details-customer.php
+++ b/newspack-theme/woocommerce/order/order-details-customer.php
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
 $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
 ?>
 <section class="woocommerce-customer-details">
+
 	<h4><?php esc_html_e( 'Your Information', 'newspack' ); ?></h4>
 
 	<?php if ( $show_shipping ) : ?>

--- a/newspack-theme/woocommerce/order/order-details-customer.php
+++ b/newspack-theme/woocommerce/order/order-details-customer.php
@@ -11,8 +11,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
- * @version 3.4.4
+ * @package WooCommerce\Templates
+ * @version 5.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +20,6 @@ defined( 'ABSPATH' ) || exit;
 $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_address();
 ?>
 <section class="woocommerce-customer-details">
-
 	<h4><?php esc_html_e( 'Your Information', 'newspack' ); ?></h4>
 
 	<?php if ( $show_shipping ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps the version of the WooCommerce order-details-customer.php  file. 

The two changes that were incorporated in the template change on the WooCommerce side were [changing the `@package` tag formatting](https://github.com/woocommerce/woocommerce/pull/27239) (included), and displaying the [Shipping phone number](https://github.com/woocommerce/woocommerce/pull/30097). Since we don't collect a Shipping phone number -- and it's not included in the Shipping address form by default -- I've opted not to add to our copy of the template.

Closes #1486

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Check the code and make sure nothing unexpected has been changed. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
