### PR TITLE
Feat: add widget area above the footer

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -411,15 +411,26 @@ hr {
 		color: $color__text-main;
 	}
 
-	.footer-branding .wrapper,
-	.footer-widgets:first-child {
-		border-top: 3px solid currentColor;
-	}
-
 	.widget-title {
 		color: $color__text-main;
 		font-size: $font__size_base;
 	}
+}
+
+.footer-branding .wrapper,
+.footer-widgets:first-child {
+	border-top: 3px solid currentColor;
+}
+
+.af-widget {
+	.footer-branding .wrapper,
+	.footer-widgets:first-child {
+		border: 0;
+	}
+}
+
+.above-footer-widgets {
+	overflow: hidden;
 }
 
 .site-content .wpnbha {

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -307,14 +307,21 @@ div.wpnbha .article-section-title {
 		color: $color__text-main;
 	}
 
-	.footer-branding .wrapper,
-	.footer-widgets:first-child {
-		border-top: 3px solid currentColor;
-	}
-
 	.widget-title {
 		color: $color__text-main;
 		font-size: $font__size_base;
+	}
+}
+
+.footer-branding .wrapper,
+.footer-widgets:first-child {
+	border-top: 3px solid currentColor;
+}
+
+.af-widget {
+	.footer-branding .wrapper,
+	.footer-widgets:first-child {
+		border: 0;
 	}
 }
 

--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -11,6 +11,14 @@
 
 ?>
 
+	<?php if ( is_active_sidebar( 'footer-3' ) ) : ?>
+		<div class="above-footer-widgets">
+			<div class="wrapper">
+				<?php dynamic_sidebar( 'footer-3' ); ?>
+			</div><!-- .wrapper -->
+		</div><!-- .above-footer-widgets -->
+	<?php endif; ?>
+
 	<?php do_action( 'before_footer' ); ?>
 
 	</div><!-- #content -->

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -332,6 +332,18 @@ function newspack_widgets_init() {
 
 	register_sidebar(
 		array(
+			'name'          => __( 'Above Footer', 'newspack' ),
+			'id'            => 'footer-3',
+			'description'   => esc_html__( 'Add widgets here to appear above the site footer.', 'newspack' ),
+			'before_widget' => '<section id="%1$s" class="above-footer widget %2$s">',
+			'after_widget'  => '</section>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+		)
+	);
+
+	register_sidebar(
+		array(
 			'name'          => __( 'Footer', 'newspack' ),
 			'id'            => 'footer-1',
 			'description'   => __( 'Add widgets here to appear in your footer.', 'newspack' ),

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -146,7 +146,7 @@ function newspack_body_classes( $classes ) {
 
 	// Adds a class of has-afw when there is an above footer widget.
 	if ( is_active_sidebar( 'footer-3' ) ) {
-		$classes[] = 'has-afw';
+		$classes[] = 'af-widget';
 	}
 
 	// Add a class for each category assigned to a single post.

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -144,6 +144,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-sidebar';
 	}
 
+	// Adds a class of has-afw when there is an above footer widget.
+	if ( is_active_sidebar( 'footer-3' ) ) {
+		$classes[] = 'has-afw';
+	}
+
 	// Add a class for each category assigned to a single post.
 	if ( is_single() ) {
 		foreach ( ( get_the_category( $page_id ) ) as $category ) {

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -41,6 +41,10 @@
 	}
 }
 
+.has-afw .site-footer {
+	margin-top: 0;
+}
+
 /* When the Customizer option is enabled, override the footer columns layout */
 .fw-stacked .footer-widgets .wrapper {
 	display: block;

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -41,7 +41,7 @@
 	}
 }
 
-.has-afw .site-footer {
+.af-widget .site-footer {
 	margin-top: 0;
 }
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -159,7 +159,8 @@
 }
 
 // Header widgets
-.header-widget {
+.header-widget,
+.above-footer-widgets {
 	.wrapper {
 		display: block;
 	}
@@ -189,6 +190,10 @@
 		margin: 0 auto;
 		max-width: 1200px;
 	}
+}
+
+.above-footer-widgets {
+	margin-top: #{2 * $size__spacing-unit};
 }
 
 .h-db .above-header-widgets {

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -185,3 +185,12 @@
 		border-top: 4px solid $color__border;
 	}
 }
+
+.af-widget {
+	.site-footer .footer-branding,
+	.site-footer .footer-widgets:first-child {
+		.wrapper {
+			border: 0;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #1475, this PR adds a widget area above the footer, and I used a similar approach, trying to maximize the stuff we can do with the widget block area. 

When the widget is populated, the margin at the top of the site footer is removed, so they should be able to touch, say, if you have a full-width group block with a background in the widget area.

Closes #1428

### How to test the changes in this Pull Request:

How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Widgets, and confirm you now have a new Above Footer widget area.
3. Try adding a widget to this widget area; I'd recommend using an image, or starting with a group block with a background.
4. Make sure you can align the group block wide and full, and that if you do it takes up all available space; an image or cover block should work the same way:

![image](https://user-images.githubusercontent.com/177561/129976616-c78768d4-08ca-47ca-9966-347dd42d03ad.png)

5. If it's not already, switch the footer background to default under Customizer > Colors. 
6. When there's no background colour, the default Newspack theme, Newspack Scott and Newspack Joseph all have a border on top of their footers. So cycle through Newspack theme, Newspack Scott and Newspack Joseph, and confirm there's no top border. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
