### PR TITLE
fix: ensure header_color is defined in child themes

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -11,6 +11,9 @@ function newspack_joseph_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -11,6 +11,9 @@ function newspack_katharine_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -11,6 +11,9 @@ function newspack_nelson_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
@@ -18,9 +21,6 @@ function newspack_nelson_custom_colors_css() {
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
 			$header_color_contrast = newspack_get_color_contrast( $header_color );
-		} else {
-			$header_color          = $primary_color;
-			$header_color_contrast = newspack_get_color_contrast( $primary_color );
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -11,6 +11,9 @@ function newspack_sacha_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -11,6 +11,9 @@ function newspack_scott_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -14,6 +14,9 @@ function newspack_custom_colors_css() {
 	$secondary_color = newspack_get_secondary_color();
 	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
 
+	$header_color          = $primary_color;
+	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+			
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
@@ -23,9 +26,6 @@ function newspack_custom_colors_css() {
 			$header_color_contrast       = newspack_get_color_contrast( $header_color );
 			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '' );
 			$primary_menu_color_contrast = newspack_get_color_contrast( $primary_menu_color );
-		} else {
-			$header_color          = $primary_color;
-			$header_color_contrast = newspack_get_color_contrast( $primary_color );
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP notice. This PR sets the default value of `$header_color` to the primary color. @laurelfulford - please have a look and let me know if that's ok. 

### How to test the changes in this Pull Request:

1. With the WP debugging on, visit the Customizer while having Newspack Nelson set as the theme 
2. Observe PHP notices stemming from the fact that `$header_color` variable is undefined  
3. Switch to this branch, observe the notices are gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->