### PR TITLE
Feat: add support for Typenetwork.com fonts

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1583,10 +1583,11 @@ function newspack_sanitize_font_provider_url( $code ) {
 		return '';
 	}
 	$font_service_urls = array(
-		'google'     => 'fonts.googleapis.com',
-		'fonts'      => 'fast.fonts.net',
-		'typekit'    => 'use.typekit.net',
-		'typography' => 'cloud.typography.com',
+		'google'      => 'fonts.googleapis.com',
+		'fonts'       => 'fast.fonts.net',
+		'typekit'     => 'use.typekit.net',
+		'typography'  => 'cloud.typography.com',
+		'typenetwork' => 'cloud.typenetwork.com',
 	);
 
 	$regex = '/\/\/[^\("\') \n]+/i';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for fonts enqueued from cloud.typenetwork.com.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Typography, and try adding a url for Typenetwork to one of the Font Provider fields (eg. https://cloud.typenetwork.com/projects/1111/fontface.css)
2. Click Publish; note the error. 
3. Apply the PR.
4. Repeat steps 1 and 2; confirm that the error is now gone, and the URL value saves.

If you like, ping me and I can share a real font URL to save (the project # is from a real project, so it seems like it shouldn't be shared here 😅 ).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
