### PR TITLE
feat: option to pick page default template

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1001,10 +1001,17 @@ add_filter( 'get_the_archive_title', 'newspack_update_the_archive_title', 11, 1 
  * @param boolean $update Whether this is an existing post being updated or not.
  */
 function newspack_maybe_set_default_post_template( $post_ID, $post, $update ) {
-	if ( ! $update && 'post' === $post->post_type ) {
-		$post_template_default = get_theme_mod( 'post_template_default' );
-		if ( 'default' !== $post_template_default ) {
-			update_post_meta( $post_ID, '_wp_page_template', $post_template_default );
+	if ( ! $update ) {
+		if ( 'post' === $post->post_type ) {
+			$post_template_default = get_theme_mod( 'post_template_default' );
+			if ( 'default' !== $post_template_default ) {
+				update_post_meta( $post_ID, '_wp_page_template', $post_template_default );
+			}
+		} elseif ( 'page' === $post->post_type ) {
+			$page_template_default = get_theme_mod( 'page_template_default' );
+			if ( 'default' !== $page_template_default ) {
+				update_post_meta( $post_ID, '_wp_page_template', $page_template_default );
+			}
 		}
 	}
 }

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -812,7 +812,7 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
-	// Add option to select the default post template
+	// Add option to select the default post template.
 	$wp_customize->add_setting(
 		'post_template_default',
 		array(
@@ -953,6 +953,28 @@ function newspack_customize_register( $wp_customize ) {
 				'beside' => esc_html__( 'Beside article title', 'newspack' ),
 				'above'  => esc_html__( 'Above article title', 'newspack' ),
 				'hidden' => esc_html__( 'Hidden', 'newspack' ),
+			),
+			'section' => 'page_default_settings',
+		)
+	);
+
+	// Add option to select the d page template.
+	$wp_customize->add_setting(
+		'page_template_default',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_post_template',
+		)
+	);
+	$wp_customize->add_control(
+		'page_template_default',
+		array(
+			'type'    => 'select',
+			'label'   => __( 'Default Page Template', 'newspack' ),
+			'choices' => array(
+				'default'            => esc_html__( 'Default Template', 'newspack' ),
+				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
+				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
 			'section' => 'page_default_settings',
 		)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to the option to set a default post template, this PR adds an option to pick a default page template. 

Closes #1324 

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Template Settings > Page Settings; confirm you now have an option to pick a default page template.
3. Change the dropdown to One Column or One Column Wide, and save the settings.
4. Create a new page.
5. Confirm that your new default template is selected in the right column of the editor, and is applied on publish. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
