### PR TITLE
fix: turn off AMP lightbox by default for theme elements

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -17,7 +17,7 @@
 	<?php wp_head(); ?>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php body_class(); ?> data-amp-auto-lightbox-disable>
 <?php
 
 do_action( 'wp_body_open' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR disables the AMP lightbox by default; it's currently applied to all images, some which are too-easily clicked (featured images), or seem odd to zoom in on (author avatars). 

Closes #1450 

### How to test the changes in this Pull Request:

1. Start with a test site with AMP enabled. 
2. View a single post, and try clicking the featured image, and author avatar. Both will open in a lightbox.
3. Apply the PR and run `npm run build`. 
4. Confirm that clicking the featured image/avatar no longer open the images in a lightbox.
5. Try adding an Image Block to a post or page, and in the right sidebar, enable "Add lightbox effect" under AMP Settings; publish.
6. On the front-end, try clicking the image and confirm that the lightbox works for the block where it's enabled. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
