### PR TITLE
feat: add option to change archive title format

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -448,10 +448,6 @@ cite {
 	&.author .page-header {
 		display: block;
 
-		.page-title {
-			margin: 0 0 1rem;
-		}
-
 		> span {
 			display: inline;
 		}

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -448,6 +448,14 @@ cite {
 	&.author .page-header {
 		display: block;
 
+		.page-title {
+			margin: 0 0 1rem;
+		}
+
+		> span {
+			display: inline;
+		}
+
 		.avatar {
 			margin: 0 auto $size__spacing-unit;
 
@@ -460,6 +468,10 @@ cite {
 				height: 80px;
 				width: 80px;
 			}
+		}
+
+		.author-social-links {
+			justify-content: center;
 		}
 	}
 }

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -81,22 +81,32 @@ $show_excerpt        = get_theme_mod( 'archive_show_excerpt', false );
 					// Get info for underwriter archive sponsors.
 					newspack_sponsored_underwriters_info( $underwriter_sponsors );
 				}
-			?>
 
-				<?php if ( is_author() ) : ?>
-					<div class="author-meta">
-						<?php
-							$author_email = get_the_author_meta( 'user_email', get_query_var( 'author' ) );
-							if ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author_email ) :
-							?>
-							<a class="author-email" href="<?php echo 'mailto:' . esc_attr( $author_email ); ?>">
-								<?php echo wp_kses( newspack_get_social_icon_svg( 'mail', 18 ), newspack_sanitize_svgs() ); ?>
-								<?php echo esc_html( $author_email ); ?>
-							</a>
-						<?php endif; ?>
+				if ( is_author() ) :
+					// Get all of the author information.
+					$author_id          = get_the_author_meta( 'ID' );
+					$show_author_social = get_theme_mod( 'show_author_social', false );
+					$show_author_email  = get_theme_mod( 'show_author_email', false );
+					$author_social      = newspack_author_get_social_links( $author_id );
+					$author_email       = get_the_author_meta( 'user_email', get_query_var( 'author' ) );
 
-						<?php newspack_author_social_links( get_the_author_meta( 'ID' ), 20 ); ?>
-					</div><!-- .author-meta -->
+					// Don't output author-meta container unless it's populated.
+					if ( ( $show_author_social && '' !== $author_social ) || ( $show_author_email && '' !== $author_email ) ) :
+						?>
+						<div class="author-meta">
+							<?php
+							if ( $show_author_email && '' !== $author_email ) :
+								?>
+								<a class="author-email" href="<?php echo 'mailto:' . esc_attr( $author_email ); ?>">
+									<?php echo wp_kses( newspack_get_social_icon_svg( 'mail', 18 ), newspack_sanitize_svgs() ); ?>
+									<?php echo esc_html( $author_email ); ?>
+								</a>
+							<?php endif; ?>
+
+							<?php newspack_author_social_links( $author_id, 20 ); ?>
+						</div><!-- .author-meta -->
+
+					<?php endif; ?>
 
 					<?php do_action( 'newspack_theme_below_author_archive_meta' ); ?>
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -976,7 +976,9 @@ add_filter( 'the_content_feed', 'newspack_thumbnails_in_rss' );
  */
 function newspack_update_the_archive_title( $title ) {
 	// Split the title into parts so we can wrap them with spans:
-	$title_parts = explode( '<span class="page-description">', $title, 2 );
+	$title_parts  = explode( '<span class="page-description">', $title, 2 );
+	$title_format = get_theme_mod( 'archive_title_format', 'default' );
+
 	// Glue it back together again.
 	if ( ! empty( $title_parts[1] ) ) {
 		$title = wp_kses(
@@ -987,7 +989,11 @@ function newspack_update_the_archive_title( $title ) {
 				),
 			)
 		);
-		$title = '<span class="page-subtitle">' . esc_html( $title_parts[0] ) . '</span><span class="page-description">' . $title;
+		if ( 'default' === $title_format ) {
+			$title = '<span class="page-subtitle">' . esc_html( $title_parts[0] ) . '</span><span class="page-description">' . $title;
+		} else {
+			$title = '<span class="page-description">' . $title;
+		}
 	}
 	return $title;
 }

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1027,6 +1027,29 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to customize archive titles.
+	$wp_customize->add_setting(
+		'archive_title_format',
+		array(
+			'default'           => 'default',
+			'sanitize_callback' => 'newspack_sanitize_radio',
+		)
+	);
+
+	$wp_customize->add_control(
+		'archive_title_format',
+		array(
+			'type'        => 'radio',
+			'label'       => esc_html__( 'Archive Title Format', 'newspack' ),
+			'description' => esc_html__( 'Change the format of the title used on archive pages.', 'newspack' ),
+			'choices'     => array(
+				'default' => esc_html__( 'Default (eg. "Category: Featured", "Author: Jane Doe")', 'newspack' ),
+				'short'   => esc_html__( 'Only archive name (eg. "Featured", "Jane Doe")', 'newspack' ),
+			),
+			'section'     => 'archive_options',
+		)
+	);
+
 	/**
 	 * Comments settings
 	 */

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -156,7 +156,35 @@ if ( ! function_exists( 'newspack_author_social_links' ) ) :
 	 * Prints list of social links for the current author.
 	 */
 	function newspack_author_social_links( $author_id, $size = 24 ) {
+		$links = newspack_author_get_social_links( $author_id, $size );
 
+		// Create array of allowed HTML, including SVG markup.
+		$allowed_html = array(
+			'a'  => array(
+				'href'   => array(),
+				'title'  => array(),
+				'target' => array(),
+			),
+			'li' => array(
+				'class' => array(),
+			),
+		);
+		$allowed_html = array_merge( $allowed_html, newspack_sanitize_svgs() );
+
+		if ( '' !== $links && true === get_theme_mod( 'show_author_social', false ) ) {
+			echo '<ul class="author-social-links">' . wp_kses( $links, $allowed_html ) . '</ul>';
+		}
+	}
+endif;
+
+if ( ! function_exists( 'newspack_author_get_social_links' ) ) :
+	/**
+	 * Gets a list of social links for the current author.
+	 *
+	 * @param integer $author_id The author ID.
+	 * @param integer $size The SVG icon size.
+	 */
+	function newspack_author_get_social_links( $author_id, $size = 24 ) {
 		// Get list of available social profiles.
 		$social_profiles = array(
 			'facebook',
@@ -174,19 +202,6 @@ if ( ! function_exists( 'newspack_author_social_links' ) ) :
 		// Create empty string for links.
 		$links = '';
 
-		// Create array of allowed HTML, including SVG markup.
-		$allowed_html = array(
-			'a'  => array(
-				'href'   => array(),
-				'title'  => array(),
-				'target' => array(),
-			),
-			'li' => array(
-				'class' => array(),
-			),
-		);
-		$allowed_html = array_merge( $allowed_html, newspack_sanitize_svgs() );
-
 		foreach ( $social_profiles as $profile ) {
 			if ( '' !== get_the_author_meta( $profile, $author_id ) ) {
 				if ( 'twitter' === $profile ) {
@@ -197,9 +212,7 @@ if ( ! function_exists( 'newspack_author_social_links' ) ) :
 			}
 		}
 
-		if ( '' !== $links && true === get_theme_mod( 'show_author_social', false ) ) {
-			echo '<ul class="author-social-links">' . wp_kses( $links, $allowed_html ) . '</ul>';
-		}
+		return $links;
 	}
 endif;
 

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -97,6 +97,20 @@
 			width: 30px;
 		}
 
+		.page-title {
+			margin-bottom: 0;
+		}
+
+		> span {
+			align-items: center;
+			display: inline-flex;
+			flex-wrap: wrap;
+
+			> * {
+				width: 100%;
+			}
+		}
+
 		@include media( mobile ) {
 			.avatar {
 				height: 80px;

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -97,6 +97,10 @@
 			width: 30px;
 		}
 
+		.page-title:last-child {
+			margin-bottom: 0;
+		}
+
 		.taxonomy-description p:first-child {
 			margin-top: 0;
 		}

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -98,7 +98,7 @@
 		}
 
 		.page-title {
-			margin-bottom: 0;
+			margin: 0;
 		}
 
 		> span {

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -97,8 +97,8 @@
 			width: 30px;
 		}
 
-		.page-title {
-			margin: 0;
+		.taxonomy-description p:first-child {
+			margin-top: 0;
 		}
 
 		> span {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an option to remove the archive page title 'prefixes', eg. removing 'Category:', 'Tag:', 'Author:'...

Given the different kinds of archives (especially with different CPTs) this seemed like the simplest approach, and closest mimics what's possible with the theme visually now. But if we do find that publishers want more options for these titles, we can explore that further in a different PR. 

Closes #1493

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Navigate to Customizer > Template Settings > Archive Settings, and confirm you now have an option to change the Archive Title. 
3. Confirm that the option labels make sense. 
4. Try switching to "Only Archive Name"; confirm that the prefix part of the archive titles are removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
