### PR TITLE
Update header colour logic

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -18,8 +18,6 @@ function newspack_joseph_custom_colors_css() {
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
-		} else {
-			$header_color = '#111';
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {

--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -10,17 +10,16 @@
 function newspack_joseph_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
-
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	$header_color    = '#111';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
+		} else {
+			$header_color = '#111';
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -32,6 +31,7 @@ function newspack_joseph_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '
 		@media only screen and (min-width: 782px) {

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -10,17 +10,16 @@
 function newspack_katharine_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
-
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	$header_color    = '#333';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
+		} else {
+			$header_color = '#333';
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -32,6 +31,7 @@ function newspack_katharine_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '
 		.archive .page-title,

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -18,8 +18,6 @@ function newspack_katharine_custom_colors_css() {
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
-		} else {
-			$header_color = '#333';
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -10,17 +10,16 @@
 function newspack_nelson_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
-
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	$header_color    = $primary_color;
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
+		} else {
+			$header_color = $primary_color;
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -32,6 +31,7 @@ function newspack_nelson_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '
 		.site-header,

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -10,9 +10,7 @@
 function newspack_sacha_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
-
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	$header_color    = '#333';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
@@ -20,7 +18,8 @@ function newspack_sacha_custom_colors_css() {
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+		} else {
+			$header_color = '#333';
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -32,6 +31,7 @@ function newspack_sacha_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '
 		.archive .page-title,

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -17,9 +17,7 @@ function newspack_sacha_custom_colors_css() {
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-		} else {
-			$header_color = '#333';
+			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -10,20 +10,16 @@
 function newspack_scott_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
-
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
+	$header_color    = $primary_color;
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color          = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast = newspack_get_color_contrast( $header_color );
+			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
 		} else {
-			$header_color          = $primary_color;
-			$header_color_contrast = newspack_get_color_contrast( $primary_color );
+			$header_color = $primary_color;
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -35,6 +31,7 @@ function newspack_scott_custom_colors_css() {
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '
 		.accent-header:not(.widget-title):before,

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -13,19 +13,18 @@ function newspack_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
 	$secondary_color = newspack_get_secondary_color();
 	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
+	$header_color    = $primary_color;
 
-	$header_color          = $primary_color;
-	$header_color_contrast = newspack_get_color_contrast( $primary_color );
-			
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
 		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color                = get_theme_mod( 'header_color_hex', '#666666' );
-			$header_color_contrast       = newspack_get_color_contrast( $header_color );
 			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '' );
 			$primary_menu_color_contrast = newspack_get_color_contrast( $primary_menu_color );
+		} else {
+			$header_color = $primary_color;
 		}
 
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
@@ -38,6 +37,7 @@ function newspack_custom_colors_css() {
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$cta_color_contrast       = newspack_get_color_contrast( $cta_color );
+	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the header colour code defaults. 

Originally some formatting feedback of mine resulted in an issue with Newspack Nelson, but when testing that more fully, I found a couple other odd cases where the colours do not behave as expected when you don't have a specific header colour set (or in cases where the header colour should be picking up the primary colour as a default, but it wasn't picking up the _updated_ primary colour). So this PR tweaks all to the header colour assignment code, taking into account the convoluted ways different child themes work (eg. Newspack Sacha, Katharine and Joseph all use greys for their default solid headers). 

I tested this against an older version of the theme, and took how the different colour/header settings acted there as a source of truth, since it's pretty convoluted! 😐 For context, the solid header background option predates the option to actually change the header colour, so the theme-to-theme defaults were different because they were the only options there were. 

Closes #1505.

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Navigate to Customizer > Colours, and set it to the default header colours, then default colours.
3. Navigate to Customizer > Header Settings > Appearance and check Solid Background. 

4. **Switch the theme to Newspack Default.**
 a. Check the header and mobile menu; confirm both are using Newspack blue:

![image](https://user-images.githubusercontent.com/177561/132597726-53374d2b-da47-43ad-89f4-5811d5fa6e2e.png)

![image](https://user-images.githubusercontent.com/177561/132597739-17f0182d-b53c-4c57-88c6-3c54da956cab.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:
     
![image](https://user-images.githubusercontent.com/177561/132597975-20db7ea0-b018-4dbb-a142-46e402ac3cb5.png)

![image](https://user-images.githubusercontent.com/177561/132597988-dd0a0c19-1d3f-4db3-9030-abd68847b262.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:
     
![image](https://user-images.githubusercontent.com/177561/132598266-98282a3b-757f-427e-8c92-3cdb8580d326.png)

![image](https://user-images.githubusercontent.com/177561/132598284-260f8f4a-2ea4-4b7f-91b8-a2bdf78b1884.png)

5. **Repeat Step 2, and switch to Newspack Joseph:**
 a. Check the header and mobile menu; confirm both are using very dark grey (basically black):

![image](https://user-images.githubusercontent.com/177561/132600588-b25c68d1-22ce-426c-8cd0-28085be844f3.png)

![image](https://user-images.githubusercontent.com/177561/132600599-9178d876-a259-41a2-adb6-718639d292bf.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that the header stays dark grey/black, but the mobile menu picks up your primary colour:

![image](https://user-images.githubusercontent.com/177561/132601373-b305382e-2b90-4f8a-b438-038a270efd4b.png)

![image](https://user-images.githubusercontent.com/177561/132601386-999a6b4f-56b5-4d8c-af1e-3655c388da28.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132601628-2e96fbab-7671-4010-935b-53a55d916d61.png)

![image](https://user-images.githubusercontent.com/177561/132601634-e5178332-caf0-4491-9a97-abea511b3432.png)

6. **Repeat Step 2, and switch to Newspack Katharine:**
 a. Check the header and mobile menu; confirm that the header is using dark grey, and the mobile menu is using the primary colour:

![image](https://user-images.githubusercontent.com/177561/132602239-71089c2b-445c-4809-aaa5-41c813340621.png)

![image](https://user-images.githubusercontent.com/177561/132602250-4a129596-d7ae-4b37-b7db-6b09f2ee3b34.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that the header stays grey, and the mobile menu picks up your new primary colour:

![image](https://user-images.githubusercontent.com/177561/132602431-d6d1eff6-5cee-4c30-ba89-dd2c56f20478.png)

![image](https://user-images.githubusercontent.com/177561/132602441-0fe57583-9f7a-4792-99c4-60e9721765d2.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132602557-e6e5514c-e727-4613-99b1-a25d38082d14.png)

![image](https://user-images.githubusercontent.com/177561/132602570-031a71e3-d6f0-4dbd-8889-0fedb2b6f148.png)

7. **Repeat Step 2, and switch to Newspack Nelson:**
 a. Check the header and mobile menu; confirm that the header and mobile menu are both using the primary colour:

![image](https://user-images.githubusercontent.com/177561/132602858-30ba51a4-6a05-40d6-8420-e9eeb60dc0f2.png)

![image](https://user-images.githubusercontent.com/177561/132602869-1e86d5ea-6120-4454-a4ce-9ea711ce6b29.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132603028-b80a200a-fd8a-4f1d-8060-3c901554a387.png)

![image](https://user-images.githubusercontent.com/177561/132603039-40e9c271-5824-4407-a530-ff213ec38ab6.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132603134-7429575c-5067-4ce4-af52-e58a6d2cf38d.png)

![image](https://user-images.githubusercontent.com/177561/132603143-15300165-8dfd-42a7-b46b-4bdb3b13f262.png)

8. **Repeat Step 2, and switch to Newspack Sacha:**
 a. Check the header and mobile menu; confirm that the header is dark grey and mobile menu is the primary colour:

![image](https://user-images.githubusercontent.com/177561/132603454-8c1a3a42-ee34-4dd2-b961-e1927c64f4b1.png)

![image](https://user-images.githubusercontent.com/177561/132603482-d9b78960-daa2-44c9-a579-4a9e4f93452f.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that the header stays grey, and the mobile menu picks up your new primary colour:

![image](https://user-images.githubusercontent.com/177561/132603625-3e6995f1-7f6a-4f74-86f7-22d4fd793466.png)

![image](https://user-images.githubusercontent.com/177561/132603615-5238de5d-3976-4853-b41e-9c009febef78.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132603697-3390cc23-472c-4874-afd0-df086b5a556f.png)

![image](https://user-images.githubusercontent.com/177561/132603710-8e3b9be0-9e1d-44e8-a906-088560aaea61.png)

9. **Repeat Step 2, and switch to Newspack Scott:**
 a. Check the header and mobile menu; confirm that the header and mobile menu are both using the primary colour:

![image](https://user-images.githubusercontent.com/177561/132603920-fa04d8bd-fc34-4677-a37f-8a8c987720da.png)

![image](https://user-images.githubusercontent.com/177561/132603930-13a662c0-1b85-47df-a54a-977c9c0c2ce2.png)

 b. Navigate to Customizer > Colours, and turn on the custom colours, and change the primary colour.
 c. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132604090-3c84c2d3-d5b9-4f56-a993-cb840ca86282.png)

![image](https://user-images.githubusercontent.com/177561/132604108-de0afb95-af6a-48fb-a4f7-c14c4afb0308.png)

 d. Navigate to Customizer > Colours and turn on the custom header colour, and change the header colour.
 e. Confirm that it's being picked up by the header and mobile menu backgrounds, both in the customizer and on the front-end:

![image](https://user-images.githubusercontent.com/177561/132604219-179331e0-138c-40f1-9e8e-51f05d073ace.png)

![image](https://user-images.githubusercontent.com/177561/132604231-9e2b339f-ace1-4b54-9812-553b7a8e63d1.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
