### PR TITLE
feat(archive template): add after_archive_post action

### DIFF
--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -125,6 +125,7 @@ $show_excerpt        = get_theme_mod( 'archive_show_excerpt', false );
 					get_template_part( 'template-parts/content/content', 'archive' );
 				}
 
+				do_action( 'after_archive_post', $post_count );
 				// End the loop.
 			endwhile;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a hook on archive pages after each post in the posts loop. The hook is necessary to [show campaign prompts after x articles or every x article in the archive pages](https://github.com/Automattic/newspack-popups/pull/621).

### How to test the changes in this Pull Request:

1. This PR shouldn't affect the theme in theory, just make sure the archive page is not throwing any error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
