### PR TITLE
Fix centred image block caption on smaller screens

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -907,16 +907,6 @@ p.has-background {
 	figcaption {
 		text-align: left;
 	}
-
-	@include media( mobileonly ) {
-		.aligncenter {
-			display: block;
-			img {
-				margin-left: auto;
-				margin-right: auto;
-			}
-		}
-	}
 }
 
 //! Galleries


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes some styles that were causing the caption to display very narrow on centred image blocks when they are displayed on mobile sized-screens. These styles should be unnecessary for this block and it should still centre without them.

Closes #1508.

### How to test the changes in this Pull Request:

1. Add two image blocks to a post; give them both captions and centre them. Make sure one image is narrower than a mobile-sized screen to make sure it's still centred on those smaller screens -- the 'thumbnail' image size should work. 
2. View on the front and and shrink the browser window down; note that the captions get very narrow on screens less than 600px wide:

![image](https://user-images.githubusercontent.com/177561/133298485-4cafe14b-431e-4f3a-95ed-126009655e76.png)

3. Apply the PR and run `npm run build`.
4. Refresh the post; confirm the captions now display as expected, and that the blocks stay centred, even on those smaller screens:

![image](https://user-images.githubusercontent.com/177561/133298377-21d1356a-a5ac-49f5-b1de-33107d61c175.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
