### PR TITLE
feat: allow links in the article subtitle field

### DIFF
--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -51,6 +51,11 @@ $subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
 					'small'  => true,
 					'sub'    => true,
 					'sup'    => true,
+					'a'      => array(
+						'href'   => true,
+						'target' => true,
+						'rel'    => true,
+					),
 				]
 			);
 			?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `<a>` tags and some of their most-common attributes (`href`, `rel`, `target`) to the HTML allowed in the Article Subtitles field. 

Closes #1500.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Edit a post's Article Subtitle field. Add a link (has to be done via HTML). Publish.
3. Confirm that the link displays on the front-end, and is not stripped out on the backend. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
