### PR TITLE
fix: update SVG sanitization to include more HTML elements

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -780,7 +780,7 @@ add_action( 'wp_head', 'newspack_typography_css_wrap' );
  */
 function newspack_sanitize_svgs() {
 	$svg_args = array(
-		'svg'   => array(
+		'svg'      => array(
 			'class'           => true,
 			'aria-hidden'     => true,
 			'aria-labelledby' => true,
@@ -790,15 +790,21 @@ function newspack_sanitize_svgs() {
 			'height'          => true,
 			'viewbox'         => true,
 		),
-		'g'     => array(
-			'fill' => true,
+		'g'        => array(
+			'fill'      => true,
+			'fill-rule' => true,
 		),
-		'title' => array(
+		'title'    => array(
 			'title' => true,
 		),
-		'path'  => array(
+		'path'     => array(
 			'd'    => true,
 			'fill' => true,
+		),
+		'defs'     => true,
+		'clipPath' => true,
+		'polygon'  => array(
+			'points' => true,
 		),
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the HTML allowed by our SVG sanitation function to include some tags/attributes that are used by social links icons, but were missed. 

Closes #1515

### How to test the changes in this Pull Request:

Outside of checking for errors, one good way to test this is to make sure the sanitation is now allowing tags that it previously stripped out: 

1. Edit the social links menu, and add a link to Flipboard (https://flipboard.com); publish.
2. View on the front end and note the icon doesn't display; if you inspect it, it has an empty `<svg>` tag but nothing in it -- this is because this icon uses the `<polygon>` tag, which is currently stripped out by the SVG sanitation function.
3. Apply the PR. 
4. Confirm that the Flipboard icon is now showing. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
