### PR TITLE
fix: add responsive sizes for large, huge font sizes

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1252,11 +1252,21 @@ hr {
 }
 
 .has-large-font-size {
-	font-size: $font__size-xl;
+	font-size: $font__size-lg;
 }
 
 .has-huge-font-size {
-	font-size: $font__size-xxl;
+	font-size: $font__size-xl;
+}
+
+@include media( tablet ) {
+	.has-large-font-size {
+		font-size: $font__size-xl;
+	}
+
+	.has-huge-font-size {
+		font-size: $font__size-xxl;
+	}
 }
 
 //! Custom background colors


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a small tweak, but it makes the 'Large' and 'Huge' font sizes you can apply through the Gutenberg editor a bit smaller on mobile. 

Closes #1231

### How to test the changes in this Pull Request:

1. Add five paragraph blocks, and five header blocks to a post. Leave one of each block as the default size, and then set one of each to Small, Normal, Large and Huge. 
2. View on the front and and scale down the browser size; note the site of the fonts:

![image](https://user-images.githubusercontent.com/177561/133323768-63d4c910-ee83-4660-9d7d-a3b399caae17.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the font size for the two larger sizes is a bit smaller; I didn't want to bring them to the point where, say, the large headers were smaller than the default ones, but it hopefully makes the huge paragraph tags 'feel' better. I'm definitely open to feedback if this doesn't seem like enough of a difference! I'm erring on the side of keeping it simple but we could also change how these sizes scale down depending on block type. 

![image](https://user-images.githubusercontent.com/177561/133323680-988a4b8e-370c-4e8a-8a0d-c5472e21cc74.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
