### PR TITLE
Homepage Posts Block: Update theme styles to go with new alignments

### DIFF
--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -91,25 +91,7 @@ Newspack Joseph Editor Styles
 }
 
 /* Newspack Homepage Articles */
-.article-section-title {
-	font-family: $font__body;
-	font-size: $font__size-base;
-	margin-bottom: $size__spacing-unit;
-	overflow: hidden;
-	position: relative;
-
-	&::after {
-		background-color: currentColor;
-		content: '';
-		display: inline-block;
-		height: 1px;
-		margin: 0 0 0 0.25rem;
-		position: absolute;
-		width: 100%;
-		top: 50%;
-	}
-}
-
+.article-section-title,
 .accent-header {
 	align-items: center;
 	display: flex;
@@ -127,6 +109,21 @@ Newspack Joseph Editor Styles
 		margin: 0 0 0 0.25rem;
 		position: relative !important;
 	}
+}
+
+.wpnbha.has-text-align-right,
+.wpnbha.has-text-align-center {
+	.article-section-title::before {
+		background-color: currentColor;
+		content: '';
+		flex: 1 0 0.25rem;
+		height: 1px;
+		margin: 0 0.25rem 0 0;
+	}
+}
+
+.wpnbha.has-text-align-right .article-section-title::after {
+	display: none;
 }
 
 .wp-block-newspack-blocks-homepage-articles {

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -146,6 +146,23 @@ div.wpnbha .article-section-title,
 	}
 }
 
+.wpnbha.has-text-align-right,
+.wpnbha.has-text-align-center {
+	.article-section-title span {
+		&::before {
+			background-color: currentColor;
+			content: '';
+			flex: 1 0 0.25rem;
+			height: 1px;
+			margin: 0 0.25rem 0 0;
+		}
+	}
+}
+
+.wpnbha.has-text-align-right .article-section-title span::after {
+	display: none;
+}
+
 .cat-links {
 	a {
 		color: inherit;

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -24,6 +24,22 @@ Newspack Katharine Editor Styles
 	}
 }
 
+.has-text-align-center .article-section-title::before {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.has-text-align-right .article-section-title {
+	padding-top: calc( 1rem + 5px );
+	position: relative;
+
+	&::before {
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+}
+
 .wp-block-newspack-blocks-homepage-articles article .entry-meta,
 .entry-meta {
 	font-size: $font__size-xs;

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -24,23 +24,7 @@ Newspack Katharine Editor Styles
 	}
 }
 
-.has-text-align-center .article-section-title::before {
-	margin-left: auto;
-	margin-right: auto;
-}
-
-.has-text-align-right .article-section-title {
-	padding-top: calc( 1rem + 5px );
-	position: relative;
-
-	&::before {
-		position: absolute;
-		right: 0;
-		top: 0;
-	}
-}
-
-.wp-block-newspack-blocks-homepage-articles article .entry-meta,
+.wpnbha article .entry-meta,
 .entry-meta {
 	font-size: $font__size-xs;
 }
@@ -73,6 +57,34 @@ Newspack Katharine Editor Styles
 .wp-block-newspack-blocks-homepage-articles.is-style-borders article {
 	border-bottom-style: dotted;
 	border-bottom-color: $color__text-main;
+}
+
+.wpnbha.has-text-align-center {
+	.article-section-title::before,
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
+		.post-has-image
+		.entry-title {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+.wpnbha.has-text-align-right {
+	.article-section-title {
+		padding-top: calc( 1rem + 5px );
+		position: relative;
+
+		&::before {
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
+	}
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
+		.post-has-image
+		.entry-title {
+		margin-left: 15%;
+	}
 }
 
 .wp-block-cover,

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -64,18 +64,31 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
-.has-text-align-center .article-section-title::before {
-	margin-left: auto;
-	margin-right: auto;
+.wpnbha.has-text-align-center {
+	.article-section-title::before,
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
+		.post-has-image
+		.entry-title {
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
-.has-text-align-right .article-section-title {
-	&::before {
-		float: right;
+.wpnbha.has-text-align-right {
+	.article-section-title {
+		&::before {
+			float: right;
+		}
+		span {
+			clear: right;
+			display: block;
+		}
 	}
-	span {
-		clear: right;
-		display: block;
+
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
+		.post-has-image
+		.entry-title {
+		margin-left: 15%;
 	}
 }
 .mobile-sidebar,

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -64,6 +64,20 @@ Nicolas Gallagher and Jonathan Neal https://necolas.github.io/normalize.css/
 	}
 }
 
+.has-text-align-center .article-section-title::before {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.has-text-align-right .article-section-title {
+	&::before {
+		float: right;
+	}
+	span {
+		clear: right;
+		display: block;
+	}
+}
 .mobile-sidebar,
 .site-footer {
 	.accent-header,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR goes with [this block PR](https://github.com/Automattic/newspack-blocks/pull/876), which adds text alignment options to the Homepage Posts block. This theme PR limits some visual weirdness introduced by the text alignments.

Closes #1525

### How to test the changes in this Pull Request:

1. If https://github.com/Automattic/newspack-blocks/pull/876 is not already merged, apply the PR to your newspack-blocks directory, and run `npm run build`.
2. Switch to the Newspack Theme. 
3. In the editor, add three Homepage Posts blocks; leave one as default, align one's text centre using the new option in the Homepage Posts block, and align one's text right. 
4. View on the front-end and in the editor; confirm that the 'section title' at the top usually matches the alignment (more details about that on individual themes below), and the other accents within the theme seem to mesh with the alignments. 
 
**Note:** I'm open to any feedback about visual decisions made here, on top of any issues you may find! In some cases, there didn't seem like a clear "right" approach, so I tried to stick with what I thought would be least disruptive to existing sites' CSS.

**Newspack**
![image](https://user-images.githubusercontent.com/177561/135730094-bc71b52b-757e-4933-9fb4-3456549b4931.png)

![image](https://user-images.githubusercontent.com/177561/135730091-bd0c9bc7-1f5a-4590-80d8-8dc924a91965.png)

**Newspack Joseph**
![image](https://user-images.githubusercontent.com/177561/135730127-5e9c9f6e-a28f-459d-8081-0c70149d8355.png)

![image](https://user-images.githubusercontent.com/177561/135730133-354d20b8-55d2-46b9-8e36-3e34138e2232.png)

**Newspack Katharine**
_For this theme, the little accent above the section title seems odd centred, but seems the safest route for avoiding adding too-specific CSS to the theme at this point._

![image](https://user-images.githubusercontent.com/177561/135729998-5a6d4304-c359-4c4a-a64d-01eb09e91ba9.png)

![image](https://user-images.githubusercontent.com/177561/135730006-02595d3d-b66e-4ba7-941c-65960e36473f.png)

**Newspack Nelson** 
![image](https://user-images.githubusercontent.com/177561/135730170-6f50b061-d514-4f16-8120-4dc3669ad6c9.png)

![image](https://user-images.githubusercontent.com/177561/135730177-5992bb54-337d-4f10-9bd9-9a3183a705cc.png)

**Newspack Sacha**
_I opted to keep the section title centred in all cases for this theme, as it seemed more logical than aligning it left or right_

![image](https://user-images.githubusercontent.com/177561/135730217-b0f71723-e93c-43dc-8bc2-70ce40cc8ff2.png)

![image](https://user-images.githubusercontent.com/177561/135730224-4ceda664-8487-427f-86a6-b53dcdf023da.png)


**Newspack Scott**

![image](https://user-images.githubusercontent.com/177561/135730250-a4905fa2-5230-4d5a-bab4-97631e984a06.png)

![image](https://user-images.githubusercontent.com/177561/135730253-ab010f47-6bcf-4680-9f22-080fb0a02474.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
