### PR TITLE
fix: make separator block picks up custom colors

### DIFF
--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -400,6 +400,12 @@ hr {
 	&.is-style-dots::before {
 		color: currentColor;
 	}
+
+	&:not( .is-style-dots ).has-background {
+		border-color: currentColor;
+		border-top-style: double;
+		border-top-width: 3px;
+	}
 }
 
 //! Newspack

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -212,7 +212,13 @@ figcaption,
 
 .wp-block-separator:not( .is-style-dots ),
 hr {
+	background: transparent !important;
 	border-top: 1px dotted $color__text-main;
+	height: 0;
+
+	&.has-background {
+		border-top: 1px dotted currentColor;
+	}
 }
 
 .wp-block .wp-block-columns.is-style-borders {

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -410,6 +410,15 @@ figcaption,
 .wp-block-separator,
 hr {
 	border-top: 1px dotted $color__text-main;
+	background: transparent !important;
+
+	&.has-background {
+		border-top: 1px dotted currentColor;
+
+		&.is-style-dots {
+			border: 0;
+		}
+	}
 }
 
 // Archives

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -140,10 +140,18 @@ blockquote {
 .wp-block-separator {
 	&:not( .is-style-dots ) {
 		border-top: 2px solid $color__text-main;
+
+		&.has-background {
+			border-top-color: currentColor;
+		}
 	}
 
 	&:not( .is-style-dots ):not( .is-style-wide ) {
 		border-top: 5px solid $color__text-main;
+
+		&.has-background {
+			border-top-color: currentColor;
+		}
 	}
 
 	&.is-style-dots::before {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -459,12 +459,27 @@ blockquote {
 .wp-block-separator {
 	border-top: 2px solid $color__text-main;
 
-	&:not( .is-style-dots ):not( .is-style-wide ) {
-		border-top: 5px solid $color__text-main;
+	&.has-background {
+		border-top: 2px solid currentColor;
+		height: 0;
 	}
 
-	&.is-style-dots::before {
-		color: $color__text-main;
+	&:not( .is-style-dots ):not( .is-style-wide ) {
+		border-top: 5px solid $color__text-main;
+		height: 0;
+
+		&.has-background {
+			border-top-color: currentColor;
+			height: 0;
+		}
+	}
+
+	&.is-style-dots {
+		border: 0;
+
+		&::before {
+			color: $color__text-main;
+		}
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -954,6 +954,14 @@ hr {
 			padding-left: $font__size-sm;
 		}
 	}
+
+	&.has-background {
+		border: 0;
+
+		&.is-style-dots::before {
+			color: inherit;
+		}
+	}
 }
 
 .entry .entry-content > .wp-block-separator,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -682,6 +682,14 @@ figcaption,
 		letter-spacing: calc( 2 * #{$size__spacing-unit} );
 		padding-left: calc( 2 * #{$size__spacing-unit} );
 	}
+
+	&.has-background {
+		border: 0;
+
+		&.is-style-dots::before {
+			color: inherit;
+		}
+	}
 }
 
 /** === Latest Posts, Archives, Categories === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the separator block actually picks up the custom colours you set, on all of the child themes.

Closes #668

### How to test the changes in this Pull Request:

1. Switch your test site to the default Newspack theme. 
2. Create a new post/page and add a series of separator blocks: default width, default width + primary colour, default width + custom colour; wide width, wide width + primary colour, wide width + custom colour, and dots, dots + primary colour, dots + custom colour. (alternatively, you can copy-paste the below demo content into the code view of the editor):

<details>
<summary>Demo content</summary>

```
<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:separator {"color":"primary"} -->
<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color"/>
<!-- /wp:separator -->

<!-- wp:separator {"customColor":"#ff1f1f"} -->
<hr class="wp-block-separator has-text-color has-background" style="background-color:#ff1f1f;color:#ff1f1f"/>
<!-- /wp:separator -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:separator {"color":"primary","className":"is-style-wide"} -->
<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:separator {"customColor":"#02b3ff","className":"is-style-wide"} -->
<hr class="wp-block-separator has-text-color has-background is-style-wide" style="background-color:#02b3ff;color:#02b3ff"/>
<!-- /wp:separator -->

<!-- wp:separator {"className":"is-style-dots"} -->
<hr class="wp-block-separator is-style-dots"/>
<!-- /wp:separator -->

<!-- wp:separator {"color":"primary","className":"is-style-dots"} -->
<hr class="wp-block-separator has-text-color has-background has-primary-background-color has-primary-color is-style-dots"/>
<!-- /wp:separator -->

<!-- wp:separator {"customColor":"#a30003","className":"is-style-dots"} -->
<hr class="wp-block-separator has-text-color has-background is-style-dots" style="background-color:#a30003;color:#a30003"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```
</details>

3. Publish the post; have two tabs open, one with the editor view, and one with the front-end view.
4. Apply the PR and run `npm run build`.
5. Confirm that the seperators are each showing the default (light grey), the primary colour, and the custom colour: 

![image](https://user-images.githubusercontent.com/177561/136276356-ea122a7c-f10c-4005-95b1-815cf832743c.png)


6. Cycle through Newspack Joseph, Katharine, and Nelson and test to confirm the separators are picking up the correct styles, and each child theme's border styles is resepected (Newspack Sacha and Scott use the same, default separator block styles as the main theme).

**Newspack Joseph**

![image](https://user-images.githubusercontent.com/177561/136276528-7628d2fe-3964-4440-8353-2a8a908241cc.png)

**Newspack Katharine**

![image](https://user-images.githubusercontent.com/177561/136276696-f492d176-e6e8-40e3-a6f1-6458ace8541b.png)

**Newspack Nelson**

![image](https://user-images.githubusercontent.com/177561/136276033-c70c2daa-8e4f-4131-a0f9-7c0e3b58c64e.png)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
