### PR TITLE
feat: allow safe HTML in WooCommerce thank you message

### DIFF
--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -44,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php else : ?>
 
 			<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
-				<?php echo esc_html( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), $order ) ); ?>
+				<?php echo wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), $order ) ); ?>
 			</p>
 
 			<h4><?php esc_html_e( 'Summary', 'newspack' ); ?></h4>
@@ -96,7 +96,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php else : ?>
 
 		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
-			<?php echo esc_html( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), null ) ); ?>
+			<?php echo wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), null ) ); ?>
 		</p>
 
 	<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A small feature that allows sanitized HTML in the WooCommerce "thank you" message shown to users after a purchase or donation. This is a requirement for [self-serve listings](https://github.com/Automattic/newspack-listings/pull/135). Note that this only allows HTML when appended via code, not when added in the Customizer feature that lets you set the message.

### How to test the changes in this Pull Request:

1. In your theme's `functions.php`, temporarily add a filter to append some HTML to the thank you message:

```
public static function newspack_append_thank_you( $message, $order ) {
	if ( ! $order ) {
		return $message;
	}

	$message .=' Visit <a href="https://newspack.pub">Newspack</a> for some <strong>exciting</strong> news!';
	return $message;
}
add_action( 'woocommerce_thankyou_order_received_text', 'newspack_append_thank_you', 99, 2 ); // Priority 99 to supersede the priority on the same filter used in Newspack Theme.
```

2. Complete a WooCommerce purchase, e.g. by donating via the Donate block.
3. Confirm that your filtered message is displayed with intact HTML.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
