### PR TITLE
feat(image-credits): handle image credits from newspack-plugin

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -374,8 +374,8 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 					$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
 
 					// Account for featured images that have a credit but no caption.
-					if ( ! $caption_exists && class_exists( 'Newspack_Image_Credits' ) ) {
-						$maybe_newspack_image_credit = Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
+					if ( ! $caption_exists && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+						$maybe_newspack_image_credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
 						if ( strlen( wp_strip_all_tags( $maybe_newspack_image_credit ) ) ) {
 							$caption_exists = true;
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Newspack Image Credits plugin was [merged into Newspack Plugin](https://github.com/Automattic/newspack-plugin/pull/1147). This change ensures that credits are added to featured images are handling the credits with the Newspack plugin method.  

### How to test the changes in this Pull Request:

1. On `master`, add a featured image to a post, ensure the image has no caption, but has credit
2. Visit the post, observe the featured image has no credit below
3. Switch to this branch, observe the image has credit displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->