### PR TITLE
Dequeue media element CSS when AMP is enabled

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1114,6 +1114,18 @@ function newspack_maybe_set_default_post_template( $post_ID, $post, $update ) {
 add_action( 'wp_insert_post', 'newspack_maybe_set_default_post_template', 10, 3 );
 
 /**
+ * Dequeue Media Element styles if AMP is enabled.
+ */
+function newspack_dequeue_mediaelement() {
+	if ( newspack_is_amp() ) {
+		wp_deregister_script( 'wp-mediaelement' );
+		wp_deregister_style( 'wp-mediaelement' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'newspack_dequeue_mediaelement', 20 );
+
+
+/**
  * SVG Icons class.
  */
 require get_template_directory() . '/classes/class-newspack-svg-icons.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The AMP plugin removes unneeded CSS through tree-shaking, but there are some kinds of CSS -- like animations and fonts -- that it doesn't remove, I assume, because it's not at the point where it "knows" whether these styles are used. 

One of the files that's not totally removed is the 'Media Element JS' CSS because it includes some animation code; since the JS from this is also removed, none of the styles are needed (not to mention the fact blocks don't use it). Removing this will free up a whopping 304b of CSS, or 4% of the total 😄 

### How to test the changes in this Pull Request:

1. Add a video block to a post or page with a regular video in it; view on the front-end with AMP enabled. 
2. Check the AMP CSS report (by clicking AMP > CSS Usage in the Admin Toolbar) and find the Media Element styles in the CSS listed. Note: it was appearing under WooCommerce for me for some reason. You can tell which file it is by looking at the ID:

![Screen Shot 2021-10-12 at 4 56 20 PM](https://user-images.githubusercontent.com/177561/137047378-28c052cf-10d3-493e-b874-fbd63dcd3f0b.png)

3. Apply the PR.
4. Confirm that the video looks the same, but the mediaelement CSS is removed (for me, I checked to see if there was a CSS file getting loaded that had that original size):

![Screen Shot 2021-10-12 at 4 54 52 PM](https://user-images.githubusercontent.com/177561/137047319-efaf66c6-62ed-4535-b2f7-4620805d7e8f.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
