### PR TITLE
fix: simplify @font-face list in WooCommerce styles

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -9,24 +9,14 @@
  */
 @font-face {
 	font-family: star;
-	src: url( '../../../plugins/woocommerce/assets/fonts/star.eot' );
-	src: url( '../../../plugins/woocommerce/assets/fonts/star.eot?#iefix' )
-			format( 'embedded-opentype' ),
-		url( '../../../plugins/woocommerce/assets/fonts/star.woff' ) format( 'woff' ),
-		url( '../../../plugins/woocommerce/assets/fonts/star.ttf' ) format( 'truetype' ),
-		url( '../../../plugins/woocommerce/assets/fonts/star.svg#star' ) format( 'svg' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/star.woff' ) format( 'woff' );
 	font-weight: normal;
 	font-style: normal;
 }
 
 @font-face {
 	font-family: WooCommerce;
-	src: url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.eot' );
-	src: url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.eot?#iefix' )
-			format( 'embedded-opentype' ),
-		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.woff' ) format( 'woff' ),
-		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.ttf' ) format( 'truetype' ),
-		url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.svg#WooCommerce' ) format( 'svg' );
+	src: url( '../../../plugins/woocommerce/assets/fonts/WooCommerce.woff' ) format( 'woff' );
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme includes styles for WooCommerce, including `@font-face` styles to load WooCommerce's ratings and icons fonts. 

Originally, these styles listed multiple font formats, but since `.woff` alone is [well supported by the browsers we support](https://caniuse.com/?search=woff), this seems like an opportunity to simplify these styles, especially since AMP does not tree-shake `@font-face`. 

See #1549.

### How to test the changes in this Pull Request:

1. Start with a test site running WooCommerce. On a non-WC page, click the AMP > CSS Usage menu item in the Admin Toolbar, and find 'newspack-woocommerce-style-css' in the list. Note the file size after tree-shaking (below, it's 1241b):

![Screen Shot 2021-10-13 at 12 46 58 PM](https://user-images.githubusercontent.com/177561/137203294-8bb7969d-f424-43c7-a096-a464a9e77c13.png)

2. Apply the PR and run `npm run build`.
3. Repeat step 1; note the tree-shaken file size should be smaller on non-WooCommerce pages (on my test site it dropped down to 358k -- the difference is a bit over 1% of the total allowed CSS):

![Screen Shot 2021-10-13 at 12 44 47 PM](https://user-images.githubusercontent.com/177561/137203285-f912c8e5-537c-4a6d-bf41-360014e3f44a.png)

4. Visit your WooCommerce listings and confirm things like the ratings are still working (you may need to turn these on for your products under WP Admin > WooCommerce > Settings > Products tab, at the very bottom; if they don't show up then, you may also need to enable them under the 'Advanced' tab when editing an individual product):

![image](https://user-images.githubusercontent.com/177561/137209184-3939bd08-243c-421d-bc79-057ca6dd06c7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
