### PR TITLE
fix: move sticky ad down when sticky header is enabled

### DIFF
--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -23,6 +23,16 @@
 	}
 }
 
+.post-template-default,
+.page-template-default:not( .newspack-front-page ),
+.archive,
+.search,
+.blog {
+	.site-content {
+		overflow: unset;
+	}
+}
+
 #primary {
 	margin: auto;
 	max-width: 90%;

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -143,3 +143,8 @@ body {
 		}
 	}
 }
+
+// Move the sidebar sticky ad down a bit further when the header is sticky.
+.h-stk #secondary .stick-to-top:last-child {
+	top: calc( 80px + 1rem );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the `overflow: hidden` from the `.site-content` when you're using a two column template, so the sticky ad option will actually stick.

It also adds a bit of space on top of the sticky ad when the sticky header is enabled, so they don't run over each other :) 

Closes #1551

### How to test the changes in this Pull Request:

1. Start with a test site with Newspack Ads, and add an Ad Widget to the bottom of the sidebar. Check "Stick to the top"
2. View on the front-end and scroll down; note the widget doesn't stick.
3. Apply the PR and run `npm run build`.
4. Repeat step two; confirm that the ad now moves down the page with you.
5. Navigate to Customizer > Header Settings > Appearance and check 'Sticky Header'.
6. View the front-end again; confirm that both the ad and header stick, and the ad is an appropriate distance from the header. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
