### PR TITLE
feat: add option to dequeue some WooCommerce styles on home

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1317,6 +1317,51 @@ function newspack_customize_register( $wp_customize ) {
 			'section'     => 'woocommerce_thank_you',
 		)
 	);
+
+	/**
+	 * WooCommerce Advanced Settings
+	 */
+	$wp_customize->add_section(
+		'woocommerce_advanced',
+		array(
+			'title' => esc_html__( 'Advanced Settings', 'newspack' ),
+			'panel' => 'woocommerce',
+		)
+	);
+
+	// Dequeue WooCommerce block CSS on the homepage.
+	$wp_customize->add_setting(
+		'woocommerce_block_home_dequeue',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'woocommerce_block_home_dequeue',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Dequeue WooCommerce Block CSS on the homepage.', 'newspack' ),
+			'section' => 'woocommerce_advanced',
+		)
+	);
+
+	// Dequeue WooCommerce CSS on the homepage.
+	$wp_customize->add_setting(
+		'woocommerce_styles_home_dequeue',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'woocommerce_styles_home_dequeue',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Dequeue WooCommerce CSS on the homepage.', 'newspack' ),
+			'section' => 'woocommerce_advanced',
+		)
+	);
 }
 add_action( 'customize_register', 'newspack_customize_register' );
 

--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -26,24 +26,37 @@ function newspack_woocommerce_setup() {
 }
 add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
 
-
 /**
  * Add theme's WooCommerce styles.
  *
  * @return void
  */
 function newspack_woocommerce_scripts() {
+	// Load WooCommerce styles from theme.
 	wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/styles/woocommerce.css', array( 'newspack-style' ), wp_get_theme()->get( 'Version' ) );
 	wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );
 }
 add_action( 'wp_enqueue_scripts', 'newspack_woocommerce_scripts' );
 
+/**
+ * Optionally dequeue WooCommerce's block styles.
+ */
+function newspack_disable_woocommerce_block_styles() {
+	if ( true === get_theme_mod( 'woocommerce_block_home_dequeue', false ) && is_front_page() ) {
+		wp_deregister_style( 'wc-blocks-style' );
+	}
+}
+add_action( 'enqueue_block_assets', 'newspack_disable_woocommerce_block_styles', 999 );
 
 /**
  * Remove WooCommerce general styles.
  */
 function newspack_dequeue_styles( $enqueue_styles ) {
 	unset( $enqueue_styles['woocommerce-general'] );
+	if ( true === get_theme_mod( 'woocommerce_styles_home_dequeue', false ) && is_front_page() ) {
+		unset( $enqueue_styles['woocommerce-layout'] );
+		unset( $enqueue_styles['woocommerce-smallscreen'] );
+	}
 	return $enqueue_styles;
 }
 add_filter( 'woocommerce_enqueue_styles', 'newspack_dequeue_styles' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an option to dequeue the WooCommerce block, layout and small screen CSS from the site's homepage -- AMP removes most of these styles through tree-shaking, but a bit of each file is left over because they contain things like animations and CSS variables, or classes that exist on the homepage (like `.screen-reader-text`).

The purpose is to buy a little more wiggle room for CSS on the homepage. It's a little hacky/clunky but I also wanted to avoid possibly removing styles when they may be needed on subpages -- I don't want to introduce a weird edge case, like removing styles when they may be 'expected' by third-party WC plugins. That being said, I'm definitely open to suggestions for other approaches! 

In my testing, this should free up around 3.5-4% of the available CSS on the homepage. 

See #1549

### How to test the changes in this Pull Request:

1. Start with a test site with AMP and WooCommerce enabled.
2. When viewing the homepage, navigate to AMP > CSS Usage. 
3. Click though the CSS being loaded; note that the WC Blocks, Small Screen and Layout styles are loaded, even though they aren't needed on the homepage: 

![image](https://user-images.githubusercontent.com/177561/137819730-b4f73e35-d60a-4051-a0ce-3c573d59ca5a.png)

![image](https://user-images.githubusercontent.com/177561/137819757-4afa9cfb-2610-4821-98bc-f32bb7f8cdf9.png)

4. Apply the PR.
5. Navigate to Customizer > WooCommerce; there should now be a new Advanced Settings panel. 
6. Open the panel and check the two options to dequeue styles on the homepage, then click 'Publish'.

![image](https://user-images.githubusercontent.com/177561/137819893-448ac371-0fa9-4d82-9fcb-a62afbdc4200.png)

7. Navigate back to AMP > CSS Usage from the homepage, and click 'Recheck'.
8. Confirm that the block, small screen and layout stylesheets are no longer loaded on the homepage. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
