### PR TITLE
feat: Add field for Article Summary

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -453,7 +453,7 @@ function newspack_scripts() {
 				return $tag;
 			},
 			10,
-			3 
+			3
 		);
 	}
 
@@ -573,6 +573,10 @@ function newspack_enqueue_scripts() {
 	if ( 'post' === $post_type ) {
 		wp_enqueue_script( 'newspack-post-subtitle', get_theme_file_uri( '/js/dist/post-subtitle.js' ), array(), $theme_version, true );
 		wp_set_script_translations( 'newspack-post-subtitle', 'newspack', $languages_path );
+
+		wp_enqueue_script( 'newspack-post-summary', get_theme_file_uri( '/js/dist/post-summary.js' ), array(), $theme_version, true );
+		wp_set_script_translations( 'newspack-post-summary', 'newspack', $languages_path );
+
 	}
 
 	// Post meta options.
@@ -775,6 +779,16 @@ function newspack_register_meta() {
 	register_post_meta(
 		'post',
 		'newspack_post_subtitle',
+		array(
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		)
+	);
+
+	register_post_meta(
+		'post',
+		'newspack_article_summary',
 		array(
 			'show_in_rest' => true,
 			'single'       => true,

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -196,6 +196,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'show-updated';
 	}
 
+	// Add a class if the post has a summary.
+	if ( '' !== newspack_has_post_summary() ) {
+		$classes[] = 'has-summary';
+	}
+
 	// Adds a class for the archive page layout.
 	$archive_layout = get_theme_mod( 'archive_layout', 'default' );
 	if ( is_archive() && 'default' !== $archive_layout ) {
@@ -656,7 +661,6 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
 	return newspack_math_to_time_ago( $post_time, $format, $post, true );
 }
 
-
 /**
  * Check whether updated date should be displayed.
  */
@@ -678,3 +682,51 @@ function newspack_should_display_updated_date() {
 	}
 	return false;
 }
+
+/**
+ * Check whether there's a Post Summary, and return it.
+ */
+function newspack_has_post_summary() {
+	if ( 'post' !== get_post_type() ) {
+		return;
+	}
+
+	$post    = get_post();
+	$summary = get_post_meta( $post->ID, 'newspack_article_summary', true );
+
+	return trim( $summary );
+}
+
+/**
+ * Give the post summary some markup, and run it through wpautop().
+ *
+ * @param string $summary The post summary.
+ */
+function newspack_post_summary_markup( $summary ) {
+	ob_start();
+	?>
+	<div class="article-summary">
+		<h2 class="article-summary-title"><?php esc_html_e( 'Overview:', 'newspack-article-summary' ); ?></h2>
+		<?php echo wp_kses_post( wpautop( $summary ) ); ?>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Inject the post summary at the top of a post.
+ *
+ * @param string $content The post content.
+ */
+function newspack_inject_post_summary( $content ) {
+	if ( 'post' !== get_post_type() ) {
+		return $content;
+	}
+	$summary = newspack_has_post_summary();
+	if ( ! $summary ) {
+		return $content;
+	}
+
+	return newspack_post_summary_markup( $summary ) . $content;
+}
+add_filter( 'the_content', 'newspack_inject_post_summary', 5 );

--- a/newspack-theme/js/src/post-summary/SummaryEditor.js
+++ b/newspack-theme/js/src/post-summary/SummaryEditor.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
+import { TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { connectWithSelect, META_FIELD_NAME } from './utils';
+
+const decorate = compose(
+	connectWithSelect,
+	withDispatch( dispatch => ( {
+		saveSummary: summary => {
+			dispatch( 'core/editor' ).editPost( {
+				meta: {
+					[ META_FIELD_NAME ]: summary,
+				},
+			} );
+		},
+	} ) )
+);
+
+const SummaryEditor = ( { summary, saveSummary } ) => {
+	const [ value, setValue ] = useState( summary );
+
+	useEffect( () => {
+		saveSummary( value );
+	}, [ value ] );
+
+	return (
+		<TextareaControl
+			value={ value }
+			onChange={ setValue }
+			style={ { marginTop: '10px', width: '100%' } }
+		/>
+	);
+};
+
+export default decorate( SummaryEditor );

--- a/newspack-theme/js/src/post-summary/index.js
+++ b/newspack-theme/js/src/post-summary/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SummaryEditor from './SummaryEditor';
+import { connectWithSelect } from './utils';
+
+/**
+ * Component to be used as a panel in the Document tab of the Editor.
+ *
+ * https://developer.wordpress.org/block-editor/developers/slotfills/plugin-document-setting-panel/
+ */
+const NewspackSummaryPanel = () => {
+	return (
+		<PluginDocumentSettingPanel
+			name="newspack-summary"
+			title={ __( 'Article Summary', 'newspack' ) }
+			className="newspack-summary"
+		>
+			{ __(
+				'Write a summary that will be appended to the top of the article content.',
+				'newspack'
+			) }
+			<SummaryEditor />
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'plugin-document-setting-panel-newspack-summary', {
+	render: connectWithSelect( NewspackSummaryPanel ),
+	icon: null,
+} );

--- a/newspack-theme/js/src/post-summary/utils.js
+++ b/newspack-theme/js/src/post-summary/utils.js
@@ -1,0 +1,11 @@
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+
+export const META_FIELD_NAME = 'newspack_article_summary';
+
+export const connectWithSelect = withSelect( select => ( {
+	summary: select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ META_FIELD_NAME ],
+	mode: select( 'core/edit-post' ).getEditorMode(),
+} ) );

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -58,6 +58,21 @@
 	}
 }
 
+.article-summary {
+	background: $color__background-pre;
+	font-size: 0.9rem;
+	padding: 1.5rem;
+
+	.article-summary-title {
+		font-size: 1rem;
+		margin-top: 0;
+	}
+
+	*:last-child {
+		margin-bottom: 0;
+	}
+}
+
 body.page {
 	.entry-title {
 		font-size: $font__size-xl;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a field for an 'Article Summary' that will be appended at the top of the post content, without appearing in/replacing the post excerpt.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Edit a post; confirm that you now have a field labelled 'Article Summary' in the right sidebar.
3. Add text to the 'Article Summary' field and publish.
4. View on the front-end; confirm that your text is being appended to the top of the post; it should be in a light grey box and have the intro text "Overview:".
5. Try adding basic HTML (like `<ul>`, `<li>`, or `<strong>`, and confirm that it's respected.
6. Try adding line breaks to the content without any paragraph markup and confirm that they are transformed into paragraphs on the front-end. 

![image](https://user-images.githubusercontent.com/177561/137995079-755678a1-9ee2-45bb-86ef-8c838ab85e9d.png)

![image](https://user-images.githubusercontent.com/177561/137995353-398d803a-e02e-4a0c-85ec-da8895862c55.png)

7. Inspect a post that you've added a summary to, and confirm that the body is getting the class `.has-summary`.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
