### PR TITLE
fix: add theme's WC styles to those dequeued from the homepage

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -33,6 +33,9 @@ add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
  */
 function newspack_woocommerce_scripts() {
 	// Load WooCommerce styles from theme.
+	if ( true === get_theme_mod( 'woocommerce_styles_home_dequeue', false ) && is_front_page() ) {
+		return;
+	}
 	wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/styles/woocommerce.css', array( 'newspack-style' ), wp_get_theme()->get( 'Version' ) );
 	wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR builds on the work done in #1555, and also removes the theme's WooCommerce styles from the homepage when that option is checked. 

See #1549.

### How to test the changes in this Pull Request:

1. Start with a site with the WooCommerce plugin installed. 
2. Navigate to Customizer > WooCommerce > Advanced Settings, and check both options to remove WC styles from the homepage. 
3. View the front-page, and click on AMP > CSS Usage in the Admin Toolbar.
4. Pick through the CSS that's loaded and find the theme's WooCommerce styles; these should be adding about 603b of CSS to the homepage, and is still loaded because it includes `@font-face` and styles for the `.button` class:

![image](https://user-images.githubusercontent.com/177561/138515525-5a7a3cdb-3baa-46b7-8fdd-c14f31d65dc6.png)

5. Apply the PR.
6. Re-check the CSS usage on your homepage; confirm that the theme's WooCommerce CSS is gone, and your total should be down a bit (on my test site the total CSS for the homepage went from 49.1% to 48.3%).
7. Check the subpages/a WooCommerce page and confirm that the CSS is still being loaded there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
