### PR TITLE
Prevent centred logo from getting cut off with Sticky Header

### DIFF
--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -126,22 +126,20 @@ function newspack_customize_logo_resize( $html ) {
 
 		@media (min-width: 782px) {
 			.h-stk .site-header .custom-logo {
-				height: auto;
-				max-width: 100%;
+				height: ' . $sticky['height'] . 'px;
+				max-width: 245px;
 				width: ' . $sticky['width'] . 'px;
-			}
-
-			.newspack-customizer.h-stk .site-header .custom-logo {
-				max-width: ' . $sticky['width'] . 'px;
-			}
-
-			.newspack-customizer.h-stk.h-cl .site-header .middle-header-contain .wrapper > div.site-branding {
-				width: 400px;
 			}
 
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
+			}
+		}
+
+		@media (min-width: 1100px) {
+			.h-stk .site-header .custom-logo {
+				max-width: ' . $sticky['width'] . 'px;
 			}
 		}
 

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -131,18 +131,21 @@ function newspack_customize_logo_resize( $html ) {
 				width: ' . $sticky['width'] . 'px;
 			}
 
+			.newspack-customizer.h-stk .site-header .custom-logo {
+				max-width: ' . $sticky['width'] . 'px;
+			}
+
+			.newspack-customizer.h-stk.h-cl .site-header .middle-header-contain .wrapper > div.site-branding {
+				width: 400px;
+			}
+
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
 			}
 		}
 
-		@media (min-width: 1200px) {
-			.h-stk:not(.h-sub) .site-header .custom-logo {
-				max-height: ' . $sticky['height'] . 'px;
-				max-width: ' . $sticky['width'] . 'px;
-			}
-		}
+
 		</style>';
 
 		$html = $css . $html;

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -127,7 +127,6 @@ function newspack_customize_logo_resize( $html ) {
 		@media (min-width: 782px) {
 			.h-stk .site-header .custom-logo {
 				height: auto;
-				max-height: ' . $sticky['height'] . 'px;
 				max-width: 100%;
 				width: ' . $sticky['width'] . 'px;
 			}
@@ -135,6 +134,13 @@ function newspack_customize_logo_resize( $html ) {
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
+			}
+		}
+
+		@media (min-width: 1200px) {
+			.h-stk:not(.h-sub) .site-header .custom-logo {
+				max-height: ' . $sticky['height'] . 'px;
+				max-width: ' . $sticky['width'] . 'px;
 			}
 		}
 		</style>';

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -126,8 +126,10 @@ function newspack_customize_logo_resize( $html ) {
 
 		@media (min-width: 782px) {
 			.h-stk .site-header .custom-logo {
-				max-width: ' . $sticky['width'] . 'px;
+				height: auto;
 				max-height: ' . $sticky['height'] . 'px;
+				max-width: 100%;
+				width: ' . $sticky['width'] . 'px;
 			}
 
 			.h-sub .site-header .custom-logo {

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -562,6 +562,10 @@
 				border: 0;
 			}
 		}
+
+		&.h-cl .site-header .middle-header-contain .wrapper > div.site-branding {
+			width: 35%;
+		}
 	}
 
 	&.h-sub.single-featured-image-behind,

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -563,8 +563,12 @@
 			}
 		}
 
-		&.h-cl .site-header .middle-header-contain .wrapper > div.site-branding {
-			width: 35%;
+		&.h-cl .site-header .middle-header-contain .wrapper > div {
+			width: 31%;
+
+			&.site-branding {
+				width: 38%;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The logo sizing styles that go with the sticky header can cause centered logos to get cut off at 'mid' (between desktop and tablet) screen sizes. This PR should help prevent that going forward!

Closes #1561.

### How to test the changes in this Pull Request:

1. Start with a test site with a centred logo, and a sticky header (both can be turned on under Customizer > Header Settings > Appearance). 
2. Adjust your screen size; note that the logo starts to get cut off before the site switches to the mobile header: 

![image](https://user-images.githubusercontent.com/177561/139101298-2d4bed9e-e375-43b1-93a4-9b6d87da86e3.png)

3. Apply the PR.
4. Confirm that the logo no longer gets cut off, and instead starts to scale down (with and without AMP enabled, since this affects how the image behaves!):

![image](https://user-images.githubusercontent.com/177561/139101407-d311c5fc-0c6c-43fd-a916-bc53e5ceb353.png)

5. Compare the before and after of the logo, to confirm that these changes don't cause the logo size to change on desktop sizes (it will, out of necessity, shrink a bit between desktop and tablet sized screens).
6. Toggle AMP on your testing page (turning it off if it's on, or turning it on if it's off), and confirm that no scaling/cropping issues occur. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
