### PR TITLE
fix: make sure mobile CTA is always clickable

### DIFF
--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -166,6 +166,7 @@
 			.mb-cta {
 				right: 2.25rem;
 				position: absolute;
+				z-index: 1;
 			}
 
 			&:not( .h-stk ).single-featured-image-beside {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you combine a centred logo, a simplified subpage header, and showing the mobile CTA in the simplified subpage header, the button is not clickable -- it is (oddly!) actually behind the search. This fixes that. 

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Header Settings > Appearance, and centre your site's logo.
2. Navigate to Customizer > Header Settings > Subpage Header and enable the simplified subpage header.
3. Navigate to Customizer > Header Settings > Mobile CTA, and add a mobile CTA, and check "Show Mobile CTA in Simplified Subpage Header".
4. View one of the subpages on your site and try to click on the CTA -- nothing happens.
5. Apply the PR and run `npm run build.`
6. Retry step 4; the link should now be clickable. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
