### PR TITLE
fix: make sure the featured image description is not output

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -377,6 +377,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 					if ( ! $caption_exists && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
 						$maybe_newspack_image_credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
 						if ( strlen( wp_strip_all_tags( $maybe_newspack_image_credit ) ) ) {
+							$caption        = $maybe_newspack_image_credit;
 							$caption_exists = true;
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where a caption-less featured image with a credit and description was displaying the description in lieu of the caption, and attaching the `the_content` filters to it. 

Closes #1564

### How to test the changes in this Pull Request:

1. Set up two single posts with featured images - one with a caption and credit, and one with a description and credit, but no caption.
2. In the right sidebar, open the 'Article Summary' panel and add some text to the field -- this is appended to `the_content` via filter.
3. Publish both posts.
4. Note that the post with the description and caption is showing the description, and adding your article summary to it. The post with the caption displays the caption and credit as expected.
5. Apply the PR and run `npm run build.`
6. Confirm that the post with the description and credit is now only showing the credit, without your article summary attached.
7. Confirm that the post with the caption is still displaying your caption and credit as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
