### PR TITLE
fix: sticky ad on amp plus

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -248,33 +248,4 @@
 			false
 		);
 	}
-
-	// AMP sticky ad polyfills.
-	const stickyAdClose = document.querySelector( '.newspack_sticky_ad__close' );
-	const stickyAd = document.querySelector( '.newspack_global_ad.sticky' );
-
-	if ( stickyAdClose && stickyAd ) {
-		window.googletag = window.googletag || { cmd: [] };
-		window.googletag.cmd.push( function() {
-			const initialBodyPadding = body.style.paddingBottom;
-
-			// Add padding to body to accommodate the sticky ad.
-			window.googletag.pubads().addEventListener( 'slotRenderEnded', event => {
-				const renderedSlotId = event.slot.getSlotElementId();
-				const stickyAdSlot = stickyAd.querySelector( '#' + renderedSlotId );
-
-				if ( stickyAdSlot ) {
-					stickyAd.classList.add( 'active' );
-					body.style.paddingBottom = stickyAd.clientHeight + 'px';
-				}
-			} );
-
-			stickyAdClose.addEventListener( 'click', () => {
-				stickyAd.parentElement.removeChild( stickyAd );
-
-				// Reset body padding.
-				body.style.paddingBottom = initialBodyPadding;
-			} );
-		} );
-	}
 } )();

--- a/newspack-theme/js/src/amp-plus.js
+++ b/newspack-theme/js/src/amp-plus.js
@@ -5,8 +5,42 @@
  * be offset by the header height in order to stack the sticky
  * elements on top of each other.
  */
-const stickyAd = document.querySelector( '.h-stk .stick-to-top:last-child' );
-const siteHeader = document.querySelector( '.h-stk .site-header' );
-if ( stickyAd && siteHeader ) {
-	stickyAd.style.top = `calc(${ siteHeader.offsetHeight }px + 1rem)`;
-}
+( function() {
+	const stickyAd = document.querySelector( '.h-stk .stick-to-top:last-child' );
+	const siteHeader = document.querySelector( '.h-stk .site-header' );
+	if ( stickyAd && siteHeader ) {
+		stickyAd.style.top = `calc(${ siteHeader.offsetHeight }px + 1rem)`;
+	}
+} )();
+
+// AMP sticky ad polyfills.
+( function() {
+	const body = document.body;
+	const stickyAdClose = document.querySelector( '.newspack_sticky_ad__close' );
+	const stickyAd = document.querySelector( '.newspack_global_ad.sticky' );
+
+	if ( stickyAdClose && stickyAd ) {
+		window.googletag = window.googletag || { cmd: [] };
+		window.googletag.cmd.push( function() {
+			const initialBodyPadding = body.style.paddingBottom;
+
+			// Add padding to body to accommodate the sticky ad.
+			window.googletag.pubads().addEventListener( 'slotRenderEnded', event => {
+				const renderedSlotId = event.slot.getSlotElementId();
+				const stickyAdSlot = stickyAd.querySelector( '#' + renderedSlotId );
+
+				if ( stickyAdSlot && body.clientWidth <= 600 ) {
+					stickyAd.style.display = 'flex';
+					body.style.paddingBottom = stickyAd.clientHeight + 'px';
+				}
+			} );
+
+			stickyAdClose.addEventListener( 'click', () => {
+				stickyAd.parentElement.removeChild( stickyAd );
+
+				// Reset body padding.
+				body.style.paddingBottom = initialBodyPadding;
+			} );
+		} );
+	}
+} )();

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -24,12 +24,6 @@
 		width: 100%;
 		z-index: 11;
 
-		&.active {
-			@include media( mobileonly ) {
-				display: flex;
-			}
-		}
-
 		button {
 			align-items: center;
 			background-color: $color__background-body;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix support for sticky ads on AMP Plus. The fallback script is currently only supporting non-AMP sites.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-ads/issues/217

### How to test the changes in this Pull Request:

1. Make sure you are on the master branch and with AMP Plus disabled.
2. Set a 320x50 ad unit to the `Sticky` ad placement on the **Advertising > Global Settings** wizard
3. Visit your homepage on mobile and confirm your ad is displayed
4. Enable AMP Plus, refresh and confirm that your ad is not visible
5. Check out this branch, run `npm run build`
6. Refresh the homepage and confirm your sticky ad is visible
7. Disable AMP completely, refresh the page and confirm it also works without AMP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
