### PR TITLE
fix: improve logo sizing behavior with sticky header

### DIFF
--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -125,10 +125,8 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (min-width: 782px) {
-			.h-stk .site-header .custom-logo {
-				height: ' . $sticky['height'] . 'px;
-				max-width: 245px;
-				width: ' . $sticky['width'] . 'px;
+			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
+				max-width: 30vw;
 			}
 
 			.h-sub .site-header .custom-logo {
@@ -137,12 +135,12 @@ function newspack_customize_logo_resize( $html ) {
 			}
 		}
 
-		@media (min-width: 1100px) {
-			.h-stk .site-header .custom-logo {
+		@media (min-width: 1200px) {
+			.h-stk:not(.h-sub) .site-header .custom-logo {
 				max-width: ' . $sticky['width'] . 'px;
+				max-height: ' . $sticky['height'] . 'px;
 			}
 		}
-
 
 		</style>';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is to fix some issues introduced with #1563, a PR meant to stop the centred logo from getting cut off when the sticky header was enabled. That PR ended up causing the logo to become distorted, or display too large in some cases. 

Closes #1561.

### How to test the changes in this Pull Request:

I think the best way to test this PR is by comparing it to how the header looked prior to #1563 getting merged -- the main two things to check for are making sure the centred logo does not get cut off with this PR applied, and also that the logo size is the same as it was prior to #1563.

1. On your test site, navigate to Customize > Header Settings > Appearance and enable the sticky header, and centre the logo.
2. Navigate to Customize > Header Settings > Subpage Header, and enable the simplified subpage header. 
3. Upload a horizontal logo, and make it fairly small using the logo sizer (~200px wide). 
4. View the regular and non-AMP versions of the page; note the size of the logo -- it will be larger than in the Customizer, and the non-AMP version may be distorted (depending on the logo's aspect ratio) -- this it the main issue we're trying to fix: 

Customizer: 

![image](https://user-images.githubusercontent.com/177561/141536057-6a09b02b-e93b-43dd-b1a4-a3c379257d79.png)

Front-end: 

![image](https://user-images.githubusercontent.com/177561/141536309-7a627494-152d-47a7-810e-764b8f8a5091.png)

5. Open two tabs with the master branch, on of the homepage, and one of a subpage.

Homepage:

![image](https://user-images.githubusercontent.com/177561/141536309-7a627494-152d-47a7-810e-764b8f8a5091.png)

Subpage:
![image](https://user-images.githubusercontent.com/177561/141536986-3369ee47-0d08-4828-a661-f5fa3c854b45.png)

6. Check out the pre-sticky-header fix version of the theme (`git checkout 1.0.0-alpha.33-340-g36c52397`), and run `npm run build`.
7. Open two more tabs, and open the homepage and a subpage in each -- these will be left open for comparison.

Homepage: 
![image](https://user-images.githubusercontent.com/177561/141536484-b1ae4690-059c-47c5-ae31-9ca39e0eeb30.png)

Subpage: 
![image](https://user-images.githubusercontent.com/177561/141536612-fdc1d226-2200-4fe0-9b7d-41407c7e0d91.png)

8. Check out this PR and run `npm run build.`
9. Open two more tabs, one with the homepage and one with a subpage. 

Homepage: 
![image](https://user-images.githubusercontent.com/177561/141536734-b3762dc9-a021-402a-9af5-bcd13e51ebd4.png)

Subpage: 
![image](https://user-images.githubusercontent.com/177561/141536759-fa86537b-7d1d-40ba-b35f-6d0a6d231449.png)

10. Compare the tabs; note that the ones running `master` have a larger, maybe distorted version of the logo.
11. Compare the `1.0.0-alpha.33-340-g36c52397` tabs and the one from this PR; confirm that the logos are the same size. 
12. Switch to a horizontal logo, and make it very large.
13. Repeat the steps to compare the pre-1563 commit (`1.0.0-alpha.33-340-g36c52397`) to this PR and confirm the logos are sized the same

`1.0.0-alpha.33-340-g36c52397`
![image](https://user-images.githubusercontent.com/177561/141539801-0cee39f3-4a6b-4ddd-855a-105b46af7126.png)

![image](https://user-images.githubusercontent.com/177561/141539784-c739a75e-3415-4fd5-9f5c-65680c4ba3e2.png)

This PR:
![image](https://user-images.githubusercontent.com/177561/141539938-fa6cf5dd-1e43-47c3-b76c-edbd1fecbdfc.png)

http://build.newspack.test/2021/10/article-summary-test/

14. With this PR, make the browser window narrower -- until it switches to the mobile  header -- and confirm that the logo doesn't get cut off: 

![image](https://user-images.githubusercontent.com/177561/141539976-c9dcbc22-3c2e-4af2-84d9-b4fc1fde5dc2.png)

![image](https://user-images.githubusercontent.com/177561/141540002-cc580f95-3769-4974-9a5f-b6e892fd99a7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
