### PR TITLE
fix: add wptexturize to the article subtitle

### DIFF
--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -39,25 +39,24 @@ $subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
 	<?php if ( $subtitle ) : ?>
 		<div class="newspack-post-subtitle">
 			<?php
-			echo wp_kses(
-				$subtitle,
-				[
-					'b'      => true,
-					'strong' => true,
-					'i'      => true,
-					'em'     => true,
-					'mark'   => true,
-					'u'      => true,
-					'small'  => true,
-					'sub'    => true,
-					'sup'    => true,
-					'a'      => array(
-						'href'   => true,
-						'target' => true,
-						'rel'    => true,
-					),
-				]
+			$allowed_tags = array(
+				'b'      => true,
+				'strong' => true,
+				'i'      => true,
+				'em'     => true,
+				'mark'   => true,
+				'u'      => true,
+				'small'  => true,
+				'sub'    => true,
+				'sup'    => true,
+				'a'      => array(
+					'href'   => true,
+					'target' => true,
+					'rel'    => true,
+				),
 			);
+
+			echo wptexturize( wp_kses( $subtitle, $allowed_tags ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds [`wptexturize`](https://developer.wordpress.org/reference/functions/wptexturize/) to the subtitle.

Closes #1570

### How to test the changes in this Pull Request:

1. Add a subtitle to a post; make sure to include a quote or apostrophe, or `--`.
2. View on the front end -- the quotes/apostrophes will be straight up-and-down, and your `--` will look like `--`.
3. Apply the PR.
4. View your post again; you should now have smartquotes, and/or a proper m-dash (&mdash;).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
