### PR TITLE
Add description to the default templates, featured image settings

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -858,14 +858,15 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'post_template_default',
 		array(
-			'type'    => 'select',
-			'label'   => __( 'Default Post Template', 'newspack' ),
-			'choices' => array(
+			'type'        => 'select',
+			'label'       => __( 'Default Post Template', 'newspack' ),
+			'description' => esc_html__( 'This option chnages the selected template used for newly created posts going forward. The template can still be changed on a per-post basis.', 'newspack' ),
+			'choices'     => array(
 				'default'            => esc_html__( 'Default Template', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
 				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
-			'section' => 'post_default_settings',
+			'section'     => 'post_default_settings',
 		)
 	);
 
@@ -1004,14 +1005,15 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'page_template_default',
 		array(
-			'type'    => 'select',
-			'label'   => __( 'Default Page Template', 'newspack' ),
-			'choices' => array(
+			'type'        => 'select',
+			'label'       => __( 'Default Page Template', 'newspack' ),
+			'description' => esc_html__( 'This option chnages the selected template used for newly created pages going forward. The template can still be changed on a per-page basis.', 'newspack' ),
+			'choices'     => array(
 				'default'            => esc_html__( 'Default Template', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
 				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
-			'section' => 'page_default_settings',
+			'section'     => 'page_default_settings',
 		)
 	);
 

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -833,9 +833,10 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'featured_image_default',
 		array(
-			'type'    => 'radio',
-			'label'   => __( 'Featured Image Default Position', 'newspack' ),
-			'choices' => array(
+			'type'        => 'radio',
+			'label'       => __( 'Featured Image Default Position', 'newspack' ),
+			'description' => esc_html__( 'Affects all posts where the Featured Image Position is set to \'Default\'.', 'newspack' ),
+			'choices'     => array(
 				'large'  => esc_html__( 'Large', 'newspack' ),
 				'small'  => esc_html__( 'Small', 'newspack' ),
 				'behind' => esc_html__( 'Behind article title', 'newspack' ),
@@ -843,7 +844,7 @@ function newspack_customize_register( $wp_customize ) {
 				'above'  => esc_html__( 'Above article title', 'newspack' ),
 				'hidden' => esc_html__( 'Hidden', 'newspack' ),
 			),
-			'section' => 'post_default_settings',
+			'section'     => 'post_default_settings',
 		)
 	);
 
@@ -860,7 +861,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'select',
 			'label'       => __( 'Default Post Template', 'newspack' ),
-			'description' => esc_html__( 'This option chnages the selected template used for newly created posts going forward. The template can still be changed on a per-post basis.', 'newspack' ),
+			'description' => esc_html__( 'This option changes the selected template used for newly created posts going forward. The template can still be changed on a per-post basis.', 'newspack' ),
 			'choices'     => array(
 				'default'            => esc_html__( 'Default Template', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
@@ -980,9 +981,10 @@ function newspack_customize_register( $wp_customize ) {
 	$wp_customize->add_control(
 		'page_featured_image_default',
 		array(
-			'type'    => 'radio',
-			'label'   => __( 'Featured Image Default Position', 'newspack' ),
-			'choices' => array(
+			'type'        => 'radio',
+			'label'       => __( 'Featured Image Default Position', 'newspack' ),
+			'description' => esc_html__( 'Affects all pages where the Featured Image Position is set to \'Default\'.', 'newspack' ),
+			'choices'     => array(
 				'large'  => esc_html__( 'Large', 'newspack' ),
 				'small'  => esc_html__( 'Small', 'newspack' ),
 				'behind' => esc_html__( 'Behind article title', 'newspack' ),
@@ -990,7 +992,7 @@ function newspack_customize_register( $wp_customize ) {
 				'above'  => esc_html__( 'Above article title', 'newspack' ),
 				'hidden' => esc_html__( 'Hidden', 'newspack' ),
 			),
-			'section' => 'page_default_settings',
+			'section'     => 'page_default_settings',
 		)
 	);
 
@@ -1007,7 +1009,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'        => 'select',
 			'label'       => __( 'Default Page Template', 'newspack' ),
-			'description' => esc_html__( 'This option chnages the selected template used for newly created pages going forward. The template can still be changed on a per-page basis.', 'newspack' ),
+			'description' => esc_html__( 'This option changes the selected template used for newly created pages going forward. The template can still be changed on a per-page basis.', 'newspack' ),
 			'choices'     => array(
 				'default'            => esc_html__( 'Default Template', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds descriptions to the default template and featured image options in the Customizer. This will hopefully help reduce confusion around what the settings do, and when they're applied -- there's been a few cases now where people expect the template option will change existing posts/pages, and it does not. 

Closes #1568 

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customize > Template Settings > Post Settings; confirm the featured image and template options have descriptions, and that they make sense. 
3. Navigate to Customize > Template Settings > Page Settings; confirm the featured image and template options have descriptions, and that they make sense. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
