### PR TITLE
fix: make the imprint open in a new tab

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -45,7 +45,7 @@
 					<span class="copyright">&copy; <?php echo esc_html( date( 'Y' ) ); ?> <?php echo esc_html( $copyright_info ); ?>.</span>
 				<?php endif; ?>
 
-				<a href="<?php echo esc_url( __( 'https://newspack.pub/', 'newspack' ) ); ?>" class="imprint">
+				<a target="_blank" href="<?php echo esc_url( __( 'https://newspack.pub/', 'newspack' ) ); ?>" class="imprint">
 					<?php echo esc_html__( 'Proudly powered by Newspack by Automattic', 'newspack' ); ?>
 				</a>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a `target="_blank"` to the Automattic/Newspack imprint in the footer. Since the link leaves the site, it makes more sense that it would be opened in a new tab, rather than bringing people away from the current site completely.

Closes #1521

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Click the "Proudly powered by Newspack by Automattic" link in the footer, and confirm that it opens in a new tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
