### PR TITLE
Newspack Nelson: Correct issues with header getting hidden

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -87,6 +87,14 @@ body:not( .h-stk ) .site-breadcrumb {
 	}
 }
 
+body:not( .h-stk ).single-featured-image-beside,
+body:not( .h-stk ).single-featured-image-behind,
+body:not( .h-stk ).single-featured-image-above {
+	.site-content {
+		margin-top: 0;
+	}
+}
+
 // Header
 .site-header {
 	border-bottom: 2px solid $color__primary-variation;
@@ -231,6 +239,7 @@ body:not( .h-sb ) .site-header {
 	.single-featured-image-beside {
 		.site-header {
 			padding: 0;
+			z-index: 2;
 		}
 
 		#primary {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some style changes to Newspack Nelson for the sticky header have had some unintended consiquences for the non-sticky header styles: the changes made the style pulling up the content to overlap the header 'stronger', so they were no longer being overridden in cases where they shouldn't be added. This meant the header is partially or fully not visible in some cases.

Closes #1581.

### How to test the changes in this Pull Request:

1. Switch your test site to Newspack Nelson.
2. If the header is already sticky, turn it off under Customizer > Header Settings > Appearance.
3. Create a post and set the featured image to 'beside'.
4. View on the front end and note the header is either partially covered (if it has the 'default' height), or covered entirely (if it is shorter):

![image](https://user-images.githubusercontent.com/177561/142080933-9f5bcd52-d86d-45f4-aa93-874cb4cc3c10.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the header is now visible:

![image](https://user-images.githubusercontent.com/177561/142080689-a449b1f9-c1d4-4033-ac5a-1e56aacd6998.png)

7. Test also with the featured image placements 'large/small', 'behind' and 'above' and make sure there aren't any issues. 
8. Navigate to Customizer > Header Settings > Appearance and turn on the sticky header. 
9. Cycle back through the posts with the different featured image settings, and confirm the header is always visible. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
