### PR TITLE
fix: if no logo, show site title with simplified header

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -416,7 +416,7 @@
 
 // h-sub
 .h-sub {
-	.site-title,
+	&.wp-custom-logo .site-title,
 	.site-description,
 	.alternative-logo {
 		display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, if you don't have a site logo, and use the Simplified Subpage Header, nothing displays in the place of the logo -- the site title is intentionally hidden, but that only makes sense if you also have a simple logo mark that will stay behind.

This PR updates that behaviour, so if you don't have a logo, the site title will display. 

Closes #1265

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Header Settings > Subpage Header, and turn on the Simplified Subpage header. 
2. Navigate to Customizer > Site Identity, delete your site logo and make the 'Site Title' visible.
3. View on the homepage and note your Site Title displays:

![image](https://user-images.githubusercontent.com/177561/143493699-4303a0f1-d61e-4824-9ac5-453bdbe0d91c.png)

4. Navigate to a subpage and note that your Site Title no longer displays:

![image](https://user-images.githubusercontent.com/177561/143493808-ff828691-9f2a-4a2b-be60-da47c4680aac.png)

5. Apply the PR; refresh your subpage and confirm that the site title is now displaying: 

![image](https://user-images.githubusercontent.com/177561/143493662-6137b167-6d37-4d59-b248-cb68b0bfdd2c.png)

6. Navigate back to Customizer > Site Identity; add the logo, and leave the Site Title as visible. 
7. View the homepage and confirm you have both the logo and site title:

![image](https://user-images.githubusercontent.com/177561/143494302-a5b68ae6-463f-4262-a221-0b38f53d59cb.png)

8. View one of your subpages and confirm it's now only showing your logo, and no longer showing your site title:

![image](https://user-images.githubusercontent.com/177561/143495568-cb09fe06-06b7-4a11-bd99-f9fd5e51eef0.png)

9. Navigate to Customize > Header Settings > Appearance and Center the logo.
10. Test the homepage and subpage to make sure things display as expected on both the homepage and subpages:

![image](https://user-images.githubusercontent.com/177561/143495795-1bd54d82-4664-4c26-98f2-a2ebc7e958fe.png)

![image](https://user-images.githubusercontent.com/177561/143495777-58857b61-8b28-408f-864b-fe4fd659b70b.png)

11. Delete the logo again under Customize > Site Identity, and confirm that the site title displays centred as expected on both the homepage and subpages: 

![image](https://user-images.githubusercontent.com/177561/143496075-ae169c26-cb39-40a3-811d-9d164a248c7a.png)

![image](https://user-images.githubusercontent.com/177561/143496083-7dd4d8b4-a2fe-4969-a5af-d62e8b956557.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
