### PR TITLE
fix: correct issue with Mobile CTA gap

### DIFF
--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -112,14 +112,14 @@
 
 	// Mobile Menu toggle
 	.h-dh .site-header .mobile-menu-toggle,
-	.h-sub .site-header .mobile-menu-toggle,
+	.h-dh.h-sub .site-header .mobile-menu-toggle,
 	.h-dh .site-header .mb-cta {
 		display: none;
 	}
 
 	// Desktop Menu toggle
 	.h-dh .site-header .desktop-menu-toggle,
-	.subpage-toggle-contain {
+	.h-dh .subpage-toggle-contain {
 		display: flex;
 	}
 }
@@ -129,12 +129,14 @@
 
 	// Mobile Menu toggle
 	.h-sh .site-header .mobile-menu-toggle,
+	.h-sh.h-sub .site-header .mobile-menu-toggle,
 	.h-sh .site-header .mb-cta {
 		display: none;
 	}
 
 	// Desktop Menu toggle
-	.h-sh .site-header .desktop-menu-toggle {
+	.h-sh .site-header .desktop-menu-toggle,
+	.h-sh.h-sub .subpage-toggle-contain {
 		display: flex;
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -150,10 +150,6 @@
 	margin-left: #{0.75 * $size__spacing-unit};
 	position: relative;
 
-	@include media( tablet ) {
-		display: block;
-	}
-
 	#header-search {
 		position: absolute;
 		top: calc( 100% + 4px );
@@ -163,6 +159,18 @@
 		@include media( tablet ) {
 			right: 0;
 		}
+	}
+}
+
+@include media( tablet ) {
+	.h-dh .header-search-contain {
+		display: block;
+	}
+}
+
+@include media( narrowdesktop ) {
+	.h-sh .header-search-contain {
+		display: block;
 	}
 }
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -248,8 +248,7 @@
 			margin: auto;
 		}
 
-		&.h-dh,
-		&.h-sub {
+		&.h-dh {
 			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Pairing the short header, simplified subpage header, and mobile CTA together can cause weird gaps in the header. This is because the 'default' and 'short' header switch to the mobile version of the header at different breakpoints, and this was not taken into consideration with how the simplified subpage header works. 

This PR (hopefully!) addresses that by making the simplified subpage header more consistent with the header used on the homepage.

Closes #1466.

### How to test the changes in this Pull Request:

1. Set up your site header with the following settings:
* Under Customizer > Header Settings > Appearance, select 'Short Header' and unselect 'Center Logo'
* Under Customizer > Header Settings > Subpage Header, turn on the simplified subpage header
* Under Customizer > Header Settings > Mobile CTA, enable the Mobile Call to Action. 
2. View the front end of the site, and navigate to a subpage. 
3. Shrink your browser window; at a certain point (less than 960px wide, but more than 782px wide), the Mobile CTA should appear, even though desktop-like elements, like the search, are still visible. The CTA should be weirdly floating in the middle: 

![image](https://user-images.githubusercontent.com/177561/143504196-0d190203-4366-4086-8fe8-22e62542e88f.png)

4. Apply the PR and run `npm run build`.
5. Refresh the subpage; if you haven't changed the browser window size, the gap should be gone, and the header should be more of the 'mobile's style header:

![image](https://user-images.githubusercontent.com/177561/143504299-1b9f1fad-cbbb-4907-953b-8974e67820d3.png)

6. Scale up and down the browser window on this page, and make sure no new weird issues are introduced.
7. Navigate to the homepage, and test the different screen sizes; make sure no new weird issues are introduced:

![image](https://user-images.githubusercontent.com/177561/143504365-ff3a3522-a25d-432f-87b2-2c2b0922d8c7.png)

![image](https://user-images.githubusercontent.com/177561/143504373-9c2cf836-69d7-489e-8048-6a05ff6366cb.png)

8. Navigate to Customizer > Header Settings > Mobile CTA, and turn on the mobile CTA on the simplified subpage header.
9. Return to one of your subpages, and make sure no new weird issues are introduced on different screen sizes -- the mobile CTA should always be visible, and not jump around. 
10. Navigate to Customizer > Header Settings > Appearance, and check 'Center Logo'; check the homepage and subpage on different screen sized and confirm there aren't any issues.
11. Navigate to Customizer > Header Settings > Appearance, and uncheck 'Short Logo'; check the homepage and subpage on different screen sized and confirm there aren't any issues.
12. Navigate to Customizer > Header Settings > Appearance, and uncheck 'Center Logo'; check the homepage and subpage on different screen sized and confirm there aren't any issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
