### PR TITLE
Correct checks before adding the `no-sidebar` and `has-sidebar CSS classes

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -148,9 +148,14 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-highlight-menu';
 	}
 
-	// Adds a class of has-sidebar when there is a sidebar present.
-	if ( is_active_sidebar( 'sidebar-1' ) && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) ) {
+	// Adds a class of has-sidebar when there is a sidebar present and populated.
+	if ( is_active_sidebar( 'sidebar-1' )
+		&& ( ( ! is_archive() && ! is_page_template() && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) )
+		|| ( is_archive() && 'default' === get_theme_mod( 'archive_layout', 'default' ) ) )
+	) {
 		$classes[] = 'has-sidebar';
+	} else {
+		$classes[] = 'no-sidebar';
 	}
 
 	// Adds a class of has-afw when there is an above footer widget.
@@ -184,11 +189,6 @@ function newspack_body_classes( $classes ) {
 	// Adds a class if singular post has a large featured image
 	if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside' ) ) ) {
 		$classes[] = 'has-large-featured-image';
-	}
-
-	// Add a class to determine whether it has a sidebar.
-	if ( ! is_active_sidebar( 'sidebar-1' ) ) {
-		$classes[] = 'no-sidebar';
 	}
 
 	// Add a class if updated date should display


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now the theme adds the CSS classes `has-sidebar` or `no-sidebar`, depending on whether or not widgets are assigned to the sidebar widget space. 

However, the logic adding this class doesn't check if the current post or page is using a template that _shows_ the sidebar, so the class `has-sidebar` could be applied when none are present. 

This PR improves the logic around adding the `has-sidebar` class, so it's only added when sidebar widgets have been added AND the current post/page/archive has the right settings to actually display the sidebar. Otherwise, if there are no sidebar widgets assigned and/or the sidebar widgets are not visible, the class `no-sidebar` should be added. 

Closes #1595

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customizer > Widgets > Sidebar, and add at least one widget to the sidebar area if there aren't any already.
3. View the static front page and inspect elements; find the body tag and confirm it has the CSS class `no-sidebar`.
4. View a post or page with the default template; confirm that it has the body class `has-sidebar`. 
5. View a post or page with the one column and/or the one column wide template. Confirm that it has the body class `no-sidebar`. 
6. View an archive page; confirm that is has the body class `has-sidebar`.
7. Navigate to Customizer > Template Settings > Archive Settings; under 'Archive Layout' select either One Column or One Column wide.
8. Return to an archive page and inspect elements; find the body tag and confirm it now has the CSS class `no-sidebar`.
9. Navigate back to Customizer > Widgets > Sidebar and remove your sidebar widget. 
10. Double check a post or page with the default template, and confirm that it now has the CSS class `no-sidebar`. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
