### PR TITLE
perf: disable lazy load for featured images

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -335,11 +335,18 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 	 *
 	 * Wraps the post thumbnail in an anchor element on index views, or a div
 	 * element when on single views.
+	 *
+	 * @param string $size Optional custom image size name to use.
 	 */
 	function newspack_post_thumbnail( $size = 'newspack-featured-image' ) {
 		if ( ! newspack_can_show_post_thumbnail() ) {
 			return;
 		}
+
+		$default_image_attributes = array(
+			'loading'             => false, // Disable lazy loading.
+			'data-hero-candidate' => true, // Make this image a hero candidate for AMP prerendering.
+		);
 
 		if ( is_singular() ) : ?>
 
@@ -352,8 +359,11 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 					the_post_thumbnail(
 						$size,
-						array(
-							'object-fit' => 'cover',
+						wp_parse_args(
+							array(
+								'object-fit' => 'cover',
+							),
+							$default_image_attributes
 						)
 					);
 				else :
@@ -361,8 +371,11 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 					if ( 'above' === newspack_featured_image_position() ) :
 						the_post_thumbnail(
 							$size,
-							array(
-								'layout' => 'responsive',
+							wp_parse_args(
+								array(
+									'layout' => 'responsive',
+								),
+								$default_image_attributes
 							)
 						);
 					else :
@@ -396,7 +409,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 			<figure class="post-thumbnail">
 				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
-					<?php the_post_thumbnail( $size ); ?>
+					<?php the_post_thumbnail( $size, $default_image_attributes ); ?>
 				</a>
 			</figure>
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -348,10 +348,6 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 			'data-hero-candidate' => isset( $GLOBALS['newspack_after_first_featured_image'] ) ? false : true, // Make this image a hero candidate for AMP prerendering.
 		);
 
-		if ( ! isset( $GLOBALS['newspack_after_first_featured_image'] ) ) {
-			$GLOBALS['newspack_after_first_featured_image'] = true;
-		}
-
 		if ( is_singular() ) : ?>
 
 			<figure class="post-thumbnail">
@@ -419,6 +415,11 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 
 			<?php
 		endif; // End is_singular().
+
+		// Set a global variable to identify that the first featured image has been displayed.
+		if ( ! isset( $GLOBALS['newspack_after_first_featured_image'] ) ) {
+			$GLOBALS['newspack_after_first_featured_image'] = true;
+		}
 	}
 endif;
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -344,9 +344,13 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 		}
 
 		$default_image_attributes = array(
-			'loading'             => false, // Disable lazy loading.
-			'data-hero-candidate' => true, // Make this image a hero candidate for AMP prerendering.
+			'loading'             => isset( $GLOBALS['newspack_after_first_featured_image'] ) ? 'lazy' : false, // Disable lazy loading for first featured image on the page.
+			'data-hero-candidate' => isset( $GLOBALS['newspack_after_first_featured_image'] ) ? false : true, // Make this image a hero candidate for AMP prerendering.
 		);
+
+		if ( ! isset( $GLOBALS['newspack_after_first_featured_image'] ) ) {
+			$GLOBALS['newspack_after_first_featured_image'] = true;
+		}
 
 		if ( is_singular() ) : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR disables lazy loading for every first featured image to be displayed on a page in order to improve Largest Contentful Paint (LCP) score.

Also adds the `data-hero-candidate` attribute to take advantage of AMP's prerendering features for LCP improvement.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1605.

### How to test the changes in this Pull Request:

With AMP Plus on:

1. With a site on JN or behind ngrok, while on the master branch, visit a single post with the featured image positioned to "behind article title".
2. Visit the post and observe the featured image `<img />` tag with `loading="lazy"` attribute.
3. Run this URL on https://web.dev/measure and observe the red flag "Largest Contentful Paint image was lazily loaded"
4. Switch to this branch
5. Refresh the page and see the `<img />` tag no longer has the attribute
6. Run the URL on https://web.dev/measure again, with an extra `?v=2` for caching purposes
7. Observe the lazy load flag is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
