### PR TITLE
perf: load amp-plus.js async

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -448,7 +448,7 @@ function newspack_scripts() {
 			'script_loader_tag',
 			function( $tag, $handle, $src ) {
 				if ( 'newspack-amp-plus' == $handle ) {
-					return '<script data-amp-plus-allowed src="' . $src . '"></script>';
+					return '<script data-amp-plus-allowed async src="' . $src . '"></script>';
 				}
 				return $tag;
 			},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Although it's a small script, there's no reason to not load it asynchronously.

### How to test the changes in this Pull Request:

On AMP Plus:

1. With a sticky header, the sidebar sticky ad should stick below the header
2. Make sure the Mobile Sticky Footer ad placement still displays as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
