### PR TITLE
Fix compatibility check for The Events Calendar to prevent critical/fatal errors

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1246,6 +1246,6 @@ require get_template_directory() . '/inc/web-stories.php';
 /**
  * Load The Events Calendar compatibility file.
  */
-if ( class_exists( 'Tribe__Main' ) ) {
+if ( class_exists( 'Tribe__Events__Main' ) ) {
 	require get_template_directory() . '/inc/the-events-calendar.php';
 }


### PR DESCRIPTION
The `Tribe__Main` class is part of The Events Calendar only because it's part of it's shared library "Tribe Common" used by other plugins. The issue with using `Tribe__Main` is that if another plugin that is not The Events Calendar is using that library, then it will ultimately trigger a call to a TEC specific function that does not exist.

The Events Calendar team maintains another plugin called Event Tickets (https://wordpress.org/plugins/event-tickets/) with this exact issue. It can be used without The Events Calendar and in that instance it will trigger this problem.

Pods 2.8+ now also implements this shared library as well, which is where this issue was originally reported by a shared user (https://github.com/pods-framework/pods/issues/6372).

This PR addresses that compatibility issue by checking for the class that exists in The Events Calendar itself, `Tribe__Events__Main`