### PR TITLE
Fix remaining sticky header logo distortion

### DIFF
--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -136,7 +136,7 @@ function newspack_customize_logo_resize( $html ) {
 			}
 		}
 
-		@media (max-width: 1199px) and (min-width: 600px) {
+		@media (max-width: 1199px) and (min-width: 782px) {
 			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
 				max-width: 100%;
 			}

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -125,6 +125,11 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (min-width: 782px) {
+			.h-stk:not(.h-sub) .site-header .custom-logo {
+				max-width: ' . $sticky['width'] . 'px;
+				max-height: ' . $sticky['height'] . 'px;
+			}
+
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
@@ -132,11 +137,6 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (min-width: 1200px) {
-			.h-stk:not(.h-sub) .site-header .custom-logo {
-				max-width: ' . $sticky['width'] . 'px;
-				max-height: ' . $sticky['height'] . 'px;
-			}
-
 			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
 				/* max-width: 30vw; */
 			}

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -139,6 +139,7 @@ function newspack_customize_logo_resize( $html ) {
 		@media (max-width: 1199px) and (min-width: 782px) {
 			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
 				max-width: 100%;
+				width: auto;
 			}
 		}
 

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -130,15 +130,18 @@ function newspack_customize_logo_resize( $html ) {
 				max-width: ' . $sticky['width'] . 'px;
 			}
 
-			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
-				max-width: 100%;
-			}
-
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
 			}
 		}
+
+		@media (max-width: 1199px) and (min-width: 600px) {
+			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
+				max-width: 100%;
+			}
+		}
+
 		</style>';
 
 		$html = $css . $html;

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -135,13 +135,6 @@ function newspack_customize_logo_resize( $html ) {
 				max-height: ' . $subhead['height'] . 'px;
 			}
 		}
-
-		@media (min-width: 1200px) {
-			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
-				/* max-width: 30vw; */
-			}
-		}
-
 		</style>';
 
 		$html = $css . $html;

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -126,8 +126,12 @@ function newspack_customize_logo_resize( $html ) {
 
 		@media (min-width: 782px) {
 			.h-stk:not(.h-sub) .site-header .custom-logo {
-				max-width: ' . $sticky['width'] . 'px;
 				max-height: ' . $sticky['height'] . 'px;
+				max-width: ' . $sticky['width'] . 'px;
+			}
+
+			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
+				max-width: 100%;
 			}
 
 			.h-sub .site-header .custom-logo {

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -125,10 +125,6 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (min-width: 782px) {
-			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
-				max-width: 30vw;
-			}
-
 			.h-sub .site-header .custom-logo {
 				max-width: ' . $subhead['width'] . 'px;
 				max-height: ' . $subhead['height'] . 'px;
@@ -139,6 +135,10 @@ function newspack_customize_logo_resize( $html ) {
 			.h-stk:not(.h-sub) .site-header .custom-logo {
 				max-width: ' . $sticky['width'] . 'px;
 				max-height: ' . $sticky['height'] . 'px;
+			}
+
+			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
+				/* max-width: 30vw; */
 			}
 		}
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -25,6 +25,10 @@
 @include media( mobileonly ) {
 	.h-cta .site-header .custom-logo-link {
 		max-width: 140px;
+
+		.custom-logo {
+			max-width: 100%;
+		}
 	}
 }
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -576,6 +576,10 @@
 			&.site-branding {
 				width: 38%;
 			}
+
+			.custom-logo {
+				object-fit: contain;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -38,22 +38,6 @@
 	}
 }
 
-@include media( tablet ) {
-	.h-dh {
-		.custom-logo {
-			object-position: left center;
-		}
-	}
-}
-
-@include media( narrowdesktop ) {
-	.h-sh {
-		.custom-logo {
-			object-position: left center;
-		}
-	}
-}
-
 // Site identity
 .site-identity {
 	align-items: baseline;

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -25,10 +25,6 @@
 @include media( mobileonly ) {
 	.h-cta .site-header .custom-logo-link {
 		max-width: 140px;
-
-		.custom-logo {
-			max-width: 100%;
-		}
 	}
 }
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -32,26 +32,12 @@
 	}
 }
 
-.site-header .custom-logo {
-	object-fit: contain;
-	object-position: left center;
-
+.site-header .custom-logo-link .custom-logo {
 	@include media( tabletonly ) {
 		height: auto;
 		min-height: 45px;
+		object-fit: contain;
 		width: auto;
-	}
-}
-
-@include media( tablet ) {
-	.h-dh.h-cl .site-header .custom-logo {
-		object-position: center center;
-	}
-}
-
-@include media( narrowdesktop ) {
-	.h-sh.h-cl .site-header .custom-logo {
-		object-position: center center;
 	}
 }
 
@@ -589,6 +575,24 @@
 
 			&.site-branding {
 				width: 38%;
+			}
+		}
+	}
+
+	&.h-cl .site-header .custom-logo {
+		object-position: left center;
+	}
+
+	&.h-cl {
+		&.h-dh .site-header .custom-logo {
+			@include media( tablet ) {
+				object-position: center center;
+			}
+		}
+
+		&.h-sh .site-header .custom-logo {
+			@include media( narrowdesktop ) {
+				object-position: center center;
 			}
 		}
 	}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -32,13 +32,26 @@
 	}
 }
 
-.site-header .custom-logo-link .custom-logo {
+.site-header .custom-logo {
 	object-fit: contain;
+	object-position: left center;
 
 	@include media( tabletonly ) {
 		height: auto;
 		min-height: 45px;
 		width: auto;
+	}
+}
+
+@include media( tablet ) {
+	.h-dh.h-cl .site-header .custom-logo {
+		object-position: center center;
+	}
+}
+
+@include media( narrowdesktop ) {
+	.h-sh.h-cl .site-header .custom-logo {
+		object-position: center center;
 	}
 }
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -29,11 +29,28 @@
 }
 
 .site-header .custom-logo-link .custom-logo {
+	object-fit: contain;
+
 	@include media( tabletonly ) {
 		height: auto;
 		min-height: 45px;
-		object-fit: contain;
 		width: auto;
+	}
+}
+
+@include media( tablet ) {
+	.h-dh {
+		.custom-logo {
+			object-position: left center;
+		}
+	}
+}
+
+@include media( narrowdesktop ) {
+	.h-sh {
+		.custom-logo {
+			object-position: left center;
+		}
 	}
 }
 
@@ -571,10 +588,6 @@
 
 			&.site-branding {
 				width: 38%;
-			}
-
-			.custom-logo {
-				object-fit: contain;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the sticky header logo styles a bit, to prevent some odd cases of logo distortion (and are hopefully the last set of changes related to this!).

Closes #1617

I've created some fake logos based on the size/shape of logos I've recreated issues with here: https://cloudup.com/cvzeMzjEnrd

These specific logos showcase some different issues:
* [Medium example logo](https://cloudup.com/iEKZMtl3h5B)
* [Wide example logo](https://cloudup.com/iu-SdOI2H6B)
* [Small example logo](https://cloudup.com/i2kEAmdqxC1)
* [X-Small example logo](https://cloudup.com/iespwoToKnH)

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Site Identity, and upload the 'Medium example logo'; make it as large as possible. 
2. Navigate to Customizer > Header Settings > Appearance, and check 'Centre Logo' and 'Sticky Header'
3. Copy-paste the following CSS into the Customizer > Custom CSS field. This will add a dotted border around the 'site branding' section of the header, to easier see where the logo is sitting relative to it:

```
.site-branding {
	outline: 1px dotted red;
}
```

4. View on the front end with and without AMP -- try scaling down the browser window and note how the logo looks at different breakpoints. This logo should be distorted on desktop-sized screens with AMP disabled, but correct as it scales down. 

![image](https://user-images.githubusercontent.com/177561/146849067-b0e721eb-d7e9-4299-99b7-b68c8773f557.png)

When AMP is enabled it should be fine, but slightly off-centre in the `site-branding` area of the header:

![image](https://user-images.githubusercontent.com/177561/146849160-439e2047-6d6a-47a7-801f-604ae5f066ca.png)

5. Apply the PR and run `npm run build`.
6. Hard-refresh the page, and  repeat step #4. The logos should be the same size as they were on `master`.
7. When AMP is disabled, the logo should maintain its shape:

![image](https://user-images.githubusercontent.com/177561/146849838-0c9b16e8-f600-4222-8da6-d771dc8f8b1b.png)

... and when AMP is enabled, the logo should be the same size, but better aligned inside of the site-branding area:

![image](https://user-images.githubusercontent.com/177561/146849912-5f2cec54-323e-43a8-9c81-b8057f5fb954.png)

8. Try switching to a left-aligned logo, and make sure everything still looks good.
9. Switch the logo to "Wide example logo", and the logo alignment back to centred. 
10. Switch back to `master` and run `npm run build`. 
11. Repeat step #4 with this new logo; there should be some vertical distortion when AMP is disabled: 

![image](https://user-images.githubusercontent.com/177561/146852001-0faa0ef5-5e68-464b-b61c-b8723139472a.png)

12. Apply the PR and run `npm run build`; confirm that the logo is scaled correctly with and without AMP, at different screen sizes: 

![image](https://user-images.githubusercontent.com/177561/146853678-c91866ea-7962-4ca2-974a-110389823fc2.png)

13. Try switching to a left-aligned logo, and make sure everything still looks good.
14. Switch the logo to "Small example logo", and the logo alignment back to centred. 
15. Switch back to `master` and run `npm run build`. 
16. Repeat step #4 with this new logo; the distortion without AMP is pretty epic:

![image](https://user-images.githubusercontent.com/177561/146853995-f4b95129-9dc1-4fc8-bc4c-569918933cd6.png)

17. With AMP enabled, the logo's shape should be correct, but again it's misaligned in the site branding: 

![image](https://user-images.githubusercontent.com/177561/146854032-0c4f75b8-02bc-41b8-9665-e93cf66d6972.png)

18. Apply the PR and run `npm run build`; confirm that the logo is scaled correctly with and without AMP, at different screen sizes, and be centred inside of the `site-branding` section:

![image](https://user-images.githubusercontent.com/177561/146855461-aeb74646-3537-415a-b431-0c82e9d6a66a.png)

19. Try switching to a left-aligned logo, and make sure everything still looks good.
20. Switch the logo to "Small example logo", and the logo alignment back to centred. 
21. Switch back to `master` and run `npm run build`. 
22. Much like the above, non-AMP is kind of a mess:

![image](https://user-images.githubusercontent.com/177561/146856152-503e8921-f6a8-49c3-9b09-21d4dd5c2fa4.png)

23. Apply the PR and run `npm run build`; confirm that the logo is scaling correctly both with and without AMP:

![image](https://user-images.githubusercontent.com/177561/146857332-2dbb1131-abbe-472d-9564-5d588b10694d.png)

24. Please try some other header settings -- the 'simplified subpage' header, the mobile CTA, and the short-vs-default height header, to see if you spot any issues. While I've tested and tweaked this at length, there is still a not-terrible chance you will find something I haven't 🙏 😅 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
