### PR TITLE
Update post title styles for WP 5.9

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -254,7 +254,8 @@ function newspack_custom_typography_css() {
 
 		/* Post Title */
 		.edit-post-visual-editor.editor-styles-wrapper .editor-post-title__block .editor-post-title__input, /* legacy */
-		.edit-post-visual-editor .editor-styles-wrapper .editor-post-title__block .editor-post-title__input,
+		.edit-post-visual-editor .editor-styles-wrapper .editor-post-title__block .editor-post-title__input, /* legacy */
+		.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper h1.wp-block-post-title,
 
 		/* Homepage Posts Block */
 		.block-editor-block-list__layout .wp-block .entry-title,

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -130,18 +130,20 @@ figcaption,
 
 /** === Post Title === */
 
-.editor-post-title__block {
+.editor-post-title__block,
+h1.wp-block-post-title {
 	font-size: $font__size_base; // Set on the title so the font size variables math as expected.
+}
 
-	.editor-post-title__input {
-		font-family: $font__heading;
-		font-size: $font__size-xxl;
-		font-weight: 700;
-		line-height: 1.2;
+.editor-post-title__block .editor-post-title__input,
+h1.wp-block-post-title {
+	font-family: $font__heading;
+	font-size: $font__size-xxl;
+	font-weight: 700;
+	line-height: 1.2;
 
-		@include media( desktop ) {
-			font-size: $font__size-xxxl;
-		}
+	@include media( desktop ) {
+		font-size: $font__size-xxxl;
 	}
 }
 

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -104,22 +104,25 @@ body.newspack-single-column-template {
 /** === Single Posts === */
 
 body.post-type-post {
-	.editor-post-title__block {
+	.editor-post-title__block,
+	.editor-styles-wrapper h1.wp-block-post-title {
 		max-width: 1200px;
-		.editor-post-title__input {
-			font-size: $font__size-xl;
+	}
 
-			@include media( mobile ) {
-				font-size: $font__size-xxl;
-			}
+	.editor-post-title__block .editor-post-title__input,
+	.editor-styles-wrapper h1.wp-block-post-title {
+		font-size: $font__size-xl;
 
-			@include media( tablet ) {
-				font-size: $font__size-xxxl;
-			}
+		@include media( mobile ) {
+			font-size: $font__size-xxl;
+		}
 
-			@include media( desktop ) {
-				font-size: $font__size-xxxxl;
-			}
+		@include media( tablet ) {
+			font-size: $font__size-xxxl;
+		}
+
+		@include media( desktop ) {
+			font-size: $font__size-xxxxl;
 		}
 	}
 }

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -105,8 +105,14 @@ body.newspack-single-column-template {
 
 body.post-type-post {
 	.editor-post-title__block,
-	.edit-post-visual-editor__post-title-wrapper {
+	.edit-post-visual-editor__post-title-wrapper,
+	.editor-styles-wrapper h1.wp-block-post-title {
 		max-width: 1200px;
+	}
+
+	.edit-post-visual-editor__post-title-wrapper {
+		margin-left: auto;
+		margin-right: auto;
 	}
 
 	.editor-post-title__block .editor-post-title__input,

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -105,7 +105,7 @@ body.newspack-single-column-template {
 
 body.post-type-post {
 	.editor-post-title__block,
-	.editor-styles-wrapper h1.wp-block-post-title {
+	.edit-post-visual-editor__post-title-wrapper {
 		max-width: 1200px;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the updated post title class to the theme's styles and Typography settings, so it previews correctly in the block editor when WP is updated to 5.9.

Closes #1654.

### How to test the changes in this Pull Request:

1. Start with a test site running the WordPress 5.9 RC -- you can do that by installing the [WordPress Beta Tester](https://en-ca.wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Navigate to Customizer > Typography and change your Heading font to something noticeably different.
3. Edit a post or page and note that the header is not picking up your custom font -- instead, it's using the theme/child theme's default. On posts, the title will also be smaller than it appears on the front-end, or compared to the editor using 5.8:

Front end: 

![image](https://user-images.githubusercontent.com/177561/149578043-dc547fc5-3206-4229-9156-0dddabf46dd1.png)

Editor: 

![image](https://user-images.githubusercontent.com/177561/149578356-4c303c1e-8604-407e-a159-2ed1ab5964ec.png)

4. Apply the PR and run `npm run build`.
5. Confirm your custom font choice is now used, and the post title font size is larger. 

Editor: 

![image](https://user-images.githubusercontent.com/177561/149578075-d0522efb-7b0d-4d95-b29b-b8799bd4fb69.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
