### PR TITLE
Update article subtitle preview selector

### DIFF
--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -12,7 +12,11 @@ export const META_FIELD_NAME = 'newspack_post_subtitle';
  * @param  {string} subtitle Subtitle text
  */
 export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
-	const titleEl = document.querySelector( '.editor-post-title__block' );
+	let titleEl = document.querySelector( '.editor-post-title__block' ); // Legacy selector
+	if ( ! titleEl ) {
+		titleEl = document.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
+	}
+
 	if ( titleEl && typeof subtitle === 'string' ) {
 		let subtitleEl = document.getElementById( SUBTITLE_ID );
 		if ( ! subtitleEl ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the selector for the article subtitle preview, so it gets appended to the post title in the editor.

It also keeps the original selector in place, just for the short-term as backwards compatibility. 

Note: testing this after #1659 is merged will avoid any display issues -- otherwise the article subtitle will display, but be fully flush to the left.

Closes #1658

### How to test the changes in this Pull Request:

1. Start with a test site running the WordPress 5.9 RC -- you can do that by installing the [WordPress Beta Tester](https://en-ca.wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Edit a post and try adding text to the Article subtitle text. Note that it doesn't appear below the post title in the editor.
3. Apply the PR and run `npm run build`.
4. Confirm that the Article subtitle text now appears below the post title in the editor preview.
5. Test this PR on a site running WP 5.8.X and confirm that the article subtitle preview still works there with these changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
