### PR TITLE
Update figcaption styles for WordPress 5.9

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -126,6 +126,8 @@ figcaption,
 	line-height: $font__line-height-pre;
 	margin: 0 auto #{0.5 * $size__spacing-unit};
 	max-width: 780px;
+	padding-left: 0;
+	padding-right: 0;
 }
 
 /** === Post Title === */
@@ -357,10 +359,20 @@ h1.wp-block-post-title {
 
 /** === Image === */
 
-.wp-block-image {
-	figcaption {
-		margin-top: 0;
-		text-align: left;
+.wp-block-image figcaption {
+	margin-top: 0;
+	text-align: left;
+}
+
+:not( [data-align] ) > .wp-block-image figcaption {
+	width: 100%;
+}
+
+div:not( [data-align] ),
+div[data-align='wide'],
+div[data-align='full'] {
+	> .wp-block-image figcaption {
+		margin-top: 10px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Image block figcaptions styles are changing in WP 5.9, and they are causing a minor display error in the editor preview. This PR tweaks the editor styles to fix that.

Closes #1657

### How to test the changes in this Pull Request:

1. Start with a test site running the latest 5.9 RC - you can do this using the [WordPress Beta Tester](https://en-ca.wordpress.org/plugins/wordpress-beta-tester/) plugin.
2. Create a new post and add some image blocks with different alignments (none, centred, left, right, wide, full). Add short captions to each block.
3. Note when the block has no alignment, the caption appears to be centred (if you keep adding text to make it longer, it will eventually fill the whole space and appear left-aligned). When the block has no alignment, or a wide or full alignment, the caption seems extra close to the image:

![image](https://user-images.githubusercontent.com/177561/149635474-bc61c052-3e6c-4dc7-b54a-1c51a1d231bf.png)

4. Apply the PR and run `npm run build`.
5. Confirm that the captions now preview as expected in 5.9:

![image](https://user-images.githubusercontent.com/177561/149635520-ac5203ee-65cc-4eed-9d4f-b603be2f00b1.png)

6. Test the PR in the same fashion on a site still running 5.8.X and confirm it causes no major issues -- it _will_ cause the space above the caption to increase in some cases (like when the image is not aligned), but this seems like an acceptable trade-off for the short-term:

![image](https://user-images.githubusercontent.com/177561/149635527-c185e75e-1cdb-4620-9e1f-09ff9ef8e62d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
