### PR TITLE
Update Pullquote block styles for WordPress 5.9

### DIFF
--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -52,6 +52,7 @@ Newspack Joseph Editor Styles
 	font-family: $font__heading;
 	font-style: normal;
 	font-weight: bold;
+	text-align: center;
 
 	p {
 		font-style: inherit;
@@ -68,7 +69,6 @@ Newspack Joseph Editor Styles
 
 	blockquote {
 		border-color: inherit;
-		text-align: center;
 	}
 
 	.wp-block-pullquote__citation {
@@ -80,9 +80,7 @@ Newspack Joseph Editor Styles
 
 [data-align='left'] .wp-block-pullquote,
 [data-align='right'] .wp-block-pullquote {
-	blockquote {
-		text-align: left;
-	}
+	text-align: left;
 
 	@include media( tablet ) {
 		p {

--- a/newspack-joseph/sass/style-editor.scss
+++ b/newspack-joseph/sass/style-editor.scss
@@ -61,7 +61,8 @@ Newspack Joseph Editor Styles
 		}
 	}
 
-	&.is-style-solid-color {
+	&.is-style-solid-color,
+	&.has-background {
 		border: 0;
 	}
 

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -359,6 +359,7 @@ textarea {
 	font-family: $font__heading;
 	font-style: normal;
 	font-weight: bold;
+	text-align: center;
 
 	p {
 		font-style: inherit;
@@ -370,16 +371,11 @@ textarea {
 
 	blockquote {
 		border-color: inherit;
-		text-align: center;
 	}
 
 	&.is-style-solid-color,
 	&.has-background {
 		border: 0;
-
-		&:not( .alignleft ):not( .alignright ) blockquote {
-			text-align: center;
-		}
 	}
 
 	cite {
@@ -387,6 +383,15 @@ textarea {
 		font-family: $font__body;
 		font-size: $font__size-base;
 		font-weight: normal;
+	}
+
+	&.alignleft,
+	&.alignright {
+		text-align: left;
+	}
+
+	&.has-text-align-center {
+		text-align: center;
 	}
 }
 

--- a/newspack-joseph/sass/style.scss
+++ b/newspack-joseph/sass/style.scss
@@ -373,7 +373,8 @@ textarea {
 		text-align: center;
 	}
 
-	&.is-style-solid-color {
+	&.is-style-solid-color,
+	&.has-background {
 		border: 0;
 
 		&:not( .alignleft ):not( .alignright ) blockquote {

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -106,7 +106,7 @@ figure.wp-block-pullquote {
 .wp-block-pullquote {
 	position: relative;
 
-	&:not( .is-style-solid-color ) {
+	&:not( .is-style-solid-color ):not( .has-background ) {
 		blockquote {
 			padding-left: #{2 * $size__spacing-unit};
 		}

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -104,6 +104,7 @@ figure.wp-block-pullquote {
 }
 
 .wp-block-pullquote {
+	font-weight: bold;
 	position: relative;
 
 	&:not( .is-style-solid-color ):not( .has-background ) {
@@ -123,6 +124,10 @@ figure.wp-block-pullquote {
 			top: 0;
 			width: 40px;
 		}
+
+		&[style*='border-width']::before {
+			display: none;
+		}
 	}
 
 	blockquote p,
@@ -136,7 +141,6 @@ figure.wp-block-pullquote {
 
 	p {
 		font-style: normal;
-		font-weight: bold;
 	}
 
 	em {

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -304,6 +304,7 @@ figcaption,
 //! Pullquote
 .wp-block-pullquote {
 	border-width: 0;
+	font-weight: bold;
 	position: relative;
 
 	blockquote p,
@@ -313,8 +314,16 @@ figcaption,
 		}
 	}
 
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-xl;
+			}
+		}
+	}
+
 	blockquote {
-		font-weight: bold;
 		p {
 			font-style: normal;
 			font-size: $font__size-lg;
@@ -334,7 +343,7 @@ figcaption,
 		text-transform: uppercase;
 	}
 
-	&:not( .is-style-solid-color ) {
+	&:not( .is-style-solid-color ):not( .has-background ) {
 		blockquote {
 			padding-left: #{2 * $size__spacing-unit};
 		}
@@ -353,6 +362,11 @@ figcaption,
 		}
 	}
 
+	&.has-background blockquote {
+		margin-left: 0;
+		margin-right: 0;
+	}
+
 	&.alignleft,
 	&.alignright {
 		@include media( tablet ) {
@@ -361,7 +375,7 @@ figcaption,
 			}
 		}
 
-		&:not( .is-style-solid-color ) {
+		&:not( .is-style-solid-color ):not( .has-background ) {
 			padding-top: $size__spacing-unit;
 
 			blockquote {
@@ -374,7 +388,7 @@ figcaption,
 		}
 	}
 
-	&.alignfull:not( .is-style-solid-color )::before {
+	&.alignfull:not( .is-style-solid-color ):not( .has-background )::before {
 		left: 8px;
 	}
 }

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -360,6 +360,10 @@ figcaption,
 			top: 0;
 			width: 40px;
 		}
+
+		&[style*='border-width']::before {
+			display: none;
+		}
 	}
 
 	&.has-background blockquote {

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -134,6 +134,11 @@ blockquote {
 		display: block;
 		width: 75%;
 	}
+
+	&.is-style-solid-color::before,
+	&[style*='border-width']::before {
+		display: none;
+	}
 }
 
 .wp-block-separator {

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -13,7 +13,6 @@ h1,
 h2,
 h3,
 h4,
-blockquote p,
 .editor-post-title__block .editor-post-title__input {
 	font-weight: 800;
 }
@@ -79,6 +78,7 @@ blockquote {
 
 .wp-block-pullquote {
 	border-width: 16px 0 4px;
+	font-weight: bold;
 
 	blockquote {
 		margin: #{2 * $size__spacing-unit} 0;
@@ -95,7 +95,6 @@ blockquote {
 
 	p {
 		font-style: normal;
-		font-weight: bold;
 	}
 
 	em {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -364,10 +364,6 @@ div.wpnbha .article-section-title {
 
 blockquote {
 	font-family: $font__heading;
-
-	p {
-		font-weight: 800;
-	}
 }
 
 //! Paragraph
@@ -401,11 +397,21 @@ blockquote {
 //! Pullquote
 .wp-block-pullquote {
 	border-width: 16px 0 4px;
+	font-weight: bold;
 
 	blockquote p,
 	&.is-style-solid-color blockquote p {
 		@include media( tablet ) {
 			font-size: $font__size-xl;
+		}
+	}
+
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-xl;
+			}
 		}
 	}
 
@@ -426,7 +432,6 @@ blockquote {
 	}
 
 	cite {
-		font-weight: bold;
 		letter-spacing: 0.05em;
 		opacity: 0.9;
 	}

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -464,7 +464,8 @@ blockquote {
 			width: 75%;
 		}
 
-		&.is-style-solid-color::before {
+		&.is-style-solid-color::before,
+		&[style*='border-width']::before {
 			display: none;
 		}
 	}

--- a/newspack-sacha/sass/style-editor.scss
+++ b/newspack-sacha/sass/style-editor.scss
@@ -58,7 +58,6 @@ figcaption,
 blockquote,
 cite {
 	font-family: $font__heading;
-	text-align: center;
 
 	em,
 	i {
@@ -69,6 +68,7 @@ cite {
 .wp-block-pullquote {
 	border-width: 2px 0;
 	font-style: italic;
+	text-align: center;
 
 	blockquote {
 		margin: #{2 * $size__spacing-unit} 0;
@@ -85,13 +85,11 @@ cite {
 
 	p {
 		font-family: $font__heading;
-		text-align: center;
 	}
 
 	.wp-block-pullquote__citation {
 		font-family: $font__heading;
 		font-style: italic;
-		text-align: center;
 
 		em,
 		i {
@@ -104,17 +102,13 @@ cite {
 [data-align='right'] .wp-block-pullquote {
 	margin-top: #{1.5 * $size__spacing-unit};
 	margin-bottom: #{1.5 * $size__spacing-unit};
+	text-align: left;
 
 	@include media( tablet ) {
 		&.is-style-solid-color blockquote p,
 		blockquote p {
 			font-size: $font__size-lg;
 		}
-	}
-
-	p,
-	.wp-block-pullquote__citation {
-		text-align: left;
 	}
 }
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -178,6 +178,7 @@ cite {
 
 .wp-block-pullquote {
 	border-width: 2px 0;
+	text-align: center;
 
 	blockquote p,
 	&.is-style-solid-color blockquote p {
@@ -186,22 +187,25 @@ cite {
 		}
 	}
 
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-xl;
+			}
+		}
+	}
+
 	&.is-style-solid-color blockquote cite,
 	cite {
 		font-style: italic;
-	}
-
-	&.is-style-solid-color blockquote {
-		text-align: center;
 	}
 
 	&.alignleft,
 	&.alignright {
 		margin-top: #{1.5 * $size__spacing-unit};
 		margin-bottom: #{1.5 * $size__spacing-unit};
-		blockquote {
-			text-align: left;
-		}
+		text-align: left;
 
 		@include media( tablet ) {
 			blockquote p,

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -156,7 +156,6 @@ blockquote,
 cite {
 	font-family: $font__heading;
 	font-style: italic;
-	text-align: center;
 
 	em,
 	i {

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -123,11 +123,11 @@ function newspack_scott_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .article-section-title:before {
 			background-color: ' . esc_html( $primary_color ) . ';
 		}
-		.editor-styles-wrapper .wp-block-pullquote:not(.is-style-solid-color) blockquote p:first-of-type::before {
+		.editor-styles-wrapper .wp-block-pullquote:not(.is-style-solid-color):not(.has-background) blockquote p:first-of-type::before {
 			color: ' . esc_html( $primary_color ) . ';
 		}
-		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]) blockquote::before,
-		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]) blockquote::after {
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]):not(.has-background) blockquote::before,
+		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-pullquote:not(.is-style-solid-color):not([style*="border-color"]):not(.has-background) blockquote::after {
 			border-top-color: ' . esc_html( $primary_color ) . ';
 		}
 	';

--- a/newspack-scott/sass/style-editor.scss
+++ b/newspack-scott/sass/style-editor.scss
@@ -51,8 +51,10 @@ Newspack Scott Editor Styles
 
 .wp-block-pullquote {
 	border-width: 0;
+	font-weight: bold;
 	padding-top: #{3 * $size__spacing-unit};
 	position: relative;
+	text-align: center;
 
 	.block-library-pullquote__content {
 		position: relative;
@@ -62,7 +64,6 @@ Newspack Scott Editor Styles
 	blockquote {
 		border-color: inherit;
 		margin: #{2 * $size__spacing-unit} 0;
-		text-align: center;
 
 		&::before,
 		&::after {
@@ -93,17 +94,6 @@ Newspack Scott Editor Styles
 		}
 	}
 
-	&.is-style-solid-color {
-		blockquote::before,
-		blockquote::after {
-			border-top-color: currentColor;
-		}
-
-		blockquote {
-			padding-top: #{2 * $size__spacing-unit};
-		}
-	}
-
 	blockquote p:first-of-type::before {
 		color: $color__primary;
 		content: '\201C';
@@ -125,8 +115,24 @@ Newspack Scott Editor Styles
 		}
 	}
 
-	&.is-style-solid-color blockquote p:first-of-type::before {
-		color: inherit;
+	&.is-style-solid-color,
+	&.has-background {
+		blockquote::before,
+		blockquote::after {
+			border-top-color: currentColor;
+		}
+
+		p:first-of-type::before {
+			color: inherit;
+		}
+	}
+
+	&.is-style-solid-color blockquote {
+		padding-top: #{2 * $size__spacing-unit};
+	}
+
+	&.has-background blockquote {
+		padding-top: $size__spacing-unit;
 	}
 
 	&.is-style-solid-color blockquote p,
@@ -140,13 +146,75 @@ Newspack Scott Editor Styles
 
 	p {
 		font-family: $font__heading;
-		font-weight: bold;
 	}
 
 	.wp-block-pullquote__citation {
 		font-size: $font__size-sm;
 		font-weight: normal;
 		text-transform: uppercase;
+	}
+
+	&.has-text-align-left,
+	&.has-text-align-right {
+		blockquote::after {
+			display: none;
+		}
+
+		blockquote p:first-of-type::before {
+			width: 0.5em;
+		}
+
+		&.is-style-solid-color blockquote,
+		&.has-background blockquote {
+			padding-top: #{1.5 * $size__spacing-unit};
+		}
+	}
+
+	&.has-text-align-left {
+		blockquote::before {
+			left: 4em;
+			right: 0;
+		}
+
+		blockquote p:first-of-type::before {
+			left: 0;
+			text-align: left;
+		}
+
+		&.is-style-solid-color blockquote {
+			&::before {
+				left: #{5 * $size__spacing-unit};
+				right: #{2 * $size__spacing-unit};
+			}
+
+			p:first-of-type::before {
+				left: #{1.5 * $size__spacing-unit};
+			}
+		}
+	}
+
+	&.has-text-align-right {
+		blockquote::before {
+			right: 3em;
+			left: 0;
+		}
+
+		blockquote p:first-of-type::before {
+			left: auto;
+			right: 0;
+			text-align: right;
+		}
+
+		&.is-style-solid-color blockquote {
+			&::before {
+				right: #{5 * $size__spacing-unit};
+				left: #{2 * $size__spacing-unit};
+			}
+
+			p:first-of-type::before {
+				right: #{1.5 * $size__spacing-unit};
+			}
+		}
 	}
 }
 
@@ -176,17 +244,26 @@ Newspack Scott Editor Styles
 		width: 0.5em;
 	}
 
+	&.is-style-solid-color,
+	&.has-background {
+		blockquote {
+			&::before {
+				left: #{5 * $size__spacing-unit};
+				right: #{2 * $size__spacing-unit};
+			}
+
+			p:first-of-type::before {
+				left: #{1.5 * $size__spacing-unit};
+			}
+		}
+	}
+
 	&.is-style-solid-color blockquote {
 		padding-top: #{1.5 * $size__spacing-unit};
+	}
 
-		&::before {
-			left: #{5 * $size__spacing-unit};
-			right: #{2 * $size__spacing-unit};
-		}
-
-		p:first-of-type::before {
-			left: #{1.5 * $size__spacing-unit};
-		}
+	&.has-background blockquote {
+		padding-top: #{0.5 * $size__spacing-unit};
 	}
 
 	&.is-style-solid-color blockquote p,

--- a/newspack-scott/sass/style-editor.scss
+++ b/newspack-scott/sass/style-editor.scss
@@ -216,15 +216,27 @@ Newspack Scott Editor Styles
 			}
 		}
 	}
+
+	&[style*='border-width'] {
+		blockquote {
+			margin-top: 0;
+		}
+
+		p:first-of-type::before,
+		blockquote::before,
+		blockquote::after {
+			display: none;
+		}
+	}
 }
 
 [data-align='left'] .wp-block-pullquote,
 [data-align='right'] .wp-block-pullquote {
 	border-width: 0;
+	text-align: left;
 
 	blockquote {
 		padding-top: #{1.5 * $size__spacing-unit};
-		text-align: left;
 
 		&::before {
 			left: 3em;

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -143,7 +143,6 @@ div.wpnbha .article-section-title {
 //! Pullquote
 .wp-block-pullquote {
 	border-width: 0;
-	border-color: $color__primary;
 	font-family: $font__heading;
 	font-weight: bold;
 	padding-top: #{4 * $size__spacing-unit};
@@ -153,6 +152,15 @@ div.wpnbha .article-section-title {
 	blockquote p {
 		@include media( tablet ) {
 			font-size: $font__size-xl;
+		}
+	}
+
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
+		@include media( tablet ) {
+			p {
+				font-size: $font__size-xl;
+			}
 		}
 	}
 
@@ -201,19 +209,24 @@ div.wpnbha .article-section-title {
 		}
 	}
 
-	&.is-style-solid-color {
+	&.is-style-solid-color,
+	&.has-background {
 		blockquote {
 			text-align: center;
+
 			&::before {
 				color: inherit;
 			}
+
 			&::after {
 				border-top-color: currentColor;
 			}
+
 			&::before,
 			&::after {
 				border-top-color: currentColor;
 			}
+
 			cite {
 				text-transform: uppercase;
 			}
@@ -228,6 +241,76 @@ div.wpnbha .article-section-title {
 		font-size: $font__size-sm;
 		font-weight: normal;
 		text-transform: uppercase;
+	}
+
+	&.has-text-align-left,
+	&.has-text-align-right {
+		blockquote::after {
+			display: none;
+		}
+
+		&,
+		&.is-style-solid-color,
+		&.has-background {
+			padding-top: #{3 * $size__spacing-unit};
+		}
+	}
+
+	&.has-text-align-left {
+		blockquote {
+			&::before {
+				left: 3em;
+				right: 0;
+
+				@include media( tablet ) {
+					left: 4em;
+				}
+			}
+		}
+
+		p:first-of-type::before {
+			left: 0;
+		}
+
+		&.is-style-solid-color,
+		&.has-background {
+			p:first-of-type::before {
+				left: #{1.5 * $size__spacing-unit};
+			}
+
+			blockquote::before {
+				left: 4em;
+			}
+		}
+	}
+
+	&.has-text-align-right {
+		blockquote {
+			&::before {
+				right: 3em;
+				left: 0;
+
+				@include media( tablet ) {
+					right: 4em;
+				}
+			}
+		}
+
+		p:first-of-type::before {
+			left: auto;
+			right: 0;
+		}
+
+		&.is-style-solid-color,
+		&.has-background {
+			p:first-of-type::before {
+				right: #{1.5 * $size__spacing-unit};
+			}
+
+			blockquote::before {
+				right: 4em;
+			}
+		}
 	}
 
 	&.alignleft,
@@ -250,7 +333,8 @@ div.wpnbha .article-section-title {
 		}
 
 		&,
-		&.is-style-solid-color {
+		&.is-style-solid-color,
+		&.has-background {
 			padding-top: #{3 * $size__spacing-unit};
 		}
 
@@ -261,13 +345,14 @@ div.wpnbha .article-section-title {
 			width: 0.5em;
 		}
 
-		&.is-style-solid-color {
+		&.is-style-solid-color,
+		&.has-background {
 			p:first-of-type::before {
 				left: #{1.5 * $size__spacing-unit};
 			}
 
 			blockquote::before {
-				left: 4em;
+				left: 4.5em;
 			}
 		}
 	}

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -147,6 +147,7 @@ div.wpnbha .article-section-title {
 	font-weight: bold;
 	padding-top: #{4 * $size__spacing-unit};
 	position: relative;
+	text-align: center;
 
 	&.is-style-solid-color blockquote p,
 	blockquote p {
@@ -166,7 +167,6 @@ div.wpnbha .article-section-title {
 
 	blockquote {
 		border-color: inherit;
-		text-align: center;
 
 		&::before,
 		&::after {
@@ -212,8 +212,6 @@ div.wpnbha .article-section-title {
 	&.is-style-solid-color,
 	&.has-background {
 		blockquote {
-			text-align: center;
-
 			&::before {
 				color: inherit;
 			}
@@ -315,8 +313,9 @@ div.wpnbha .article-section-title {
 
 	&.alignleft,
 	&.alignright {
+		text-align: left;
+
 		blockquote {
-			text-align: left;
 			&::before {
 				left: 3em;
 				right: 15%;
@@ -354,6 +353,16 @@ div.wpnbha .article-section-title {
 			blockquote::before {
 				left: 4.5em;
 			}
+		}
+	}
+
+	&[style*='border-width'] {
+		padding-top: $size__spacing-unit;
+
+		p:first-of-type::before,
+		blockquote::before,
+		blockquote::after {
+			display: none;
 		}
 	}
 }

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -128,7 +128,9 @@ function newspack_custom_colors_css() {
 			blockquote,
 			.wp-block-quote:not(.is-large),
 			.wp-block-quote:not(.is-style-large),
-			.woocommerce-tabs ul li.active a {
+			.woocommerce-tabs ul li.active a,
+			.has-primary-border-color,
+			.wp-block-pullquote .has-primary-border-color {
 				border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 			}
 
@@ -195,6 +197,12 @@ function newspack_custom_colors_css() {
 				color:' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
 			}
 
+			/* Set secondary border color */
+			.has-secondary-border-color,
+			.wp-block-pullquote.has-secondary-border-color {
+				border-color:' . esc_html( $secondary_color ) . ';
+			}
+
 			/* Set primary variation background color */
 			.has-primary-variation-background-color,
 			*[class^="wp-block-"].has-primary-variation-background-color,
@@ -221,6 +229,12 @@ function newspack_custom_colors_css() {
 			.is-style-outline .wp-block-button__link.has-primary-variation-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-primary-variation-color:not(:hover) {
 				color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
+			}
+
+			/* Set primary variation border color */
+			.has-primary-variation-border-color,
+			.wp-block-pullquote.has-primary-variation-border-color {
+				border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 			}
 
 			/* Set secondary variation background color */
@@ -250,7 +264,9 @@ function newspack_custom_colors_css() {
 			}
 
 			/* Set secondary border */
-			#ship-to-different-address label input[type="checkbox"]:checked + span::before {
+			#ship-to-different-address label input[type="checkbox"]:checked + span::before,
+			.has-secondary-variation-border-color,
+			.wp-block-pullquote.has-secondary-variation-border-color {
 				border-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ';
 			}
 
@@ -481,7 +497,8 @@ function newspack_custom_colors_css() {
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
-		.editor-styles-wrapper .block-editor-block-list__layout .wp-block-freeform blockquote {
+		.editor-styles-wrapper .block-editor-block-list__layout .wp-block-freeform blockquote,
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-border-color {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 		}
 
@@ -523,6 +540,10 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-background-color {
 			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-border-color {
+			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
 		}
 
 		/* Secondary color */
@@ -570,6 +591,10 @@ function newspack_custom_colors_css() {
 			color: ' . esc_html( $secondary_color ) . ';
 		}
 
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-border-color {
+			border-color: ' . esc_html( $secondary_color ) . ';
+		}
+
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color, /* legacy */
 		.edit-post-visual-editor .editor-styles-wrapper .has-secondary-variation-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-color, /* legacy selector */
@@ -587,6 +612,10 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-background-color {
 			background-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+		}
+
+		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-border-color {
+			border-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
 		}
 
 		/* Set gradients */

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -499,10 +499,6 @@ p.has-background {
 		}
 	}
 
-	&.has-text-align-center {
-		text-align: center;
-	}
-
 	cite {
 		display: inline-block;
 		color: inherit;
@@ -521,6 +517,7 @@ p.has-background {
 	&.alignleft,
 	&.alignright {
 		padding: 0;
+		text-align: left;
 		width: 100%;
 
 		@include media( mobile ) {
@@ -535,7 +532,6 @@ p.has-background {
 
 		blockquote {
 			padding: 0;
-			text-align: left;
 			max-width: 100%;
 
 			p {
@@ -596,7 +592,8 @@ p.has-background {
 	}
 
 	&.is-style-solid-color,
-	&.has-background {
+	&.has-background,
+	&[style*='border-style'][style*='border-width'] {
 		@include media( tablet ) {
 			padding-left: #{1.5 * $size__spacing-unit};
 			padding-right: #{1.5 * $size__spacing-unit};
@@ -614,6 +611,10 @@ p.has-background {
 			padding-bottom: 1rem;
 			padding-top: 1rem;
 		}
+	}
+
+	&.has-text-align-center {
+		text-align: center;
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -489,6 +489,20 @@ p.has-background {
 		}
 	}
 
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
+		p {
+			font-size: $font__size-lg;
+			@include media( tablet ) {
+				font-size: $font__size-lg;
+			}
+		}
+	}
+
+	&.has-text-align-center {
+		text-align: center;
+	}
+
 	cite {
 		display: inline-block;
 		color: inherit;
@@ -514,8 +528,12 @@ p.has-background {
 			width: 50%;
 		}
 
+		&.has-background blockquote,
 		blockquote {
 			margin: $size__spacing-unit 0;
+		}
+
+		blockquote {
 			padding: 0;
 			text-align: left;
 			max-width: 100%;
@@ -538,11 +556,6 @@ p.has-background {
 		background-color: $color__primary;
 		padding-left: 0;
 		padding-right: 0;
-
-		@include media( tablet ) {
-			padding-left: #{1.5 * $size__spacing-unit};
-			padding-right: #{1.5 * $size__spacing-unit};
-		}
 
 		a {
 			color: $color__background-body;
@@ -579,6 +592,27 @@ p.has-background {
 			@include media( tablet ) {
 				padding: $size__spacing-unit calc( 2 * #{$size__spacing-unit} );
 			}
+		}
+	}
+
+	&.is-style-solid-color,
+	&.has-background {
+		@include media( tablet ) {
+			padding-left: #{1.5 * $size__spacing-unit};
+			padding-right: #{1.5 * $size__spacing-unit};
+		}
+	}
+
+	&.has-background {
+		blockquote {
+			margin-left: 1rem;
+			margin-right: 1rem;
+		}
+
+		&.alignleft,
+		&.alignright {
+			padding-bottom: 1rem;
+			padding-top: 1rem;
 		}
 	}
 }
@@ -1399,6 +1433,47 @@ hr {
 .is-style-outline .wp-block-button__link.has-white-color:not( :hover ), // legacy selector
 .wp-block-button__link.is-style-outline.has-white-color:not( :hover ) {
 	color: #fff;
+}
+
+//! Custom border colors
+.has-primary-border-color,
+.wp-block-pullquote.has-primary-border-color {
+	border-color: $color__primary;
+}
+
+.has-primary-variation-border-color,
+.wp-block-pullquote.has-primary-variation-border-color {
+	border-color: $color__primary-variation;
+}
+
+.has-secondary-border-color,
+.wp-block-pullquote.has-secondary-border-color {
+	border-color: $color__secondary;
+}
+
+.has-secondary-variation-border-color,
+.wp-block-pullquote.has-secondary-variation-border-color {
+	border-color: $color__secondary-variation;
+}
+
+.has-dark-gray-border-color,
+.wp-block-pullquote.has-dark-gray-border-color {
+	border-color: #111;
+}
+
+.has-medium-gray-border-color,
+.wp-block-pullquote.has-medium-gray-border-color {
+	border-color: #767676;
+}
+
+.has-light-gray-border-color,
+.wp-block-pullquote.has-light-gray-border-color {
+	border-color: #eee;
+}
+
+.has-white-border-color,
+.wp-block-pullquote.has-white-border-color {
+	border-color: #fff;
 }
 
 // Gradients

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -520,9 +520,12 @@ h1.wp-block-post-title {
 		font-style: normal;
 	}
 
-	&.is-style-solid-color {
+	&.is-style-solid-color,
+	&.has-background {
 		padding: $size__spacing-unit #{3 * $size__spacing-unit} #{1.25 * $size__spacing-unit};
+	}
 
+	&.is-style-solid-color {
 		blockquote {
 			max-width: 100%;
 			width: 100%;
@@ -537,6 +540,10 @@ h1.wp-block-post-title {
 		&:not( .has-background-color ) {
 			background-color: $color__link;
 		}
+	}
+
+	&.has-text-align-center {
+		text-align: center;
 	}
 }
 
@@ -553,7 +560,8 @@ h1.wp-block-post-title {
 		padding: 0;
 	}
 
-	&.is-style-solid-color {
+	&.is-style-solid-color,
+	&.has-background {
 		padding: $size__spacing-unit #{2 * $size__spacing-unit};
 	}
 
@@ -565,9 +573,14 @@ h1.wp-block-post-title {
 			font-size: $font__size-md;
 		}
 	}
+
+	&.has-text-align-center {
+		text-align: center;
+	}
 }
 
-.wp-block[data-type='core/pullquote'][data-align='full'] {
+.wp-block[data-type='core/pullquote'][data-align='full'],
+[data-align='full'] {
 	.wp-block-pullquote {
 		padding-left: $size__spacing-unit;
 		padding-right: $size__spacing-unit;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -521,7 +521,8 @@ h1.wp-block-post-title {
 	}
 
 	&.is-style-solid-color,
-	&.has-background {
+	&.has-background,
+	&[style*='border-style'][style*='border-width'] {
 		padding: $size__spacing-unit #{3 * $size__spacing-unit} #{1.25 * $size__spacing-unit};
 	}
 
@@ -561,7 +562,8 @@ h1.wp-block-post-title {
 	}
 
 	&.is-style-solid-color,
-	&.has-background {
+	&.has-background,
+	&[style*='border-style'][style*='border-width'] {
 		padding: $size__spacing-unit #{2 * $size__spacing-unit};
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Pullquote block includes some changes in WordPress 5.9:
* The solid background style is replaced with just an option to add a background colour.
* A border option has been added, including width, style and colour.
* A font weight option has been added to the Typography panel.
* A text align option has been added to the block toolbar.

Closes #1655

### How to test the changes in this Pull Request:

Unfortunately, this is one of those PRs that requires testing multiple settings in multiple child themes, in both WordPress 5.9 and 5.8.X to confirm that the new styles are applied as expected, and that the changes don't break anything in the old pullquote markup.

I would recommend testing on two concurrent test sites if possible, one running 5.9 and one running 5.8.X; the testing steps reflect that, but you could also test them one at a time on the same site, making sure the blocks match the screenshots below.

1. On the test site running WordPress 5.9 RC, copy [this test markup](https://github.com/Automattic/newspack-theme/files/7878072/pullquote-markup-59.txt) into the code editor and publish the post. Alternatively, you can add multiple Pullquote blocks, making sure to apply the different settings (text colours, background colours, border colours and styles, text alignments, block alignments and font weights).
2. On the test site running WordPress 5.8.X, [copy this text markup](https://github.com/Automattic/newspack-theme/files/7878078/pullquote-markup-58.txt) into the code editor and publish the post. Alternatively, you can add multiple Pullquote blocks and apply the different styles (text colour, main colour, solid background colour, block alignments). 
3. Switch your test site to the default Newspack theme, and change your sites custom colours and font settings, so you can make sure everything is being applied appropriately. 
4. Apply this PR to both test sites, and run `npm run build`.
5. Cycle through all of the themes and do a visual check and confirm that the block styles are being applied correctly in both cases, on the front-end and in the editor. 

### Newspack Default

In WordPress 5.8, the 'Main' colour should change the border or background, depending on settings.

In WordPress 5.9, the Border colour will change the border colours; if you change the border style, it will affect the top and bottom border (like changing them to dotted). If you apply only a weight it will affect the top and bottom border; if you apply a border weight and style, it will wrap the whole pullquote in a border.

Using the default theme, the pullquote should use the body font on the quote and the heading font on the citation; the text should be aligned left and normal weight, unless changed in WordPress 5.9.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149680966-cb563990-8b06-42af-a20f-fcdec6925a7b.png)

![image](https://user-images.githubusercontent.com/177561/149680972-e0f04d1a-cac7-4918-99a2-3cdff30e4138.png)

![image](https://user-images.githubusercontent.com/177561/149680978-57aeb99c-1105-4309-9ca9-56495b629726.png)

</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149680987-834c286c-7f1b-4034-9cf6-5ecdcbb4b70d.png)

![image](https://user-images.githubusercontent.com/177561/149680993-2d8a5001-1136-40ad-af14-2f1b872ba7db.png)

![image](https://user-images.githubusercontent.com/177561/149681222-a86c95d3-e177-4d4e-8153-bed527db336d.png)

![image](https://user-images.githubusercontent.com/177561/149681227-13e8fe51-d4c5-4076-967c-e335349a1ef3.png)

![image](https://user-images.githubusercontent.com/177561/149681236-dee469bc-7a1e-4837-aede-66faf5247180.png)

</details>

### Newspack Joseph

In WordPress 5.8, the 'Main' colour should change the border or background, depending on settings.

In WordPress 5.9, the Border colour will change the border colours; if you change the border style, it will affect the top and bottom border (like changing them to dotted). If you apply only a weight it will affect the top and bottom border; if you apply a border weight and style, it will wrap the whole pullquote in a border.

The pullquote should use the heading font on both the quote and the citation; the text should be centered and bolded, or left aligned when floated left or right, unless changed in WordPress 5.9.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149681522-e4a62d66-a2a5-4330-9c88-e0bfae4361e3.png)

![image](https://user-images.githubusercontent.com/177561/149681527-3ed94121-7a2c-4829-aa33-84b7ca9c0be9.png)

![image](https://user-images.githubusercontent.com/177561/149681539-c6ce6d6e-cd81-4c13-be33-74437479c5c5.png)
</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>
![image](https://user-images.githubusercontent.com/177561/149681551-6d69219a-5fb5-45b9-a618-ef439d710de7.png)

![image](https://user-images.githubusercontent.com/177561/149681562-3fe214a9-c0f4-4831-a040-5b02cc1ac15c.png)

![image](https://user-images.githubusercontent.com/177561/149681567-cab8a254-d500-4907-9fbb-99c442498c9a.png)

![image](https://user-images.githubusercontent.com/177561/149681571-f5918d04-b916-415e-bc57-93a0295a8559.png)

![image](https://user-images.githubusercontent.com/177561/149681577-5bbfa70c-cde9-4090-b629-86a06fad0f81.png)

![image](https://user-images.githubusercontent.com/177561/149681585-d9acc5eb-9d21-4d56-a9aa-bdf08cbc0498.png)

</details>

### Newspack Katharine

In WordPress 5.8, the 'Main' colour should change the little border acccent in the corner or background, depending on settings.

In WordPress 5.9, the Border colour will change the little border accent; if you apply a border width, a top and bottom border will appear and the little accent will go away; if you also apply a border style, it will wrap around the pullquote. If you only apply a style and no width, the default accent remains (I couldn't find a way to make this work nicer with this particular block).

The pullquote should use the body font for the quote and the heading font for the citation; the text should be bolded and left-aligned unless changed in WordPress 5.9.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149681946-f3929d75-e8ca-462a-b03f-e80b6a704350.png)

![image](https://user-images.githubusercontent.com/177561/149681951-9cdd1a1b-28ad-4a92-b239-83bf32f36066.png)

![image](https://user-images.githubusercontent.com/177561/149681958-08dfc610-94ca-4dd8-9224-691dcd75bd09.png)

</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149681965-a7f55404-6f18-409d-b59c-bedae203f975.png)

![image](https://user-images.githubusercontent.com/177561/149681967-39015ff8-3ed3-465b-909c-21b216f4597b.png)

![image](https://user-images.githubusercontent.com/177561/149681971-bbc17782-ab16-4699-a75f-2ba7a18bd8ad.png)

![image](https://user-images.githubusercontent.com/177561/149681975-047a0320-63f5-4ddf-98e4-5aaab09926ad.png)

![image](https://user-images.githubusercontent.com/177561/149681984-27e70979-d77e-48c9-9699-c5adcf387eec.png)

</details>

### Newspack Nelson

In WordPress 5.8, the 'Main' colour should change the top and bottom border or background, depending on settings.

In WordPress 5.9, the Border colour will change top and bottom border; if you apply a border width or style it will change the top and bottom border; if you apply a style and width, it will encircle the quote in a border.

The pullquote should use the heading font for both the quote and citation, and be bolded and left aligned unless changed in the settings.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149682055-722017b2-9fa0-4e21-97f5-68364d77b39d.png)

![image](https://user-images.githubusercontent.com/177561/149682119-18579c19-22e5-4d42-a2a2-68691321001f.png)

</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149682162-b01c9e47-920e-4d17-9161-0b7743282ffc.png)

![image](https://user-images.githubusercontent.com/177561/149682166-193281bd-0b96-44d4-9916-9bed36cb9482.png)

![image](https://user-images.githubusercontent.com/177561/149682173-68b7355f-34f8-46d2-a899-2959b8b6aef0.png)

![image](https://user-images.githubusercontent.com/177561/149682236-9cff6685-8787-4936-8b07-e8e4cc298238.png)

![image](https://user-images.githubusercontent.com/177561/149682246-83ce153f-fb0e-465d-bd03-f6310b0320a7.png)

</details>

### Newspack Sasha

In WordPress 5.8, the 'Main' colour should change the border or background, depending on settings.

In WordPress 5.9, the Border colour will change the border colours; if you change the border style, it will affect the top and bottom border (like changing them to dotted). If you apply only a weight it will affect the top and bottom border; if you apply a border weight and style, it will wrap the whole pullquote in a border.

The pullquote should use the heading font on both the quote and the citation; the text should be centered and regular weight, or left aligned when floated left or right, unless changed in WordPress 5.9.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149682346-4602359a-0c40-4f81-b96e-118c06447c6d.png)

![image](https://user-images.githubusercontent.com/177561/149682349-c56757f2-1146-4e91-aaa5-1d25318690f9.png)

</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>

![image](https://user-images.githubusercontent.com/177561/149682354-c11cf190-dff7-4116-85ad-2fd83e86ca0e.png)

![image](https://user-images.githubusercontent.com/177561/149682356-7c723cc2-e2f8-454c-8224-2818aa532236.png)

![image](https://user-images.githubusercontent.com/177561/149682362-f4fe99ff-b1f3-453c-b7e1-4eaf576d06cf.png)

![image](https://user-images.githubusercontent.com/177561/149682442-84f8c396-e8bb-4076-bccf-816c1c5a5a3c.png)

![image](https://user-images.githubusercontent.com/177561/149682450-1f3418bd-77b3-4aaa-8785-0a3f1720ee1b.png)

</details>

### Newspack Scott

In WordPress 5.8, the 'Main' colour should change the border next to the quote, or background, depending on settings.

In WordPress 5.9, the Border colour will change the border colours; if you change the border style. If you apply only a border weight, the quote icon will disappear and a top and bottom border will appear; if you apply both a border style and weight, the icon will disappear and the quote will have a border on four sides.

The pullquote should use the heading font on both the quote and the citation; the text should be centered and bolded, or left aligned when floated left or right, unless changed in WordPress 5.9.

<details>
<summary><strong>WordPress 5.8.X</strong></summary>
![image](https://user-images.githubusercontent.com/177561/149682777-112903f6-0089-40b0-b550-64f439e7c288.png)
![image](https://user-images.githubusercontent.com/177561/149682780-06b1e38f-0421-4c48-b61f-c90349a9d873.png)
![image](https://user-images.githubusercontent.com/177561/149682783-6cb16f9e-789f-458a-ac70-800ab3bcfce0.png)

</details>

<details>
<summary><strong>WordPress 5.9 RC</strong></summary>
![image](https://user-images.githubusercontent.com/177561/149682796-3cfef223-da19-4bd6-b6fd-4ce4c56f9527.png)

![image](https://user-images.githubusercontent.com/177561/149682799-8ca4e542-1d5a-4d7d-90fb-5b328892e999.png)

![image](https://user-images.githubusercontent.com/177561/149682948-13cd8b12-87ba-4ec5-b593-6ab55617ebc7.png)

![image](https://user-images.githubusercontent.com/177561/149682952-cd815060-6ffc-4fe9-8e85-e70c811067b2.png)

![image](https://user-images.githubusercontent.com/177561/149682962-d8f4607a-81e4-4b52-9107-11e925d06d71.png)

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
