### PR TITLE
Correct Sacha post title styles for WordPress 5.9

### DIFF
--- a/newspack-sacha/sass/child-style-editor-overrides.scss
+++ b/newspack-sacha/sass/child-style-editor-overrides.scss
@@ -7,10 +7,14 @@
 /** === Single Posts === */
 
 body.post-type-post {
-	.editor-post-title__block {
+	.editor-post-title__block,
+	.edit-post-visual-editor__post-title-wrapper,
+	.editor-styles-wrapper h1.wp-block-post-title {
 		max-width: 1020px; // 85% of 1200px.
-		.editor-post-title__input {
-			text-align: center;
-		}
+	}
+
+	.editor-post-title__block .editor-post-title__input,
+	.editor-styles-wrapper h1.wp-block-post-title {
+		text-align: center;
 	}
 }

--- a/newspack-sacha/sass/style-editor.scss
+++ b/newspack-sacha/sass/style-editor.scss
@@ -8,6 +8,7 @@ Newspack Sacha Editor Styles
 @import '../../newspack-theme/sass/style-editor-base';
 
 .editor-post-title__block .editor-post-title__input,
+h1.wp-block-post-title,
 .entry-title {
 	font-weight: normal;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure post and page titles use a normal font weight in the editor, and post titles are centred.

Closes #1662 

### How to test the changes in this Pull Request:

1. Start with a test site running the WordPress 5.9 RC.
2. Switch you site to use Newspack Sacha.
3. Open a post and a page in the editor; note on the front end both use a normal (not bold) font weight, and the post title is centred; in the editor, the title is bolded, and not centred on the post.
4. Apply the PR and run `npm run build`.
5. Confirm that the editor preview of the post and page title now better reflect the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
