### PR TITLE
Fix: prevent odd wrapping with multiple categories

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -255,7 +255,7 @@ if ( ! function_exists( 'newspack_categories' ) ) :
 
 		if ( ! $categories_list ) {
 			/* translators: used between list items; followed by a space. */
-			$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . '&nbsp;</span>' );
+			$categories_list = get_the_category_list( '<span class="sep">' . esc_html__( ',', 'newspack' ) . ' </span>' );
 		}
 
 		if ( $categories_list ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Right now the category list markup includes `&nbsp;` after the comma separators, which causes an odd wrapping issue when you have a lot of categories displaying.

There isn't really a need for a non-breaking space there, so this PR replaces that with a regular space. 

Closes #1638

### How to test the changes in this Pull Request:

1. Switch your site to a theme other than the Newspack default theme (which hides the separators, thereby hiding this issue).
2. Navigate to Customizer > Template Settings > Post Settings, and turn off "Use Yoast's primary category functionality"
3. Create a post and add several categories -- make sure at least one is more than one word, so it contains its own space. 
4. Publish; view the post on the front-end, and make your browser window narrow; note that your categories list has some funky line breaks, possibly running off the screen. This is because the breaks are only happening inside of categories that have spaces, not between the different categories:

![image](https://user-images.githubusercontent.com/177561/151269685-de864b11-63fe-4b3a-824c-501009311a05.png)

5. Apply the PR.
6. Confirm that the funky line breaks are gone, and that your categories seem to be breaking over multiple lines in a logical fashion:

![image](https://user-images.githubusercontent.com/177561/151269786-859465e4-20a3-4684-a8a8-d358a9e553b8.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
