### PR TITLE
fix: update styles for the Event Calendar download links

### DIFF
--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -23,6 +23,36 @@
 	.tribe_events {
 		margin-top: 0;
 	}
+
+	// Calendar links
+	.tribe-events-cal-links {
+		margin-top: $size__spacing-unit;
+
+		> a.tribe-events-button {
+			background: url( "data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='25' height='18'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath fill='%23141827' d='M0 .431V17.57c0 .238.163.431.364.431h17.273c.2 0 .363-.193.363-.431V.43c0-.237-.163-.43-.363-.43H.364C.163 0 0 .193 0 .431zm18 7.585h-1.015V4.687H.991v12.07h15.994v-3.753H18V8.016zM.99 1.239h15.995v2.315H.991V1.239z'/%3E%3Cpath stroke='%23141827' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.2' d='M22.918 10.5H9.207m11.488-3.255l3.252 3.272-3.213 3.213'/%3E%3C/g%3E%3C/svg%3E" )
+				0/24px no-repeat;
+			color: var( --tec-color-link-accent );
+			display: inline-block;
+			font-size: var( --tec-font-size-2 );
+			font-weight: var( --tec-font-weight-regular );
+			letter-spacing: unset;
+			line-height: var( --tec-line-height-3 );
+			margin: 0;
+			padding: 0 0 0 var( --tec-spacer-7 );
+			text-decoration: none;
+			text-transform: unset;
+
+			&:not( :last-of-type ) {
+				margin-right: var( --tec-spacer-8 );
+			}
+		}
+	}
+
+	// Event Details
+	.tribe-events-event-meta.primary {
+		border-width: 1px 0 0;
+		width: 100%;
+	}
 }
 
 //! Photo view


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Each event generated by the Event Calendar plugin includes links to add to different calendars; for some reason, the Export to ICS link is not styled like the rest and looks very out of place.

This PR adds a fix for that for the short-term. 

Closes #1672.

### How to test the changes in this Pull Request:

1. Start on a test site running the Events Calendar plugin. 
2. Navigate to WP Admin > Events > Settings and on the General tab, uncheck "Activate Block Editor for Events" if it's checked.
3. Navigate to WP Admin > Events > Settings and on the Display tab, check "Use updated calendar designs" if it's not checked.
4. Create an event.
5. View the event on the front-end -- note that the "Export .ics file" link near the bottom does not match the others: 

![image](https://user-images.githubusercontent.com/177561/151432526-54fccc6d-fced-4c11-a695-cd93c3c11bff.png)

6. If you create an event with the Gutenberg editor, then turn off the Block editor for Events again, when the event has passed the link looks even stranger:

![image](https://user-images.githubusercontent.com/177561/151432771-742dcf75-e510-4c49-8041-26a932559fe5.png)

7. Apply the PR and run `npm run build`.
8. Confirm that the links now look consistent:

![image](https://user-images.githubusercontent.com/177561/151433802-172bf77d-7968-42b0-b55d-f3a033f8aec5.png)

9. If you did also recreate the button-y Gutenberg-to-regular-editor issue it should also be fixed (I feel like this is rather an odd edge case you'd get on a test site, though, and less likely something that would happen on a live site):

![image](https://user-images.githubusercontent.com/177561/151433920-10f2abb7-d8f8-4c03-806f-b9b86a96a195.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
