### PR TITLE
Improve mobile footer link tap target size

### DIFF
--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -183,7 +183,7 @@
 
 		ul {
 			li {
-				margin: #{0.125 * $size__spacing-unit} 0;
+				margin: #{0.3 * $size__spacing-unit} 0;
 
 				@include media( mobile ) {
 					display: inline-block;

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -169,6 +169,11 @@
 			margin: 0 $size__spacing-unit 0 0;
 		}
 
+		a {
+			display: inline;
+			margin: 0;
+		}
+
 		ul,
 		li {
 			list-style: none;
@@ -176,27 +181,31 @@
 			padding: 0;
 		}
 
-		a {
-			display: inline;
-			margin: 0;
-		}
+		ul {
+			li {
+				margin: #{0.125 * $size__spacing-unit} 0;
 
-		@include media( mobile ) {
-			ul {
-				display: inline;
+				@include media( mobile ) {
+					display: inline-block;
+					margin: 0 $size__spacing-unit 0 0;
+
+					ul {
+						display: inline-block;
+						margin-left: $size__spacing-unit;
+					}
+
+					&:last-child {
+						margin-right: 0;
+					}
+				}
 			}
 
-			li {
+			a {
 				display: inline-block;
-				margin: 0 $size__spacing-unit 0 0;
+				padding: #{0.25 * $size__spacing-unit} 0;
 
-				ul {
-					display: inline-block;
-					margin-left: $size__spacing-unit;
-				}
-
-				&:last-child {
-					margin-right: 0;
+				@include media( mobile ) {
+					padding: #{0.125 * $size__spacing-unit} 0;
 				}
 			}
 		}

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -182,6 +182,10 @@
 		}
 
 		ul {
+			@include media( mobile ) {
+				display: inline;
+			}
+
 			li {
 				margin: #{0.3 * $size__spacing-unit} 0;
 

--- a/newspack-theme/sass/site/secondary/_widgets.scss
+++ b/newspack-theme/sass/site/secondary/_widgets.scss
@@ -47,6 +47,11 @@
 
 		li {
 			font-family: $font__heading;
+			margin: #{0.125 * $size__spacing-unit} 0;
+
+			@include media( mobile ) {
+				margin: 0;
+			}
 
 			ul {
 				margin-left: 1.5em;
@@ -55,7 +60,11 @@
 
 		a {
 			display: inline-block;
-			padding: #{0.125 * $size__spacing-unit} 0;
+			padding: #{0.25 * $size__spacing-unit} 0;
+
+			@include media( mobile ) {
+				padding: #{0.125 * $size__spacing-unit} 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #1538; see #1591

### How to test the changes in this Pull Request:

1. Add a Navigation Menu and Meta widget to the Footer widget area and Above Copyright areas.
2. Run a front-end page through the Lighthouse report using Chrome dev tools, or alternatively though https://web.dev/measure/ if the site is publicly facing - if using Lighthouse, make sure to select 'Mobile' under Device. 
3. Under the SEO header, you should see an item for "Tab targets are not sized appropriately" with your footer links: 

![image](https://user-images.githubusercontent.com/177561/151468681-aaee693f-dedb-4b2b-acf1-6e39fad5c913.png)

4. Apply the PR; run `npm run build` and re-run Lighthouse or https://web.dev/measure/ on your page. 
5. Confirm that the footer links are no longer throwing errors under "Tab targets are not sized appropriately" -- that should appear under "Passed audits". Those links should also look the same on desktop (they will be more spaced out on mobile, but not horribly so):

![image](https://user-images.githubusercontent.com/177561/151469066-4fd4da18-0478-4dfc-bf3f-cee9324f38ca.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
