### PR TITLE
Fix tag contrast issues in the Newspack theme 

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -411,7 +411,8 @@ function newspack_custom_colors_css() {
 				}
 
 				.entry-meta .byline a:hover,
-				.entry-meta .byline a:visited:hover {
+				.entry-meta .byline a:visited:hover,
+				footer.entry-footer a {
 					color: ' . esc_html( newspack_color_with_contrast( newspack_adjust_brightness( $primary_color, -40 ) ) ) . ';
 				}
 			';

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -147,12 +147,14 @@
 	}
 }
 
-.tags-links {
-	a {
-		background-color: #f1f1f1;
-		margin: 0 #{0.25 * $size__spacing-unit} #{0.25 * $size__spacing-unit} 0;
-		padding: #{0.25 * $size__spacing-unit} #{0.5 * $size__spacing-unit};
-	}
+footer.entry-footer a {
+	color: $color__primary-variation;
+}
+
+.tags-links a {
+	background-color: #f1f1f1;
+	margin: 0 #{0.25 * $size__spacing-unit} #{0.25 * $size__spacing-unit} 0;
+	padding: #{0.25 * $size__spacing-unit} #{0.5 * $size__spacing-unit};
 }
 
 .cat-links,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you use the default Newspack theme and default Primary Colour, the tags on single posts do not have sufficient contrast -- they use the primary colour against a light grey background, and the default blue is just too light. 

This PR updates the tags to use the slightly darker 'variation' of the primary colour. 

Closes #1591

### How to test the changes in this Pull Request:

1. Start on a test site running the Newspack parent theme, and using the default blue primary colour.
2. View a single post that has a tag. 
3. Check the post by running it through https://web.dev/measure/ if it's a public-facing site, or by using Chrome and running the Lighthouse check using the web dev tools. 
4. Check under the Accessibility header; note that there is an issue with the contrast on the tags:

![image](https://user-images.githubusercontent.com/177561/151598782-7b96768d-fd15-4662-82ab-6bf300e2fc60.png)

5. Apply this PR and run `npm run build`.
6. Confirm that the accessibility error goes away, and the background and foreground checks now pass:

![image](https://user-images.githubusercontent.com/177561/151598168-b2de5b94-844d-44a4-9592-ccd1eca0322c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
