### PR TITLE
fix: update editor gradient styles

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -619,10 +619,10 @@ function newspack_custom_colors_css() {
 		}
 
 		/* Set gradients */
-		.edit-post-visual-editor.editor-styles-wrapper .has-grad-1-gradient-background {
+		.editor-styles-wrapper .wp-block.has-grad-1-gradient-background {
 			background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
 		}
-		.edit-post-visual-editor.editor-styles-wrapper .has-grad-2-gradient-background {
+		.editor-styles-wrapper .wp-block.has-grad-2-gradient-background {
 			background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
 		}
 		';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR corrects the CSS selectors used in the editor preview for the theme's baked-in gradient options -- as is, it works on some blocks (buttons) but not others (groups). 

Closes #1673

### How to test the changes in this Pull Request:

1. If your test site isn't already using custom colours, navigate to Customizer > Colours, and change both the Primary and Secondary colours.
2. Edit a post or a page and add two group blocks, and two buttons; set each to use gradients as backgrounds, applying each of the theme's baked in options created from the primary colour and its variation, and the secondary colour and its variation:

![image](https://user-images.githubusercontent.com/177561/151610627-24247545-16f8-433e-bcdf-14dc6c002eb3.png)

3. Note that the preview of the buttons is correct, but the group blocks use the theme's default blue and grey in the generated gradients, instead of your chosen colours; if you publish you page, though, the gradients will display correctly:

![image](https://user-images.githubusercontent.com/177561/151611022-62007372-832b-47cf-8418-ec164f2a9071.png)

4. Apply this PR.
5. Refresh the editor and confirm that your gradients are now previewing correctly on the group block, without negatively impacting the buttons:

![image](https://user-images.githubusercontent.com/177561/151610794-5fa81207-f496-4f03-8d62-ec1d96ccb605.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
