### PR TITLE
Add more specific styles for the MailChimp button

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -69,6 +69,7 @@ function newspack_custom_typography_css() {
 
 		/* _blocks.scss */
 		.wp-block-button__link,
+		.wp-block-jetpack-button button.wp-block-button__link,
 
 		/* _captions.scss */
 		figcaption,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -717,6 +717,14 @@ p.has-background {
 	}
 }
 
+.wp-block-jetpack-button button.wp-block-button__link {
+	font-family: $font__heading;
+	font-size: $font__size-sm;
+	font-weight: bold;
+	line-height: $font__line-height-heading;
+	padding: ( $size__spacing-unit * 0.76 ) $size__spacing-unit;
+}
+
 .entry-content .wp-block-button__link {
 	text-decoration: none;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is kind of an odd one: in certain cases, styles from Jetpack can override the button styles for the MailChimp block, making the font size, face, weight, and button padding incorrect.

This PR adds some more specific styles to override this.

Closes #1637.

### How to test the changes in this Pull Request:

1. Start with a site connected to Jetpack, where you can turn on the share buttons.
2. Enable share buttons under WP Admin > Jetpack > Settings > Sharing. 
3. Add a MailChimp block to a page. 
4. View the block on the front-page and disable AMP. The button should be displaying oddly (wrong font; too large); if you're working on a dev site you may need to add `apply_filters ( 'jetpack_implode_frontend_css', true );` to the theme's functions.php file to see this issue (it forces Jetpack to concatenate its CSS files; it will do this automatically on live sites, but I've found my localhost does not, even when using ngrok):

Without AMP:

![image](https://user-images.githubusercontent.com/177561/151633253-a3184576-59cd-4972-a594-d08e67640735.png)

With AMP (how it should look): 

![image](https://user-images.githubusercontent.com/177561/151633270-c39d6920-af00-46e4-8807-60c1b7efa26f.png)

![image](https://user-images.githubusercontent.com/177561/151632867-3dcae540-c75b-4ba0-879b-62b5795daa0d.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the button now looks the same with and without AMP enabled.
7. If you haven't already, switch your site to a custom header font and confirm it's being picked up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
