### PR TITLE
Make sure full-width group block contents can't touch edges

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1680,6 +1680,14 @@ hr {
 		}
 	}
 
+	// Make sure content in a full-width group block doesn't touch edges
+	.entry .entry-content > .wp-block-group {
+		&.alignfull:not( .has-background ):not( .is-style-border ) {
+			padding-left: 5.5%;
+			padding-right: 5.5%;
+		}
+	}
+
 	// keep nested align-full elements from overflowing the container.
 	.entry .entry-content {
 		.wp-block-column,

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -68,6 +68,11 @@ body.newspack-single-column-template {
 		figcaption {
 			padding: 0 $size__spacing-unit;
 		}
+
+		.wp-block-group:not( .has-background ):not( .is-style-border ) {
+			padding-left: #{0.5 * $size__spacing-unit};
+			padding-right: #{0.5 * $size__spacing-unit};
+		}
 	}
 
 	.wp-block[data-align='left'] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If you have a full-width group block with no background or padding set, its content will hit the edge of the browser window on smaller screens. 

This PR adds some padding in that case, that shouldn't affect when the block has a background or borders, and that should be over-ride-able with the block's padding options.

Closes #815.

### How to test the changes in this Pull Request:

1. Create a new post or page and switch it to the One Column or One Column Wide template.
2. Add four group blocks, each containing a paragraph, and set them all to full-width; give one padding, one a background, one a border style and leave one as the default. Alternatively, copy [this example code](https://github.com/Automattic/newspack-theme/files/7962717/group-block.txt) into the code editor.
3. View on the front-end, and shrink down the browser window; note how the paragraph in the default group block hits the edge of the window: 

![image](https://user-images.githubusercontent.com/177561/151641975-0cba1b82-cef9-4e53-b7e6-f15d549caab6.png)

![image](https://user-images.githubusercontent.com/177561/151641991-db24126f-fa64-4515-96a5-632ab645f8e1.png)

4. Apply the PR and run `npm run build`.
5. Confirm the paragraph no longer hits the edge and is roughly lined up with the post title. The other group blocks are not affected (they pick up their inline padding, or the padding attached to their background/border styles):

![image](https://user-images.githubusercontent.com/177561/151641779-96a5b096-bd60-49bd-ac22-136dbd0dc910.png)

![image](https://user-images.githubusercontent.com/177561/151641790-18d8fe37-6a20-4286-aab7-e18cbbaa0740.png)

6. Switch to the other one column template and confirm there are no issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
