### PR TITLE
feat: full-width scaip ad

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -459,6 +459,8 @@ function newspack_custom_colors_css() {
 	// Set ads background color
 	if ( 'default' !== get_theme_mod( 'ads_color', 'default' ) ) {
 		$theme_css .= '
+			.site .entry .entry-content .scaip .newspack_global_ad,
+			.site .entry .entry-content .scaip .widget_newspack-ads-widget,
 			.newspack_global_ad,
 			.newspack_global_ad.global_above_header,
 			.widget_newspack-ads-widget,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1703,6 +1703,13 @@ hr {
 			margin-left: calc( 50% - 50vw );
 			margin-right: calc( 50% - 50vw );
 			max-width: 100vw;
+			> * {
+				margin-top: $size__vertical-rhythm * 2;
+				margin-bottom: $size__vertical-rhythm * 2;
+			}
+			amp-ad {
+				display: block;
+			}
 		}
 	}
 }

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1698,7 +1698,7 @@ hr {
 	// Make SCAIP placements full-width.
 	.entry .entry-content .scaip {
 		position: relative;
-		background: #eee;
+		background: rgba( 0, 0, 0, 0.05 );
 		max-width: none;
 		width: 100vw;
 		margin-left: -50vw;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1694,6 +1694,16 @@ hr {
 			}
 		}
 	}
+
+	// Make SCAIP placements full-width.
+	.entry .entry-content .scaip {
+		position: relative;
+		background: #eee;
+		max-width: none;
+		width: 100vw;
+		margin-left: -50vw;
+		left: 50%;
+	}
 }
 
 //! Social Links block

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1697,12 +1697,13 @@ hr {
 
 	// Make SCAIP placements full-width.
 	.entry .entry-content .scaip {
-		position: relative;
-		background: rgba( 0, 0, 0, 0.05 );
-		max-width: none;
-		width: 100vw;
-		margin-left: -50vw;
-		left: 50%;
+		.newspack_global_ad,
+		.widget_newspack-ads-widget {
+			background-color: $color__background-pre;
+			margin-left: calc( 50% - 50vw );
+			margin-right: calc( 50% - 50vw );
+			max-width: 100vw;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make SCAIP ads full-width on one-column and one-column wide templates and apply a default background color. This background color should be overwritten by the **Colors -> Ads Background Color** in the Customizer.

![image](https://user-images.githubusercontent.com/820752/151817589-70adf8b4-d786-49c7-a2fd-ccc23a46c5ec.png)

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-ads/issues/295

### How to test the changes in this Pull Request:

1. With SCAIP installed and configured with ad units, create a One-column wide post with multiple paragraphs
2. Check out this branch and confirm the ad placement area is full-width and with a light gray background
3. Through the Customizer, visit **Colors -> Ads Background Color** and change it to a random color
4. Confirm the custom color is applied to the SCAIP ad as well

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
