### PR TITLE
Make sure styles are inherited correctly when using Pico

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1,7 +1,8 @@
 /* !Block styles */
 
 .entry .entry-content > *,
-.newspack-inline-popup > * {
+.newspack-inline-popup > *,
+#pico > * {
 	margin: 32px 0;
 	max-width: 100%;
 
@@ -373,7 +374,8 @@ p.has-background {
 }
 
 // Temporarily make some column styles more specific
-.entry .entry-content > .wp-block-columns {
+.entry .entry-content > .wp-block-columns,
+#pico > .wp-block-columns {
 	&.is-not-stacked-on-mobile {
 		margin-left: -16px;
 		margin-right: -16px;
@@ -1010,9 +1012,12 @@ hr {
 	}
 }
 
-.entry .entry-content > .wp-block-separator,
-.entry .entry-content > hr {
-	margin: ( 2 * $size__spacing-unit ) auto;
+.entry .entry-content,
+#pico {
+	> .wp-block-separator,
+	> hr {
+		margin: ( 2 * $size__spacing-unit ) auto;
+	}
 }
 
 //! Twitter Embed
@@ -1127,7 +1132,8 @@ hr {
 }
 
 // Remove space between full-width group block and header on homepage.
-.newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child {
+.newspack-front-page.hide-homepage-title .entry-content > .wp-block-group.alignfull:first-child,
+.newspack-front-page.hide-homepage-title #pico > .wp-block-group.alignfull:first-child {
 	margin-top: 0;
 	@include media( tablet ) {
 		margin-top: calc(
@@ -1521,7 +1527,8 @@ hr {
 //! 'Feature' alignments
 .post-template-single-feature,
 .page-template-single-feature {
-	.entry .entry-content > * {
+	.entry .entry-content > *,
+	#pico > * {
 		&.alignwide {
 			@include media( tablet ) {
 				margin-left: calc( 25% - 25vw );
@@ -1636,19 +1643,22 @@ hr {
 	}
 
 	//! Group & Cover Block
-	.entry .entry-content > .wp-block-cover,
-	.entry .entry-content > .wp-block-group {
-		&.alignfull,
-		&.alignwide {
-			> div > .alignwide {
-				margin-left: auto;
-				margin-right: auto;
-				max-width: 1200px;
-			}
-			> div > *:not( .alignfull ):not( .alignwide ) {
-				margin-left: auto;
-				margin-right: auto;
-				max-width: 780px;
+	.entry .entry-content,
+	#pico {
+		> .wp-block-cover,
+		> .wp-block-group {
+			&.alignfull,
+			&.alignwide {
+				> div > .alignwide {
+					margin-left: auto;
+					margin-right: auto;
+					max-width: 1200px;
+				}
+				> div > *:not( .alignfull ):not( .alignwide ) {
+					margin-left: auto;
+					margin-right: auto;
+					max-width: 780px;
+				}
 			}
 		}
 	}
@@ -1689,7 +1699,8 @@ hr {
 	}
 
 	// Make sure content in a full-width group block doesn't touch edges
-	.entry .entry-content > .wp-block-group {
+	.entry .entry-content > .wp-block-group,
+	#pico > .wp-block-group {
 		&.alignfull:not( .has-background ):not( .is-style-border ) {
 			padding-left: 5.5%;
 			padding-right: 5.5%;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1125,10 +1125,11 @@ hr {
 			margin-bottom: 0;
 		}
 	}
+}
 
-	&.has-background + .wp-block-group.has-background {
-		margin-top: -32px;
-	}
+.wp-block-group.has-background + .wp-block-group.has-background,
+#pico > .wp-block-group.has-background + .wp-block-group.has-background {
+	margin-top: -32px;
 }
 
 // Remove space between full-width group block and header on homepage.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A lot of the block styles in the theme rely on the theme's structure -- they 'need' blocks to be direct decendents of the `.entry-content` class to apply styles like `.alignfull` and `.alignleft`. The structure also helps set the vertical alignment. 

Pico wraps the content in an extra div with the ID `#pico`, which causes these styles not to work, and some blocks -- like cover and group -- don't have the correct vertical spacing. 

This PR adds the `#pico` selector to the mix, making sure the styles work as expected when that plugin is used. 

Closes #1656

### How to test the changes in this Pull Request:

1. Start on a test site running Pico (we have one internally -- please ping me if you need a hand tracking it down to test!), and create a page using the One Column template. 
2. Add a mix of blocks to the page that have a mix of alignments: full, wide, left, right...
3. View on the front-end -- note how the blocks are not respecting their alignments. Wide and Full aligned blocks are no wider than the content area, and while the left and right-aligned blocks work, they don't "pop out" of the content like they should using the one column template:

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/177561/153772543-e84ed575-bda6-4234-bec7-6b8a93032521.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/177561/153772552-73f28682-f42a-458a-835e-316202b00196.png">

4. Apply this PR to the Pico test site. To do this, I applied this PR to my local test site, and ran `npm run release:archive` to generate a zipped copy of the theme. Then I unzipped the Newspack parent theme, renamed it in the style.css file to distinguish it from the default on the Pico test site, rezipped it and uploaded it. 
5. View your test post and confirm that the blocks are using the correct alignments:

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/177561/153772864-dc255804-7063-4317-a98c-6687052fc25d.png">

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/177561/153772876-ec7ed595-7356-4b46-bbe7-38e5d3e43d8d.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
