### PR TITLE
fix: make sure featured image credits show up for all image placements

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -382,24 +382,7 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 						the_post_thumbnail( $size );
 					endif;
 
-					$caption = get_the_excerpt( get_post_thumbnail_id() );
-					// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
-					$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
-
-					// Account for featured images that have a credit but no caption.
-					if ( ! $caption_exists && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
-						$maybe_newspack_image_credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
-						if ( strlen( wp_strip_all_tags( $maybe_newspack_image_credit ) ) ) {
-							$caption        = $maybe_newspack_image_credit;
-							$caption_exists = true;
-						}
-					}
-
-					if ( $caption_exists ) :
-					?>
-						<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
-					<?php
-					endif;
+					newspack_post_thumbnail_caption();
 				endif;
 				?>
 
@@ -422,6 +405,38 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 		}
 	}
 endif;
+
+if ( ! function_exists( 'newspack_post_thumbnail_caption' ) ) {
+	/**
+	 * Displays a post thumbnail caption and/or credit.
+	 *
+	 * Wraps the caption and credit in a figcaption and span.
+	 */
+	function newspack_post_thumbnail_caption() {
+		if ( ! newspack_can_show_post_thumbnail() ) {
+			return;
+		}
+
+		$caption = get_the_excerpt( get_post_thumbnail_id() );
+		// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
+		$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
+
+		// Account for featured images that have a credit but no caption.
+		if ( ! $caption_exists && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {
+			$maybe_newspack_image_credit = \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() );
+			if ( strlen( wp_strip_all_tags( $maybe_newspack_image_credit ) ) ) {
+				$caption        = $maybe_newspack_image_credit;
+				$caption_exists = true;
+			}
+		}
+
+		if ( $caption_exists ) :
+			?>
+			<figcaption><span><?php echo wp_kses_post( $caption ); ?></span></figcaption>
+			<?php
+		endif;
+	}
+}
 
 if ( ! function_exists( 'newspack_comment_form' ) ) :
 	/**

--- a/newspack-theme/template-parts/post/large-featured-image.php
+++ b/newspack-theme/template-parts/post/large-featured-image.php
@@ -5,10 +5,6 @@
  * @package Newspack
  */
 
-$caption = get_the_excerpt( get_post_thumbnail_id() );
-// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
-$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
-
 $header_sticky = get_theme_mod( 'header_sticky', false );
 
 if ( 'behind' === newspack_featured_image_position() ) :
@@ -23,9 +19,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 		</div><!-- .wrapper -->
 	</div><!-- .featured-image-behind -->
 
-	<?php if ( $caption_exists ) : ?>
-		<figcaption><?php echo wp_kses_post( $caption ); ?></figcaption>
-	<?php endif; ?>
+	<?php newspack_post_thumbnail_caption(); ?>
 
 <?php elseif ( 'beside' === newspack_featured_image_position() ) : ?>
 
@@ -38,9 +32,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 
 		<?php newspack_post_thumbnail(); ?>
 
-		<?php if ( $caption_exists ) : ?>
-			<figcaption><span><?php echo wp_kses_post( $caption ); ?></span></figcaption>
-		<?php endif; ?>
+		<?php newspack_post_thumbnail_caption(); ?>
 	</div><!-- .featured-image-behind -->
 
 <?php elseif ( 'above' === newspack_featured_image_position() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Featured Image caption code was set up to display the credit if only a credit exists, but only for certain featured image placements -- for the Behind and Beside placements, the credit was only showing when you also had a caption as well.

This PR makes sure the same caption code is running for all featured image placements, so the credit will always show if it's the only thing that's been added.

Closes #1711.

### How to test the changes in this Pull Request:

1. Create a couple different posts. For each, assign a featured image that has a credit, but no caption. Set them to use a combination of different featured image placements: behind, beside, and at least one of small, large or above.
2. Note that the credit is only displaying in some cases -- for the behind and beside placements, nothing is showing up. If you do edit one of these posts and add a caption, the caption and credit will start appearing.
3. Apply the PR.
4. Refresh your posts and confirm that the credit is showing up with all featured image placements.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
