### PR TITLE
fix: remove ads custom media queries

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1015,63 +1015,6 @@ function newspack_coauthors_in_rss( $the_author ) {
 add_filter( 'the_author', 'newspack_coauthors_in_rss' );
 
 /**
- * Determine minimum theme breakpoint, below which responsive Ads media queries should not have a min-width.
- *
- * @param array  $media_queries An array of objects, one for each size, with width|height|min_width|min_height.
- * @param string $placement ID of the ad placement.
- * @param string $context Optional second string describing the ad placement. For Widget placements, the ID of the Widget.
- * @return array The correct array of media query data.
- */
-function newspack_theme_newspack_ads_media_queries( $media_queries, $placement, $context ) {
-	if ( 'newspack_ads_widget' === $placement && strpos( $context, 'scaip' ) === 0 ) {
-		switch ( get_page_template_slug() ) {
-			case 'single-wide.php':
-				foreach ( $media_queries as $index => &$media_query ) {
-					$next_media_query = ( count( $media_queries ) > $index + 1 ) ? $media_queries[ $index + 1 ] : null;
-					if ( intval( $media_query['width'] ) > 1200 ) {
-						$media_query['min_width'] = null;
-						$media_query['max_width'] = null;
-					} else {
-						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.9 );
-						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 1200 ) {
-							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.9 - 1 );
-						} else {
-							$media_query['max_width'] = null;
-						}
-					}
-				}
-				break;
-			case 'single-feature.php':
-			default:
-				foreach ( $media_queries as $index => &$media_query ) {
-					$next_media_query = ( count( $media_queries ) > $index + 1 ) ? $media_queries[ $index + 1 ] : null;
-					if ( intval( $media_query['width'] ) > 780 ) {
-						$media_query['min_width'] = null;
-						$media_query['max_width'] = null;
-					} else if ( intval( $media_query['width'] ) > ceil( 782 * 0.585 ) ) {
-						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.585 );
-						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
-							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.585 - 1 );
-						} else {
-							$media_query['max_width'] = null;
-						}
-					} else {
-						$media_query['min_width'] = ceil( intval( $media_query['width'] ) / 0.9 );
-						if ( $next_media_query && $next_media_query['width'] && $next_media_query['width'] <= 780 ) {
-							$media_query['max_width'] = ceil( $next_media_query['width'] / 0.585 - 1 );
-						} else {
-							$media_query['max_width'] = null;
-						}
-					}
-				}
-				break;
-		}
-	}
-	return $media_queries;
-}
-add_filter( 'newspack_ads_media_queries', 'newspack_theme_newspack_ads_media_queries', 10, 3 );
-
-/**
  * Should a particular Ad deployment use responsive placement.
  *
  * @param boolean $responsive Default value of whether to use responsive placement.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the recent implementation of #1699, this custom media query control of legacy SCAIP ads is preventing wider units to be displayed.

I couldn't identify a reason to keep this filter as it is only being applied to legacy (widget) SCAIP ads and its purpose is not clear to me. The native implementation of media queries should handle the different viewports without the need for this customization.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
### How to test the changes in this Pull Request:

1. On the master branch make sure you have SCAIP in legacy mode, AMP active and AMP Plus off
2. Add a valid ad unit to the first SCAIP position containing the following sizes: `300x250`, `728x90`, `970x250`
3. Visit a post with a wide template and observe you are not able to render the `970x250` size
4. Check out this branch, refresh the post page and confirm you are able to render the `970x250` size

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
