### PR TITLE
Dequeue FSE global styles

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -275,6 +275,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 endif;
 add_action( 'after_setup_theme', 'newspack_setup' );
 
+
 /**
  * Register widget area.
  *
@@ -596,6 +597,28 @@ function newspack_enqueue_scripts() {
 	wp_enqueue_script( 'newspack-post-meta-toggles' );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
+
+
+/**
+ * Dequeue Gutenberg global styles.
+ * 
+ * These styles aren't currently used because Newspack is not a Full-Site editing theme.
+ */
+function newspack_dequeue_global_styles() {
+	wp_dequeue_style( 'global-styles' );
+}
+add_action( 'wp_enqueue_scripts', 'newspack_dequeue_global_styles' );
+
+/**
+ * Dequeue Gutenberg global editor styles.
+ * 
+ * These styles aren't currently used because Newspack is not a Full-Site editing theme.
+ */
+function newspack_dequeue_global_editor_styles() {
+	wp_dequeue_style( 'global-styles-css-custom-properties' );
+}
+add_action( 'enqueue_block_editor_assets', 'newspack_dequeue_global_editor_styles', 99 );
+
 
 /**
  * Fix skip link focus in IE11.

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -603,6 +603,8 @@ add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
  * Dequeue Gutenberg global styles.
  * 
  * These styles aren't currently used because Newspack is not a Full-Site editing theme.
+ * 
+ * @link: https://developer.wordpress.org/reference/functions/wp_enqueue_global_styles/
  */
 function newspack_dequeue_global_styles() {
 	wp_dequeue_style( 'global-styles' );
@@ -613,6 +615,8 @@ add_action( 'wp_enqueue_scripts', 'newspack_dequeue_global_styles' );
  * Dequeue Gutenberg global editor styles.
  * 
  * These styles aren't currently used because Newspack is not a Full-Site editing theme.
+ * 
+ * @link: https://developer.wordpress.org/reference/functions/wp_enqueue_global_styles_css_custom_properties/
  */
 function newspack_dequeue_global_editor_styles() {
 	wp_dequeue_style( 'global-styles-css-custom-properties' );

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1306,7 +1306,8 @@ hr {
 	font-size: $font__size-lg;
 }
 
-.has-huge-font-size {
+.has-huge-font-size,
+.has-x-large-font-size {
 	font-size: $font__size-xl;
 }
 
@@ -1315,7 +1316,8 @@ hr {
 		font-size: $font__size-xl;
 	}
 
-	.has-huge-font-size {
+	.has-huge-font-size,
+	.has-x-large-font-size {
 		font-size: $font__size-xxl;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 5.9 introduced a Global Styles file, which is meant to be populated by a theme's theme.json file. It's still enqueued on non-FSE themes, and is causing a couple small issues in the Newspack theme:

* It shares a `white` background colour class with the theme, and the `!important` it uses overrides the theme's button hover styles (#1713).
* They're part of an issue between the theme, Newsletters plugin and how non-FSE theme editor font styles are handled. Dequeuing them is not a complete fix, but it does correct the font-sizes on the front-end. As part of this, I've also added a temporary x-large font size class to the theme so sites experiencing the editor font sizing mismatch will still have the correct font sizes applied (#1718, https://github.com/Automattic/newspack-newsletters/issues/755).
* AMP is not tree-shaking these styles because they're CSS variables. The styles add 3,231b (4.3% of 75kb) to a site's front-end, or more if any of the overlapping classes are used (like the colour white, and the small, large, and x-large font sizes). 

Closes #1713; see #1718 and https://github.com/Automattic/newspack-newsletters/issues/755.

### How to test the changes in this Pull Request:

1. Start on a test site running the Newsletter plugin.
2. Create and publish a blank page. Either view the non-AMP version of the page and confirm the presence of a `global-styles-inline-css` style tag in the source, or confirm those styles are there in AMP's CSS usage. 
3. In the editor, view source and confirm the presence of a `global-styles-css-custom-properties-inline-css` style tag.
4. To test out the issue in #1713, add a button block and make the background white and the text colour one of the other colours in the editor palette. On the front end, try hovering over the button; note that it turns white-on-white. 
5. To test out the issue in #1718, add multiple Heading blocks, and make one small, one large, and one x-large; note how they're smaller than the theme's defaults (small: 16px, large: 36px, huge: 44px), and are actually picking up the sizes set in the Newsletter (small: 12px, large: 24px, x-large: 36px). They should be too small in the editor and on the front-end. 
6. Apply the PR and run `npm run build`. 
7. Confirm that the button hover is now working as expected -- rather than being white on white, it is now white on `#111`. 
8. Confirm that the font sizes on the front end line up with the theme's settings (small: 16px, large: 36px, x-large/huge: 44px).
9. With AMP disabled, view the source and confirm `global-styles-inline-css` is no longer loaded, or confirm those styles are no longer there in AMP's CSS usage. 
10. In the editor, view source and confirm that the `global-styles-css-custom-properties-inline-css` styles are no longer getting loaded.
11. Out of an abundance of caution, confirm that theme/block styles that did appear in the global styles still work as expected. 
    * The theme-based custom colours (primary, secondary, and the greyscale)
    * Gradients available in the editor palette
    * Font sizes (I recommend deactivating Newsletters before testing, to untangle https://github.com/Automattic/newspack-newsletters/issues/755 from the mix). 
    * Duo-tones (can be tested by adding an image block, and clicking on the circular/starburst icon in the toolbar, then selecting one of the options):

![image](https://user-images.githubusercontent.com/177561/156826526-f4b3e089-5c60-4bb9-b4b6-ad68c3e6e89b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
