### PR TITLE
feat(newsletters): custom newsletter styles

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1207,6 +1207,13 @@ if ( function_exists( '\Newspack_Sponsors\get_sponsors_for_post' ) ) {
 }
 
 /**
+ * Load Newsletters compatibility file.
+ */
+if ( class_exists( '\Newspack_Newsletters' ) ) {
+	require get_template_directory() . '/inc/newspack-newsletters.php';
+}
+
+/**
  * Load Web Stories compatibility file.
  */
 require get_template_directory() . '/inc/web-stories.php';

--- a/newspack-theme/inc/newspack-newsletters.php
+++ b/newspack-theme/inc/newspack-newsletters.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Newspack Newsletters Compatibility File
+ *
+ * @package Newspack
+ */
+
+/**
+ * Enqueue Block Editor styles.
+ */
+function newspack_newsletters_enqueue_editor_styles() {
+	add_editor_style( 'styles/newspack-newsletters-editor.css' );
+}
+add_action( 'newspack_newsletters_enqueue_block_editor_assets', 'newspack_newsletters_enqueue_editor_styles' );
+
+/**
+ * Custom MJML components attributes.
+ *
+ * @param array $attributes MJML component attributes.
+ *
+ * @return array MJML component attributes.
+ */
+function newspack_newsletters_mjml_component_attributes( $attributes ) {
+	if ( isset( $attributes['css-class'] ) && 'image-caption' === $attributes['css-class'] ) {
+		$attributes['align']   = 'left';
+		$attributes['padding'] = '0';
+	}
+	return $attributes;
+}
+add_filter( 'newspack_newsletters_mjml_component_attributes', 'newspack_newsletters_mjml_component_attributes' );

--- a/newspack-theme/sass/plugins/newspack-newsletters-editor.scss
+++ b/newspack-theme/sass/plugins/newspack-newsletters-editor.scss
@@ -1,0 +1,12 @@
+/* !Newspack Newsletters Block styles */
+
+//! Image
+.wp-block-image {
+	img {
+		display: block;
+	}
+
+	figcaption {
+		text-align: left;
+	}
+}

--- a/scripts/compile-scss.js
+++ b/scripts/compile-scss.js
@@ -110,6 +110,11 @@ const SASS_STYLESHEETS = [
 		withRTL: true,
 	},
 	{
+		inFile: 'newspack-theme/sass/plugins/newspack-newsletters-editor.scss',
+		outFile: 'newspack-theme/styles/newspack-newsletters-editor.css',
+		withRTL: true,
+	},
+	{
 		inFile: 'newspack-theme/sass/plugins/newspack-sponsors.scss',
 		outFile: 'newspack-theme/styles/newspack-sponsors.css',
 		withRTL: true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements theme-related customization to a newsletter style.

Closes https://github.com/Automattic/newspack-newsletters/issues/756

| Current | This PR |
| --- | --- |
| <img width="651" alt="image" src="https://user-images.githubusercontent.com/820752/158656968-816d866f-ad83-4145-9626-8c0582d18043.png"> | <img width="653" alt="image" src="https://user-images.githubusercontent.com/820752/158656869-ee6b18e8-25e7-43a6-9b4d-ed22c860fa97.png"> |

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check-out https://github.com/Automattic/newspack-newsletters/pull/766
2. While in the master branch, create a newsletter with an image block and caption
3. Observe the caption style (center aligned) in the editor does not match the theme style (left aligned)
4. Send the newsletter and confirm it does not match in the rendered email as well
5. Check out this branch, repeat the steps and confirm the caption is properly styled to match the theme

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
