### PR TITLE
Add `--wp--style--block-gap` default for the button block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1,5 +1,4 @@
 /* !Block styles */
-
 .entry .entry-content > *,
 .newspack-inline-popup > *,
 [id='pico'] > * {
@@ -698,6 +697,10 @@ p.has-background {
 }
 
 //! Button
+.wp-block-buttons {
+	--wp--style--block-gap: 0.5rem;
+}
+
 .wp-block-button__link {
 	background-color: $color__background-button;
 	color: #fff;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1,4 +1,5 @@
 /* !Block styles */
+
 .entry .entry-content > *,
 .newspack-inline-popup > *,
 [id='pico'] > * {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -423,6 +423,9 @@ div[data-align='full'] {
 }
 
 /** === Button === */
+.wp-block-buttons {
+	--wp--style--block-gap: 10px;
+}
 
 .wp-block-button__link {
 	border-radius: 5px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Blocks now use the `--wp--style--block-gap` CSS variable to set the space between different block elements. Since the Newspack theme doesn't have a theme.json, it doesn't set its own values for these variables, but it does use the WordPress fallbacks, which look like they're often measured in `ems`.

For the buttons block specifically, this `em` value is affected when you change the font size of the individual buttons -- decreasing the font size can decrease the gap to the point where there is no longer space for the buttons to sit side by side. This PR adds a gap value fallback that no longer is affected by changing the button block font size, but without affecting other blocks that use the value that don't have this same issue (like the Columns block).

So far I haven't run into this issue for other blocks --  possibly because where the font styles are applied -- but it seems like something we'll want to fix on a case by case basis if there are others, just to make sure we don't add a spacing default that works in some cases, but not others!

Closes #1736

### How to test the changes in this Pull Request:

1. Add a Buttons block to the editor, and add at least two buttons.
2. Make each button 50% of the available space; note how they site side by side on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/159541796-56e974d3-5ff0-4b83-a2cb-ac9901c68797.png)

4. Decrease the font size of the first button to `15px`.
5. Note that the buttons now stack:

![image](https://user-images.githubusercontent.com/177561/159540542-39f6158e-5abf-4325-ae83-76e015d8cf71.png)

6. Apply the PR and run `npm run build`.
7. Confirm that the buttons now sit side-by-side as expected on the front-end and in the editor:

![image](https://user-images.githubusercontent.com/177561/159540328-580fd2eb-c911-41e0-a0bc-a09450895ee0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
