### PR TITLE
Update ad spacing and move ad background styles

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -471,21 +471,6 @@ function newspack_custom_colors_css() {
 			div[class*="newspack-ads-blocks-ad-unit"] {
 				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
 			}
-			.single-featured-image-behind .newspack_global_ad.global_below_header,
-			.newspack_global_ad.global_above_footer {
-				margin-bottom: -2rem;
-			}
-			.newspack_global_ad.global_above_footer {
-				margin-top: 2rem;
-			}
-			.newspack_global_ad > * {
-				margin-bottom: 8px;
-				margin-top: 8px;
-			}
-			.widget_newspack-ads-widget .textwidget,
-			div[class*="newspack-ads-blocks-ad-unit"] {
-				padding: 8px;
-			}
 		';
 	}
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -213,6 +213,12 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'feature-latest';
 	}
 
+	// Add a class when there's an ad background color.
+	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
+	if ( 'custom' === $ads_background_color ) {
+		$classes[] = 'ads-bg';
+	}
+
 	// Add a class for the footer logo size.
 	$footer_logo_size = get_theme_mod( 'footer_logo_size', 'medium' );
 	if ( 'medium' !== $footer_logo_size ) {

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -137,3 +137,27 @@ body {
 		}
 	}
 }
+
+.single-featured-image-behind .newspack_global_ad.global_below_header {
+	margin-bottom: -1.5rem;
+}
+
+body:not( .af-widget ) .newspack_global_ad.global_above_footer {
+	margin-bottom: -2rem;
+}
+
+.ads-bg {
+	.newspack_global_ad.global_above_footer {
+		margin-top: 2rem;
+	}
+
+	.newspack_global_ad > * {
+		margin-bottom: 8px;
+		margin-top: 8px;
+	}
+
+	.widget_newspack-ads-widget .textwidget,
+	div[class*='newspack-ads-blocks-ad-unit'] {
+		padding: 8px;
+	}
+}

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -142,12 +142,9 @@ body {
 	margin-bottom: -1.5rem;
 }
 
-body:not( .af-widget ) .newspack_global_ad.global_above_footer {
-	margin-bottom: -2rem;
-}
-
 .ads-bg {
 	.newspack_global_ad.global_above_footer {
+		margin-bottom: -2rem;
 		margin-top: 2rem;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes the following changes to the ads styles:

* Moves the non-colours styles out of the color-patterns.php file and into the ads Sass file. For the styles that only should be applied when the ads have a background image, the CSS class `.ads-bg` is added and used.
* Adjusts the gap underneath below-header ads when paired with the behind featured image placement so the ad isn't covered (#1739).

Note: In testing this I found a similar issue is happening with the footer ad location that I have to file/dig into further. I suspect the styles that are there worked originally, but when the `overflow: hidden` was moved to get the sticky header working, the ad started getting cut off 😕 

Closes #1739.

### How to test the changes in this Pull Request:

1. Start on a test site running ads; add ads to the below header global spot, and the above footer global spot.
2. Turn on "Ads Background Color" under Customizer > Colors.
3. Create a post; set the featured image to behind. 
4. View on the front end and note that the featured image seems to be touching your ad; if you inspect it, they're actually overlapping just a hair (2-3px):

![image](https://user-images.githubusercontent.com/177561/159993477-92e9ca22-b1f7-4738-8e38-b3d88ca32d49.png)

5. Apply the PR and run `npm run build`.
6. Recheck your post with the 'behind featured image' setting and confirm that the image and ad have a small space between them:

![image](https://user-images.githubusercontent.com/177561/159994910-b3541cbd-a103-4196-a8d5-21cf807aee30.png)

7. Confirm that the `ads-bg` class is being added so the other spacing styles originally added through the color-patterns.php file should be applied.
8. Turn off the ad background colour and confirm that the top and bottom ad spacing still seem appropriate. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
