### PR TITLE
fix: remove bottom space from last block in cover block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -439,15 +439,15 @@ p.has-background {
 		.wp-block-pullquote:not( .is-style-solid-color ) blockquote {
 			padding-left: 0;
 		}
+	}
 
-		.wp-block-cover__inner-container {
-			[class*='wp-block-']:first-child {
-				margin-top: 0;
-			}
+	.wp-block-cover__inner-container > {
+		*:first-child {
+			margin-top: 0;
+		}
 
-			[class*='wp-block-']:last-child {
-				margin-bottom: 0;
-			}
+		*:last-child {
+			margin-bottom: 0;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the Cover block styles, to make sure the first and last blocks nested inside don't have a top and bottom margin, respectively. This style already existed in the theme, but was only being applied when the cover block was aligned left or right -- it makes much more sense for it to be applied all the time. 

Closes #1210.

### How to test the changes in this Pull Request:

1. Add a cover block to a post or page, and nest a columns block inside. Add enough content to the columns block so that it's taller than the cover block's minimum height (this is 300px by default, but you can also change the minimum height to as low as 50px using the options in the right sidebar).
2. Publish and view on front-end.
3. Note that the column block has more space underneath it than above:

![image](https://user-images.githubusercontent.com/177561/160436113-966e7023-e441-4d24-93e3-afb98ce1ec29.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the space is now gone:

![image](https://user-images.githubusercontent.com/177561/160435985-0000b112-1338-43f1-8f70-d9459dfd9a83.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
