### PR TITLE
fix: make cover block link styles more specific

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -453,9 +453,9 @@ p.has-background {
 }
 
 .wp-block-cover .wp-block-cover__inner-container {
-	a,
-	a:hover,
-	a:visited {
+	a:not( .wp-block-button__link ),
+	a:not( .wp-block-button__link ):hover,
+	a:not( .wp-block-button__link ):visited {
 		color: inherit;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the button blocks were picking up the wrong link colour when nested in a cover block.

Closes #1741

### How to test the changes in this Pull Request:

1. Add two cover blocks -- one with a lighter image and one with a darker image. This is to test with both the light and dark text styles the block uses -- the lighter image should automatically use darker text, and the darker image should automatically use white text.
2. Add a buttons block to each cover block, and add multiple buttons with different settings - eg. a white button with black text, and black button with white text, and buttons using the primary and secondary colours. 
3. Publish and view on the front end. 
4. Note that the buttons are picking up the cover block's text colour, rather than the one assigned in the settings -- so you can have black text on a darker background, light text on a lighter background, and styles that just don't line up with the settings: 

![image](https://user-images.githubusercontent.com/177561/160447241-68e0ee3d-3237-4106-8d15-a6c514ec0cf3.png)

6. Apply the PR and run `npm run build`. 
7. Refresh your test page and confirm that the buttons are using the correct colours, and are white text on dark grey on hover:

![image](https://user-images.githubusercontent.com/177561/160447085-370c5ed2-54e8-4bf6-9ee8-57b51bf9ccdf.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
