### PR TITLE
fix: update approach to remove space with above footer ad

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -214,16 +214,18 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Add a class when there's an ad background color, and another when there's an ad above the footer to remove the space.
-	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
-	$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
-	if ( 'custom' === $ads_background_color ) {
-		$classes[] = 'ads-bg';
+	if ( is_plugin_active( 'newspack-ads/newspack-ads.php' ) ) {
+		$ads_background_color = get_theme_mod( 'ads_color', 'default' );
+		$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
+		if ( 'custom' === $ads_background_color ) {
+			$classes[] = 'ads-bg';
 
-		if ( str_contains( '"enabled":true', $above_footer_ad ) ) {
-			$classes[] = 'ad-above-footer';
+			if ( str_contains( '"enabled":true', $above_footer_ad ) ) {
+				$classes[] = 'ad-above-footer';
+			}
 		}
 	}
-
+	
 	// Add a class for the footer logo size.
 	$footer_logo_size = get_theme_mod( 'footer_logo_size', 'medium' );
 	if ( 'medium' !== $footer_logo_size ) {

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -219,7 +219,7 @@ function newspack_body_classes( $classes ) {
 	if ( 'custom' === $ads_background_color ) {
 		$classes[] = 'ads-bg';
 
-		if ( '' !== $above_footer_ad ) {
+		if ( str_contains( '"enabled":true', $above_footer_ad ) ) {
 			$classes[] = 'ad-above-footer';
 		}
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -213,10 +213,15 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'feature-latest';
 	}
 
-	// Add a class when there's an ad background color.
+	// Add a class when there's an ad background color, and another when there's an ad above the footer to remove the space.
 	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
+	$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
 	if ( 'custom' === $ads_background_color ) {
 		$classes[] = 'ads-bg';
+
+		if ( '' !== $above_footer_ad ) {
+			$classes[] = 'ad-above-footer';
+		}
 	}
 
 	// Add a class for the footer logo size.

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -214,15 +214,13 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Add a class when there's an ad background color, and another when there's an ad above the footer to remove the space.
-	if ( is_plugin_active( 'newspack-ads/newspack-ads.php' ) ) {
-		$ads_background_color = get_theme_mod( 'ads_color', 'default' );
-		$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
-		if ( 'custom' === $ads_background_color ) {
-			$classes[] = 'ads-bg';
+	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
+	$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
+	if ( 'custom' === $ads_background_color ) {
+		$classes[] = 'ads-bg';
 
-			if ( str_contains( '"enabled":true', $above_footer_ad ) ) {
-				$classes[] = 'ad-above-footer';
-			}
+		if ( str_contains( $above_footer_ad, '"enabled":true' ) ) {
+			$classes[] = 'ad-above-footer';
 		}
 	}
 	

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -215,11 +215,11 @@ function newspack_body_classes( $classes ) {
 
 	// Add a class when there's an ad background color, and another when there's an ad above the footer to remove the space.
 	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
-	$above_footer_ad = get_option( '_newspack_ads_placement_global_above_footer' );
+	$above_footer_ad      = method_exists( 'Newspack_Ads\Placements', 'can_display_ad_unit' ) && \Newspack_Ads\Placements::can_display_ad_unit( 'global_above_footer' );
 	if ( 'custom' === $ads_background_color ) {
 		$classes[] = 'ads-bg';
 
-		if ( str_contains( $above_footer_ad, '"enabled":true' ) ) {
+		if ( true === $above_footer_ad ) {
 			$classes[] = 'ad-above-footer';
 		}
 	}

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -143,9 +143,13 @@ body {
 }
 
 .ads-bg {
-	.newspack_global_ad.global_above_footer {
-		margin-bottom: -2rem;
+	// Add a top margin to the above-footer ad, if a above footer widget doesn't exist.
+	&:not( .af-widget ) .newspack_global_ad.global_above_footer {
 		margin-top: 2rem;
+	}
+
+	&.ad-above-footer .site-footer {
+		margin-top: 0;
 	}
 
 	.newspack_global_ad > * {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR changes the approach to removing the gap between the above footer ad space when it has a background, and the footer. 

Originally this was done by adding a negative margin to the ad space; I believe that stopped working as expected when the `overflow: hidden` was moved in #1254-- now, the negative margin causes the ad to get cut off. 

This PR checks for an ad in that location, and if there is one, adds a CSS that's then used to remove the margin above the footer. 

This approach seemed the least disruptive (it doesn't try to move the ad; it doesn't remove the margin on top of the footer outright), but I'm open to feedback if it seems like it's over-complicating things. I also may not have used the best approach for checking for the Above Footer ad space!

Closes #1743

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Colors, and add a background colour to your ads.
2. Add an ad to the 'Above Footer' location.
3. View on the front end -- there is a gap between your ad background colour, and part of your ad is getting cut off: 

![image](https://user-images.githubusercontent.com/177561/160470358-75a7e51a-0c71-4dc9-b7aa-c1788a0b214e.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the ad is no longer cut off, and there is no longer a gap between the ad background and the footer. 

![image](https://user-images.githubusercontent.com/177561/160470154-2fb95720-f804-4325-9654-3b8c8ee70d16.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
