### PR TITLE
Fix alignment of square logos when paired with the mobile CTA

### DIFF
--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -28,6 +28,7 @@
 
 		.custom-logo {
 			max-width: 100%;
+			object-position: left center;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tidies up some weird logo alignment issues when you have the mobile CTA and AMP enabled. 

Closes #1618

### How to test the changes in this Pull Request:

1. Start with a test site running AMP. 
2. Change your logo to a small square logo, and make it smaller than 140px wide (preferably more like 80-100px wide, so the issue is easier to see). 
3. Under Customizer > Header Settings, turn on the Mobile CTA, and turn off the Sticky Header (since the styles there "fix" the issue). 
4. View on the front-end, and shrink down your browser window to a mobile-sized screen.
5. Note that on screens smaller than 600px wide, the square logo seems to float slightly  away from the left. This is due to a max-width on the logo (to make sure it doesn't run into the mobile CTA), and how AMP handles max widths on images:

![image](https://user-images.githubusercontent.com/177561/160695008-fce5db31-9e1b-43da-bc32-b2277227e3b0.png)

6. Apply the PR and run `npm run build`.
7. Refresh the page; confirm that the logo is flush to the left:

![image](https://user-images.githubusercontent.com/177561/160694888-7ba2e909-2438-44d7-a6cf-d921988ffc8d.png)

8. Confirm no new issues are introduced when you increase the screen size. 
9. Try switching the header height and alignment under Customizer > Header Settings > Appearance (toggling on or off the Short Header and Centred Logo settings) and confirm no issues are present. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
