### PR TITLE
Define some of the global styles in the theme

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -130,7 +130,7 @@ function newspack_custom_colors_css() {
 			.wp-block-quote:not(.is-style-large),
 			.woocommerce-tabs ul li.active a,
 			.has-primary-border-color,
-			.wp-block-pullquote .has-primary-border-color {
+			.wp-block-pullquote.has-primary-border-color {
 				border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 			}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1353,6 +1353,7 @@ $colors: (
 	.has-#{$name}-background-color,
 	.has-#{$name}-background-color.has-background-dim,
 	.wp-block-pullquote.is-style-solid-color.has-#{$name}-background-color,
+	.wp-block-pullquote.has-#{$name}-background-color,
 	.is-style-outline .wp-block-button__link.has-#{$name}-background-color:not( :hover ) {
 		background-color: $hex;
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1383,6 +1383,83 @@ hr {
 	background-color: #fff;
 }
 
+.has-black-background-color,
+.has-black-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-black-background-color,
+.is-style-outline .wp-block-button__link.has-black-background-color:not( :hover ) {
+	background-color: #000;
+}
+
+.has-cyan-bluish-gray-background-color,
+.has-cyan-bluish-gray-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-cyan-bluish-gray-background-color,
+.is-style-outline .wp-block-button__link.has-cyan-bluish-gray-background-color:not( :hover ) {
+	background-color: #abb8c3;
+}
+
+.has-pale-pink-background-color,
+.has-pale-pink-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-pale-pink-background-color,
+.is-style-outline .wp-block-button__link.has-pale-pink-background-color:not( :hover ) {
+	background-color: #f78da7;
+}
+
+.has-vivid-red-background-color,
+.has-vivid-red-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-vivid-red-background-color,
+.is-style-outline .wp-block-button__link.has-vivid-red-background-color:not( :hover ) {
+	background-color: #cf2e2e;
+}
+
+.has-luminous-vivid-orange-background-color,
+.has-luminous-vivid-orange-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-luminous-vivid-orange-background-color,
+.is-style-outline .wp-block-button__link.has-luminous-vivid-orange-background-color:not( :hover ) {
+	background-color: #ff6900;
+}
+
+.has-luminous-vivid-amber-background-color,
+.has-luminous-vivid-amber-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-luminous-vivid-amber-background-color,
+.is-style-outline .wp-block-button__link.has-luminous-vivid-amber-background-color:not( :hover ) {
+	background-color: #fcb900;
+}
+
+.has-light-green-cyan-background-color,
+.has-light-green-cyan-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-light-green-cyan-background-color,
+.is-style-outline .wp-block-button__link.has-light-green-cyan-background-color:not( :hover ) {
+	background-color: #7bdcb5;
+}
+
+.has-vivid-green-cyan-background-color,
+.has-vivid-green-cyan-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-vivid-green-cyan-background-color,
+.is-style-outline .wp-block-button__link.has-vivid-green-cyan-background-color:not( :hover ) {
+	background-color: #00d084;
+}
+
+.has-pale-cyan-blue-background-color,
+.has-pale-cyan-blue-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-pale-cyan-blue-background-color,
+.is-style-outline .wp-block-button__link.has-pale-cyan-blue-background-color:not( :hover ) {
+	background-color: #8ed1fc;
+}
+
+.has-vivid-cyan-blue-background-color,
+.has-vivid-cyan-blue-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-vivid-cyan-blue-background-color,
+.is-style-outline .wp-block-button__link.has-vivid-cyan-blue-background-color:not( :hover ) {
+	background-color: #0693e3;
+}
+
+.has-vivid-purple-background-color,
+.has-vivid-purple-background-color.has-background-dim,
+.wp-block-pullquote.is-style-solid-color.has-vivid-purple-background-color,
+.is-style-outline .wp-block-button__link.has-vivid-purple-background-color:not( :hover ) {
+	background-color: #9b51e0;
+}
+
 //! Custom foreground colors
 .has-primary-color,
 .wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
@@ -1460,6 +1537,85 @@ hr {
 	color: #fff;
 }
 
+.has-black-color,
+.wp-block-pullquote.is-style-solid-color blockquote.has-black-color,
+.wp-block-button__link.has-black-color,
+.wp-block-button__link.has-black-color:visited:not( :hover ),
+.is-style-outline .wp-block-button__link.has-black-color:not( :hover ), // legacy selector
+.wp-block-button__link.is-style-outline.has-black-color:not( :hover ) {
+	color: #000;
+}
+
+.has-cyan-bluish-gray-color,
+.wp-block-button__link.has-cyan-bluish-gray-color,
+.wp-block-button__link.has-cyan-bluish-gray-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-cyan-bluish-gray-color:not( :hover ) {
+	color: #abb8c3;
+}
+
+.has-pale-pink-color,
+.wp-block-button__link.has-pale-pink-color,
+.wp-block-button__link.has-pale-pink-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-pale-pink-color:not( :hover ) {
+	color: #f78da7;
+}
+
+.has-vivid-red-color,
+.wp-block-button__link.has-vivid-red-color,
+.wp-block-button__link.has-vivid-red-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-vivid-red-color:not( :hover ) {
+	color: #cf2e2e;
+}
+
+.has-luminous-vivid-orange-color,
+.wp-block-button__link.has-luminous-vivid-orange-color,
+.wp-block-button__link.has-luminous-vivid-orange-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-luminous-vivid-orange-color:not( :hover ) {
+	color: #ff6900;
+}
+
+.has-luminous-vivid-amber-color,
+.wp-block-button__link.has-luminous-vivid-amber-color,
+.wp-block-button__link.has-luminous-vivid-amber-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-luminous-vivid-amber-color:not( :hover ) {
+	color: #fcb900;
+}
+
+.has-light-green-cyan-color,
+.wp-block-button__link.has-light-green-cyan-color,
+.wp-block-button__link.has-light-green-cyan-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-light-green-cyan-color:not( :hover ) {
+	color: #7bdcb5;
+}
+
+.has-vivid-green-cyan-color,
+.wp-block-button__link.has-vivid-green-cyan-color,
+.wp-block-button__link.has-vivid-green-cyan-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-vivid-green-cyan-color:not( :hover ) {
+	color: #00d084;
+}
+
+.has-pale-cyan-blue-color,
+.wp-block-button__link.has-pale-cyan-blue-color,
+.wp-block-button__link.has-pale-cyan-blue-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-pale-cyan-blue-color:not( :hover ) {
+	color: #8ed1fc;
+}
+
+.has-vivid-cyan-blue-color,
+.wp-block-button__link.has-vivid-cyan-blue-color,
+.wp-block-button__link.has-vivid-cyan-blue-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-vivid-cyan-blue-color:not( :hover ) {
+	color: #0693e3;
+}
+
+.has-vivid-purple-color,
+.wp-block-button__link.has-vivid-purple-color,
+.wp-block-button__link.has-vivid-purple-color:visited:not( :hover ),
+.wp-block-button__link.is-style-outline.has-vivid-purple-color:not( :hover ) {
+	color: #9b51e0;
+}
+
 //! Custom border colors
 .has-primary-border-color,
 .wp-block-pullquote.has-primary-border-color {
@@ -1499,6 +1655,61 @@ hr {
 .has-white-border-color,
 .wp-block-pullquote.has-white-border-color {
 	border-color: #fff;
+}
+
+.has-black-border-color,
+.wp-block-pullquote.has-black-border-color {
+	border-color: #000;
+}
+
+.has-cyan-bluish-gray-border-color,
+.wp-block-pullquote.has-cyan-bluish-gray-border-color {
+	border-color: #abb8c3;
+}
+
+.has-pale-pink-border-color,
+.wp-block-pullquote.has-pale-pink-border-color {
+	border-color: #f78da7;
+}
+
+.has-vivid-red-border-color,
+.wp-block-pullquote.has-vivid-red-border-color {
+	border-color: #cf2e2e;
+}
+
+.has-luminous-vivid-orange-border-color,
+.wp-block-pullquote.has-luminous-vivid-orange-border-color {
+	border-color: #ff6900;
+}
+
+.has-luminous-vivid-amber-border-color,
+.wp-block-pullquote.has-luminous-vivid-amber-border-color {
+	border-color: #fcb900;
+}
+
+.has-light-green-cyan-border-color,
+.wp-block-pullquote.has-light-green-cyan-border-color {
+	border-color: #7bdcb5;
+}
+
+.has-vivid-green-cyan-border-color,
+.wp-block-pullquote.has-vivid-green-cyan-border-color {
+	border-color: #00d084;
+}
+
+.has-pale-cyan-blue-border-color,
+.wp-block-pullquote.has-pale-cyan-blue-border-color {
+	border-color: #8ed1fc;
+}
+
+.has-vivid-cyan-blue-border-color,
+.wp-block-pullquote.has-vivid-cyan-blue-border-color {
+	border-color: #0693e3;
+}
+
+.has-vivid-purple-border-color,
+.wp-block-pullquote.has-vivid-purple-border-color {
+	border-color: #9b51e0;
 }
 
 // Gradients

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1326,390 +1326,53 @@ hr {
 	}
 }
 
-//! Custom background colors
-.has-primary-background-color,
-.has-primary-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-primary-background-color,
-.is-style-outline .wp-block-button__link.has-primary-background-color:not( :hover ) {
-	background-color: $color__primary;
-}
+$colors: (
+	'primary': $color__primary,
+	'primary-variation': $color__primary-variation,
+	'secondary': $color__secondary,
+	'secondary-variation': $color__secondary-variation,
+	'dark-gray': #111,
+	'medium-gray': #767676,
+	'light-gray': #eee,
+	'white': #fff,
+	'black': #000,
+	'cyan-bluish-gray': #abb8c3,
+	'pale-pink': #f78da7,
+	'vivid-red': #cf2e2e,
+	'luminous-vivid-orange': #ff6900,
+	'luminous-vivid-amber': #fcb900,
+	'light-green-cyan': #7bdcb5,
+	'vivid-green-cyan': #00d084,
+	'pale-cyan-blue': #8ed1fc,
+	'vivid-cyan-blue': #0693e3,
+	'vivid-purple': #9b51e0,
+);
 
-.has-primary-variation-background-color,
-.has-primary-variation-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-primary-variation-background-color,
-.is-style-outline .wp-block-button__link.has-primary-variation-background-color:not( :hover ) {
-	background-color: $color__primary-variation;
-}
+@each $name, $hex in $colors {
+	//! Custom background colors
+	.has-#{$name}-background-color,
+	.has-#{$name}-background-color.has-background-dim,
+	.wp-block-pullquote.is-style-solid-color.has-#{$name}-background-color,
+	.is-style-outline .wp-block-button__link.has-#{$name}-background-color:not( :hover ) {
+		background-color: $hex;
+	}
 
-.has-secondary-background-color,
-.has-secondary-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-secondary-background-color,
-.is-style-outline .wp-block-button__link.has-secondary-background-color:not( :hover ) {
-	background-color: $color__secondary;
-}
+	//! Custom foreground colors
+	.has-#{$name}-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-#{$name}-color,
+	.wp-block-pullquote.is-style-solid-color blockquote.has-#{$name}-color p,
+	.wp-block-button__link.has-#{$name}-color,
+	.wp-block-button__link.has-#{$name}-color:visited:not( :hover ),
+	.is-style-outline .wp-block-button__link.has-#{$name}-color:not( :hover ), //legacy selector
+	.wp-block-button__link.is-style-outline.has-#{$name}-color:not( :hover ) {
+		color: $hex;
+	}
 
-.has-secondary-variation-background-color,
-.has-secondary-variation-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-secondary-variation-background-color,
-.is-style-outline .wp-block-button__link.has-secondary-variation-background-color:not( :hover ) {
-	background-color: $color__secondary-variation;
-}
-
-.has-dark-gray-background-color,
-.has-dark-gray-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-dark-gray-background-color,
-.is-style-outline .wp-block-button__link.has-dark-gray-background-color:not( :hover ) {
-	background-color: #111;
-}
-
-.has-medium-gray-background-color,
-.has-medium-gray-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-medium-gray-background-color,
-.is-style-outline .wp-block-button__link.has-medium-gray-background-color:not( :hover ) {
-	background-color: #767676;
-}
-
-.has-light-gray-background-color,
-.has-light-gray-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-light-gray-background-color,
-.is-style-outline .wp-block-button__link.has-light-gray-background-color:not( :hover ) {
-	background-color: #eee;
-}
-
-.has-white-background-color,
-.has-white-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-white-background-color,
-.is-style-outline .wp-block-button__link.has-white-background-color:not( :hover ) {
-	background-color: #fff;
-}
-
-.has-black-background-color,
-.has-black-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-black-background-color,
-.is-style-outline .wp-block-button__link.has-black-background-color:not( :hover ) {
-	background-color: #000;
-}
-
-.has-cyan-bluish-gray-background-color,
-.has-cyan-bluish-gray-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-cyan-bluish-gray-background-color,
-.is-style-outline .wp-block-button__link.has-cyan-bluish-gray-background-color:not( :hover ) {
-	background-color: #abb8c3;
-}
-
-.has-pale-pink-background-color,
-.has-pale-pink-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-pale-pink-background-color,
-.is-style-outline .wp-block-button__link.has-pale-pink-background-color:not( :hover ) {
-	background-color: #f78da7;
-}
-
-.has-vivid-red-background-color,
-.has-vivid-red-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-vivid-red-background-color,
-.is-style-outline .wp-block-button__link.has-vivid-red-background-color:not( :hover ) {
-	background-color: #cf2e2e;
-}
-
-.has-luminous-vivid-orange-background-color,
-.has-luminous-vivid-orange-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-luminous-vivid-orange-background-color,
-.is-style-outline .wp-block-button__link.has-luminous-vivid-orange-background-color:not( :hover ) {
-	background-color: #ff6900;
-}
-
-.has-luminous-vivid-amber-background-color,
-.has-luminous-vivid-amber-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-luminous-vivid-amber-background-color,
-.is-style-outline .wp-block-button__link.has-luminous-vivid-amber-background-color:not( :hover ) {
-	background-color: #fcb900;
-}
-
-.has-light-green-cyan-background-color,
-.has-light-green-cyan-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-light-green-cyan-background-color,
-.is-style-outline .wp-block-button__link.has-light-green-cyan-background-color:not( :hover ) {
-	background-color: #7bdcb5;
-}
-
-.has-vivid-green-cyan-background-color,
-.has-vivid-green-cyan-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-vivid-green-cyan-background-color,
-.is-style-outline .wp-block-button__link.has-vivid-green-cyan-background-color:not( :hover ) {
-	background-color: #00d084;
-}
-
-.has-pale-cyan-blue-background-color,
-.has-pale-cyan-blue-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-pale-cyan-blue-background-color,
-.is-style-outline .wp-block-button__link.has-pale-cyan-blue-background-color:not( :hover ) {
-	background-color: #8ed1fc;
-}
-
-.has-vivid-cyan-blue-background-color,
-.has-vivid-cyan-blue-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-vivid-cyan-blue-background-color,
-.is-style-outline .wp-block-button__link.has-vivid-cyan-blue-background-color:not( :hover ) {
-	background-color: #0693e3;
-}
-
-.has-vivid-purple-background-color,
-.has-vivid-purple-background-color.has-background-dim,
-.wp-block-pullquote.is-style-solid-color.has-vivid-purple-background-color,
-.is-style-outline .wp-block-button__link.has-vivid-purple-background-color:not( :hover ) {
-	background-color: #9b51e0;
-}
-
-//! Custom foreground colors
-.has-primary-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-primary-color p,
-.wp-block-button__link.has-primary-color,
-.wp-block-button__link.has-primary-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-primary-color:not( :hover ), //legacy selector
-.wp-block-button__link.is-style-outline.has-primary-color:not( :hover ) {
-	color: $color__primary;
-}
-
-.has-primary-variation-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-primary-variation-color p,
-.wp-block-button__link.has-primary-variation-color,
-.wp-block-button__link.has-primary-variation-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-primary-variation-color:not( :hover ), //legacy selector
-.wp-block-button__link.is-style-outline.has-primary-variation-color:not( :hover ) {
-	color: $color__primary-variation;
-}
-
-.has-secondary-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p,
-.wp-block-button__link.has-secondary-color,
-.wp-block-button__link.has-secondary-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-secondary-color:not( :hover ), //legacy selector
-.wp-block-button__link.is-style-outline.has-secondary-color:not( :hover ) {
-	color: $color__secondary;
-}
-
-.has-secondary-variation-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-secondary-variation-color p,
-.wp-block-button__link.has-secondary-variation-color,
-.wp-block-button__link.has-secondary-variation-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-secondary-variation-color:not( :hover ), //legacy selector
-.wp-block-button__link.is-style-outline.has-secondary-variation-color:not( :hover ) {
-	color: $color__secondary-variation;
-}
-
-.has-dark-gray-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-dark-gray-color,
-.wp-block-button__link.has-dark-gray-color,
-.wp-block-button__link.has-dark-gray-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-dark-gray-color:not( :hover ), // legacy selector
-.wp-block-button__link.is-style-outline.has-dark-gray-color:not( :hover ) {
-	color: #111;
-}
-
-.has-medium-gray-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-medium-gray-color,
-.wp-block-button__link.has-medium-gray-color,
-.wp-block-button__link.has-medium-gray-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-medium-gray-color:not( :hover ), // legacy selector
-.wp-block-button__link.is-style-outline.has-medium-gray-color:not( :hover ) {
-	color: #767676;
-}
-
-.has-light-gray-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-light-gray-color,
-.wp-block-button__link.has-light-gray-color,
-.wp-block-button__link.has-light-gray-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-light-gray-color:not( :hover ), // legacy selector
-.wp-block-button__link.is-style-outline.has-light-gray-color:not( :hover ) {
-	color: #eee;
-}
-
-.has-white-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-white-color,
-.wp-block-button__link.has-white-color,
-.wp-block-button__link.has-white-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-white-color:not( :hover ), // legacy selector
-.wp-block-button__link.is-style-outline.has-white-color:not( :hover ) {
-	color: #fff;
-}
-
-.has-black-color,
-.wp-block-pullquote.is-style-solid-color blockquote.has-black-color,
-.wp-block-button__link.has-black-color,
-.wp-block-button__link.has-black-color:visited:not( :hover ),
-.is-style-outline .wp-block-button__link.has-black-color:not( :hover ), // legacy selector
-.wp-block-button__link.is-style-outline.has-black-color:not( :hover ) {
-	color: #000;
-}
-
-.has-cyan-bluish-gray-color,
-.wp-block-button__link.has-cyan-bluish-gray-color,
-.wp-block-button__link.has-cyan-bluish-gray-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-cyan-bluish-gray-color:not( :hover ) {
-	color: #abb8c3;
-}
-
-.has-pale-pink-color,
-.wp-block-button__link.has-pale-pink-color,
-.wp-block-button__link.has-pale-pink-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-pale-pink-color:not( :hover ) {
-	color: #f78da7;
-}
-
-.has-vivid-red-color,
-.wp-block-button__link.has-vivid-red-color,
-.wp-block-button__link.has-vivid-red-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-vivid-red-color:not( :hover ) {
-	color: #cf2e2e;
-}
-
-.has-luminous-vivid-orange-color,
-.wp-block-button__link.has-luminous-vivid-orange-color,
-.wp-block-button__link.has-luminous-vivid-orange-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-luminous-vivid-orange-color:not( :hover ) {
-	color: #ff6900;
-}
-
-.has-luminous-vivid-amber-color,
-.wp-block-button__link.has-luminous-vivid-amber-color,
-.wp-block-button__link.has-luminous-vivid-amber-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-luminous-vivid-amber-color:not( :hover ) {
-	color: #fcb900;
-}
-
-.has-light-green-cyan-color,
-.wp-block-button__link.has-light-green-cyan-color,
-.wp-block-button__link.has-light-green-cyan-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-light-green-cyan-color:not( :hover ) {
-	color: #7bdcb5;
-}
-
-.has-vivid-green-cyan-color,
-.wp-block-button__link.has-vivid-green-cyan-color,
-.wp-block-button__link.has-vivid-green-cyan-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-vivid-green-cyan-color:not( :hover ) {
-	color: #00d084;
-}
-
-.has-pale-cyan-blue-color,
-.wp-block-button__link.has-pale-cyan-blue-color,
-.wp-block-button__link.has-pale-cyan-blue-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-pale-cyan-blue-color:not( :hover ) {
-	color: #8ed1fc;
-}
-
-.has-vivid-cyan-blue-color,
-.wp-block-button__link.has-vivid-cyan-blue-color,
-.wp-block-button__link.has-vivid-cyan-blue-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-vivid-cyan-blue-color:not( :hover ) {
-	color: #0693e3;
-}
-
-.has-vivid-purple-color,
-.wp-block-button__link.has-vivid-purple-color,
-.wp-block-button__link.has-vivid-purple-color:visited:not( :hover ),
-.wp-block-button__link.is-style-outline.has-vivid-purple-color:not( :hover ) {
-	color: #9b51e0;
-}
-
-//! Custom border colors
-.has-primary-border-color,
-.wp-block-pullquote.has-primary-border-color {
-	border-color: $color__primary;
-}
-
-.has-primary-variation-border-color,
-.wp-block-pullquote.has-primary-variation-border-color {
-	border-color: $color__primary-variation;
-}
-
-.has-secondary-border-color,
-.wp-block-pullquote.has-secondary-border-color {
-	border-color: $color__secondary;
-}
-
-.has-secondary-variation-border-color,
-.wp-block-pullquote.has-secondary-variation-border-color {
-	border-color: $color__secondary-variation;
-}
-
-.has-dark-gray-border-color,
-.wp-block-pullquote.has-dark-gray-border-color {
-	border-color: #111;
-}
-
-.has-medium-gray-border-color,
-.wp-block-pullquote.has-medium-gray-border-color {
-	border-color: #767676;
-}
-
-.has-light-gray-border-color,
-.wp-block-pullquote.has-light-gray-border-color {
-	border-color: #eee;
-}
-
-.has-white-border-color,
-.wp-block-pullquote.has-white-border-color {
-	border-color: #fff;
-}
-
-.has-black-border-color,
-.wp-block-pullquote.has-black-border-color {
-	border-color: #000;
-}
-
-.has-cyan-bluish-gray-border-color,
-.wp-block-pullquote.has-cyan-bluish-gray-border-color {
-	border-color: #abb8c3;
-}
-
-.has-pale-pink-border-color,
-.wp-block-pullquote.has-pale-pink-border-color {
-	border-color: #f78da7;
-}
-
-.has-vivid-red-border-color,
-.wp-block-pullquote.has-vivid-red-border-color {
-	border-color: #cf2e2e;
-}
-
-.has-luminous-vivid-orange-border-color,
-.wp-block-pullquote.has-luminous-vivid-orange-border-color {
-	border-color: #ff6900;
-}
-
-.has-luminous-vivid-amber-border-color,
-.wp-block-pullquote.has-luminous-vivid-amber-border-color {
-	border-color: #fcb900;
-}
-
-.has-light-green-cyan-border-color,
-.wp-block-pullquote.has-light-green-cyan-border-color {
-	border-color: #7bdcb5;
-}
-
-.has-vivid-green-cyan-border-color,
-.wp-block-pullquote.has-vivid-green-cyan-border-color {
-	border-color: #00d084;
-}
-
-.has-pale-cyan-blue-border-color,
-.wp-block-pullquote.has-pale-cyan-blue-border-color {
-	border-color: #8ed1fc;
-}
-
-.has-vivid-cyan-blue-border-color,
-.wp-block-pullquote.has-vivid-cyan-blue-border-color {
-	border-color: #0693e3;
-}
-
-.has-vivid-purple-border-color,
-.wp-block-pullquote.has-vivid-purple-border-color {
-	border-color: #9b51e0;
+	//! Custom border colors
+	.has-#{$name}-border-color,
+	.wp-block-pullquote.has-#{$name}-border-color {
+		border-color: $hex;
+	}
 }
 
 // Gradients


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As of #1724, the theme has dequeued WP 5.9's global styles, because the `!important` they include were causing unexpected issues. 

If you happen to enter one of the hex values from the colours used in the Global Styles in the block colour picker, it looks like the standard inline hex value is replaced with one of the Global Styles CSS classes on the front end. Because these classes are not defined, the colour is not applied on the front end. 

Though the odds are very low that this would happen for most of the hex values, but we've already had reports of issues with folks trying to use `#000`. I have included the full set of colour, background colour and border colour classes, on the very unlikely chance some stumbles upon a "luminous-vivid-orange" exact match. 

Closes #1748 

### How to test the changes in this Pull Request:

1. Add multiple group blocks to your editor, and give them different background colours -- #000, and a couple of the other 'unlikely' defaults -- like `#9b51e0` (vivid purple) and `#7bdcb5` (light green cyan):

![image](https://user-images.githubusercontent.com/177561/160723940-5fd77cbe-751b-4a3d-9e9a-c00a3fa673b6.png)

2. Publish your post; view on the front-end and note your colours aren't applied:

![image](https://user-images.githubusercontent.com/177561/160724084-ed94b094-3a0a-4a9d-bf16-6120a0189487.png)

4. Apply the PR and run `npm run build`. 
5. Confirm the colours are now applied:

![image](https://user-images.githubusercontent.com/177561/160724003-98d6a345-8a21-4397-bd96-c13d54efc1ba.png)

6. Test out the colours (primarily black) on other blocks (headers, buttons, pullquotes...) just to make sure it displays as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
