### PR TITLE
Improve behaviour of floated groups, and fix display issues with iframe blocks nested inside

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1140,11 +1140,17 @@ hr {
 	}
 }
 
-@include media( mobileonly ) {
-	.entry .entry-content > .wp-block-group.alignleft,
-	[id='pico'] > .wp-block-group.alignleft,
-	.entry .entry-content > .wp-block-group.alignright,
-	[id='pico'] > .wp-block-group.alignright {
+.entry .entry-content > .wp-block-group.alignleft,
+[id='pico'] > .wp-block-group.alignleft,
+.entry .entry-content > .wp-block-group.alignright,
+[id='pico'] > .wp-block-group.alignright {
+	@include media( mobile ) {
+		&:not( :first-child ) {
+			margin-top: 0;
+		}
+	}
+
+	@include media( mobileonly ) {
 		float: none;
 		margin-left: 0;
 		margin-right: 0;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1129,6 +1129,27 @@ hr {
 			margin-bottom: 0;
 		}
 	}
+
+	@include media( mobile ) {
+		&.alignleft,
+		&.alignright {
+			iframe[style*='width: 100%'] {
+				width: 400px !important; // !important to override inline style.
+			}
+		}
+	}
+}
+
+@include media( mobileonly ) {
+	.entry .entry-content > .wp-block-group.alignleft,
+	[id='pico'] > .wp-block-group.alignleft,
+	.entry .entry-content > .wp-block-group.alignright,
+	[id='pico'] > .wp-block-group.alignright {
+		float: none;
+		margin-left: 0;
+		margin-right: 0;
+		max-width: 100%;
+	}
 }
 
 .wp-block-group.has-background + .wp-block-group.has-background,
@@ -1144,6 +1165,13 @@ hr {
 		margin-top: calc(
 			#{-0.5 * $size__spacing-unit} - 1px
 		); // minus 1px to offset bottom border on header
+	}
+}
+
+//! iFrame Block
+.wp-block-newspack-blocks-iframe {
+	.wp-block-embed__wrapper {
+		max-width: 100%;
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1620,7 +1620,7 @@ hr {
 
 			@include media( tablet ) {
 				/*rtl:ignore*/
-				margin-left: #{-4 * $size__spacing-unit};
+				margin-left: #{-2 * $size__spacing-unit};
 			}
 
 			@include media( desktop ) {
@@ -1638,7 +1638,7 @@ hr {
 
 			@include media( tablet ) {
 				/*rtl:ignore*/
-				margin-right: #{-4 * $size__spacing-unit};
+				margin-right: #{-2 * $size__spacing-unit};
 			}
 
 			@include media( desktop ) {

--- a/newspack-theme/sass/media/_media.scss
+++ b/newspack-theme/sass/media/_media.scss
@@ -13,6 +13,10 @@ object {
 	max-width: 100%;
 }
 
+iframe {
+	//display: block;
+}
+
 .custom-logo-link {
 	display: inline-block;
 }

--- a/newspack-theme/sass/media/_media.scss
+++ b/newspack-theme/sass/media/_media.scss
@@ -14,7 +14,7 @@ object {
 }
 
 iframe {
-	//display: block;
+	display: block;
 }
 
 .custom-logo-link {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -376,14 +376,11 @@ div[data-align='full'] {
 	}
 }
 
-.wp-block[data-type='core/image'][data-align='left'].wp-block .block-editor-block-list__block-edit,
-.wp-block[data-type='core/image'][data-align='right'].wp-block
-	.block-editor-block-list__block-edit {
-	max-width: 50%;
-
-	.wp-block-image {
+[data-align='left'],
+[data-align='right'] {
+	&.wp-block .wp-block-image {
 		table-layout: fixed;
-		max-width: 100%;
+		max-width: 50%;
 	}
 
 	.wp-block-image > div > div {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -381,6 +381,11 @@ div[data-align='full'] {
 	&.wp-block .wp-block-image {
 		table-layout: fixed;
 		max-width: 50%;
+
+		.components-resizable-box__container {
+			height: auto !important;
+			max-width: 400px !important;
+		}
 	}
 
 	.wp-block-image > div > div {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -417,6 +417,12 @@ div[data-align='full'] {
 .wp-block[data-align='left'] > .wp-block-group,
 .wp-block[data-align='right'] > .wp-block-group {
 	max-width: 50%;
+
+	@include media( mobile ) {
+		iframe[style='width: 100%; height: 600px; max-width: 100%; max-height: 100%;'] {
+			width: 400px !important; // !important to override inline style.
+		}
+	}
 }
 
 /** === Button === */

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -380,6 +380,7 @@ div[data-align='full'] {
 [data-align='right'] {
 	&.wp-block .wp-block-image {
 		table-layout: fixed;
+		margin: 0;
 		max-width: 50%;
 
 		.components-resizable-box__container {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR cleans up some behaviour of the floated group block and the iframe block:

* It adds a `display: block` to all `iframe` elements so they behave consistently across AMP and non-AMP (`amp-frame` appears to be largely styled as `display: block`).
* Adds a minimum width to the iframe block when nested inside of a floated group block when its width is 100%; otherwise, it collapses. 
* Adds a maximum width to the iframe block, so it cannot exceed the available space when it has a `px` width set. 
* Makes floated group blocks stack on mobile; we've done this in Custom CSS on a couple sites already; it seems like the most logical default, as having the group block squished to 50% of the screen space would rarely make sense. 

Closes #1710; closes #1723.

### How to test the changes in this Pull Request:

1. Create a page and add a couple of floated group blocks, containing:
   * An iframe block with the default width (`100%) 
   * An iframe block with a higher fixed `px` width, like `500px`
   * Some text content -- a paragraph block or two, or a list. 
2. View on the front end; note that:
   * The floated group block + iframe block with the default width disappears.

![image](https://user-images.githubusercontent.com/177561/160903202-be4b050c-9e73-48fc-99f7-af0a053f4a6a.png)

   * The floated group block + iframe block with a wider fixed width is too wide when you start scaling down the browser.

![image](https://user-images.githubusercontent.com/177561/160903284-7b4d4838-dada-49d3-a47d-d74854a9b26d.png)

   * The floated group block + regular content seems cramped on smaller screens.

![image](https://user-images.githubusercontent.com/177561/160903328-6cc1f1c0-cfa2-4937-84c4-8abe243c68e9.png)

3. Apply the PR and run `npm run build`.
4. Confirm the following:
    * The floated group block + iframe block with the default width is now visible.

![image](https://user-images.githubusercontent.com/177561/160903542-3e885b29-2c5f-4afe-b8ec-905c73335003.png)

    * The floated group block + iframe block with a wider fixed width doesn't exceed the available space (it is smaller than your selected width, but I think that makes sense in this case -- if you need a wider iframe, it shouldn't be floated).

![image](https://user-images.githubusercontent.com/177561/160903589-5216198f-ec82-41cb-8d9e-10a3a26be4a4.png)

    * The floated group block stacks on mobile.

![image](https://user-images.githubusercontent.com/177561/160903619-ed9a902e-050d-4279-8b45-06d762767bf8.png)

5. Double-check the page with AMP disabled as well, to make sure there are no unexpected issues!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
