### PR TITLE
Make sure captions on full-width blocks don't get cut off

### DIFF
--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -5,7 +5,7 @@
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin: auto;
-	max-width: 90%;
+	max-width: 90vw;
 	width: $size__site-main;
 
 	@include media( tablet ) {
@@ -34,7 +34,7 @@
 
 #primary {
 	margin: auto;
-	max-width: 90%;
+	max-width: 90vw;
 	width: $size__site-main;
 }
 

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -38,7 +38,7 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 90%, 780px );
+		width: min( 88%, 780px );
 	}
 }
 
@@ -53,6 +53,6 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 90%, 1200px );
+		width: min( 88%, 1200px );
 	}
 }

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -37,8 +37,11 @@ figcaption,
 		max-width: 780px;
 	}
 
-	.alignfull > figcaption {
-		width: min( 90%, 780px );
+	.alignfull,
+	.alignwide {
+		> figcaption {
+			width: min( 90vw, 780px );
+		}
 	}
 }
 
@@ -52,7 +55,10 @@ figcaption,
 		}
 	}
 
-	.alignfull > figcaption {
-		width: min( 90%, 1200px );
+	.alignfull,
+	.alignwide {
+		> figcaption {
+			width: min( 90vw, 1200px );
+		}
 	}
 }

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -38,7 +38,7 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 88vw, 780px );
+		width: min( 90%, 780px );
 	}
 }
 
@@ -53,6 +53,6 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 88vw, 1200px );
+		width: min( 90%, 1200px );
 	}
 }

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -36,6 +36,10 @@ figcaption,
 	figcaption {
 		max-width: 780px;
 	}
+
+	.alignfull > figcaption {
+		width: min( 90%, 780px );
+	}
 }
 
 .newspack-front-page,
@@ -46,5 +50,9 @@ figcaption,
 		figcaption {
 			max-width: 1200px;
 		}
+	}
+
+	.alignfull > figcaption {
+		width: min( 90%, 1200px );
 	}
 }

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -38,7 +38,7 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 87%, 780px );
+		width: min( 88vw, 780px );
 	}
 }
 
@@ -53,6 +53,6 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 87%, 1200px );
+		width: min( 88vw, 1200px );
 	}
 }

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -38,7 +38,7 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 88%, 780px );
+		width: min( 87%, 780px );
 	}
 }
 
@@ -53,6 +53,6 @@ figcaption,
 	}
 
 	.alignfull > figcaption {
-		width: min( 88%, 1200px );
+		width: min( 87%, 1200px );
 	}
 }

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -173,7 +173,7 @@
 
 			&:not( .h-stk ).single-featured-image-beside {
 				.mb-cta {
-					right: 2.75rem;
+					right: 2.25rem;
 				}
 			}
 		}

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -6,9 +6,14 @@
 @import '../mixins/mixins-master';
 
 //! Layout tweaks
-#tribe-events-pg-template,
+main#tribe-events-pg-template,
 .tribe-common--breakpoint-medium.tribe-events .tribe-events-l-container {
 	padding-top: 0;
+}
+
+main#tribe-events-pg-template {
+	padding-left: 0;
+	padding-right: 0;
 }
 
 .single-tribe_events {

--- a/newspack-theme/sass/plugins/the-events-calendar.scss
+++ b/newspack-theme/sass/plugins/the-events-calendar.scss
@@ -69,7 +69,7 @@
 //! Sidebar styles
 .tec-wrapper {
 	margin: auto;
-	max-width: 90%;
+	max-width: 90vw;
 	width: 1200px;
 }
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -525,7 +525,7 @@
 		&.single-featured-image-beside {
 			.middle-header-contain {
 				margin: auto;
-				max-width: 90%;
+				max-width: 90vw;
 				width: 1200px;
 
 				.wrapper {
@@ -659,7 +659,7 @@
 
 				.wrapper {
 					margin: auto;
-					max-width: 90%;
+					max-width: 90vw;
 					padding-right: 0;
 					width: 1200px;
 				}

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -637,7 +637,7 @@ div.sharedaddy .sd-social h3.sd-title,
 		align-self: flex-end;
 		color: #fff;
 		margin: #{4 * $size__spacing-unit} auto #{2 * $size__spacing-unit};
-		max-width: 90%;
+		max-width: 90vw;
 		position: relative;
 		z-index: 2;
 
@@ -852,7 +852,7 @@ div.sharedaddy .sd-social h3.sd-title,
 
 	figcaption {
 		margin: #{0.25 * $size__spacing-unit} auto 0;
-		max-width: 90%;
+		max-width: 90vw;
 		width: 1200px;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -125,7 +125,7 @@ figcaption,
 	font-size: $font__size-xxs;
 	line-height: $font__line-height-pre;
 	margin: 0 auto #{0.5 * $size__spacing-unit};
-	max-width: 780px;
+	max-width: 810px;
 	padding-left: 0;
 	padding-right: 0;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adjusts the width and max-width of captions on full-width blocks, to make sure they don't get cut off on smaller screens. 

Closes #1751

### How to test the changes in this Pull Request:

1. Create a new post/page and choose the one column template.
2. Add an image block and a video block; give them both captions and make each block full width. Fill in the space between with some paragraphs to compare content widths. 
3. Publish and view on the front-end; the captions should match the width of the other content (780px wide):

![image](https://user-images.githubusercontent.com/177561/160913108-9b82122c-d827-4e70-9ae3-89dc3c8ec549.png)

5. Scaled down your browser window -- note that your captions hit the edges and get cut off:

![image](https://user-images.githubusercontent.com/177561/160913161-2d196fb8-6f7e-400a-b35c-a1c5f47e7b03.png)

7. Apply the PR and run `npm run build`.
8. Confirm that the captions are still the same width as the regular content on desktop, and are also the same width on mobile:

![image](https://user-images.githubusercontent.com/177561/160913728-7dd70e7e-e404-44c3-8d60-141bb99e58bd.png)

![image](https://user-images.githubusercontent.com/177561/160915894-eaf32f9d-815f-4d95-939e-04121857c6b7.png)

10. Switch your template to the One Column wide template, and retest the above; the captions should match the content width on desktop (1200px), and not hit the edges and matches the content width on mobile:

![image](https://user-images.githubusercontent.com/177561/160913854-b34db412-5e52-4ef3-82eb-d1e44c5a875a.png)

![image](https://user-images.githubusercontent.com/177561/160915808-bebba0f7-247f-4fd8-98f3-cec0894f9df0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
