### PR TITLE
fix: change custom ads bg classname

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -217,7 +217,7 @@ function newspack_body_classes( $classes ) {
 	$ads_background_color = get_theme_mod( 'ads_color', 'default' );
 	$above_footer_ad      = method_exists( 'Newspack_Ads\Placements', 'can_display_ad_unit' ) && \Newspack_Ads\Placements::can_display_ad_unit( 'global_above_footer' );
 	if ( 'custom' === $ads_background_color ) {
-		$classes[] = 'ads-bg';
+		$classes[] = 'custom-ad-bg';
 
 		if ( true === $above_footer_ad ) {
 			$classes[] = 'ad-above-footer';

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -142,7 +142,7 @@ body {
 	margin-bottom: -1.5rem;
 }
 
-.ads-bg {
+.custom-ad-bg {
 	// Add a top margin to the above-footer ad, if a above footer widget doesn't exist.
 	&:not( .af-widget ) .newspack_global_ad.global_above_footer {
 		margin-top: 2rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change avoids an adblock interpreting the entire `<body />` tag as an ad.

### How to test the changes in this Pull Request:

1. While on the release branch, set a custom background color to ads through the Customizer
2. Visit the homepage with Chrome and  [Adblock Plus](https://chrome.google.com/webstore/detail/adblock-plus-free-ad-bloc/cfhdojbkjhnklbpkdaibdccddilifddb?hl=pt-BR) installed and active
3. Confirm the website is blank
4. Check out this branch and confirm the page renders properly and the fix from #1742 remains

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
