### PR TITLE
Add inline style to subscribe patterns

### DIFF
--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -67,7 +67,10 @@
 		margin: -32px;
 	}
 
+	.newspack-inline-popup &,
 	.newspack-lightbox & {
+		margin: 0;
+
 		~ .popup-not-interested-form {
 			bottom: 0;
 			left: 0;
@@ -79,10 +82,6 @@
 				font-weight: bold;
 				padding: 8px;
 			}
-		}
-
-		+ p:empty {
-			display: none;
 		}
 	}
 }
@@ -191,7 +190,10 @@
 		margin: -32px;
 	}
 
+	.newspack-inline-popup &,
 	.newspack-lightbox & {
+		margin: 0;
+
 		~ .popup-not-interested-form {
 			margin: 12px 0 0;
 			padding: 0 4px 4px;
@@ -205,9 +207,17 @@
 				font-family: inherit;
 			}
 		}
+	}
 
-		+ p:empty {
-			display: none;
+	.newspack-inline-popup & {
+		~ .popup-not-interested-form {
+			margin-top: -20px;
+			padding: 0 36px 36px;
+
+			@include media( tablet ) {
+				margin-top: -48px;
+				padding: 0 64px 64px;
+			}
 		}
 	}
 }
@@ -311,7 +321,10 @@
 		padding: 32px;
 	}
 
+	.newspack-inline-popup &,
 	.newspack-lightbox & {
+		margin: 0;
+
 		~ .popup-dismiss-form {
 			.newspack-lightbox__close {
 				height: 32px;
@@ -326,10 +339,6 @@
 			button {
 				font-family: inherit;
 			}
-		}
-
-		+ p:empty {
-			display: none;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x]  Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds (basic) styles for Subscribe Patterns 7 to 9 when used as an Inline Prompt (note: Pattern 8 should not really be used as an inline...)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add patterns 7 to 9
3. Do they look OK as an inline prompt 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
