### PR TITLE
Make sure captions can inherit text colours

### DIFF
--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -16,6 +16,13 @@ figcaption,
 	text-align: left;
 }
 
+.has-text-color {
+	figcaption,
+	.wp-caption-text {
+		color: inherit;
+	}
+}
+
 figcaption,
 .wp-caption-text,
 .amp-image-lightbox-caption {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -130,6 +130,13 @@ figcaption,
 	padding-right: 0;
 }
 
+.has-text-color {
+	figcaption,
+	.wp-caption-text {
+		color: inherit;
+	}
+}
+
 /** === Post Title === */
 
 .editor-post-title__block,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

You can currently use the inline colour options to change the caption text colour, but because you can't see/select the credit in the editor, you can't change its colour using this approach. 

This fix isn't perfect, it just provides a work around -- it adds styles so if you wrap the image in a group block with a text colour set, the caption, credit and link will pick it up. It's a small thing, but helps make sure the text can be made legible against dark backgrounds.

When I originally wrote the issue I had it in my head that we could somehow use the `mark` tag that's added with inline colours to also change the credit -- while this could work for any of the theme defined colours (we could use `mark.has-primary-color + .image-credit`) , it won't work for custom colours. They have a class we can target (`mark.has-text-color + .image-credit`), but no way to "tell" what the colour should be -- I figured it "kind of" working like that would be confusing, but I'm open to feedback about that!

Closes #1220.

### How to test the changes in this Pull Request:

1. Add an image block with caption and a credit, and a gallery block with per-image captions and credit, and a block level caption (this is to make sure we don't mess with the white-text-on-dark-background that's used over the images).
2. Wrap in a group block and assign it a text colour. 
3. View in the editor and front-end; note that the captions remain grey (or white, in the gallery block's case!):

![image](https://user-images.githubusercontent.com/177561/164295682-19dd1cc1-2a17-41f0-a2b3-fa24a7d641d1.png)

![image](https://user-images.githubusercontent.com/177561/164295732-62545c70-abc1-437a-b267-c250f3d70c9b.png)

4. Apply the PR and run `npm run build`. 
5. Confirm that the captions against the white background pick up the group block colour in the editor and on the front end, but that the ones overlaid on images in the gallery are still white:

![image](https://user-images.githubusercontent.com/177561/164295495-62d5e2cc-9526-4d8b-861b-92cedc11bdf9.png)

![image](https://user-images.githubusercontent.com/177561/164295556-e7965551-c1c7-4d19-a26d-90372c3a23f0.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
