### PR TITLE
fix: remove unneeded featured image content option

### DIFF
--- a/newspack-theme/inc/jetpack.php
+++ b/newspack-theme/inc/jetpack.php
@@ -52,7 +52,6 @@ function newspack_jetpack_setup() {
 			),
 			'featured-images' => array(
 				'archive' => true,
-				'page'    => true,
 			),
 		)
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a quick tweak to remove support for one of Jetpack's Content Options -- before the theme had featured image placements, it allowed you to hide featured images on all pages using Content Options. This option hasn't been needed since the theme added the ability to change the featured image position (including hiding it), and it's a bit confusing -- since it uses a filter, it also hides ALL featured images on pages, so unchecking it can cause images not to appear in the Homepage Posts and Carousel blocks 😐 

Closes #1182

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Content Options, and note you have the ability to hide images on pages from there:

![image](https://user-images.githubusercontent.com/177561/164346573-25ad1d9d-13ec-427a-a55c-c931317960a7.png)

2. Apply the PR. 
3. Confirm the option is now gone:

![image](https://user-images.githubusercontent.com/177561/164346836-57258fae-b31b-49cd-97cc-d1673f5848a7.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
