### PR TITLE
fix: correct author alignment when date is hidden

### DIFF
--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -264,6 +264,24 @@ cite {
 		}
 	}
 
+	@include media( tablet ) {
+		&.date-hidden .featured-image-beside .entry-meta {
+			display: block;
+
+			.byline {
+				margin: 0;
+			}
+		}
+	}
+
+	&.date-hidden .featured-image-behind .entry-meta {
+		display: block;
+
+		.byline {
+			margin: 0;
+		}
+	}
+
 	.entry-subhead {
 		border-bottom: 1px solid $color__border;
 		border-top: 1px solid $color__border;

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -258,27 +258,29 @@ cite {
 		}
 	}
 
-	@include media( mobileonly ) {
-		&.date-hidden .entry-header .entry-meta {
-			display: block;
+	&.date-hidden {
+		@include media( mobileonly ) {
+			.entry-header .entry-meta {
+				display: block;
+			}
 		}
-	}
 
-	@include media( tablet ) {
-		&.date-hidden .featured-image-beside .entry-meta {
+		@include media( tablet ) {
+			.featured-image-beside .entry-meta {
+				display: block;
+
+				.byline {
+					margin: 0;
+				}
+			}
+		}
+
+		.featured-image-behind .entry-meta {
 			display: block;
 
 			.byline {
 				margin: 0;
 			}
-		}
-	}
-
-	&.date-hidden .featured-image-behind .entry-meta {
-		display: block;
-
-		.byline {
-			margin: 0;
 		}
 	}
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -258,6 +258,12 @@ cite {
 		}
 	}
 
+	@include media( mobileonly ) {
+		&.date-hidden .entry-header .entry-meta {
+			display: block;
+		}
+	}
+
 	.entry-subhead {
 		border-bottom: 1px solid $color__border;
 		border-top: 1px solid $color__border;

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -317,6 +317,11 @@ amp-script .cat-links {
 		}
 	}
 
+	&.date-hidden .entry-header .entry-meta {
+		align-items: center;
+		display: flex;
+	}
+
 	.main-content > .post-thumbnail:first-child {
 		margin-top: #{2 * $size__spacing-unit};
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the alignment of the author's name when you've hidden the date using the theme's Content Options.

Closes #546

### How to test the changes in this Pull Request:

1. Start with the Newspack default theme.
2. Navigate to a post with multiple authors:

![image](https://user-images.githubusercontent.com/177561/164353988-2e9149c3-c118-4615-983d-8b89d8b30dae.png)

3. From there, open the Customizer > Content Options panel and uncheck 'Display date' and publish.
4. Note the appearance of the byline -- the names will sit on the high side:

![image](https://user-images.githubusercontent.com/177561/164354287-ab1ec291-2ebf-4a39-9d79-88cf554a9a0e.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the names are now nicely aligned:

![image](https://user-images.githubusercontent.com/177561/164354508-3339a39f-0c2b-4bca-9a71-4ce648861ff8.png)

8. Cycle through the other themes; Newspack Sacha in particular needed the styles tweaked for smaller screens, as well as the featured image behind and beside styles, to make sure the byline is still centred:

![image](https://user-images.githubusercontent.com/177561/164356443-155809c8-76bc-413e-bbdb-c36b4a613cd1.png)

![image](https://user-images.githubusercontent.com/177561/164354565-e48f97d1-3381-4d57-a3b0-b5d3e7aa550e.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
