### PR TITLE
Carousel Block: Make sure links don't incorrectly pick up custom colours

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -254,11 +254,13 @@ p.has-background {
 }
 
 //! Newspack Carousel Block
-.wp-block-newspack-blocks-carousel {
+.wpnbpc {
 	h3 a,
 	h3 a:visited,
 	.entry-meta .byline a,
 	.entry-meta .byline a:visited,
+	.entry-meta .byline a:hover,
+	.entry-meta .byline a:visited:hover,
 	.cat-links a,
 	.cat-links a:visited {
 		color: inherit;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -236,9 +236,12 @@ h1.wp-block-post-title {
 }
 
 /** === Newspack Carousel === */
-.wp-block-newspack-blocks-carousel h3 a,
-.wp-block-newspack-blocks-carousel h3 a:visited {
-	color: #fff;
+.wp-block-newspack-blocks-carousel {
+	a,
+	a:visited,
+	.entry-meta .byline a {
+		color: #fff;
+	}
 }
 
 /** === Table === */

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -100,8 +100,9 @@
 	}
 }
 
-.wpnbha .cat-links {
-	a {
+.wpnbha,
+.wpnbpc {
+	.cat-links a {
 		margin: 0;
 		padding: 0;
 		&,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the styles for the post carousel block, to prevent the theme from incorrectly overriding the white links.

Closes #1015

### How to test the changes in this Pull Request:

1. Start with the Newspack default theme.
2. Add a post carousel block to the editor; make sure the category is also displaying and publish. 
3. Note that the links aren't all white in the editor, and the category has a background on hover on the front-end.
4. Apply the PR and run `npm run build`.
5. Confirm that the links are now all white in the editor and on the front-end, when hovered and visited.
6. Optionally cycle through the other themes and confirm that the links are white. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
