### PR TITLE
Image block: Fix margin issue in editor

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -390,7 +390,6 @@ div[data-align='full'] {
 [data-align='right'] {
 	&.wp-block .wp-block-image {
 		table-layout: fixed;
-		margin: 0;
 		max-width: 50%;
 
 		.components-resizable-box__container {

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -79,10 +79,16 @@ body.newspack-single-column-template {
 		position: relative;
 
 		@include media( desktop ) {
-			left: #{-2 * $size__spacing-unit};
+			left: #{-1 * $size__spacing-unit};
 		}
 		@include media( wide ) {
-			left: #{-4 * $size__spacing-unit};
+			left: #{-2 * $size__spacing-unit};
+		}
+
+		@include media( tablet ) {
+			> .wp-block-image {
+				margin-right: 0;
+			}
 		}
 	}
 
@@ -98,6 +104,12 @@ body.newspack-single-column-template {
 		}
 		@include media( wide ) {
 			right: #{-4 * $size__spacing-unit};
+		}
+
+		@include media( tablet ) {
+			> .wp-block-image {
+				margin-left: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A recent change added a zero margin to floated images, which caused them to meet up with the text in the editor preview when you use the default template.

This PR removes it, and re-adds it for the one column and one column wide templates, so the images aren't pushed further out for those. 

Closes #1780

### How to test the changes in this Pull Request:

1. Create a post using the default template; add some text and two image blocks, one floated left and one floated right. 
2. Note the lack of spacing next to the images:

![image](https://user-images.githubusercontent.com/177561/164559136-607164a6-a0d8-437e-912a-52b0268f5f21.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the images now have a little breathing space:

![image](https://user-images.githubusercontent.com/177561/164558742-b351bb33-3ceb-4253-8781-1493d0122640.png)

5. Test with the One Column and One Column Wide templates as well, just to confirm they look okay. You'll need to switch the template, click 'Update' then refresh to get the updated styles. There is more space than on the front end (a limitation of this style with all the extra markup in the editor), but they should look roughly like:

![image](https://user-images.githubusercontent.com/177561/164559290-bb61a52f-ac9b-40ed-8b46-940bce1a450f.png)

![image](https://user-images.githubusercontent.com/177561/164560013-dc6a91bc-833b-4ac8-aae7-f9d888f8df45.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
