### PR TITLE
fix: update skip to content target

### DIFF
--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -45,7 +45,7 @@ endif;
 ?>
 
 <div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'newspack' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#main"><?php _e( 'Skip to content', 'newspack' ); ?></a>
 
 	<?php if ( is_active_sidebar( 'header-2' ) ) : ?>
 		<div class="header-widget above-header-widgets">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the 'Skip to content' link to point to the ID of the element more immediately surrounding the site content.

This change came out of a third-party accessibility audit done for one of our publishers.

Closes #1784

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate through the page using the keyboard (using 'tab').
3. When the 'Skip to Content' link appears, tap 'Return'/'Enter'
4. Confirm that the keyboard focus jumps down to the page's content (skipping over the header), and continuing to tab brings you to the first link in the content (usually the category link, or first post in archives or search). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
