### PR TITLE
fix(sponsors): ensure sponsor bios appear above Related Posts module

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -251,6 +251,8 @@ endif;
 if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 	/**
 	 * Outputs the 'bio' for the sponsor.
+	 * Appends it to post content to ensure that it appears before other injected modules,
+	 * such as Jetpack's Related Posts module.
 	 */
 	function newspack_sponsor_footer_bio( $sponsors = null, $id = null, $scope = 'native', $type = 'post' ) {
 		$sponsors = newspack_get_all_sponsors(
@@ -262,61 +264,71 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 				'maxheight' => 100,
 			)
 		);
-		if ( ! empty( $sponsors ) ) {
-			foreach ( $sponsors as $sponsor ) {
-			?>
-
-				<div class="author-bio sponsor-bio">
-
-					<?php
-					if ( ! empty( $sponsor['sponsor_logo'] ) ) {
-						echo '<figure class="avatar">';
-						if ( '' !== $sponsor['sponsor_url'] ) {
-							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
-						}
-						echo '<img src="' . esc_url( $sponsor['sponsor_logo']['src'] ) . '" width="' . esc_attr( $sponsor['sponsor_logo']['img_width'] ) . '" height="' . esc_attr( $sponsor['sponsor_logo']['img_height'] ) . '">';
-						if ( '' !== $sponsor['sponsor_url'] ) {
-							echo '</a>';
-						}
-						echo '</figure>';
-					}
+		add_filter(
+			'the_content',
+			function( $content ) use ( $sponsors ) {
+				ob_start();
+				if ( ! empty( $sponsors ) ) {
+					foreach ( $sponsors as $sponsor ) {
 					?>
 
-					<div class="author-bio-text">
-						<div class="author-bio-header">
-							<h2 class="accent-header">
-								<?php
-								echo esc_html( $sponsor['sponsor_byline'] ) . ' ';
+						<div class="author-bio sponsor-bio">
+
+							<?php
+							if ( ! empty( $sponsor['sponsor_logo'] ) ) {
+								echo '<figure class="avatar">';
 								if ( '' !== $sponsor['sponsor_url'] ) {
-									echo '<a target="_blank" href="' . esc_url( $sponsor['sponsor_url'] ) . '">';
+									echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
 								}
-								echo esc_html( $sponsor['sponsor_name'] );
+								echo '<img src="' . esc_url( $sponsor['sponsor_logo']['src'] ) . '" width="' . esc_attr( $sponsor['sponsor_logo']['img_width'] ) . '" height="' . esc_attr( $sponsor['sponsor_logo']['img_height'] ) . '">';
 								if ( '' !== $sponsor['sponsor_url'] ) {
 									echo '</a>';
 								}
-								?>
-							</h2>
-						</div><!-- .author-bio-header -->
+								echo '</figure>';
+							}
+							?>
 
-						<?php echo wp_kses_post( $sponsor['sponsor_blurb'] ); ?>
+							<div class="author-bio-text">
+								<div class="author-bio-header">
+									<h2 class="accent-header">
+										<?php
+										echo esc_html( $sponsor['sponsor_byline'] ) . ' ';
+										if ( '' !== $sponsor['sponsor_url'] ) {
+											echo '<a target="_blank" href="' . esc_url( $sponsor['sponsor_url'] ) . '">';
+										}
+										echo esc_html( $sponsor['sponsor_name'] );
+										if ( '' !== $sponsor['sponsor_url'] ) {
+											echo '</a>';
+										}
+										?>
+									</h2>
+								</div><!-- .author-bio-header -->
 
-						<?php if ( '' !== $sponsor['sponsor_url'] ) : ?>
-							<a class="author-link" target="_blank" href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>">
-								<?php
-									printf(
-										/* translators: %s is the post's sponsor's name. */
-										esc_html__( 'Learn more about %s', 'newspack' ),
-										esc_html( $sponsor['sponsor_name'] )
-									);
-								?>
-							</a>
-						<?php endif; ?>
+								<?php echo wp_kses_post( $sponsor['sponsor_blurb'] ); ?>
 
-					</div><!-- .author-bio-text -->
-				</div><!-- .author-bio -->
-			<?php
+								<?php if ( '' !== $sponsor['sponsor_url'] ) : ?>
+									<a class="author-link" target="_blank" href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>">
+										<?php
+											printf(
+												/* translators: %s is the post's sponsor's name. */
+												esc_html__( 'Learn more about %s', 'newspack' ),
+												esc_html( $sponsor['sponsor_name'] )
+											);
+										?>
+									</a>
+								<?php endif; ?>
+
+							</div><!-- .author-bio-text -->
+						</div><!-- .author-bio -->
+					<?php
+					}
+				}
+
+				$content .= "\n" . ob_get_clean();
+
+				return $content;
 			}
-		}
+		);
 	}
 endif;
 

--- a/newspack-theme/template-parts/content/content-single.php
+++ b/newspack-theme/template-parts/content/content-single.php
@@ -35,6 +35,10 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 		if ( ! empty( $underwriter_sponsors ) ) :
 			newspack_sponsored_underwriters_info( $underwriter_sponsors );
 		endif;
+
+		if ( ! empty( $native_sponsors ) ) :
+			newspack_sponsor_footer_bio( $native_sponsors );
+		endif;
 		?>
 
 		<?php
@@ -71,9 +75,7 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 	</footer><!-- .entry-footer -->
 
 	<?php
-	if ( ! empty( $native_sponsors ) ) :
-		newspack_sponsor_footer_bio( $native_sponsors );
-	elseif ( ! is_singular( 'attachment' ) ) :
+	if ( empty( $native_sponsors ) && ! is_singular( 'attachment' ) ) :
 		get_template_part( 'template-parts/post/author', 'bio' );
 	endif;
 	?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that the native sponsor bio appears above the Jetpack Related Posts module in article content. Instead of appending the sponsor bio after the content, in place of the Author Bio, this change injects the sponsor bio to the end of the post content using a `the_content` filter callback.

This change means that the sponsor bio will now appear above the tag footer, pagination links, the Newspack entry footer, the `article-2` sidebar, and other elements that normally appear after post content in Newspack sites. @laurelfulford, is this okay in your mind?

Closes https://github.com/Automattic/newspack-sponsors/issues/61.

### How to test the changes in this Pull Request:

1. Enable Jetpack's Related Posts module and apply a native sponsor to a post.
2. On `master`, observe that the sponsor bio appears below the Related Posts module.
3. Check out this branch and confirm that the sponsor bio now appears above Related Posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
