### PR TITLE
Quote Block: Update quote block styles for WordPress 6.0

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -909,7 +909,7 @@ p.has-background {
 	p {
 		font-size: 1em;
 		font-style: normal;
-		line-height: 1.8;
+		margin-bottom: 0.5em;
 	}
 
 	cite {
@@ -928,8 +928,8 @@ p.has-background {
 
 		p {
 			font-size: $font__size-lg;
-			line-height: 1.4;
 			font-style: italic;
+			line-height: 1.4;
 		}
 
 		cite,
@@ -949,6 +949,10 @@ p.has-background {
 				font-size: $font__size-lg;
 			}
 		}
+	}
+
+	&.has-background {
+		padding: 1rem;
 	}
 }
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -952,7 +952,7 @@ p.has-background {
 	}
 
 	&.has-background {
-		padding: 1rem;
+		padding: #{1.5 * $size__spacing-unit};
 	}
 }
 

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -502,6 +502,23 @@ div[data-align='full'] {
 		line-height: 1.6;
 		color: $color__text-light;
 	}
+
+	p {
+		font-size: 1em;
+		font-style: normal;
+		margin-bottom: 0.5em;
+	}
+
+	&.has-background {
+		padding: 1rem;
+	}
+
+	&.has-text-color {
+		cite,
+		footer {
+			color: inherit;
+		}
+	}
 }
 
 /** === Pullquote === */

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -510,7 +510,7 @@ div[data-align='full'] {
 	}
 
 	&.has-background {
-		padding: 1rem;
+		padding: 30px;
 	}
 
 	&.has-text-color {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some styles to work with the background and text colour options that are being added to the Quote Block in WordPress 6.0.

(It also tweaks the spacing between the quote and citation -- it seemed a bit spaced out to me when both were in place!).

Closes #1793 

### How to test the changes in this Pull Request:

1. Start with a test site running the latest WordPress 6.0 RC. 
2. Add a quote block with text and a citation and give it a background colour and a text colour.
3. In the editor, note that the citation is not picking up your text colour; in the editor and on the front-end, the quote block also doesn't get extra padding when you give it a background, so the text is very close to the edge:

4. Apply the PR and run `npm run build`
5. Confirm that the citation issue is fixed in the editor, and that the quote block with a background colour has padding both in the editor and on the front-end:

![image](https://user-images.githubusercontent.com/177561/166843312-a36de70c-4868-4ad9-b5e4-09ca9758f90e.png)

![image](https://user-images.githubusercontent.com/177561/166843338-c3e09f35-8b22-426c-895e-6e57b189d4ba.png)

![image](https://user-images.githubusercontent.com/177561/166843284-81c7c7aa-4d75-4ba6-b9fc-443f9e71bfdd.png)

![image](https://user-images.githubusercontent.com/177561/166843290-67d07b7d-f73b-4732-826c-aad807a98c63.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
