### PR TITLE
Separator Block: update colour styles in the editor for WordPress 6.0

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -714,10 +714,10 @@ div[data-align='full'] {
 
 .wp-block-separator {
 	opacity: 1;
+
 	&:not( .is-style-dots ) {
 		border: 0;
 		border-top: 1px solid $color__border;
-		background-color: transparent;
 	}
 
 	&:not( .is-style-wide ):not( .is-style-dots ) {
@@ -733,8 +733,9 @@ div[data-align='full'] {
 		padding-left: calc( 2 * #{$size__spacing-unit} );
 	}
 
-	&.has-background {
-		border: 0;
+	&.has-background,
+	&.has-text-color {
+		border-color: currentColor;
 
 		&.is-style-dots::before {
 			color: inherit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the editor styles so the Separator Block will still preview custom colours correctly in WordPress 6.0.

Closes #1794

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WordPress 6.0 RC.
2. Add three separator blocks to the editor, using the default, wide and dot styles.
3. Give each of the separator blocks a different colour.
4. Note that they don't change in the editor, but they will display correctly on the front end.
5. Apply the PR and run `npm run build`.
6. Confirm that the editor is now previewing your selected colours for the Separator blocks.
7. Test this PR on a site running WordPress 5.9.3; repeat step 2 and 3 and confirm that the colours still preview as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
