### PR TITLE
Dropdown menu accessibility improvements

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -412,29 +412,6 @@ function newspack_get_discussion_data() {
 }
 
 /**
- * WCAG 2.0 Attributes for Dropdown Menus
- *
- * Adjustments to menu attributes tot support WCAG 2.0 recommendations
- * for flyout and dropdown menus.
- *
- * @ref https://www.w3.org/WAI/tutorials/menus/flyout/
- */
-/*
-function newspack_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
-
-	// Add [aria-haspopup] and [aria-expanded] to menu items that have children
-	$item_has_children = in_array( 'menu-item-has-children', $item->classes );
-	if ( $item_has_children ) {
-		$atts['aria-haspopup'] = 'true';
-		$atts['aria-expanded'] = 'false';
-	}
-
-	return $atts;
-}
-add_filter( 'nav_menu_link_attributes', 'newspack_nav_menu_link_attributes', 10, 4 );
-*/
-
-/**
  * Add a dropdown icon to top-level menu items.
  *
  * @param string $output Nav menu item start element.
@@ -459,7 +436,7 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		$toggle_id = "toggle_" . $item->ID ;
 
 		$output .= sprintf(
-			'<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $toggle_id . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )">%s</button>',
+			'<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $toggle_id . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )" aria-haspopup="true">%s</button>',
 			$icon
 		);
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -456,17 +456,39 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// Add SVG icon to parent items.
 		$icon = newspack_get_icon_svg( 'keyboard_arrow_down', 24 );
 
-		$toggle_id = "toggle-" . $item->ID ;
+		$toggle_id = "toggle_" . $item->ID ;
 
 		$output .= sprintf(
 			'<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $toggle_id . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )">%s</button>',
 			$icon
 		);
+
+		// Get the current menu items ID and store it in a global variable so it can be added to the submenu.
+		global $menu_parent_id;
+		$menu_parent_id = $item->ID;
 	}
 
 	return $output;
 }
 add_filter( 'walker_nav_menu_start_el', 'newspack_add_dropdown_icons', 10, 4 );
+
+/**
+ * Add an ID with parent menu item's ID to each submenu.
+ *
+ * @param string $output Nav menu item start element.
+ * @param int    $depth  Depth.
+ * @param object $args   Nav menu args.
+ * @return string Nav menu level start element.
+ */
+class Newspack_Custom_Submenu_Walker extends Walker_Nav_Menu {
+	function start_lvl( &$output, $depth = 0, $args = array() ) {
+		global $menu_parent_id;
+
+		$submenu_ID = "submenu-" . esc_attr( $menu_parent_id );
+		$indent = str_repeat("\t", $depth);
+		$output .= "\n$indent<ul class=\"sub-menu\" id=\"$submenu_ID\">\n";
+	}
+}
 
 /**
  * The default color used for the primary color throughout this theme

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -419,6 +419,7 @@ function newspack_get_discussion_data() {
  *
  * @ref https://www.w3.org/WAI/tutorials/menus/flyout/
  */
+/*
 function newspack_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
 
 	// Add [aria-haspopup] and [aria-expanded] to menu items that have children
@@ -431,6 +432,7 @@ function newspack_nav_menu_link_attributes( $atts, $item, $args, $depth ) {
 	return $atts;
 }
 add_filter( 'nav_menu_link_attributes', 'newspack_nav_menu_link_attributes', 10, 4 );
+*/
 
 /**
  * Add a dropdown icon to top-level menu items.
@@ -454,10 +456,10 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// Add SVG icon to parent items.
 		$icon = newspack_get_icon_svg( 'keyboard_arrow_down', 24 );
 
-		$toggle_id = "toggle" . $item->ID ;
+		$toggle_id = "toggle-" . $item->ID ;
 
 		$output .= sprintf(
-			'<button class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )">%s</button>',
+			'<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $toggle_id . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )">%s</button>',
 			$icon
 		);
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -454,8 +454,10 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		// Add SVG icon to parent items.
 		$icon = newspack_get_icon_svg( 'keyboard_arrow_down', 24 );
 
+		$toggle_id = "toggle" . $item->ID ;
+
 		$output .= sprintf(
-			'<button class="submenu-expand" tabindex="-1" role="presentation">%s</button>',
+			'<button class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )">%s</button>',
 			$icon
 		);
 	}

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -558,6 +558,7 @@ function newspack_primary_menu() {
 				'menu_class'     => 'main-menu',
 				'container'      => false,
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				'walker'         => new Newspack_Custom_Submenu_Walker(),
 			)
 		);
 		?>
@@ -588,6 +589,7 @@ function newspack_secondary_menu() {
 				'menu_class'     => 'secondary-menu',
 				'container'      => false,
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+				'walker'         => new Newspack_Custom_Submenu_Walker(),
 			)
 		);
 		?>

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -160,6 +160,24 @@
 		}
 	} );
 
+	// Menu toggle variables.
+	const dropdownToggle = document.getElementsByClassName( 'submenu-expand' );
+	if ( 0 < dropdownToggle.length ) {
+		for ( let i = 0; i < dropdownToggle.length; i++ ) {
+			dropdownToggle[ i ].addEventListener(
+				'click',
+				function () {
+					if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
+						dropdownToggle[ i ].classList.remove( 'open-dropdown' );
+					} else {
+						dropdownToggle[ i ].classList.add( 'open-dropdown' );
+					}
+				},
+				false
+			);
+		}
+	}
+
 	// Sticky header fallback animation
 	if (
 		body.classList.contains( 'h-stk' ) &&

--- a/newspack-theme/sass/navigation/_menu-dropdown.scss
+++ b/newspack-theme/sass/navigation/_menu-dropdown.scss
@@ -102,6 +102,10 @@
 					position: relative;
 					top: -0.2em;
 				}
+
+				&.open-dropdown svg {
+					transform: rotate( 180deg );
+				}
 			}
 		}
 	}
@@ -157,9 +161,13 @@
 		}
 
 		.submenu-expand {
-			right: #{0.25 * $size__spacing-unit};
+			right: -5px;
 			top: #{0.65 * $size__spacing-unit};
 			transform: rotate( -90deg );
+
+			svg {
+				margin-top: -10px;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/navigation/_menu-dropdown.scss
+++ b/newspack-theme/sass/navigation/_menu-dropdown.scss
@@ -23,7 +23,7 @@
 		}
 
 		&:focus {
-			outline: 1px solid transparent;
+			outline: 1px dotted currentColor;
 			outline-offset: -4px;
 		}
 
@@ -135,6 +135,7 @@
 
 	.sub-menu {
 		color: $color__background-body;
+		display: none;
 		position: absolute;
 		opacity: 0;
 		transition: opacity 0.2s;
@@ -164,32 +165,9 @@
 
 	/*
 	 * Sub-menu styles
-	 *
-	 * :focus-within needs its own selector so other similar
-	 * selectors don’t get ignored if a browser doesn’t recognize it
 	 */
-	.menu-item-has-children:not( .off-canvas ):focus-within > .sub-menu {
-		display: block;
-		margin-top: 0;
-		opacity: 1;
-		position: absolute;
-		left: 0;
-		right: auto;
-		top: 100%;
-		bottom: auto;
-		height: auto;
-		transform: none;
-		width: #{12.5 * $size__spacing-unit};
-	}
-
-	.sub-menu .menu-item-has-children:not( .off-canvas ):focus-within > .sub-menu {
-		left: 100%;
-		top: 0;
-	}
-
-	.menu-item-has-children:not( .off-canvas ):hover > .sub-menu,
-	.menu-item-has-children:not( .off-canvas ):focus > .sub-menu,
-	.menu-item-has-children.is-focused:not( .off-canvas ) > .sub-menu {
+	.menu-item-has-children:hover > .sub-menu,
+	.menu-item-has-children > .submenu-expand.open-dropdown + .sub-menu {
 		display: block;
 		float: none;
 		margin-top: 0;
@@ -204,9 +182,9 @@
 		width: #{12.5 * $size__spacing-unit};
 	}
 
-	.sub-menu .menu-item-has-children:not( .off-canvas ):hover > .sub-menu,
-	.sub-menu .menu-item-has-children:not( .off-canvas ):focus > .sub-menu,
-	.sub-menu .menu-item-has-children.is-focused:not( .off-canvas ) > .sub-menu {
+	.sub-menu .menu-item-has-children:hover > .sub-menu,
+	.sub-menu .menu-item-has-children > .submenu-expand.open-dropdown + .sub-menu {
+		display: block;
 		left: 100%;
 		top: 0;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some accessibility improvements to the theme's dropdown menus that came out of a third-party accessibility audit of a publisher's site:

* **Problem:** the dropdowns are always visible to screen readers because it's not truly hidden when closed, it's just pushed to the left -- because of this it can still receive keyboard focus.
**Solution:** hide these elements using `display: none` when the dropdown isn't open.

* **Problem:** elements menu control expandable content (the dropdowns), but this isn't indicated in a way that screen readers can understand.
**Solution:** add `aria-controls` attribute sto the elements that control the dropdowns, and add unique IDs to the dropdowns. The value of each `aria-controls` attribute should match the ID of the menu it opens . Also add an `aria-expanded="true"` attribute to those same control elements when the dropdown is open, and `aria-expanded="false"` when it's closed.

* **Problem:** dropdowns expand automatically when their parent menu item is focused on, so you can't "skip" them when navigating the site via keyboard.
**Solution:** use the buttons that are already included in the menu markup to control whether or not the menu is visible, rather than just showing it on focus (the dropdown can still be visible on hover, though!). 

* **Problem:** each of the buttons in the menu has a negative `tabindex` attribute -- this causes them to not to be accessible when tabbing through the page; have the ARIA attribute `role="presentation"`, which is unnecessary and can cause issues.
**Solution:** remove the `tabindex` attributes from these elements so that they can be focused by the keyboard when navigating with the Tab and Shift + Tab keys, and remove the `role="presentation"` attribute.

Closes #1756

### How to test the changes in this Pull Request:

1. Set up a site with multi-level menus in the Primary and Secondary menu locations. 
2. View the front end of the site and navigate around with your keyboard -- note that when you hit a menu item with a dropdown, it will open on focus, and that you have to tab through each level. 
3. Apply the PR and run `npm run build`.
4. Repeat step 2; note that now on menu items with dropdowns, you can tab to the link and arrow individually; when you tab past a menu items with a dropdown, it doesn't expand automatically.
5. Tab to one of the down arrows and hit enter; confirm that the menu can be opened and closed this way, and that the arrow flips to reflect its state. Travel through different levels of the menu confirming this behaviour:

![menu-tabbing 2022-05-18 17_40_22](https://user-images.githubusercontent.com/177561/169178228-4a794ba7-6a62-437f-b9f5-b89c7f7a1999.gif)

6. Open the element inspector and confirm that each of the arrow buttons has:
     * an `aria-controls="submenu-####"` value, where the number matches the ID `menu-item-####` value of the `li` directly above it 
     * an `aria-expanded="false"` value that switches to `true` when you tab to the button and hit 'Enter`
     * an `aria-haspopup="true"`
7. In the element inspector, confirm that each dropdown's `ul` has an attribute `id="submenu-####"`, where the full value matches the `aria-controls` value of the button before it. 
8. Try using your mouse to navigate the menu and make sure the dropdowns open on hover, and that you can't click on the down arrows with the mouse to open the dropdowns (this was the best way I could think of to avoid accidentally mixing and matching menu open states)
9. Turn off AMP (or on AMP, depending on what your test site's default is) and repeat steps 4-8 and confirm things still work as expected. 

Note: the approach I used to add IDs to the submenus may be sub-optimal -- it seems kind of 'heavy duty' for me, but at the same time it was the one way I could figure out to pass the parent menu ID, but I feel like it's more functional than "correct". So any feedback there on top of with how this all works is hugely appreciated! 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
