### PR TITLE
Remove support for the Aside post format support

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -268,9 +268,6 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 
 		// Add custom theme support - post subtitle
 		add_theme_support( 'post-subtitle' );
-
-		// Add post format support.
-		add_theme_support( 'post-formats', array( 'aside' ) );
 	}
 endif;
 add_action( 'after_setup_theme', 'newspack_setup' );

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -207,38 +207,6 @@ p.has-background {
 	.more-link + .entry-meta {
 		margin-top: #{0.75 * $size__spacing-unit};
 	}
-
-	article.format-aside {
-		.entry-meta > a,
-		.entry-meta .byline {
-			display: none;
-		}
-	}
-
-	&.ts-4,
-	&.ts-5,
-	&.ts-6,
-	&.ts-7,
-	&.ts-8,
-	&.ts-9,
-	&.ts-10 {
-		article.format-aside {
-			.entry-title {
-				font-size: 1em;
-			}
-			.entry-wrapper {
-				font-size: 90%;
-			}
-		}
-	}
-
-	&.ts-3 article.format-aside .entry-title {
-		font-size: 0.8em;
-	}
-
-	&.ts-2 article.format-aside .entry-title {
-		font-size: 0.7em;
-	}
 }
 
 .mobile-sidebar,

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -64,10 +64,6 @@
 			margin-right: $size__spacing-unit;
 		}
 	}
-
-	.format-aside .byline {
-		display: none;
-	}
 }
 
 .archive {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -862,15 +862,6 @@ div.sharedaddy .sd-social h3.sd-title,
 	}
 }
 
-/* Aside */
-.single-format-aside {
-	.author-avatar,
-	.byline,
-	.author-bio {
-		display: none;
-	}
-}
-
 /* Related Posts */
 
 .jp-relatedposts-i2 {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -203,43 +203,6 @@ h1.wp-block-post-title {
 	.more-link + .entry-meta {
 		margin-top: #{0.75 * $size__spacing-unit};
 	}
-
-	article.format-aside {
-		.entry-meta > a,
-		.entry-meta .byline,
-		.entry-meta .author-avatar {
-			display: none;
-		}
-	}
-
-	&.ts-4,
-	&.ts-5,
-	&.ts-6,
-	&.ts-7,
-	&.ts-8,
-	&.ts-9,
-	&.ts-10 {
-		article.format-aside {
-			.entry-title {
-				font-size: 1em;
-			}
-			.entry-wrapper {
-				font-size: 90%;
-			}
-
-			p {
-				font-size: inherit;
-			}
-		}
-	}
-
-	&.ts-3 article.format-aside .entry-title {
-		font-size: 0.8em;
-	}
-
-	&.ts-2 article.format-aside .entry-title {
-		font-size: 0.7em;
-	}
 }
 
 /** === Newspack Carousel === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With https://github.com/Automattic/newspack-blocks/pull/1139, this PR removes support for the Aside Post Format from the theme and Homepage Posts block. 

Closes #1807, https://github.com/Automattic/newspack-blocks/issues/611, https://github.com/Automattic/newspack-blocks/issues/610, https://github.com/Automattic/newspack-blocks/issues/660

### How to test the changes in this Pull Request:

1. Add a couple posts with the Post Format 'Aside' assigned under 'Status & visibility'

![image](https://user-images.githubusercontent.com/177561/169409041-9beb6942-c511-4b41-bcdb-6493d0986e44.png)

2. Set up a Homepage Posts block that will show posts with both the 'Standard' and 'Aside' formats. 
3. For the single view of the Aside posts, note that the post author is hidden.
4. For the block view of the Aside posts, note that they look pretty different: they use a smaller font (regardless of type scale setting); they show the full body of the post; they have the author information hidden; and the post title doesn't link off to the full post:

A single post missing the byline at the top: 
![image](https://user-images.githubusercontent.com/177561/169408955-86c95f4c-205c-4296-95dd-80f5431f9757.png)

Homepage Posts block -- post #3 below is an Aside:
![image](https://user-images.githubusercontent.com/177561/169408822-e1646f25-35d6-4a42-be90-9fdcf1f2fcfe.png)

5. Apply both this PR to the theme and https://github.com/Automattic/newspack-blocks/pull/1139 to the Newspack Blocks repo; run `npm run build` for each.  
6. Confirm that the posts marked 'Aside' are now being handled the same as regular posts: in the single post view, they should display the post author. In the Homepage Posts block, they should be the same size and show the same elements as standard posts.
7. Try editing one of your posts and confirm that you no longer have an option to set a Post Format. 
8. Just out of an abundance of caution, confirm that single posts still have the CSS class `single-format-aside` on the body (indicating that they have still stored their 'Aside' format). The Homepage posts block will no longer display aside-related classes because the code adding the CSS class there has been removed with these changes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
