### PR TITLE
Override hover effect from video block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -697,6 +697,10 @@ p.has-background {
 	figcaption {
 		text-align: left;
 	}
+
+	amp-video button:hover {
+		background: transparent;
+	}
 }
 
 //! Button


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where a video block with certain settings will turn black on hover when AMP is enabled. This is because a `button` element is added to the video, covering the whole thing, and it's picking up the theme's black background on hover. 

Closes #1814. 

### How to test the changes in this Pull Request:

1. Start with a test site running AMP.
2. Add a video block to a post; turn on Autoplay and Playback controls in the right sidebar: 

![image](https://user-images.githubusercontent.com/177561/170147722-b881af53-390b-4ce6-ba2c-d29c4db2448c.png)

3. Publish the post and view on the front-end.
4. Hover over the video; note it turns black. 
5. Apply the PR and run `npm run build`.
6. Confirm that the video no longer turns black on hover. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
