### PR TITLE
fix: make third level headings a unique size on mobile

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -72,7 +72,11 @@ h2 {
 }
 
 h3 {
-	font-size: $font__size-lg;
+	font-size: calc( 1em * 1.3 );
+
+	@include media( tablet ) {
+		font-size: $font__size-lg;
+	}
 }
 
 h4 {

--- a/newspack-theme/sass/typography/_headings.scss
+++ b/newspack-theme/sass/typography/_headings.scss
@@ -126,9 +126,16 @@ h2 {
 .comments-title,
 .archive .entry-title,
 .search .entry-title,
-.blog .entry-title,
-h3 {
+.blog .entry-title {
 	font-size: $font__size-lg;
+}
+
+h3 {
+	font-size: calc( 1em * 1.3 );
+
+	@include media( tablet ) {
+		font-size: $font__size-lg;
+	}
 }
 
 .site-title,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now both the `h2` and `h3` are the same size on mobile screens. 

This PR makes the `h3` slightly smaller than the `h2 on smaller screen sizes, while still being larger than the `h4`. This lead to me adding a non-variable defined font size, but this seemed to be the most straight forward fix, that didn't involve renaming/reworking existing variables to squeeze another one into the naming convention.

Closes #1812

### How to test the changes in this Pull Request:

1. Edit a post and add an `h2`, `h3`, and `h4`.
2. Publish and view the front end; shrink down the browser window and note the `h2` and `h3` display at the same size:

![image](https://user-images.githubusercontent.com/177561/170152531-6ccdcded-4435-4230-9039-fa0a5839c4e3.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the `h3` now falls between the `h2` and `h4` in size on smaller screens: 

![image](https://user-images.githubusercontent.com/177561/170152441-2a78f34d-d14c-4522-b84f-7373afb3f8e6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
