### PR TITLE
Add blank template to theme

### DIFF
--- a/newspack-theme/blank.php
+++ b/newspack-theme/blank.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Blank Template
+ * Template Name: Blank template
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/newspack-theme/blank.php
+++ b/newspack-theme/blank.php
@@ -27,13 +27,36 @@
 		<section id="primary" class="content-area">
 			<main id="main" class="site-main">
 				<?php
+
 				/* Start the Loop */
 				while ( have_posts() ) :
 					the_post();
+
+					// Template part for large featured images.
+					if ( in_array( newspack_featured_image_position(), array( 'large', 'behind', 'beside', 'above' ) ) ) :
+						get_template_part( 'template-parts/post/large-featured-image' );
+					else :
 					?>
+						<header class="entry-header">
+							<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
+						</header>
+					<?php endif; ?>
 
 					<div class="main-content">
-						<?php get_template_part( 'template-parts/content/content', 'page' ); ?>
+
+						<?php
+						// Place smaller featured images inside of 'content' area.
+						if ( 'small' === newspack_featured_image_position() ) {
+							newspack_post_thumbnail();
+						}
+
+						get_template_part( 'template-parts/content/content', 'page' );
+
+						// If comments are open or we have at least one comment, load up the comment template.
+						if ( comments_open() || get_comments_number() ) {
+							newspack_comments_template();
+						}
+						?>
 					</div>
 
 				<?php endwhile; ?>

--- a/newspack-theme/blank.php
+++ b/newspack-theme/blank.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: No Header or Footer
+ * Template Name: Blank Template
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -730,7 +730,7 @@ function newspack_filter_admin_body_class( $classes ) {
 
 	if ( 
 		'single-feature.php' === newspack_check_current_template() 
-		|| 'no-header-footer.php'  === newspack_check_current_template() 
+		|| 'blank.php'  === newspack_check_current_template() 
 	) {
 		$classes .= ' newspack-single-column-template';
 	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -730,7 +730,7 @@ function newspack_filter_admin_body_class( $classes ) {
 
 	if ( 
 		'single-feature.php' === newspack_check_current_template() 
-		|| 'blank.php'  === newspack_check_current_template() 
+		|| 'no-header-footer.php'  === newspack_check_current_template() 
 	) {
 		$classes .= ' newspack-single-column-template';
 	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -728,7 +728,10 @@ function newspack_filter_admin_body_class( $classes ) {
 		$classes .= ' no-sidebar';
 	}
 
-	if ( 'single-feature.php' === newspack_check_current_template() ) {
+	if ( 
+		'single-feature.php' === newspack_check_current_template() 
+		|| 'no-header-footer.php'  === newspack_check_current_template() 
+	) {
 		$classes .= ' newspack-single-column-template';
 	} elseif ( 'single-wide.php' === newspack_check_current_template() ) {
 		$classes .= ' newspack-single-wide-template';

--- a/newspack-theme/no-header-footer.php
+++ b/newspack-theme/no-header-footer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Blank template
+ * Template Name: No header or footer
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/newspack-theme/no-header-footer.php
+++ b/newspack-theme/no-header-footer.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Template Name: No Header or Footer
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package Newspack
+ */
+
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="profile" href="https://gmpg.org/xfn/11" />
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?> data-amp-auto-lightbox-disable>
+<?php
+
+do_action( 'wp_body_open' );
+?>
+
+<div id="page" class="site">
+	<a class="skip-link screen-reader-text" href="#main"><?php _e( 'Skip to content', 'newspack' ); ?></a>
+
+	<div id="content" class="site-content">
+
+		<section id="primary" class="content-area">
+			<main id="main" class="site-main">
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					?>
+
+					<div class="main-content">
+						<?php get_template_part( 'template-parts/content/content', 'page' ); ?>
+					</div>
+
+				<?php endwhile; ?>
+
+			</main><!-- #main -->
+		</section><!-- #primary -->
+
+	</div><!-- #content -->
+
+</div><!-- #page -->
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/newspack-theme/no-header-footer.php
+++ b/newspack-theme/no-header-footer.php
@@ -17,10 +17,7 @@
 </head>
 
 <body <?php body_class(); ?> data-amp-auto-lightbox-disable>
-<?php
-
-do_action( 'wp_body_open' );
-?>
+<?php do_action( 'wp_body_open' ); ?>
 
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#main"><?php _e( 'Skip to content', 'newspack' ); ?></a>

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -104,7 +104,7 @@
 	}
 }
 
-.page-template-blank {
+.page-template-no-header-footer {
 	.entry .entry-content,
 	[id='pico'] {
 		> *.alignfull:first-child {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1382,7 +1382,7 @@ $colors: (
 //! 'Feature' alignments
 .post-template-single-feature,
 .page-template-single-feature,
-.page-template-blank {
+.page-template-no-header-footer {
 	.entry .entry-content > *,
 	[id='pico'] > * {
 		&.alignwide {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -111,7 +111,7 @@
 			margin-top: 0;
 		}
 
-		> *:not(.alignfull):last-child {
+		> *:not( .alignfull ):last-child {
 			margin-bottom: 32px;
 		}
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -104,7 +104,7 @@
 	}
 }
 
-.page-template-no-header-footer {
+.page-template-blank {
 	.entry .entry-content,
 	[id='pico'] {
 		> *.alignfull:first-child {
@@ -1382,7 +1382,7 @@ $colors: (
 //! 'Feature' alignments
 .post-template-single-feature,
 .page-template-single-feature,
-.page-template-no-header-footer {
+.page-template-blank {
 	.entry .entry-content > *,
 	[id='pico'] > * {
 		&.alignwide {

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -104,6 +104,19 @@
 	}
 }
 
+.page-template-no-header-footer {
+	.entry .entry-content,
+	[id='pico'] {
+		> *.alignfull:first-child {
+			margin-top: 0;
+		}
+
+		> *:not(.alignfull):last-child {
+			margin-bottom: 32px;
+		}
+	}
+}
+
 .entry .entry-content {
 	/*
 	 * Unset nested content selector styles
@@ -1368,7 +1381,8 @@ $colors: (
 
 //! 'Feature' alignments
 .post-template-single-feature,
-.page-template-single-feature {
+.page-template-single-feature,
+.page-template-no-header-footer {
 	.entry .entry-content > *,
 	[id='pico'] > * {
 		&.alignwide {

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -107,6 +107,7 @@
 
 @include media( tablet ) {
 	.page-template-single-feature .entry-header,
+	.page-template-blank .entry-header,
 	.archive.archive-one-column .page-header {
 		margin-left: auto;
 		margin-right: auto;
@@ -137,6 +138,17 @@
 }
 
 /* 'Blank' page template */
-.page-template-blank .site-content {
-	margin-top: 0;
+.page-template-blank {
+	&,
+	&.hide-page-title {
+		.site-content {
+			margin-top: 0;
+		}
+	}
+
+	&:not( .hide-page-title ):not( [class*='single-featured-image-'] ) {
+		.entry-header {
+			margin-top: $size__spacing-unit;
+		}
+	}
 }

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -24,7 +24,7 @@
 
 .post-template-single-feature,
 .page-template-single-feature,
-.page-template-no-header-footer,
+.page-template-blank,
 .post-template-single-wide,
 .page-template-single-wide,
 .newspack-front-page {
@@ -96,7 +96,7 @@
 // Single-column layouts
 .post-template-single-feature .main-content,
 .page-template-single-feature .main-content,
-.page-template-no-header-footer .main-content,
+.page-template-blank .main-content,
 .archive-one-column #main,
 .newspack-front-page.page-template-single-feature .site-main {
 	margin-left: auto;
@@ -136,7 +136,7 @@
 	}
 }
 
-/* No header footer template */
-.page-template-no-header-footer .site-content {
+/* 'Blank' page template */
+.page-template-blank .site-content {
 	margin-top: 0;
 }

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -24,7 +24,7 @@
 
 .post-template-single-feature,
 .page-template-single-feature,
-.page-template-blank,
+.page-template-no-header-footer,
 .post-template-single-wide,
 .page-template-single-wide,
 .newspack-front-page {
@@ -96,7 +96,7 @@
 // Single-column layouts
 .post-template-single-feature .main-content,
 .page-template-single-feature .main-content,
-.page-template-blank .main-content,
+.page-template-no-header-footer .main-content,
 .archive-one-column #main,
 .newspack-front-page.page-template-single-feature .site-main {
 	margin-left: auto;
@@ -107,7 +107,7 @@
 
 @include media( tablet ) {
 	.page-template-single-feature .entry-header,
-	.page-template-blank .entry-header,
+	.page-template-no-header-footer .entry-header,
 	.archive.archive-one-column .page-header {
 		margin-left: auto;
 		margin-right: auto;
@@ -137,8 +137,8 @@
 	}
 }
 
-/* 'Blank' page template */
-.page-template-blank {
+/* 'No Header or Fotoer' page template */
+.page-template-no-header-footer {
 	&,
 	&.hide-page-title {
 		.site-content {

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -24,6 +24,7 @@
 
 .post-template-single-feature,
 .page-template-single-feature,
+.page-template-no-header-footer,
 .post-template-single-wide,
 .page-template-single-wide,
 .newspack-front-page {
@@ -95,6 +96,7 @@
 // Single-column layouts
 .post-template-single-feature .main-content,
 .page-template-single-feature .main-content,
+.page-template-no-header-footer .main-content,
 .archive-one-column #main,
 .newspack-front-page.page-template-single-feature .site-main {
 	margin-left: auto;
@@ -132,4 +134,9 @@
 			width: 65%;
 		}
 	}
+}
+
+/* No header footer template */
+.page-template-no-header-footer .site-content {
+	margin-top:  0;
 }

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -138,5 +138,5 @@
 
 /* No header footer template */
 .page-template-no-header-footer .site-content {
-	margin-top:  0;
+	margin-top: 0;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a blank template to the theme. It doesn't have a header or footer, any hooks around the header or footer (like after header and before footer), and it doesn't have any widget areas. 

Some general notes:

* This template is only available for pages, not other post types. 
* This template uses the same layout base as the one-column template: the content is 780px wide, which will work well with paragraphs of text; wide and full aligned blocks can be used to make the content wider (for things like information tables). 
* This template displays the page title (though it can be hidden in the page's settings). 
* This template includes all of the featured image settings (though you can also opt to hide them). 

I made the above decisions based on the templates use case, consistency with how the other templates work, and flexibility. I imagine as we auto-create pages with it -- like we do for the "Support Our Publication" page -- we'll likely want to change certain settings (hide the title and featured image, and turn off campaigns).

Closes #1819

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Create a new page; confirm you have a template called "Blank template" and apply it to the new page. 
3. Add some content to the page, and publish.
4. Confirm that the page doesn't have a header or footer on the front-end. 
5. Cycle through the different featured image placements; confirm they look similar to how they look with the One Column template.

<details><summary><strong>Screenshots</strong></summary>

Small featured image:
![image](https://user-images.githubusercontent.com/177561/171753394-ae9c49bc-a626-43ee-bca7-c4bbaa93459c.png)

Large featured image:
![image](https://user-images.githubusercontent.com/177561/171753443-6d5ada96-5ef1-4866-9a1b-f3ee666a3d20.png)

Featured image behind:
![image](https://user-images.githubusercontent.com/177561/171753468-7b6c6319-0fae-4e7e-a519-f453916ea0cb.png)

Featured image beside:
![image](https://user-images.githubusercontent.com/177561/171753505-d1ff6853-5f11-4606-9e65-481217adff2f.png)

Featured image above:
![image](https://user-images.githubusercontent.com/177561/171753532-086b4785-c772-4450-972d-a1732d26b943.png)

</details>

6. Hide the page title and featured image; publish and view on the front-end -- regular paragraphs shouldn't totally hit the top of the screen but should be close-ish:

![image](https://user-images.githubusercontent.com/177561/171753751-418b5e49-d23f-49ba-ba25-80f6621a0381.png)

7. Edit the page and wrap all of the content in a full-width group block and give it a background colour; publish.
8. Confirm that the group block touches the top of the browser window; if you open it in an incognito window, it should also touch the bottom (by default, the theme's edit link will be in the way when you're logged in; it was also left for consistency, but I'm open to feedback about that!):

![image](https://user-images.githubusercontent.com/177561/171753272-6aaf70e7-5139-4147-9bb8-fa4685361f5b.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
