### PR TITLE
Remove FSE-related blocks from editor

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -591,6 +591,9 @@ function newspack_enqueue_scripts() {
 		newspack_get_post_toggle_post_types()
 	);
 	wp_enqueue_script( 'newspack-post-meta-toggles' );
+
+	// Remove FSE-related Gutenberg blocks.
+	wp_enqueue_script( 'newspack-hide-fse-blocks', get_theme_file_uri( '/js/dist/editor-remove-blocks.js' ), array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ), $theme_version, true );
 }
 add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
 
@@ -1128,7 +1131,6 @@ function newspack_dequeue_mediaelement() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_dequeue_mediaelement', 20 );
-
 
 /**
  * SVG Icons class.

--- a/newspack-theme/js/src/editor-remove-blocks.js
+++ b/newspack-theme/js/src/editor-remove-blocks.js
@@ -1,0 +1,33 @@
+'use strict';
+
+import { unregisterBlockType } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+const removeBlocks = [
+	'core/loginout',
+	// Comments
+	'core/post-comments-form',
+	'core/comments-query-loop',
+	// Post Query
+	'core/query', // query loop and posts list
+	'core/post-title',
+	'core/post-featured-image',
+	'core/post-excerpt',
+	'core/post-content',
+	'core/post-terms', // post categories and tags
+	'core/post-date',
+	'core/post-author',
+	'core/post-navigation-link', // previous and next links
+	'core/read-more',
+	'core/avatar',
+	'core/post-author-biography',
+	// Archives
+	'core/query-title', // archive title
+	'core/term-description',
+];
+
+domReady( function () {
+	removeBlocks.forEach( function ( blockName ) {
+		unregisterBlockType( blockName );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes most of the full-side editing related blocks from the editor. This is to help reduce confusion between Newspack-related functionality and these blocks, and to also remove some unnecessary noise from the editor. 

Related: pamTN9-4uP-p2

Closes #1823.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Edit a post or page and try to add any of the following blocks, or find them in the block picker:

* Login/Out
* Post Comments Form
* Comments Query Loop
* Query Loop
* Posts List
* Post Title
* Post Featured Image
* Post Excerpt
* Post Content
* Post Tags
* Post Categories
* Post Date
* Post Author
* Previous and Next Post links
* Read More
* Avatar
* Post Author Biography
* Archive title
* Term Description

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
