### PR TITLE
Search: make sure the search forms have a predictable unique ID

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -695,6 +695,16 @@ function newspack_should_display_updated_date() {
 }
 
 /**
+ * Create a predictable unique ID for the search forms.
+ *
+ * @param string $prefix Text to prepend the ID with.
+ */
+function newspack_search_id( $prefix = '' ) {
+	static $id_counter = 0;
+	return $prefix . ( string ) ++$id_counter;
+}
+
+/**
  * Check whether there's a Post Summary, and return it.
  */
 function newspack_has_post_summary() {

--- a/newspack-theme/searchform.php
+++ b/newspack-theme/searchform.php
@@ -5,7 +5,7 @@
  * @package Newspack
  */
 
-$unique_id = wp_unique_id( 'search-form-' );
+$unique_id = newspack_search_id( 'search-form-' );
 ?>
 
 <form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme originally used `wp_unique_id()` to generate a number for a unique ID for each search form the theme output. 

For the search in the header, the ID is required by AMP to set focus on the search input when the search is opened. 

We can predict the search number ID when on the Newspack theme is active (it's the second search the theme outputs, so the ID is `wp_unique_id()`. However, plugins also use `wp_unique_id()` (including the AMP plugin!), so it's not always possible to predict what ID number the search in the header will end up with. 

This PR adds a function to the theme to generate an ID just for the search forms, rather than using a more universal WordPress one, since we (unfortunately!) require the ID over, say, proximity to select the right input.

Closes #1832.

### How to test the changes in this Pull Request:

1. On your test site viewing an AMP version of the site, open the search field; odds are, on open the search field does not receive focus (if it does, the ID will be using the `-2`; in that case you can recreate this issue on sites like YubaNet and MTFP). 
2. Apply the PR. 
3. Repeat step one; confirm that the search field gets focus when the search is opened (if this already worked for you, just confirm that it still works!). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
