### PR TITLE
Add checkbox style

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -156,6 +156,7 @@ function newspack_custom_colors_css() {
 			input[type="button"],
 			input[type="reset"],
 			input[type="submit"],
+			input[type="checkbox"]:checked,
 			.has-secondary-background-color,
 			*[class^="wp-block-"].has-secondary-background-color,
 			*[class^="wp-block-"] .has-secondary-background-color,
@@ -173,6 +174,10 @@ function newspack_custom_colors_css() {
 			input[type="reset"],
 			input[type="submit"] {
 				color: ' . esc_html( $secondary_color_contrast ) . ';
+			}
+
+			input[type="checkbox"]::before {
+				background-image: url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' width=\'24\' height=\'24\'%3E%3Cpath d=\'M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z\' fill=\'' . esc_html( $secondary_color_contrast ) . '\'%3E%3C/path%3E%3C/svg%3E");
 			}
 
 			/* Set secondary color */
@@ -362,7 +367,7 @@ function newspack_custom_colors_css() {
 					color: ' . esc_html( $primary_color_contrast ) . ';
 				}
 				.accent-header,
-				#secondary .widgettitle, 
+				#secondary .widgettitle,
 				.article-section-title,
 				.entry .entry-footer a:hover {
 					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -565,8 +565,8 @@ function newspack_get_color_contrast( $hex ) {
  */
 function newspack_color_with_contrast( $color ) {
 	$contrast = newspack_get_color_contrast( $color );
-	if ( '#000' === $contrast ) {
-		return '#5a5a5a';
+	if ( 'black' === $contrast ) {
+		return 'dimgray';
 	}
 	return $color;
 }

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -223,7 +223,7 @@ function newspack_body_classes( $classes ) {
 			$classes[] = 'ad-above-footer';
 		}
 	}
-	
+
 	// Add a class for the footer logo size.
 	$footer_logo_size = get_theme_mod( 'footer_logo_size', 'medium' );
 	if ( 'medium' !== $footer_logo_size ) {
@@ -553,10 +553,10 @@ function newspack_get_color_contrast( $hex ) {
 	}
 	if ( $contrast_ratio > 5 ) {
 		// If contrast is more than 5, return black color
-		return '#000';
+		return 'black';
 	} else {
 		// if not, return white color.
-		return '#fff';
+		return 'white';
 	}
 }
 

--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -72,8 +72,9 @@ input[type='checkbox'] {
 			url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E" )
 			0 0 no-repeat;
 		content: '';
-		display: none;
+		display: block;
 		height: 24px;
+		opacity: 0;
 		width: 24px;
 	}
 
@@ -82,7 +83,7 @@ input[type='checkbox'] {
 		border-color: transparent;
 
 		&::before {
-			display: block;
+			opacity: 1;
 		}
 	}
 

--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -59,20 +59,21 @@ input[type='checkbox'] {
 	border: solid 1px $color__border;
 	border-radius: 2px;
 	color: white;
-	display: grid;
+	cursor: pointer;
+	display: inline-grid;
 	font: inherit;
-	height: 24px !important;
+	height: 20px !important;
 	margin: 0;
 	place-content: center;
-	width: 24px !important;
+	width: 20px !important;
 
 	&::before {
 		background: transparent
 			url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E" )
 			0 0 no-repeat;
 		content: '';
+		display: none;
 		height: 24px;
-		opacity: 0;
 		width: 24px;
 	}
 
@@ -81,7 +82,7 @@ input[type='checkbox'] {
 		border-color: transparent;
 
 		&::before {
-			opacity: 1;
+			display: block;
 		}
 	}
 

--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -51,3 +51,45 @@ form {
 		margin: $size__spacing-unit 0;
 	}
 }
+
+input[type="checkbox"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: white;
+	border: solid 1px $color__border;
+  border-radius: 2px;
+	color: white;
+	display: grid;
+	font: inherit;
+	height: 24px !important;
+  margin: 0;
+	place-content: center;
+  width: 24px !important;
+
+	&::before {
+		background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E") 0 0 no-repeat;
+	  content: "";
+	  height: 24px;
+		opacity: 0;
+		width: 24px;
+	}
+
+	&:checked {
+		background: $color__background-button;
+		border-color: transparent;
+
+		&::before {
+		  opacity: 1;
+		}
+	}
+
+	&:focus {
+		outline: 1.5px solid $color__background-button;
+		outline-offset: 1px;
+	}
+
+	&:disabled {
+	  cursor: not-allowed;
+		opacity: 0.75;
+	}
+}

--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -52,24 +52,26 @@ form {
 	}
 }
 
-input[type="checkbox"] {
-  -webkit-appearance: none;
-  appearance: none;
-  background: white;
+input[type='checkbox'] {
+	-webkit-appearance: none;
+	appearance: none;
+	background: white;
 	border: solid 1px $color__border;
-  border-radius: 2px;
+	border-radius: 2px;
 	color: white;
 	display: grid;
 	font: inherit;
 	height: 24px !important;
-  margin: 0;
+	margin: 0;
 	place-content: center;
-  width: 24px !important;
+	width: 24px !important;
 
 	&::before {
-		background: transparent url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E") 0 0 no-repeat;
-	  content: "";
-	  height: 24px;
+		background: transparent
+			url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E" )
+			0 0 no-repeat;
+		content: '';
+		height: 24px;
 		opacity: 0;
 		width: 24px;
 	}
@@ -79,7 +81,7 @@ input[type="checkbox"] {
 		border-color: transparent;
 
 		&::before {
-		  opacity: 1;
+			opacity: 1;
 		}
 	}
 
@@ -89,7 +91,7 @@ input[type="checkbox"] {
 	}
 
 	&:disabled {
-	  cursor: not-allowed;
+		cursor: not-allowed;
 		opacity: 0.75;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The theme currently doesn't have custom style for checkboxes, this PR adds a simple checkbox style.

Note: I saw WooCommerce has some custom styles already (#ship-to-different-address) but I wasn't able to find out how to test it

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Navigate to a screen that has a checkbox (e.g. yoururl.com/product/donate/)
3. Update button's background colour and play with text colour contrast (black/white)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
