### PR TITLE
fix: correct issue with duplicated Trust Indicator role in author bio

### DIFF
--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -124,16 +124,20 @@ function newspack_trust_indicators_output_author_job_title( $title ) {
 		if ( $role ) {
 			$title .= '<span class="author-job-title">' . $role . '</span>';
 		}
-	} else if ( is_single() ) {
-		$role = get_user_meta( get_the_author_meta( 'ID' ), 'title', true );
-		if ( $role ) {
-			$title .= '<span class="author-job-title">' . $role . '</span>';
-		}
 	}
 	return $title;
 }
 add_filter( 'get_the_archive_title', 'newspack_trust_indicators_output_author_job_title' );
-add_filter( 'newspack_author_bio_name', 'newspack_trust_indicators_output_author_job_title' );
+
+/**
+ * Gets author role to add to single post author bios.
+ */
+function newspack_trust_indicators_job_title_single( $author_ID ) {
+	if ( '' !== $author_ID ) {
+		$role = get_user_meta( $author_ID, 'title', true );
+		return $role;
+	}
+}
 
 /**
  * Output location and expertise info on author archive pages.

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -5,7 +5,6 @@
  * @package Newspack
  */
 
-
 // Check if the author bio is turned on, or if the post is set to hide the author.
 if ( false === get_theme_mod( 'show_author_bio', true ) || true === apply_filters( 'newspack_listings_hide_author', false ) ) {
 	return;
@@ -46,7 +45,15 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<div class="author-bio-header">
 						<div>
 							<h2 class="accent-header">
-								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								<?php
+								echo esc_html( $author->display_name );
+								if ( class_exists( 'Trust_Indicators' ) ) {
+									$author_role = newspack_trust_indicators_job_title_single( $author->ID );
+									if ( '' !== $author_role ) {
+										echo '<span class="author-job-title">' . esc_html( $author_role ) . '</span>';
+									}
+								}
+								?>
 							</h2>
 
 							<?php if ( ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -110,7 +117,15 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 			<div>
 				<h2 class="accent-header">
-					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author() ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					<?php
+					echo esc_html( get_the_author() );
+					if ( class_exists( 'Trust_Indicators' ) ) {
+						$author_role = newspack_trust_indicators_job_title_single( get_the_author_meta( 'ID' ) );
+						if ( '' !== $author_role ) {
+							echo '<span class="author-job-title">' . esc_html( $author_role ) . '</span>';
+						}
+					}
+					?>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In #1806, I updated our Trust Indicators plugin integration in the theme and added the official title to the Author Bio at the bottom of single posts. This title had already been set up to display on the author archives. 

Unfortunately, the approach I used caused the job title to display incorrectly when there was more than one author assigned to a post -- rather than each author having their own unique Role listed, the Role of the first author was repeated for each bio. 

This PR updates the approach to correct that issue. 

Closes #1847 

### How to test the changes in this Pull Request:

1. Start on a test site running the Co-Authors Plus plugin and the Trust Project's Trust Indicators plugin (if you don't have a copy of this plugin, please ping me!). 
2. Set up a post and assign three authors: two regular WordPress users (one of them your current user), and a Guest Author. Only the regular WordPress users will have the Official Title field when editing their profiles, so the Guest Authors will not have an option to add an Official Title. With this bug, it's the actual user account (so the account that you're logged into) whose title will be used for all authors. 
3. Edit each of the WordPress user authors to add an Official Title under the Trust Indicators header: 

![image](https://user-images.githubusercontent.com/177561/173621656-2ada8646-0af0-474f-a6a8-9cebe4cdd64b.png)

4. Edit each user and add a description if they don't have one already -- this is required for their Author Bios to appear on single posts.
5. Navigate to [Customize > Author Bio Settings](https://newspack.pub/support/themes/posts/author-bios/#change), and check "Display Author Bio" if it's not already checked.
6. View your post on the front end; note for each author, the same title is displaying; it should be the title you gave the user you're logged in as:
 
![Screen Shot 2022-06-14 at 8 58 48 AM](https://user-images.githubusercontent.com/177561/173622914-da626e92-333a-4ee1-bead-bdc921334d86.png)

7. Apply the PR and refresh the post; confirm that the Official Titles are now correct:
![Screen Shot 2022-06-14 at 9 02 00 AM](https://user-images.githubusercontent.com/177561/173623523-595ed8b0-eeb2-42a5-9dc3-fbd0359c0fd0.png)

8. Disable the Co-Authors Plus plugin. 
9. Refresh your post; confirm that your one author remains, and that their job title displays correctly. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
