### PR TITLE
feat: add single post body class for Yoast's primary category

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -170,6 +170,18 @@ function newspack_body_classes( $classes ) {
 		}
 	}
 
+	// Add a special class for the single post's primary category.
+	if ( is_single() && class_exists( 'WPSEO_Primary_Term' ) ) {
+		$primary_term = new WPSEO_Primary_Term( 'category', $page_id );
+		$category_id = $primary_term->get_primary_term();
+		if ( $category_id ) {
+			$category = get_term( $category_id );
+			if ( $category ) {
+				$classes[] = 'primary-cat-' . $category->slug;
+			}
+		}
+	}
+
 	// Adds class if singular post or page has a featured image.
 	if ( is_singular() && has_post_thumbnail() && 'hidden' !== newspack_featured_image_position() ) {
 		$classes[] = 'has-featured-image';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For each category you have assigned to a single post, the theme adds a CSS class to the `<body>` with the format `cat-[category-slug]` -- so for example a Special Feature category would be turned into the CSS class `cat-special-feature`.

This PR extends on that functionality -- it adds a second special class for the Category that's designated the "Primary Category" using Yoast. To differentiate it, it's formatted like `primary-cat-[category-slug]` -- so when the Special Feature category is made a primary category, it would also add the CSS class `primary-cat-special-feature`.

Closes #1841

### How to test the changes in this Pull Request:

1. Start on a test site with the Yoast plugin activated.
2. Apply the PR.
3. Create a post with multiple categories assigned, and publish -- when Yoast is enabled, it will assign a Primary Category automatically, or you can pick a different one using the dropdown:

![image](https://user-images.githubusercontent.com/177561/173689376-bf3894ef-a097-49c5-9bac-b84b8c3ff634.png)

4. View the source of your post, or inspect the page using the browser's element inspector, and look at the `<body>` tag. It should have a CSS class for each category that was assigned to the post, prefixed with `cat-` (example: `cat-arts`) and a special class for the Primary Category that you assigned to the post, prefixed with `primary-cat-` (example: `primary-cat-arts`). The primary category should generate two CSS classes -- the standard `cat-[slug]` version, and the new `primary-cat-[slug]` version.
5. Deactivate Yoast, and make sure that the `primary-cat-` class is no longer added to your post, and that there are no issues. 
6. Create a new post while Yoast is disabled, and add multiple categories; publish.
7. Reactivate Yoast, and visit your post -- if Yoast is not active when a post is published, a Primary Category is not saved for the post. So if you inspect the page and look at the CSS classes on the body, they should not include a `primary-cat-` class. 
8. Edit that post and re-publish it; because Yoast is now active, a Primary Category will be set -- if you don't select one, it'll be the first category you assigned when you created the post.
9. Confirm that a `primary-cat-` is now added to the body. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
