### PR TITLE
Deprecate support for Hoefler & Co. Cloud.typography fonts

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1715,7 +1715,6 @@ function newspack_sanitize_font_provider_url( $code ) {
 		'google'      => 'fonts.googleapis.com',
 		'fonts'       => 'fast.fonts.net',
 		'typekit'     => 'use.typekit.net',
-		'typography'  => 'cloud.typography.com',
 		'typenetwork' => 'cloud.typenetwork.com',
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme technically includes support for Hoefler & Co's Cloud.typography, but this support has not worked for quite a long time, if ever. 

Given that, and Hoefler & Co's [data collection when using the Cloud.typography service](https://www.typography.com/policies/privacy), specifically this bit:

> Computer Information Collected. Additionally, H&Co automatically collects certain non-personal computer or device-related information from visitors to the Website (and, if you are a subscriber to the Cloud.typography service, visitors to your website), including the operating system (e.g. Mac OS, iOS, Windows, Android), **the visitor’s IP address**, and the web browser (e.g. Safari, Firefox, Chrome) and for visitors to the websites of Cloud.typography subscribers, the webfonts served and the referring URL (collectively “Computer Information”).

... we've opted to deprecate this support. 

I've already updated the documentation to remove mention of Hoefler & Co. 

Closes #798

### How to test the changes in this Pull Request:

1. Apply the PR. 
2. Try to add a URL starting with `https://cloud.typography.com` to one of the "Font Provider Import Code or URL" fields under Customizer > Typography.
3. Try publishing the setting; you should get an error:

![image](https://user-images.githubusercontent.com/177561/175149860-b10d8079-0ed9-4a15-927b-536ad247d595.png)

4. Try using one of the still-supported service URLs instead, like `https://fonts.googleapis.com`.
5. Confirm that the Customizer still lets you save that value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
