### PR TITLE
Improve check for theme's default template

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -49,6 +49,22 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 	}
 endif;
 
+if ( ! function_exists( 'newspack_featured_image_position' ) ) :
+	/**
+	 * Returns whether or not the current post/page is using hte default template.
+	 *
+	 * @return bool
+	 */
+	function newspack_is_default_template() {
+		$default_template = true;
+		// Check against templates assigned in the Newspack theme, to rule out any other non-default _wp_page_template values.
+		if ( is_page_template( array( 'no-header-footer.php', 'single-feature.php', 'single-wide.php' ) ) ) {
+			$default_template = false;
+		}
+		return $default_template;
+	}
+endif;
+
 /**
  * Adds custom classes to the array of body classes.
  *
@@ -150,7 +166,7 @@ function newspack_body_classes( $classes ) {
 
 	// Adds a class of has-sidebar when there is a sidebar present and populated.
 	if ( is_active_sidebar( 'sidebar-1' )
-		&& ( ( ! is_archive() && ! is_page_template() && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) )
+		&& ( ( ! is_archive() && newspack_is_default_template() && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) )
 		|| ( is_archive() && 'default' === get_theme_mod( 'archive_layout', 'default' ) ) )
 	) {
 		$classes[] = 'has-sidebar';

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 	}
 endif;
 
-if ( ! function_exists( 'newspack_featured_image_position' ) ) :
+if ( ! function_exists( 'newspack_is_default_template' ) ) :
 	/**
 	 * Returns whether or not the current post/page is using hte default template.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme checks if a post or page is using the default template using `is_page_template()` -- if no template is assigned, this check returns `false`. 

However, when we migrate content from another WordPress site, posts and pages can come over with data stored in the `_wp_page_template` field. If this template name doesn't match anything in the current theme, the post or page will be rendered with the default template, but `is_page_template()` will return `true`. 

This PR replaces the `! is_page_template()` with a function specifically checking against each of the Newspack theme's three templates. This should help make sure a post or page will return the expected result when they are displayed with the Default Template, even though they may have old `_wp_page_template` data. 

Closes #1811.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. If you site doesn't any any already, add some widgets to your sidebar.
3. Create a post or page and assign the default template; publish.
4. Confirm that the `has-sidebar` class is being added to the post/page's body. 
5. Swap the template to the One Column, One Column Wide and/or No Headers or Footer templates, and make sure the class is switched to `no-sidebar`. 
6. Switch your post back to using the Default Template. 
7. Navigate to Customizer > Widgets and remove all of your sidebar widgets. 
8. Confirm that your post/page with the Default Template still has the `no-sidebar` class. 
9. Check a couple different post types to confirm the above is behaving correctly (Newspack Listings is a good one, since you can switch the templates; Newsletters is a good one for testing just the Default Template). 
10. Check the homepage and confirm it has the `no-sidebar` class, even though it has the Default Template assigned. 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
