### PR TITLE
chore(release): update which files should be auto-updated on release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -18,14 +18,14 @@ module.exports = {
 			{
 				// build script is run before semantic-release, so the version in *.css files
 				// have to be updated explicitly
-				files: [ 'newspack-*/sass/style.scss', 'newspack-*/style.css' ],
+				files: [ 'newspack-*/sass/theme-description.scss', 'newspack-*/style.css' ],
 				callback: 'npm run release:archive',
 			},
 		],
 		{
 			path: '@semantic-release/git',
 			assets: [
-				...THEMES.map( name => `${ name }/sass/style.scss` ),
+				...THEMES.map( name => `${ name }/sass/theme-description.scss` ),
 				'package.json',
 				'package-lock.json',
 				'CHANGELOG.md',


### PR DESCRIPTION
#1845 changed where the version is stored in Sass files, but the release config was not updated accordingly. As a consequence, the wrong [files were updated in the release process](https://app.circleci.com/pipelines/github/Automattic/newspack-theme/2240/workflows/cc921abf-0ab5-4033-a598-a7cc74aae35d/jobs/4248), and this is probably why some changes [were accidentally reverted](https://github.com/Automattic/newspack-theme/commit/ff56ad9553683f3a88116b0a29460dbd006fb986) which had to be fixed in https://github.com/Automattic/newspack-theme/pull/1873. 

This PR updates the release config to reflect that the version numbers in Sass files are now stored in `<child-theme>/sass/theme-description.sass`. 