### PR TITLE
feat: colors' css variables and action hook for mobile toggle

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -910,26 +910,54 @@ function newspack_colors_css_wrap() {
 add_action( 'wp_head', 'newspack_colors_css_wrap' );
 
 /**
+ * Get theme colors' values.
+ *
+ * @return string[] Array of colors.
+ */
+function newspack_get_colors() {
+	$colors              = [];
+	$colors['primary']   = newspack_get_primary_color();
+	$colors['secondary'] = newspack_get_secondary_color();
+	$colors['cta']       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
+
+	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
+		$colors['header'] = $colors['primary'];
+	}
+
+	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
+		$colors['primary']   = get_theme_mod( 'primary_color_hex', $colors['primary'] );
+		$colors['secondary'] = get_theme_mod( 'secondary_color_hex', $colors['secondary'] );
+
+		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
+			$colors['header']       = get_theme_mod( 'header_color_hex', '#666666' );
+			$colors['primary_menu'] = get_theme_mod( 'header_primary_menu_color_hex', '' );
+		} else {
+			$colors['header'] = $colors['primary'];
+		}
+
+		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
+			$colors['footer'] = get_theme_mod( 'footer_color_hex', '' );
+		}
+	}
+
+	// Set color contrasts.
+	foreach ( $colors as $color_key => $color_value ) {
+		$colors[ $color_key . '_contrast' ] = newspack_get_color_contrast( $color_value );
+	}
+
+	return $colors;
+}
+
+/**
  * Add CSS variables to theme's colors.
  */
 function newspack_colors_css_variables() {
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
-	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
-	$header_color    = $primary_color;
-
-	$colors = [
-		'primary'   => $primary_color,
-		'secondary' => $secondary_color,
-		'cta'       => $cta_color,
-		'header'    => $header_color,
-	];
-
+	$colors = newspack_get_colors();
 	?>
 	<style type="text/css" id="newspack-theme-colors-variables">
 		:root {
 			<?php foreach ( $colors as $color_key => $color_value ) : ?>
-				--newspack-<?php echo esc_attr( $color_key ); ?>-color: <?php echo esc_attr( $color_value ); ?>;
+				--newspack-<?php echo esc_attr( str_replace( '_', '-', $color_key ) ); ?>-color: <?php echo esc_attr( $color_value ); ?>;
 			<?php endforeach; ?>
 		}
 	</style>

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -910,6 +910,34 @@ function newspack_colors_css_wrap() {
 add_action( 'wp_head', 'newspack_colors_css_wrap' );
 
 /**
+ * Add CSS variables to theme's colors.
+ */
+function newspack_colors_css_variables() {
+	$primary_color   = newspack_get_primary_color();
+	$secondary_color = newspack_get_secondary_color();
+	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
+	$header_color    = $primary_color;
+
+	$colors = [
+		'primary'   => $primary_color,
+		'secondary' => $secondary_color,
+		'cta'       => $cta_color,
+		'header'    => $header_color,
+	];
+
+	?>
+	<style type="text/css" id="newspack-theme-colors-variables">
+		:root {
+			<?php foreach ( $colors as $color_key => $color_value ) : ?>
+				--newspack-<?php echo esc_attr( $color_key ); ?>-color: <?php echo esc_attr( $color_value ); ?>;
+			<?php endforeach; ?>
+		}
+	</style>
+	<?php
+}
+add_action( 'wp_head', 'newspack_colors_css_variables' );
+
+/**
  * Display custom font CSS in customizer and on frontend.
  */
 function newspack_typography_css_wrap() {

--- a/newspack-theme/header.php
+++ b/newspack-theme/header.php
@@ -220,12 +220,16 @@ endif;
 
 					<?php newspack_mobile_cta(); ?>
 
+					<?php do_action( 'newspack_header_before_mobile_toggle' ); ?>
+
 					<?php if ( newspack_has_menus() ) : ?>
 						<button class="mobile-menu-toggle" on="tap:mobile-sidebar.toggle">
 							<?php echo wp_kses( newspack_get_icon_svg( 'menu', 20 ), newspack_sanitize_svgs() ); ?>
 							<span><?php esc_html_e( 'Menu', 'newspack' ); ?></span>
 						</button>
 					<?php endif; ?>
+
+					<?php do_action( 'newspack_header_after_mobile_toggle' ); ?>
 
 				</div><!-- .wrapper -->
 			</div><!-- .middle-header-contain -->

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -9,35 +9,7 @@
  * Generate the CSS for the current primary color.
  */
 function newspack_custom_colors_css() {
-
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
-	$cta_color       = get_theme_mod( 'header_cta_hex', newspack_get_mobile_cta_color() );
-	$header_color    = $primary_color;
-
-	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
-
-		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
-			$header_color                = get_theme_mod( 'header_color_hex', '#666666' );
-			$primary_menu_color          = get_theme_mod( 'header_primary_menu_color_hex', '' );
-			$primary_menu_color_contrast = newspack_get_color_contrast( $primary_menu_color );
-		} else {
-			$header_color = $primary_color;
-		}
-
-		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
-			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
-			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
-		}
-	}
-
-	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
-	$cta_color_contrast       = newspack_get_color_contrast( $cta_color );
-	$header_color_contrast    = newspack_get_color_contrast( $header_color );
+	$colors = newspack_get_colors();
 
 	$theme_css = '';
 
@@ -60,13 +32,13 @@ function newspack_custom_colors_css() {
 			.comment .comment-author .post-author-badge,
 			.woocommerce .onsale,
 			.woocommerce-store-notice {
-				background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+				background-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 			}
 
 			@media only screen and (min-width: 782px) {
 				/* Header default background */
 				.h-db .featured-image-beside {
-					background-color: ' . esc_html( $primary_color ) . ';
+					background-color: ' . esc_attr( $colors['primary'] ) . ';
 				}
 			}
 
@@ -81,7 +53,7 @@ function newspack_custom_colors_css() {
 			.comment .comment-metadata .comment-edit-link:hover,
 			.site-info a:hover,
 			.comments-toggle:hover, .comments-toggle:focus {
-				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+				color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 			}
 
 			/* Set primary color */
@@ -93,7 +65,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color blockquote.has-primary-color p,
 			.is-style-outline .wp-block-button__link.has-primary-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
-				color: ' . esc_html( $primary_color ) . ';
+				color: ' . esc_attr( $colors['primary'] ) . ';
 			}
 
 			/* Set color that contrasts against the primary color */
@@ -112,14 +84,14 @@ function newspack_custom_colors_css() {
 			div.wpbnbd.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label,
 			.woocommerce .onsale,
 			.woocommerce-store-notice {
-				color: ' . esc_html( $primary_color_contrast ) . ';
+				color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 			}
 
 			@media only screen and (min-width: 782px) {
 				/* Header default background */
 				.h-db .featured-image-beside .entry-header,
 				.h-db.h-sub.single-featured-image-beside .middle-header-contain {
-					color: ' . esc_html( $primary_color_contrast ) . ';
+					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 				}
 			}
 
@@ -131,21 +103,21 @@ function newspack_custom_colors_css() {
 			.woocommerce-tabs ul li.active a,
 			.has-primary-border-color,
 			.wp-block-pullquote.has-primary-border-color {
-				border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+				border-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 			}
 
 			.sponsor-uw-info {
-				border-left-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+				border-left-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 			}
 
 			.mobile-sidebar nav + nav,
 			.mobile-sidebar nav + .widget,
 			.mobile-sidebar .widget + .widget {
-				border-color: ' . esc_html( $primary_color_contrast ) . ';
+				border-color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 			}
 
 			.gallery-item > div > a:focus {
-				box-shadow: 0 0 0 2px ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+				box-shadow: 0 0 0 2px ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 			}
 
 			/* Set secondary background color */
@@ -162,7 +134,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"] .has-secondary-background-color,
 			*[class^="wp-block-"].is-style-solid-color.has-secondary-background-color,
 			.is-style-outline .wp-block-button__link.has-secondary-background-color:not( :hover ) {
-				background-color:' . esc_html( $secondary_color ) . '; /* base: #666 */
+				background-color:' . esc_attr( $colors['secondary'] ) . '; /* base: #666 */
 			}
 
 			/* Set colour that contrasts against the secondary background */
@@ -173,11 +145,11 @@ function newspack_custom_colors_css() {
 			input[type="button"],
 			input[type="reset"],
 			input[type="submit"] {
-				color: ' . esc_html( $secondary_color_contrast ) . ';
+				color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 			}
 
 			input[type="checkbox"]::before {
-				background-image: url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' width=\'24\' height=\'24\'%3E%3Cpath d=\'M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z\' fill=\'' . esc_html( $secondary_color_contrast ) . '\'%3E%3C/path%3E%3C/svg%3E");
+				background-image: url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' width=\'24\' height=\'24\'%3E%3Cpath d=\'M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z\' fill=\'' . esc_attr( $colors['secondary_contrast'] ) . '\'%3E%3C/path%3E%3C/svg%3E");
 			}
 
 			/* Set secondary color */
@@ -190,7 +162,7 @@ function newspack_custom_colors_css() {
 			.is-style-outline .wp-block-button__link.has-secondary-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-secondary-color:not(:hover),
 			.is-style-outline > .wp-block-button__link:not(.has-text-color):not(:hover) {
-				color:' . esc_html( $secondary_color ) . '; /* base: #666 */
+				color:' . esc_attr( $colors['secondary'] ) . '; /* base: #666 */
 			}
 
 			/* Set secondary color with contrast */
@@ -199,13 +171,13 @@ function newspack_custom_colors_css() {
 			.author-bio .author-link,
 			.is-style-outline .wp-block-button__link, /* legacy selector */
 			.wp-block-button__link.is-style-outline {
-				color:' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
+				color:' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
 			}
 
 			/* Set secondary border color */
 			.has-secondary-border-color,
 			.wp-block-pullquote.has-secondary-border-color {
-				border-color:' . esc_html( $secondary_color ) . ';
+				border-color:' . esc_attr( $colors['secondary'] ) . ';
 			}
 
 			/* Set primary variation background color */
@@ -214,7 +186,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"] .has-primary-variation-background-color,
 			*[class^="wp-block-"].is-style-solid-color.has-primary-variation-background-color,
 			.is-style-outline .wp-block-button__link.has-primary-variation-background-color:not( :hover )  {
-				background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . '; /* base: #005177; */
+				background-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . '; /* base: #005177; */
 			}
 
 			/* Set primary variation color */
@@ -233,13 +205,13 @@ function newspack_custom_colors_css() {
 			#cancel-comment-reply-link:hover,
 			.is-style-outline .wp-block-button__link.has-primary-variation-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-primary-variation-color:not(:hover) {
-				color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . '; /* base: #0073a8; */
+				color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -40 ) ) . '; /* base: #0073a8; */
 			}
 
 			/* Set primary variation border color */
 			.has-primary-variation-border-color,
 			.wp-block-pullquote.has-primary-variation-border-color {
-				border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+				border-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
 			}
 
 			/* Set secondary variation background color */
@@ -250,7 +222,7 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color.has-secondary-variation-background-color,
 			.is-style-outline .wp-block-button__link.has-secondary-variation-background-color:not( :hover ),
 			#ship-to-different-address label input[type="checkbox"]:checked + span::before {
-				background-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+				background-color:' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . '; /* base: #666 */
 			}
 
 			/* Set secondary variation color */
@@ -265,29 +237,29 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color blockquote.has-secondary-variation-color p,
 			.is-style-outline .wp-block-button__link.has-secondary-variation-color:not(:hover), /* legacy styles */
 			.wp-block-button__link.is-style-outline.has-secondary-variation-color:not(:hover){
-				color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #666 */
+				color:' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . '; /* base: #666 */
 			}
 
 			/* Set secondary border */
 			#ship-to-different-address label input[type="checkbox"]:checked + span::before,
 			.has-secondary-variation-border-color,
 			.wp-block-pullquote.has-secondary-variation-border-color {
-				border-color:' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ';
+				border-color:' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . ';
 			}
 
 			/* Set gradients */
 			.has-grad-1-gradient-background {
-				background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
+				background-image: linear-gradient( 135deg, ' . esc_attr( $colors['primary'] ) . ' 0%, ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -40 ) ) . ' 100% );
 			}
 			.has-grad-2-gradient-background {
-				background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
+				background-image: linear-gradient( 135deg, ' . esc_attr( $colors['secondary'] ) . ' 0%, ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . ' 100% );
 			}
 			';
 
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
 				.mobile-sidebar {
-					background: ' . esc_html( $header_color ) . ';
+					background: ' . esc_attr( $colors['header'] ) . ';
 				}
 
 				.mobile-sidebar,
@@ -296,29 +268,29 @@ function newspack_custom_colors_css() {
 				.mobile-sidebar a:visited,
 				.mobile-sidebar .nav1 .sub-menu > li > a,
 				.mobile-sidebar .nav1 ul.main-menu > li > a {
-					color: ' . esc_html( $header_color_contrast ) . ';
+					color: ' . esc_attr( $colors['header_contrast'] ) . ';
 				}
 			';
 
-			if ( isset( $primary_menu_color ) && '' !== $primary_menu_color ) {
+			if ( isset( $colors['primary_menu'] ) && '' !== $colors['primary_menu'] ) {
 				$theme_css .= '
 					.h-sb .bottom-header-contain {
-						background: ' . esc_html( $primary_menu_color ) . ';
+						background: ' . esc_attr( $colors['primary_menu'] ) . ';
 					}
 
 					.h-sb .bottom-header-contain .nav1 .main-menu > li,
 					.h-sb .bottom-header-contain .nav1 .main-menu > li > a,
 					.h-sb .bottom-header-contain #search-toggle {
-						color: ' . esc_html( $primary_menu_color_contrast ) . ';
+						color: ' . esc_attr( $colors['primary_menu_contrast'] ) . ';
 					}
 				';
 			}
 		}
 
-		if ( isset( $footer_color ) && '' !== $footer_color ) {
+		if ( isset( $colors['footer'] ) && '' !== $colors['footer'] ) {
 			$theme_css .= '
 				.site-footer {
-					background: ' . esc_html( $footer_color ) . ';
+					background: ' . esc_attr( $colors['footer'] ) . ';
 				}
 
 				.site-footer,
@@ -327,7 +299,7 @@ function newspack_custom_colors_css() {
 				.site-footer .widget-title,
 				.site-footer .widgettitle,
 				.site-info {
-					color: ' . esc_html( $footer_color_contrast ) . ';
+					color: ' . esc_attr( $colors['footer_contrast'] ) . ';
 				}
 
 				.site-footer a:hover,
@@ -337,7 +309,7 @@ function newspack_custom_colors_css() {
 
 				.site-info .widget-area .wrapper,
 				.site-info .site-info-contain:first-child {
-					border-top-color: ' . esc_html( newspack_adjust_brightness( $footer_color, -20 ) ) . ';
+					border-top-color: ' . esc_attr( newspack_adjust_brightness( $colors['footer'], -20 ) ) . ';
 				}
 			';
 		}
@@ -348,49 +320,49 @@ function newspack_custom_colors_css() {
 					background: transparent;
 				}
 				.mobile-sidebar .nav3 .menu-highlight a {
-					background: ' . esc_html( newspack_adjust_brightness( $primary_color, -20 ) ) . ';
+					background: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -20 ) ) . ';
 				}
 				.mobile-sidebar .accent-header,
 				.mobile-sidebar .article-section-title {
-					border-color: ' . newspack_adjust_brightness( $header_color, -20 ) . ';
-					color: ' . esc_html( $header_color_contrast ) . ';
+					border-color: ' . newspack_adjust_brightness( $colors['header'], -20 ) . ';
+					color: ' . esc_attr( $colors['header_contrast'] ) . ';
 				}
 				.cat-links a,
 				.cat-links a:visited,
 				.site-header .nav3 .menu-highlight a,
 				.subpage-sidebar .nav3 .menu-highlight a {
-					background-color: ' . esc_html( $primary_color ) . ';
-					color: ' . esc_html( $primary_color_contrast ) . ';
+					background-color: ' . esc_attr( $colors['primary'] ) . ';
+					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 				}
 				.cat-links a:hover {
-					background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-					color: ' . esc_html( $primary_color_contrast ) . ';
+					background-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -40 ) ) . ';
+					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 				}
 				.accent-header,
 				#secondary .widgettitle,
 				.article-section-title,
 				.entry .entry-footer a:hover {
-					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+					color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 				}
 			';
 
 			if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 				$theme_css .= '
 					.mobile-sidebar .nav3 .menu-highlight a {
-						background: ' . esc_html( newspack_adjust_brightness( $header_color, -20 ) ) . ';
+						background: ' . esc_attr( newspack_adjust_brightness( $colors['header'], -20 ) ) . ';
 					}
 					.h-sb .site-header .nav3 a {
-						background-color: ' . newspack_adjust_brightness( $header_color, -17 ) . ';
-						color: ' . esc_html( $header_color_contrast ) . ';
+						background-color: ' . newspack_adjust_brightness( $colors['header'], -17 ) . ';
+						color: ' . esc_attr( $colors['header_contrast'] ) . ';
 					}
 					.h-sb .site-header .nav3 .menu-highlight a {
-						background-color: ' . $secondary_color . ';
-						color: ' . esc_html( $secondary_color_contrast ) . ';
+						background-color: ' . $colors['secondary'] . ';
+						color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 					}
 				';
 			}
 
-			if ( isset( $footer_color ) && '' !== $footer_color ) {
+			if ( isset( $colors['footer'] ) && '' !== $colors['footer'] ) {
 				$theme_css .= '
 					.site-footer .footer-branding .wrapper,
 					.site-footer .footer-widgets:first-child .wrapper {
@@ -399,12 +371,12 @@ function newspack_custom_colors_css() {
 
 					.site-footer .accent-header,
 					.site-footer .article-section-title {
-						border-color: ' . newspack_adjust_brightness( $footer_color, -20 ) . ';
+						border-color: ' . newspack_adjust_brightness( $colors['footer'], -20 ) . ';
 					}
 
 					.site-footer .accent-header,
 					.site-footer .article-section-title {
-						color: ' . esc_html( $footer_color_contrast ) . ';
+						color: ' . esc_attr( $colors['footer_contrast'] ) . ';
 					}
 				';
 			}
@@ -415,13 +387,13 @@ function newspack_custom_colors_css() {
 				.archive .page-title,
 				.entry-meta .byline a,
 				.entry-meta .byline a:visited {
-					color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+					color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 				}
 
 				.entry-meta .byline a:hover,
 				.entry-meta .byline a:visited:hover,
 				footer.entry-footer a {
-					color: ' . esc_html( newspack_color_with_contrast( newspack_adjust_brightness( $primary_color, -40 ) ) ) . ';
+					color: ' . esc_attr( newspack_color_with_contrast( newspack_adjust_brightness( $colors['primary'], -40 ) ) ) . ';
 				}
 			';
 
@@ -429,11 +401,11 @@ function newspack_custom_colors_css() {
 				$theme_css .= '
 					/* Header solid background */
 					.h-sb .middle-header-contain {
-						background-color: ' . esc_html( $header_color ) . ';
+						background-color: ' . esc_attr( $colors['header'] ) . ';
 					}
 					.h-sb .top-header-contain {
-						background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -10 ) ) . ';
-						border-bottom-color: ' . esc_html( newspack_adjust_brightness( $header_color, -15 ) ) . ';
+						background-color: ' . esc_attr( newspack_adjust_brightness( $colors['header'], -10 ) ) . ';
+						border-bottom-color: ' . esc_attr( newspack_adjust_brightness( $colors['header'], -15 ) ) . ';
 					}
 					.h-sb .site-header,
 					.h-sb .site-title,
@@ -446,7 +418,7 @@ function newspack_custom_colors_css() {
 					.h-sb.h-sh .site-header .nav1 ul.main-menu > li > a:hover,
 					.h-sb .top-header-contain,
 					.h-sb .middle-header-contain {
-						color: ' . esc_html( $header_color_contrast ) . ';
+						color: ' . esc_attr( $colors['header_contrast'] ) . ';
 					}
 				';
 			}
@@ -454,13 +426,13 @@ function newspack_custom_colors_css() {
 	}
 
 	// Front-end colors that don't require the theme_colors to be set to 'custom':
-	if ( newspack_get_mobile_cta_color() !== $cta_color ) {
+	if ( newspack_get_mobile_cta_color() !== $colors['cta'] ) {
 		$theme_css .= '
 			.button.mb-cta,
 			.button.mb-cta:not(:hover):visited,
 			.tribe_community_edit .button.mb-cta {
-				background-color: ' . esc_html( $cta_color ) . ';
-				color: ' . esc_html( $cta_color_contrast ) . ';
+				background-color: ' . esc_attr( $colors['cta'] ) . ';
+				color: ' . esc_attr( $colors['cta_contrast'] ) . ';
 			}
 		';
 	}
@@ -474,7 +446,7 @@ function newspack_custom_colors_css() {
 			.newspack_global_ad.global_above_header,
 			.widget_newspack-ads-widget,
 			div[class*="newspack-ads-blocks-ad-unit"] {
-				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
+				background-color: ' . esc_attr( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
 			}
 		';
 	}
@@ -489,13 +461,13 @@ function newspack_custom_colors_css() {
 		 */
 
 		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . '; /* base: #0073a8; */
+			color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-quote:not(.is-large):not(.is-style-large),
 		.editor-styles-wrapper .block-editor-block-list__layout .wp-block-freeform blockquote,
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-border-color {
-			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+			border-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button, /* legacy */
@@ -503,69 +475,69 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
-			background-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+			background-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
 		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate.tiered .wp-block-newspack-blocks-donate__tiers input[type="radio"]:checked + .tier-select-label {
-			color: ' . esc_html( $primary_color_contrast ) . ';
+			color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-color, /* legacy */
 		.edit-post-visual-editor .editor-styles-wrapper .has-primary-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-color {
-			color: ' . esc_html( $primary_color ) . ';
+			color: ' . esc_attr( $colors['primary'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-color, /* legacy */
 		.edit-post-visual-editor .editor-styles-wrapper .has-primary-variation-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-color {
-			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+			color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-background-color {
-			background-color: ' . esc_html( $primary_color ) . ';
+			background-color: ' . esc_attr( $colors['primary'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-background-color {
-			background-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+			background-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-border-color {
-			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -30 ) ) . ';
+			border-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
 		}
 
 		/* Secondary color */
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-background),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
-			background-color: ' . esc_html( $secondary_color ) . '; /* base: #0073a8; */
+			background-color: ' . esc_attr( $colors['secondary'] ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-text-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
-			color: ' . esc_html( $secondary_color_contrast ) . '; /* base: #0073a8; */
+			color: ' . esc_attr( $colors['secondary_contrast'] ) . '; /* base: #0073a8; */
 		}
 
 		/* Hover colors */
 		.block-editor-block-list__layout .block-editor-block-list__block a:hover,
 		.block-editor-block-list__layout .block-editor-block-list__block a:active,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink:hover {
-			color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . '; /* base: #005177; */
+			color: ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . '; /* base: #005177; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block a,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link:not(.has-text-color), /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link:not(.has-text-color),
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink {
-			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
+			color: ' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
 		}
 
 		/* Do not overwrite solid color pullquote or cover links */
@@ -584,44 +556,44 @@ function newspack_custom_colors_css() {
 		.edit-post-visual-editor .editor-styles-wrapper .has-secondary-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-color {
-			color: ' . esc_html( $secondary_color ) . ';
+			color: ' . esc_attr( $colors['secondary'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-border-color {
-			border-color: ' . esc_html( $secondary_color ) . ';
+			border-color: ' . esc_attr( $colors['secondary'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-color, /* legacy */
 		.edit-post-visual-editor .editor-styles-wrapper .has-secondary-variation-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-color {
-			color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+			color: ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -30 ) ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-background-color {
-			background-color: ' . esc_html( $secondary_color ) . ';
+			background-color: ' . esc_attr( $colors['secondary'] ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-background-color,
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-secondary-variation-background-color, /* legacy selector */
 		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-secondary-variation-background-color {
-			background-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+			background-color: ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -30 ) ) . ';
 		}
 
 		.edit-post-visual-editor.editor-styles-wrapper .has-secondary-variation-border-color {
-			border-color: ' . esc_html( newspack_adjust_brightness( $secondary_color, -30 ) ) . ';
+			border-color: ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -30 ) ) . ';
 		}
 
 		/* Set gradients */
 		.editor-styles-wrapper .wp-block.has-grad-1-gradient-background,
 		.editor-styles-wrapper .wp-block .has-grad-1-gradient-background {
-			background-image: linear-gradient( 135deg, ' . esc_html( $primary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ' 100% );
+			background-image: linear-gradient( 135deg, ' . esc_attr( $colors['primary'] ) . ' 0%, ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -40 ) ) . ' 100% );
 		}
 		.editor-styles-wrapper .wp-block.has-grad-2-gradient-background,
 		.editor-styles-wrapper .wp-block .has-grad-2-gradient-background {
-			background-image: linear-gradient( 135deg, ' . esc_html( $secondary_color ) . ' 0%, ' . esc_html( newspack_adjust_brightness( $secondary_color, -40 ) ) . ' 100% );
+			background-image: linear-gradient( 135deg, ' . esc_attr( $colors['secondary'] ) . ' 0%, ' . esc_attr( newspack_adjust_brightness( $colors['secondary'], -40 ) ) . ' 100% );
 		}
 		';
 
@@ -630,7 +602,7 @@ function newspack_custom_colors_css() {
 			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
 			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
 			.block-editor-block-list__layout .block-editor-block-list__block.accent-header {
-				color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
+				color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 			}
 		';
 	}
@@ -638,7 +610,7 @@ function newspack_custom_colors_css() {
 	if ( 'default' !== get_theme_mod( 'ads_color', 'default' ) ) {
 		$editor_css .= '
 			.wp-block-newspack-ads-blocks-ad-unit > div {
-				background-color: ' . esc_html( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
+				background-color: ' . esc_attr( get_theme_mod( 'ads_color_hex', '#ffffff' ) ) . ';
 				padding: 8px;
 			}
 		';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -41,19 +41,6 @@ function newspack_custom_colors_css() {
 
 	$theme_css = '';
 
-	/** Add color global variables */
-	$colors     = [
-		'primary'   => $primary_color,
-		'secondary' => $secondary_color,
-		'cta'       => $cta_color,
-		'header'    => $header_color,
-	];
-	$theme_css .= ':root {';
-	foreach ( $colors as $color_key => $color_value ) {
-		$theme_css .= "\t--newspack-{$color_key}-color: {$color_value};\n";
-	}
-	$theme_css .= '}';
-
 	// Front-end colors that require the theme_colors to be set to 'custom':
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$theme_css .= '

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -41,6 +41,19 @@ function newspack_custom_colors_css() {
 
 	$theme_css = '';
 
+	/** Add color global variables */
+	$colors     = [
+		'primary'   => $primary_color,
+		'secondary' => $secondary_color,
+		'cta'       => $cta_color,
+		'header'    => $header_color,
+	];
+	$theme_css .= ':root {';
+	foreach ( $colors as $color_key => $color_value ) {
+		$theme_css .= "\t--newspack-{$color_key}-color: {$color_value};\n";
+	}
+	$theme_css .= '}';
+
 	// Front-end colors that require the theme_colors to be set to 'custom':
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$theme_css .= '


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces root CSS variables for the theme's colors and 2 action hooks placed before and after the header mobile menu toggle.

### How to test the changes in this Pull Request:

Further details and instructions at https://github.com/Automattic/newspack-plugin/pull/1754

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
