### PR TITLE
Feature: Add option to re-allow FSE blocks

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -603,6 +603,9 @@ add_action( 'enqueue_block_editor_assets', 'newspack_enqueue_scripts' );
 
 /**
  * Check for additional allowed blocks
+ * 
+ * Add this flag to the wp-config.php to allow more blocks, formatted in a array --
+ * for example: `define( 'NEWSPACK_FSE_BLOCKS_ALLOWED', ['core/avatar', 'core/loginout'] );`
  *
  * @return array List of allowed FSE blocks.
  */

--- a/newspack-theme/js/src/editor-remove-blocks.js
+++ b/newspack-theme/js/src/editor-remove-blocks.js
@@ -3,28 +3,8 @@
 import { unregisterBlockType } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 
-const removeBlocks = [
-	'core/loginout',
-	// Comments
-	'core/post-comments-form',
-	'core/comments-query-loop',
-	// Post Query
-	'core/query', // query loop and posts list
-	'core/post-title',
-	'core/post-featured-image',
-	'core/post-excerpt',
-	'core/post-content',
-	'core/post-terms', // post categories and tags
-	'core/post-date',
-	'core/post-author',
-	'core/post-navigation-link', // previous and next links
-	'core/read-more',
-	'core/avatar',
-	'core/post-author-biography',
-	// Archives
-	'core/query-title', // archive title
-	'core/term-description',
-];
+// eslint-disable-next-line no-undef
+const removeBlocks = updateAllowedBlocks.removeblocks.split( ',' );
 
 domReady( function () {
 	removeBlocks.forEach( function ( blockName ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the ability to "allow" FSE blocks on certain sites, using an environmental variable. Re-allowed FSE blocks are listed in an array, and removed from the list of blocks to dequeue; the list of blocks to dequeue is passed to the JavaScript file using <a href="https://developer.wordpress.org/reference/functions/wp_localize_script/">`wp_localize_script`</a>, a function normally used to pass translations from PHP to JavaScript in an associative array.

Note: this is my first swing at something like this, so if I've taken a route that is making you scratch your head, just let me know 🙂 There's some discussion around how to handle this update in this Slack thread: p1656363263749809-slack-newspack-private-v2. 

Closes #1864

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`. 
2. Retest some of the removed blocks listed in #1827 and make sure they still can't be added. 
3. In the wp-config.php, add a `NEWSPACK_FSE_BLOCKS_ALLOWED` flag and pass it an array of FSE blocks you'd like to allow, following the format `core/blockslug` -- you can also find a list in this PR in the `newspack_fse_blocks_to_remove()` function. A couple examples could be:
* `define( 'NEWSPACK_FSE_BLOCKS_ALLOWED', ['core/avatar'] );`
* `define( 'NEWSPACK_FSE_BLOCKS_ALLOWED', ['core/loginout', 'core/query'] );`
4. Re-test in the editor and try to add one of the blocks you've "allowed" -- it should now let you insert that block.
5. Re-test in the editor and try to add one of the blocks that still shouldn't be "allowed" -- it should still not allow you to use that block. 
6. Try passing some nonsense/incorrectly formatted values to `NEWSPACK_FSE_BLOCKS_ALLOWED` to make sure it ignores them and the block removal continues to work as usual. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
