### PR TITLE
feat: Add featured listing styles

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -148,6 +148,16 @@ function newspack_custom_colors_css() {
 				box-shadow: 0 0 0 2px ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
 			}
 
+			.wpnbha .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+			.wpnbpc .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+			.archive .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+			.search .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+			.blog .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+			.newspack-listings__curated-list .featured-listing .newspack-listings__listing-title::before {
+				border-left-color: ' . esc_html( $primary_color ) . ';
+				border-right-color: ' . esc_html( $primary_color ) . ';
+			}
+
 			/* Set secondary background color */
 
 			.wp-block-button__link:not(.has-background),
@@ -496,6 +506,13 @@ function newspack_custom_colors_css() {
 		.editor-styles-wrapper .block-editor-block-list__layout .wp-block-freeform blockquote,
 		.edit-post-visual-editor.editor-styles-wrapper .has-primary-border-color {
 			border-color: ' . esc_html( $primary_color ) . '; /* base: #0073a8; */
+		}
+
+		.editor-styles-wrapper .block-editor-block-list__block .wpnbha .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+		.editor-styles-wrapper .block-editor-block-list__block .wpnbpc .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
+		.editor-styles-wrapper .block-editor-block-list__block .newspack-listings__curated-list .featured-listing .newspack-listings__listing-title::before {
+			border-left-color: ' . esc_html( $primary_color ) . ';
+			border-right-color: ' . esc_html( $primary_color ) . ';
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button, /* legacy */

--- a/newspack-theme/sass/plugins/newspack-listings.scss
+++ b/newspack-theme/sass/plugins/newspack-listings.scss
@@ -19,6 +19,7 @@
 		border: 0.25em solid colors.$color__primary; // half the width
 		border-top: 0;
 		border-bottom: 6px solid transparent; // the 'cut in'
+		box-sizing: border-box;
 		content: '';
 		display: inline-block;
 		height: 0.8em;

--- a/newspack-theme/sass/plugins/newspack-listings.scss
+++ b/newspack-theme/sass/plugins/newspack-listings.scss
@@ -16,9 +16,9 @@
 .blog .featured-listing[class*='type-newspack_lst_'] .entry-title a,
 .newspack-listings__curated-list .featured-listing .newspack-listings__listing-title {
 	&::before {
-		border: 0.25em solid colors.$color__primary; // half the width
+		border: calc( 0.25em + 1px ) solid colors.$color__primary; // half the width
 		border-top: 0;
-		border-bottom: 6px solid transparent; // the 'cut in'
+		border-bottom-color: transparent; // the 'cut in'
 		box-sizing: border-box;
 		content: '';
 		display: inline-block;

--- a/newspack-theme/sass/plugins/newspack-listings.scss
+++ b/newspack-theme/sass/plugins/newspack-listings.scss
@@ -1,8 +1,30 @@
+@use '../variables-site/colors';
+
 // Listings
 .newspack-listings {
 	&.hide-date.hide-author {
 		.entry-subhead {
 			padding: 0;
 		}
+	}
+}
+
+.wpnbha .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.wpnbpc .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.archive .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.search .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.blog .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.newspack-listings__curated-list .featured-listing .newspack-listings__listing-title {
+	&::before {
+		border: 0.25em solid colors.$color__primary; // half the width
+		border-top: 0;
+		border-bottom: 6px solid transparent; // the 'cut in'
+		content: '';
+		display: inline-block;
+		height: 0.8em;
+		margin-right: 0.3em;
+		position: relative;
+		top: 0.05em;
+		width: 0.5em;
 	}
 }

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -1270,9 +1270,9 @@ ul.wp-block-archives,
 .wpnbpc .featured-listing[class*='type-newspack_lst_'] .entry-title a,
 .newspack-listings__curated-list .featured-listing .newspack-listings__listing-title {
 	&::before {
-		border: 0.25em solid colors.$color__primary; // half the width
+		border: calc( 0.25em + 1px ) solid colors.$color__primary; // half the width
 		border-top: 0;
-		border-bottom: 6px solid transparent; // the 'cut in'
+		border-bottom-color: transparent; // the 'cut in'
 		box-sizing: border-box;
 		content: '';
 		display: inline-block;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -1265,6 +1265,25 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Newspack Listings === */
+.wpnbha .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.wpnbpc .featured-listing[class*='type-newspack_lst_'] .entry-title a,
+.newspack-listings__curated-list .featured-listing .newspack-listings__listing-title {
+	&::before {
+		border: 0.25em solid colors.$color__primary; // half the width
+		border-top: 0;
+		border-bottom: 6px solid transparent; // the 'cut in'
+		box-sizing: border-box;
+		content: '';
+		display: inline-block;
+		height: 0.8em;
+		margin-right: 0.3em;
+		position: relative;
+		top: 0.05em;
+		width: 0.5em;
+	}
+}
+
 /** === Classic Editor === */
 
 /* Properly center-align captions in the classic-editor block */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR contains a first swing at the featured listing styles for the Newspack theme. 

I think it made sense to tackle them in the theme rather than the plugin because the styles might differ from theme to theme, and that the styles are applied to blocks in two different plugins (Newspack Blocks, Newspack Listings), on top of the archive and search styles in the theme. Happy to discuss that further if moving them makes sense though!

See https://github.com/Automattic/newspack-listings/issues/131.

### How to test the changes in this Pull Request:

1. Enable Featured Listings on your test site by adding `define( 'NEWSPACK_LISTINGS_FEATURED_ENABLED', true );` to your wp-config.php file. 
2. Create a number of listings and mark some as 'Featured'.
3. Add the Homepage Posts block, Post Carousel Block and Curated List Listings block; make sure at least one Featured listing appears in all three. 
4. Navigate to Customizer > Colors and change your primary colour. 
5. View your post on the front-end and in the editor; confirm that your featured listings have a little "ribbon" icon that uses the site's primary colour:

Homepage Posts block: 

![image](https://user-images.githubusercontent.com/177561/178581274-73e4c9c5-87e6-4b18-bac2-fc22f74e54e2.png)

Post Carousel:

![image](https://user-images.githubusercontent.com/177561/178581206-aa75b5e2-d4bb-4f5a-a730-c78068abdcd9.png)

Curated List (note: the featured image classes are not yet added to the curated list block in the editor; issue filed [here](https://github.com/Automattic/newspack-listings/issues/282)). 

![image](https://user-images.githubusercontent.com/177561/178581154-8a68252d-c402-4334-b3fe-852957e1b51a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
