### PR TITLE
fix(registration-block): make sure font-family in the editor matches front-end

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -323,6 +323,9 @@ function newspack_custom_typography_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .wpbnbd .tier-label,
 		.block-editor-block-list__layout .block-editor-block-list__block .wpbnbd button,
 
+		/* Reader Registration Block */
+		.block-editor-block-list__layout .block-editor-block-list__block .newspack-registration button,
+
 		/* Classic Editor */
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-caption dd,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-freeform blockquote cite

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -1256,6 +1256,11 @@ ul.wp-block-archives,
 	font-family: fonts.$font__heading;
 }
 
+/** === Reader Registration Block === */
+.newspack-registration button {
+	font-family: fonts.$font__heading;
+}
+
 /** === Ad Unit Block === */
 .wp-block-newspack-ads-blocks-ad-unit {
 	> div {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Making sure the correct font-family is applied to the submit button in the editor.

### How to test the changes in this Pull Request:

1. Open the editor and insert a Reader Registration block
2. Check the font on the submit button
3. Publish page and check the front-end
4. The submit button should have a different font
5. Switch to this branch
6. Refresh the editor
7. Fonts should match

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
