### PR TITLE
fix: use proper variable and escape function for primary color

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -34,7 +34,7 @@ function newspack_custom_colors_css() {
 			.woocommerce-store-notice,
 			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a,
 			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a {
-				background-color: ' . esc_html( $colors['primary'] ) . '; /* base: #0073a8; */
+				background-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 			}
 
 			@media only screen and (min-width: 782px) {
@@ -59,7 +59,7 @@ function newspack_custom_colors_css() {
 			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover:visited,
 			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover,
 			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover:visited {
-				color: ' . esc_html( newspack_color_with_contrast( $colors['primary'] ) ) . ';
+				color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 			}
 
 			/* Set primary color */
@@ -92,7 +92,7 @@ function newspack_custom_colors_css() {
 			.woocommerce-store-notice,
 			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a,
 			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a {
-				color: ' . esc_html( $colors['primary_contrast'] ) . ';
+				color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 			}
 
 			@media only screen and (min-width: 782px) {
@@ -134,8 +134,8 @@ function newspack_custom_colors_css() {
 			.search .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
 			.blog .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
 			.newspack-listings__curated-list .featured-listing .newspack-listings__listing-title::before {
-				border-left-color: ' . esc_html( $primary_color ) . ';
-				border-right-color: ' . esc_html( $primary_color ) . ';
+				border-left-color: ' . esc_attr( $colors['primary'] ) . ';
+				border-right-color: ' . esc_attr( $colors['primary'] ) . ';
 			}
 
 			/* Set secondary background color */
@@ -491,8 +491,8 @@ function newspack_custom_colors_css() {
 		.editor-styles-wrapper .block-editor-block-list__block .wpnbha .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
 		.editor-styles-wrapper .block-editor-block-list__block .wpnbpc .featured-listing[class*="type-newspack_lst_"] .entry-title a::before,
 		.editor-styles-wrapper .block-editor-block-list__block .newspack-listings__curated-list .featured-listing .newspack-listings__listing-title::before {
-			border-left-color: ' . esc_html( $primary_color ) . ';
-			border-right-color: ' . esc_html( $primary_color ) . ';
+			border-left-color: ' . esc_attr( $colors['primary'] ) . ';
+			border-right-color: ' . esc_attr( $colors['primary'] ) . ';
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button, /* legacy */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some places were still using the previous color definition. This PR updates the escape function and the proper variable.

### How to test the changes in this Pull Request:

1. On `alpha`, edit any post and confirm the variable warnings
2. Check out this branch and confirm the warnings are gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
