### PR TITLE
Donate Block: unset vertical alignment on the submit button

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -271,7 +271,6 @@ p.has-background {
 		margin-left: #{0.62 * structure.$size__spacing-unit};
 		margin-right: #{0.62 * structure.$size__spacing-unit};
 	}
-
 	.wpbnbd .thanks,
 	.wpbnbd button {
 		margin-left: structure.$size__spacing-unit;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -205,6 +205,11 @@ p.has-background {
 	}
 }
 
+//! Newspack Donate Block
+.wpbnbd button {
+	vertical-align: unset;
+}
+
 #secondary,
 .desktop-sidebar,
 .mobile-sidebar,
@@ -266,6 +271,7 @@ p.has-background {
 		margin-left: #{0.62 * structure.$size__spacing-unit};
 		margin-right: #{0.62 * structure.$size__spacing-unit};
 	}
+
 	.wpbnbd .thanks,
 	.wpbnbd button {
 		margin-left: structure.$size__spacing-unit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Newspack theme sets `vertical-align: bottom` on all button elements (`button`, `.button`, `input[type="button"]`...). I believe this was copied over when the theme was forked from Twenty Nineteen waaaay back when, so I'm not sure its exact purpose, but it's causing an alignment issue with the Donate block.

Rather than fully remove the style and possibly introduce other issues, this PR unsets the vertical alignment for the button when it appears in the Donate block.

Closes #1911.

### How to test the changes in this Pull Request:

1. Add a "standard" Donate block to a page (default style; using Newspack as the Reader Revenue platform).
2. Publish the page and view on the front-end -- note the alignment of the "thank you" text and the button (especially compared to the editor, where they are nicely vertically aligned):
![image](https://user-images.githubusercontent.com/177561/186719406-2189c747-7e3b-4321-a49f-c945df01b219.png)

3. Apply the PR and run `npm run build`.
4. Confirm that the thank you message and the button now appear to be lined up:

![image](https://user-images.githubusercontent.com/177561/186719527-8c735aed-e1a0-401d-ae80-5207f04ce702.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
