### PR TITLE
style: don’t rely on nested newspack-popup class name

### DIFF
--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -69,9 +69,7 @@
 
 		.newspack-lightbox & {
 			margin: -32px;
-		}
 
-		.newspack-lightbox & {
 			~ .popup-not-interested-form {
 				bottom: 0;
 				left: 0;
@@ -144,9 +142,7 @@
 
 		.newspack-lightbox & {
 			margin: -32px;
-		}
 
-		.newspack-lightbox & {
 			~ .popup-not-interested-form {
 				margin: 12px 0 0;
 				padding: 0 4px 4px;

--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -67,7 +67,7 @@
 			padding: 0;
 		}
 
-		.newspack-lightbox .newspack-popup > & {
+		.newspack-lightbox & {
 			margin: -32px;
 		}
 
@@ -142,7 +142,7 @@
 			padding: 0;
 		}
 
-		.newspack-lightbox .newspack-popup > & {
+		.newspack-lightbox & {
 			margin: -32px;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

To accommodate a class name change in https://github.com/Automattic/newspack-popups/pull/947.

### How to test the changes in this Pull Request:

1. Publish an overlay prompt with Subscribe pattern 7. Confirm on the front-end that it renders without a white border surrounding the content (image should be "full-bleed").
2. Repeat with Subscribe pattern 8.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
