### PR TITLE
Re-add support for Global Styles

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -666,31 +666,6 @@ function newspack_fse_blocks_to_remove() {
 }
 
 /**
- * Dequeue Gutenberg global styles.
- * 
- * These styles aren't currently used because Newspack is not a Full-Site editing theme.
- * 
- * @link: https://developer.wordpress.org/reference/functions/wp_enqueue_global_styles/
- */
-function newspack_dequeue_global_styles() {
-	wp_dequeue_style( 'global-styles' );
-}
-add_action( 'wp_enqueue_scripts', 'newspack_dequeue_global_styles' );
-
-/**
- * Dequeue Gutenberg global editor styles.
- * 
- * These styles aren't currently used because Newspack is not a Full-Site editing theme.
- * 
- * @link: https://developer.wordpress.org/reference/functions/wp_enqueue_global_styles_css_custom_properties/
- */
-function newspack_dequeue_global_editor_styles() {
-	wp_dequeue_style( 'global-styles-css-custom-properties' );
-}
-add_action( 'enqueue_block_editor_assets', 'newspack_dequeue_global_editor_styles' );
-
-
-/**
  * Fix skip link focus in IE11.
  *
  * This does not enqueue the script because it is tiny and because it is only for IE11,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -674,8 +674,8 @@ p.has-background {
 		&:hover,
 		&:active,
 		&:focus {
-			color: #fff;
-			background: colors.$color__background-button-hover;
+			color: #fff !important; // to override !important from Gutenberg styles
+			background: colors.$color__background-button-hover !important; // to override !important from Gutenberg styles
 		}
 
 		&:focus {
@@ -1287,17 +1287,6 @@ $colors: (
 	'medium-gray': #767676,
 	'light-gray': #eee,
 	'white': #fff,
-	'black': #000,
-	'cyan-bluish-gray': #abb8c3,
-	'pale-pink': #f78da7,
-	'vivid-red': #cf2e2e,
-	'luminous-vivid-orange': #ff6900,
-	'luminous-vivid-amber': #fcb900,
-	'light-green-cyan': #7bdcb5,
-	'vivid-green-cyan': #00d084,
-	'pale-cyan-blue': #8ed1fc,
-	'vivid-cyan-blue': #0693e3,
-	'vivid-purple': #9b51e0,
 );
 
 @each $name, $hex in $colors {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A few months ago I opted to fix an issue with new global styles coming from WordPress by [dequeuing them](https://github.com/Automattic/newspack-theme/pull/1724) and [recreating the styles in the theme](https://github.com/Automattic/newspack-theme/pull/1749).

Unfortunately, this fix looks to have been short-sighted: in the current version of the Gutenberg plugin some of the new global styles control the Gallery Block and the Row block. And with the ongoing progression of the block styles and FSE in Gutenberg, there's no reason to think that that'll be it. Rather than continuing to add new styles to the theme as they're added to Gutenberg, I think it makes sense to reverse course, and just override the `!important` styles when needed. 

So this PR:

* Re-adds the global styles coming from WordPress
* Removes the styles added to the theme that replaced the WordPress global styles (primarily all the different core colour styles)
* Fixes the original issue -- the button hover styles not being able to override some colour combinations -- by adding `!important` to the theme styles. The potential downside here is that if an existing site has added custom CSS to override the button block hover styles, they'll need to add `!important` to that. 

Closes #1897

### How to test the changes in this Pull Request:

1. Add the following blocks to the editor and publish the page:
     * A gallery block
     * A buttons block to the editor and add a few buttons; give at least one a white background and use one of the theme's colour palette colours for the text. 
     * A row block with a couple text blocks inside (eg. two short paragraph blocks). 

Alternatively, you can copy and paste this markup into the code view of the editor (it also includes some examples of blocks loading colours defined in the global styles).

<details>
<summary>Example blocks</summary>

```
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":3818,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-39-800x600.jpg" alt="" class="wp-image-3818"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3815,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-36-800x600.jpg" alt="" class="wp-image-3815"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3812,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-28-800x600.jpg" alt="" class="wp-image-3812"/><figcaption class="wp-element-caption">This is a caption <a href="#" target="_blank" rel="noopener">with a link</a></figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3809,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-12-800x600.jpg" alt="" class="wp-image-3809"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3808,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-14-800x600.jpg" alt="" class="wp-image-3808"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3803,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="https://scott.newspackstaging.com/wp-content/uploads/2020/01/automated_upload-27-800x600.jpg" alt="" class="wp-image-3803"/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary-variation","textColor":"white"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-white-color has-primary-variation-background-color has-text-color has-background wp-element-button" href="#">Example Button</a></div>
<!-- /wp:button -->

<!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="#">Example Button</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"white","textColor":"secondary-variation"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-secondary-variation-color has-white-background-color has-text-color has-background wp-element-button" href="#">Example Button</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"black","textColor":"secondary"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-secondary-color has-black-background-color has-text-color has-background wp-element-button" href="#">Example Button</a></div>
<!-- /wp:button -->

<!-- wp:button {"backgroundColor":"light-green-cyan","textColor":"black"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-black-color has-light-green-cyan-background-color has-text-color has-background wp-element-button" href="#">Example Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:group {"backgroundColor":"light-green-cyan"} -->
<div class="wp-block-group has-light-green-cyan-background-color has-background"><!-- wp:paragraph -->
<p>Group block - #7bdcb5 (light green cyan)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"20px"}}} -->
<h2 style="font-size:20px">This is a row block </h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>This is a row block</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"vivid-red"} -->
<div class="wp-block-group has-vivid-red-background-color has-background"><!-- wp:paragraph -->
<p>Group block - #cf2e2e (vivid red)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontSize":"20px"}}} -->
<h2 style="font-size:20px">This is a stacked block </h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>This is a row block</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"backgroundColor":"black"} -->
<div class="wp-block-group has-black-background-color has-background"><!-- wp:paragraph {"textColor":"white"} -->
<p class="has-white-color has-text-color">Group block - #000000</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details>

2. Install and activate the Gutenberg plugin.
3. View your page on the front end -- both the gallery and row block are stacked, but they shouldn't be:

![image](https://user-images.githubusercontent.com/177561/187554641-5a9c08c3-c06e-4204-98fa-ad1c0435503e.png)

![image](https://user-images.githubusercontent.com/177561/187554661-a5c44483-0ff4-417f-8640-e04a7ecc6d2c.png)

4. Apply the PR and run `npm run build`.
5. Refresh your page; confirm that the gallery and row block display issues are resolved.
6. Deactivate the Gutenberg plugin and retest your page, confirming there are no display issues. The big one is making sure all of the button block styles work correctly; the big one is making sure the white button and the green-ish button both become white text on black on hover -- this is confirming that the theme's hover styles are overriding the `!important` styles coming from WordPress's global styles.

**Note:** This PR is definitely fixing something that's not an issue yet, so I might be jumping the gun here -- I thought it'd be nice to get it out of the way if it can be fixed now without causing other issues, but if it seems too soon for any reason, let me know and I can switch it to a draft until it's necessary!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
