### PR TITLE
Footer: add option to toggle off branding

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -60,7 +60,8 @@ if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 
 					the_privacy_policy_link( '', '' );
 				}
 
-				if ( ( ! is_active_sidebar( 'footer-1' ) || ! has_custom_logo() ) || ! $show_footer_branding ) {
+
+				if ( ( ! is_active_sidebar( 'footer-1' ) || ! ( has_custom_logo() || $has_footer_logo ) ) || ! $show_footer_branding ) {
 					newspack_social_menu_footer();
 				}
 				?>

--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -9,6 +9,12 @@
  * @package Newspack
  */
 
+
+$show_footer_branding = get_theme_mod( 'footer_show_branding', true );
+$has_footer_logo = false;
+if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) {
+	$has_footer_logo = true;
+}
 ?>
 
 	<?php if ( is_active_sidebar( 'footer-3' ) ) : ?>
@@ -54,7 +60,7 @@
 					the_privacy_policy_link( '', '' );
 				}
 
-				if ( ! is_active_sidebar( 'footer-1' ) || ( ! has_custom_logo() ) ) {
+				if ( ! is_active_sidebar( 'footer-1' ) || ! $show_footer_branding || ! ( has_custom_logo() && $has_footer_logo ) ) {
 					newspack_social_menu_footer();
 				}
 				?>

--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -60,7 +60,7 @@ if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 
 					the_privacy_policy_link( '', '' );
 				}
 
-				if ( ! is_active_sidebar( 'footer-1' ) || ! $show_footer_branding || ! ( has_custom_logo() && $has_footer_logo ) ) {
+				if ( ( ! is_active_sidebar( 'footer-1' ) || ! has_custom_logo() ) || ! $show_footer_branding ) {
 					newspack_social_menu_footer();
 				}
 				?>

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1184,6 +1184,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to toggle off the footer branding.
+	$wp_customize->add_setting(
+		'footer_show_branding',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'footer_show_branding',
+		array(
+			'type'        => 'checkbox',
+			'label'       => esc_html__( 'Show footer branding', 'newspack' ),
+			'description' => esc_html__( 'Display the site logo in the footer when the footer widget area is populated.', 'newspack' ),
+			'section'     => 'footer_options',
+		)
+	);
+
 	// Add option to toggle off the default footer layout.
 	$wp_customize->add_setting(
 		'footer_widget_layout',

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -14,7 +14,7 @@
 	}
 
 	.footer-widgets {
-		padding: structure.$size__spacing-unit 0 #{2 * structure.$size__spacing-unit};
+		padding: structure.$size__spacing-unit 0 #{1.5 * structure.$size__spacing-unit};
 
 		.wrapper {
 			flex-wrap: wrap;
@@ -63,7 +63,6 @@
 
 	.custom-logo-link,
 	.footer-logo-link {
-		margin-bottom: structure.$size__spacing-unit;
 		max-height: 76px;
 		max-width: 200px;
 

--- a/newspack-theme/template-parts/footer/footer-branding.php
+++ b/newspack-theme/template-parts/footer/footer-branding.php
@@ -12,7 +12,7 @@ if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 
 	$has_footer_logo = true;
 }
 
-if ( is_active_sidebar( 'footer-1' ) && $show_footer_branding && ( has_custom_logo() || $has_footer_logo ) ) : ?>
+if ( is_active_sidebar( 'footer-1' ) && ( has_custom_logo() || $has_footer_logo ) && $show_footer_branding ) : ?>
 	<div class="footer-branding">
 		<div class="wrapper">
 			<?php if ( $has_footer_logo ) : ?>

--- a/newspack-theme/template-parts/footer/footer-branding.php
+++ b/newspack-theme/template-parts/footer/footer-branding.php
@@ -5,12 +5,14 @@
  * @package Newspack
  */
 
+
+$show_footer_branding = get_theme_mod( 'footer_show_branding', true );
 $has_footer_logo = false;
 if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 'newspack_footer_logo', '' ) ) {
 	$has_footer_logo = true;
 }
 
-if ( is_active_sidebar( 'footer-1' ) && ( has_custom_logo() || $has_footer_logo ) ) : ?>
+if ( is_active_sidebar( 'footer-1' ) && $show_footer_branding && ( has_custom_logo() || $has_footer_logo ) ) : ?>
 	<div class="footer-branding">
 		<div class="wrapper">
 			<?php if ( $has_footer_logo ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme uses the following behaviour for the footer branding and social links menu:

* If you don't have any footer widgets assigned, the footer logo does not display. The social links menu, if present, will appear in line with the website copyright at the very bottom.
* If you do have footer widgets assigned, the site logo (or footer logo) will appear at the top of the footer with the social links menu next to it. 

This doesn't work well with different footer layouts, especially with widget blocks -- it's not uncommon to hide the footer branding section with CSS, and then re-add the logo, social links, or both as blocks so they can be laid out differently. 

This PR adds a toggle to hide the "footer branding"; it overrides the default behaviour, rather than replacing it. If I could go back in time, I would've taken this approach to start, but unfortunately, that's hard to do now without affecting live sites. So: compromise! 🙂 

Closes #1185

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build.`
2. Navigate to Customizer > Footer Settings and confirm you now have an option to toggle off footer branding; it should be checked by default. 

![image](https://user-images.githubusercontent.com/177561/188982966-4ad4bc55-67aa-42e0-aff4-58a934ab8e62.png)


3. On your test site, if you don't already have the following, add a site logo, a social links menu, and at least one widget in the Footer area.
4. Confirm that your site has a logo in the footer, and the social links next to it:

![image](https://user-images.githubusercontent.com/177561/188982607-568d9642-aa86-4ea9-8927-1040108258e8.png)

5. Uncheck "Show footer branding" and save the Customizer settings.
6. Confirm that the footer logo is gone, and that the social links menu now appears at the very bottom in the right corner:

![image](https://user-images.githubusercontent.com/177561/188982902-a7b7ce6d-00bd-47ce-9f0d-c97473fa7148.png)

7. Re-check "Show footer branding".
8. Remove the site logo and confirm that the footer branding section doesn't display, and that the social links are in the bottom right corner.
9. Re-add the logo, and remove the footer widgets; confirm that the logo does not display, and the social links appear in the bottom right corner. 
10. Remove the site logo, and add a logo to the footer logo space instead; re-add the footer widgets and confirm that the branding appears at the top of the footer with the social links, until you uncheck "Show footer branding" again; at that point it should disappear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
