### PR TITLE
Print styles: fix issue with ad background colours, and improve styles hiding ads

### DIFF
--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -153,7 +153,6 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	// Ads
 	.newspack_global_ad,
 	.newspack_amp_sticky_ad,
-	.custom-ad-bg,
 	.newspack-ads-blocks-ad-unit,
 	.widget_newspack-ads-widget,
 	broadstreet-zone-container,
@@ -172,7 +171,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	#pico_header, 
 	#pico_prompt, 
 	#pico_launcher {
-		display: none;
+		display: none !important;
 	}
 	/* stylelint-enable */
 

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -151,12 +151,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.wc-memberships-frontend-banner,
 	#atomic-proxy-bar,
 	// Ads
-	.newspack_global_ad,
-	.newspack_amp_sticky_ad,
-	.newspack-ads-blocks-ad-unit,
 	.widget_newspack-ads-widget,
-	broadstreet-zone-container,
-	.bs_zones,
 	.scaip,
 	//Widgets
 	.widget-area,
@@ -167,11 +162,20 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	// Campaigns
 	.newspack-lightbox,
 	.newspack-popup,
-	.newspack-inline-popup,
-	#pico_header, 
-	#pico_prompt, 
+	.newspack-inline-popup {
+		display: none;
+	}
+
+	// Third-party elements to hide
+	broadstreet-zone-container,
+	.bs_zones,
+	.newspack_global_ad,
+	.newspack_amp_sticky_ad,
+	.newspack-ads-blocks-ad-unit,
+	#pico_header,
+	#pico_prompt,
 	#pico_launcher {
-		display: none !important;
+		display: none !important; // !important to override styles loaded after the theme's styles, or inline styles.
 	}
 	/* stylelint-enable */
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some issues with the recent print style updates in #1913: 

* It removed the `custom-ad-bg` class from the selectors that are hidden on print -- [this is actually added to the `<body>` tag when an ad background colour is set](https://github.com/Automattic/newspack-theme/blob/f46b79b5838286c2eef9758dfb5c7035eefbe607/newspack-theme/inc/template-functions.php#L248), causing the page content not to be printed 🤦‍♀️ Including this in the styles was entirely my fault.
* It also separates some of the ads spaces and Pico styles out into their own list, so `!important` could be appended to those ad styles without adding it to everything. The current styles aren't correctly hiding the ads, either because the ad styles are loaded after the print styles, or because the ads include their own inline `display` styles. 

(re) Closes #1910.

### How to test the changes in this Pull Request:

Ideally, this PR will be tested on a site running ads or Pico to make sure the `!important` styles work, but the primary issue it's fixing is removing `custom-ad-bg` from the mix, so if you can just test that, that's perfect! Steps for that below:

1. Start on a test site with Google Ad Manager enabled in the Newspack Wizard, even if you don't have a Network Code.
2. Navigate to Customizer > Colors, and turn on the Ads custom colours. 
3. Preview the print version of the site (either by viewing a print preview in the browser, or [these tricks](https://css-tricks.com/can-you-view-print-stylesheets-applied-directly-in-the-browser/) in dev tools (hattip @dkoo!). Note the page is blank.
4. Apply the PR and run `npm run build`.
5. Refresh the page and repeat step 3; confirm the print version is no longer blank.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
