### PR TITLE
Print styles: correct sticky header, Safari page width

### DIFF
--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -18,9 +18,9 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 @media print {
 	/* Margins */
 	#page {
-		max-width: 96%;
+		max-width: 94%;
 		margin: auto;
-		width: 96%;
+		width: 94%;
 	}
 
 	#primary,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -150,6 +150,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.highlight-menu-contain,
 	.mobile-menu-toggle,
 	.desktop-menu-toggle,
+	.newspack-reader__account-link__mobile,
 	.jp-relatedposts-i2,
 	.social-navigation,
 	.subpage-toggle-contain,

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -17,9 +17,14 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
 @media print {
 	/* Margins */
+	@page {
+		margin: 1cm 0;
+	}
+
 	#page {
-		max-width: 94%;
+		display: block;
 		margin: auto;
+		max-width: 94%;
 		width: 94%;
 	}
 

--- a/newspack-theme/sass/print.scss
+++ b/newspack-theme/sass/print.scss
@@ -17,9 +17,22 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 
 @media print {
 	/* Margins */
+	#page {
+		max-width: 96%;
+		margin: auto;
+		width: 96%;
+	}
 
-	@page {
-		margin: 2cm;
+	#primary,
+	.post-template-single-feature .main-content,
+	.wrapper {
+		max-width: 100%;
+		width: 100%;
+	}
+
+	#page,
+	.admin-bar #page {
+		min-height: 0;
 	}
 
 	#primary {
@@ -116,6 +129,12 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	.entry .entry-content .button {
 		color: #000;
 		background: transparent;
+	}
+
+	/* Header */
+	.h-stk .site-header {
+		box-shadow: none;
+		position: static;
 	}
 
 	/* Footer */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR further tweaks the print styles by: 
* "Unsticking" the sticky header when printing -- in some browsers, like Chrome, if you printed the page after scrolling a bit, the header would appear mid-page. 
* Swapping out the page margin approach -- `@page` isn't supported by Safari, so it was causing the right edge of the page to be cut off in some cases. 

Closes #1936

### How to test the changes in this Pull Request:

1. Set your header to sticky, and create a post and use the two column template.
2. In Chrome or Safari, scroll partway down the page, and then print/view the print preview -- the header will appear mid-page, instead of at the top (for some reason, I wasn't able to recreate this in Firefox):

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/177561/192422554-93f45570-5b58-48d5-9ced-4c6ff86ba18b.png">

3. In Safari, review the rest of the print preview -- note that the edge is getting cut off on the right side. This doesn't happen with the one column templates: 

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/177561/192422662-d0226292-0fd4-46c0-8519-5771a6d88ee1.png">

4. Apply the PR and run `npm run build`. 
5. Repeat steps 2 and 3, and confirm that these issues are now resolved. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
