### PR TITLE
Update tagline display check to work with Newspack wizard

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -105,7 +105,7 @@ function newspack_body_classes( $classes ) {
 	}
 
 	$show_tagline = get_theme_mod( 'header_display_tagline', true );
-	if ( false === $show_tagline ) {
+	if ( ! ( $show_tagline ) ) {
 		$classes[] = 'hide-site-tagline';
 	} else {
 		$classes[] = 'show-site-tagline';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The theme is too-specifically checking for `get_theme_mod( 'header_display_tagline' );` to be `false` when deciding whether to show/hide the tagline, but the Site Design Wizard sets it to `0` -- this causes the option to be unchecked even though the theme still displays it. 

This PR makes the `header_display_tagline` work with `0` or `false` instead. 

Closes #1928

### How to test the changes in this Pull Request:

1. Run the setup wizard from scratch (even on a site with the setting reset, or on a new test site).
2. When complete, navigate to Customizer > Site Identity. Note that Display Tagline is unchecked, even though the tagline is visible on the site and in the preview: 

![image](https://user-images.githubusercontent.com/177561/193921185-52663e7d-a2e1-4c14-84e2-1d29ddb94c05.png)
 
3. Apply the PR to the site.
4. Confirm that the preview/front end view of the site now correctly hides the tagline to match the Site Identity setting:

![image](https://user-images.githubusercontent.com/177561/193921886-61190477-9494-4161-b147-aaf2c3982e44.png)

6. Check the Display Tagline option and Publish, and confirm it works as expected on the front-end. 
7. Uncheck the Display Tagline option again and Publish, and confirm it works as expected on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
