### PR TITLE
fix: Correct search block styles

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -26,7 +26,6 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].is-style-solid-color,
 			*[class^="wp-block-"].is-style-solid-color.has-primary-background-color,
 			.is-style-outline .wp-block-button__link.has-primary-background-color:not( :hover ),
-			.wp-block-search__button-outside .wp-block-search__button,
 			.wp-block-file .wp-block-file__button,
 			.comment .comment-author .post-author-badge,
 			.woocommerce .onsale,
@@ -80,7 +79,6 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar a:visited,
 			.mobile-sidebar .nav1 .sub-menu > li > a,
 			.mobile-sidebar .nav1 ul.main-menu > li > a,
-			.wp-block-search__button-outside .wp-block-search__button,
 			.wp-block-file .wp-block-file__button,
 			.highlight-menu .menu-label,
 			/* Header default background; default height */
@@ -149,7 +147,8 @@ function newspack_custom_colors_css() {
 			*[class^="wp-block-"].has-secondary-background-color,
 			*[class^="wp-block-"] .has-secondary-background-color,
 			*[class^="wp-block-"].is-style-solid-color.has-secondary-background-color,
-			.is-style-outline .wp-block-button__link.has-secondary-background-color:not( :hover ) {
+			.is-style-outline .wp-block-button__link.has-secondary-background-color:not( :hover ),
+			.wp-block-search__button {
 				background-color:' . esc_attr( $colors['secondary'] ) . '; /* base: #666 */
 			}
 
@@ -160,7 +159,8 @@ function newspack_custom_colors_css() {
 			button,
 			input[type="button"],
 			input[type="reset"],
-			input[type="submit"] {
+			input[type="submit"],
+			.wp-block-search__button {
 				color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 			}
 
@@ -495,13 +495,11 @@ function newspack_custom_colors_css() {
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button, /* legacy */
 		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-file .wp-block-file__button,
-		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-pullquote.is-style-solid-color:not(.has-background-color) {
 			background-color: ' . esc_attr( $colors['primary'] ) . '; /* base: #0073a8; */
 		}
 
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button,
-		.block-editor-block-list__layout .block-editor-block-list__block.wp-block-search__button-outside .wp-block-search__button {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button {
 			color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 		}
 
@@ -536,12 +534,14 @@ function newspack_custom_colors_css() {
 		/* Secondary color */
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-background),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"],
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-search__button {
 			background-color: ' . esc_attr( $colors['secondary'] ) . '; /* base: #0073a8; */
 		}
 
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"] {
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"],
+		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-search__button {
 			color: ' . esc_attr( $colors['secondary_contrast'] ) . '; /* base: #0073a8; */
 		}
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1007,8 +1007,18 @@ hr {
 	}
 
 	&.wp-block-search__button-inside {
-		.wp-block-search__inside-wrapper .wp-block-search__button {
-			padding: #{0.45 * structure.$size__spacing-unit};
+		.wp-block-search__inside-wrapper {
+			border-color: colors.$color__border;
+			padding: 0;
+
+			input {
+				border: 0;
+			}
+		}
+
+		.wp-block-search__button {
+			margin: 2px;
+			padding: calc( 0.76rem - 4px ) 1rem;
 
 			&.has-icon {
 				padding: #{0.15 * structure.$size__spacing-unit} #{0.25 * structure.$size__spacing-unit};
@@ -1016,8 +1026,14 @@ hr {
 		}
 
 		.has-icon {
-			background: transparent;
 			border: 0;
+			&:not( .has-background ) {
+				background: transparent;
+			}
+
+			&:not( .has-text-color ) {
+				color: colors.$color__text-main;
+			}
 		}
 	}
 }
@@ -1301,7 +1317,8 @@ $colors: (
 	.wp-block-pullquote.is-style-solid-color.has-#{$name}-background-color,
 	.wp-block-pullquote.has-#{$name}-background-color,
 	.is-style-outline .wp-block-button__link.has-#{$name}-background-color:not( :hover ),
-	.wp-block-navigation-item.has-#{$name}-background-color {
+	.wp-block-navigation-item.has-#{$name}-background-color,
+	.wp-block-search__button.has-#{$name}-background-color {
 		background-color: $hex;
 	}
 
@@ -1312,7 +1329,8 @@ $colors: (
 	.wp-block-button__link.has-#{$name}-color,
 	.wp-block-button__link.has-#{$name}-color:visited:not( :hover ),
 	.is-style-outline .wp-block-button__link.has-#{$name}-color:not( :hover ), //legacy selector
-	.wp-block-button__link.is-style-outline.has-#{$name}-color:not( :hover ) {
+	.wp-block-button__link.is-style-outline.has-#{$name}-color:not( :hover ),
+	.wp-block-search__button.has-#{$name}-color {
 		color: $hex;
 	}
 

--- a/newspack-theme/sass/forms/_buttons.scss
+++ b/newspack-theme/sass/forms/_buttons.scss
@@ -8,7 +8,7 @@ button,
 input[type='button'],
 input[type='reset'],
 input[type='submit'],
-.wp-block-search__button-outside .wp-block-search__button {
+.wp-block-search__button {
 	@include utilities.button-transition;
 	background: colors.$color__background-button;
 	border: none;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -650,41 +650,62 @@ div[data-align='full'] {
 
 /** === Search === */
 
-.wp-block-search {
-	.wp-block-search__button {
-		border-radius: 5px;
-		line-height: 1.8;
-		font-family: fonts.$font__heading;
-		font-size: fonts.$font__size-sm;
-		font-weight: bold;
-		padding: ( 0.55 * structure.$size__spacing-unit ) structure.$size__spacing-unit !important; // !important to override style from Gutenberg.
+.wp-block-search__button {
+	background: colors.$color__background-button;
+	border: 0;
+	border-radius: 5px;
+	color: #fff;
+	line-height: 1.8;
+	font-family: fonts.$font__heading;
+	font-size: fonts.$font__size-sm;
+	font-weight: bold;
+	padding: ( 0.55 * structure.$size__spacing-unit ) structure.$size__spacing-unit !important; // !important to override style from Gutenberg.
 
-		svg {
-			height: 32px;
-			width: 32px;
-		}
-
-		&.has-icon {
-			padding: #{0.3 * structure.$size__spacing-unit} #{0.5 * structure.$size__spacing-unit} !important; // !important to override style from Gutenberg.
-		}
+	svg {
+		height: 32px;
+		width: 32px;
 	}
 
-	&.wp-block-search__button-outside .wp-block-search__button {
-		border: 0;
+	&.has-icon {
+		padding: #{0.3 * structure.$size__spacing-unit} #{0.5 * structure.$size__spacing-unit} !important; // !important to override style from Gutenberg.
+	}
+}
+
+.wp-block-search {
+	input {
+		border-color: colors.$color__border;
+		border-radius: 0;
+		padding: 0.36rem 0.66rem;
 	}
 
 	&.wp-block-search__button-inside {
-		.wp-block-search__inside-wrapper .wp-block-search__button {
-			padding: #{0.25 * structure.$size__spacing-unit} #{0.5 * structure.$size__spacing-unit} !important; // !important to override style from Gutenberg.
+		.wp-block-search__inside-wrapper {
+			border-color: colors.$color__border;
+			padding: 0;
 
-			&.has-icon {
-				padding: #{0.125 * structure.$size__spacing-unit} #{0.25 * structure.$size__spacing-unit} !important; // !important to override style from Gutenberg.
+			input {
+				border: 0;
+			}
+
+			.wp-block-search__button {
+				margin: 2px;
+				padding: calc( 0.76rem - 4px ) 1rem;
+
+				&.has-icon {
+					padding: #{0.125 * structure.$size__spacing-unit} #{0.25 * structure.$size__spacing-unit} !important; // !important to override style from Gutenberg.
+				}
 			}
 		}
 
 		.has-icon {
-			background: transparent;
 			border: 0;
+			&:not( .has-background ) {
+				background: transparent;
+			}
+
+			&:not( .has-text-color ) {
+				color: colors.$color__text-main;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes some display issues with the search block, both for the upcoming 6.1 release, and issues that exist with 6.0.3.

Closes #1947

### How to test the changes in this Pull Request:

1. Add multiple copies of the search block to the editor, using the different button placements and colours (alternatively, [you can copy-paste this code into the editor](https://gist.github.com/laurelfulford/771e5f6942feace9911b3fa453b26e66) to get all of the combinations).
2. View in the editor and on the front-end and note the issues (you can also see screenshots in [this issue](https://github.com/Automattic/newspack-theme/issues/1947#issuecomment-1288164066)).
* When the button is placed inside, there's an extra border around the form.
* The buttons aren't using the correct colours - by default they should use your primary colour like other buttons, but they should also let you change the button colour, and it's not always being applied.
3. Apply the PR and run `npm run build`.
4. In the editor and on the front-end, confirm that:
* The button, by default, uses your secondary colour. The only exception is when the button is placed inside the search and uses the icon -- in that case, the button should have a transparent background with a black icon. (This is so the block looks like the search field in the theme by default). 
* When the button is inside of the search, you don't have an extra border anymore.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/177561/197414341-26404bc9-1ff5-4120-b1ad-abc792b24449.png">
<img width="643" alt="image" src="https://user-images.githubusercontent.com/177561/197414353-c3d3d6a4-f854-4027-9f3d-1abf376dafd5.png">

5. Upgrade to the 6.1 RC and confirm things still look correct (currently the search doesn't look 1:1 between the current and future release -- you can see screenshots of the pre-fixed styles [here](https://github.com/Automattic/newspack-theme/issues/1947#issuecomment-1288164583)).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
