### PR TITLE
style: remove custom margin/padding for registration block pattern

### DIFF
--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -255,16 +255,4 @@
 			}
 		}
 	}
-
-	/* Registration Style 1 */
-
-	&.registration__style-1 {
-		@include utilities.media( tablet ) {
-			padding: 32px;
-		}
-
-		.newspack-registration {
-			margin-bottom: 0;
-		}
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes a bit of unused CSS that was still affecting some sites that used early RAS test patterns.

### How to test the changes in this Pull Request:

Nothing to test—the block pattern targeted by this CSS is no longer available in the UI.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
