### PR TITLE
fix: usage of filter for post author footer bio name

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -41,7 +41,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 
 						<div>
 							<h2 class="accent-header">
-								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
 							</h2>
 
 							<?php if ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) : ?>
@@ -81,12 +81,12 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 				</div><!-- .author-bio-text -->
 
 			</div><!-- .author-bio -->
-		<?php
+			<?php
 		}
 	}
 
 elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
-?>
+	?>
 
 <div class="author-bio">
 
@@ -94,15 +94,15 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<div class="author-bio-header">
 			<?php
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-				if ( $author_avatar ) {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $author_avatar;
-				}
+			if ( $author_avatar ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $author_avatar;
+			}
 			?>
 
 			<div>
 				<h2 class="accent-header">
-					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author() ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) ) : ?>

--- a/newspack-theme/inc/trust-indicators.php
+++ b/newspack-theme/inc/trust-indicators.php
@@ -83,7 +83,7 @@ function newspack_trust_indicators_output_author_info() {
 		}
 	}
 
-	$author_phone = get_user_meta( $author->ID, 'public_contact_info_tel', true );
+	$author_phone   = get_user_meta( $author->ID, 'public_contact_info_tel', true );
 	$author_twitter = get_user_meta( $author->ID, 'twitter', true );
 	?>
 	<div class="trust-indicators author-meta">
@@ -130,6 +130,21 @@ function newspack_trust_indicators_output_author_job_title( $title ) {
 add_filter( 'get_the_archive_title', 'newspack_trust_indicators_output_author_job_title' );
 
 /**
+ * Adds author role to author footer.
+ *
+ * @param string $author_name string The author name.
+ * @param int    $author_id string The author ID.
+ */
+function newspack_trust_indicators_author_bio_name( $author_name, $author_id ) {
+	$role = get_user_meta( $author_id, 'title', true );
+	if ( $role ) {
+		$author_name .= '<span class="author-job-title">' . $role . '</span>';
+	}
+	return $author_name;
+}
+add_filter( 'newspack_author_bio_name', 'newspack_trust_indicators_author_bio_name', 10, 2 );
+
+/**
  * Gets author role to add to single post author bios.
  */
 function newspack_trust_indicators_job_title_single( $author_ID ) {
@@ -150,7 +165,7 @@ function newspack_trust_indicators_output_author_details() {
 	$author = get_queried_object();
 
 	$all_settings_fields = Trust_Indicators_User_Settings::get_fields();
-	$fields = [
+	$fields              = [
 		'location',
 		'languages_spoken',
 		'areas_of_expertise',

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -45,15 +45,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<div class="author-bio-header">
 						<div>
 							<h2 class="accent-header">
-								<?php
-								echo esc_html( $author->display_name );
-								if ( class_exists( 'Trust_Indicators' ) ) {
-									$author_role = newspack_trust_indicators_job_title_single( $author->ID );
-									if ( '' !== $author_role ) {
-										echo '<span class="author-job-title">' . esc_html( $author_role ) . '</span>';
-									}
-								}
-								?>
+								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
 							</h2>
 
 							<?php if ( ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -95,21 +87,21 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 				</div><!-- .author-bio-text -->
 
 			</div><!-- .author-bio -->
-		<?php
+			<?php
 		}
 	}
 
 elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
-?>
+	?>
 
 <div class="author-bio">
 
 	<?php
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-		if ( $author_avatar ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $author_avatar;
-		}
+	if ( $author_avatar ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $author_avatar;
+	}
 	?>
 
 	<div class="author-bio-text">
@@ -117,15 +109,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 			<div>
 				<h2 class="accent-header">
-					<?php
-					echo esc_html( get_the_author() );
-					if ( class_exists( 'Trust_Indicators' ) ) {
-						$author_role = newspack_trust_indicators_job_title_single( get_the_author_meta( 'ID' ) );
-						if ( '' !== $author_role ) {
-							echo '<span class="author-job-title">' . esc_html( $author_role ) . '</span>';
-						}
-					}
-					?>
+					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `newspack_author_bio_name` filter was added in #1806, then its use was partially removed in #1848. This change introduces a different approach to the issue (partially) solved in #1848, and re-enables the `newspack_author_bio_name` filter.

### How to test the changes in this Pull Request:

1. Re-test #1848 
2. _See instructions in https://github.com/Automattic/newspack-plugin/pull/2102_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->