### PR TITLE
chore: update Newspack website URL in the themes' style.css headers

### DIFF
--- a/newspack-joseph/sass/theme-description.scss
+++ b/newspack-joseph/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack Joseph
 Theme URI:
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2

--- a/newspack-katharine/sass/theme-description.scss
+++ b/newspack-katharine/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack Katharine
 Theme URI:
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2

--- a/newspack-nelson/sass/theme-description.scss
+++ b/newspack-nelson/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack Nelson
 Theme URI:
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2

--- a/newspack-sacha/sass/theme-description.scss
+++ b/newspack-sacha/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack Sacha
 Theme URI:
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2

--- a/newspack-scott/sass/theme-description.scss
+++ b/newspack-scott/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack Scott
 Theme URI:
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2

--- a/newspack-theme/sass/theme-description.scss
+++ b/newspack-theme/sass/theme-description.scss
@@ -2,7 +2,7 @@
 Theme Name: Newspack
 Theme URI: https://github.com/Automattic/newspack-theme
 Author: Automattic
-Author URI: https://newspack.blog
+Author URI: https://newspack.com
 Description:
 Requires at least: WordPress 4.9.6
 Version: 1.65.2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is the more behind-the-scenes housekeeping version of #1983, and updates the Newspack URL in each style.css's header from the very old newspack.blog to newspack.com.

### How to test the changes in this Pull Request:

1. Check the 'Author URL' value in each theme's sass/theme-description.scss, and confirm it says to newspack.com, not newspack.blog.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
