### PR TITLE
fix: woocommerce CSS loading condition

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -36,8 +36,14 @@ function newspack_woocommerce_scripts() {
 	if ( true === get_theme_mod( 'woocommerce_styles_home_dequeue', false ) && is_front_page() ) {
 		return;
 	}
-	wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/styles/woocommerce.css', array( 'newspack-style' ), wp_get_theme()->get( 'Version' ) );
-	wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );
+	if (
+		function_exists( 'is_woocommerce' ) && is_woocommerce()
+		|| function_exists( 'is_cart' ) && is_cart()
+		|| function_exists( 'is_checkout' ) && is_checkout()
+	) {
+		wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/styles/woocommerce.css', array( 'newspack-style' ), wp_get_theme()->get( 'Version' ) );
+		wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );
+	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_woocommerce_scripts' );
 
@@ -115,7 +121,8 @@ if ( ! function_exists( 'newspack_woocommerce_wrapper_before' ) ) {
 	 *
 	 * @return void
 	 */
-	function newspack_woocommerce_wrapper_before() { ?>
+	function newspack_woocommerce_wrapper_before() {
+		?>
 		<section id="primary" class="content-area">
 			<main id="main" class="site-main">
 		<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures WooCommerce styles are loaded only when needed. 

### How to test the changes in this Pull Request:

1. On `master`, set the Reader Revenue platform to Newspack
2. Visit the homepage, observe the `/wp-content/themes/newspack-theme/styles/woocommerce.css` file is loaded
3. Switch to this branch, observe the file is not loaded on the homepage
4. Make a donation, observe the file is loaded on the checkout page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->