### PR TITLE
fix: restore styles on My Account page

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -40,6 +40,7 @@ function newspack_woocommerce_scripts() {
 		function_exists( 'is_woocommerce' ) && is_woocommerce()
 		|| function_exists( 'is_cart' ) && is_cart()
 		|| function_exists( 'is_checkout' ) && is_checkout()
+		|| function_exists( 'is_account_page' ) && is_account_page()
 	) {
 		wp_enqueue_style( 'newspack-woocommerce-style', get_template_directory_uri() . '/styles/woocommerce.css', array( 'newspack-style' ), wp_get_theme()->get( 'Version' ) );
 		wp_style_add_data( 'newspack-woocommerce-style', 'rtl', 'replace' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug introduced by #1988 that stripped styles from the WC My Acccount pages.

### How to test the changes in this Pull Request:

1. Log into a reader account via My Account.
2. On `master`, observe missing styles:

<img width="1241" alt="Screen Shot 2022-12-02 at 12 21 28 PM" src="https://user-images.githubusercontent.com/2230142/205369653-31e7387a-bf5d-4c60-a227-a53c6a232daa.png">

3. Check out this branch, refresh, confirm the styes are restored.

<img width="1237" alt="Screen Shot 2022-12-02 at 12 21 12 PM" src="https://user-images.githubusercontent.com/2230142/205369705-d38dc5cb-00b5-4072-a806-8c51271515f3.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
