### PR TITLE
fix: correct issues with users and guest authors sharing IDs

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -21,17 +21,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	foreach ( $authors as $author ) {
 
 		if ( '' !== $author->description ) {
-
-			if ( 'guest-author' === get_post_type( $author->ID ) ) {
-				if ( get_post_thumbnail_id( $author->ID ) ) {
-					$author_avatar = coauthors_get_avatar( $author, 80 );
-				} else {
-					// If there is no avatar, force it to return the current fallback image.
-					$author_avatar = get_avatar( ' ' );
-				}
-			} else {
-				$author_avatar = coauthors_get_avatar( $author, 80 );
-			}
+			$author_avatar = coauthors_get_avatar( $author, 80 );
 			?>
 
 			<div class="author-bio">

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -49,28 +49,22 @@ $queried             = get_queried_object();
 				}
 				?>
 
+				<?php the_archive_title( '<h1 class="page-title">', '</h1>' ); ?>
+
+				<?php do_action( 'newspack_theme_below_archive_title' ); ?>
+
 				<?php
-				if ( is_author() && 'guest-author' === get_post_type( $queried->ID ) ) {
-					printf(
-						'<h1 class="page-title"><span class="page-subtitle">%1$s</span> <span class="page-description">%2$s</span></h1>',
-						esc_html__( 'Author Archives:', 'newspack' ),
-						esc_html( $queried->display_name )
-					);
-				} else {
-					the_archive_title( '<h1 class="page-title">', '</h1>' );
-				}
-
-				do_action( 'newspack_theme_below_archive_title' );
-
 				if ( ( is_category() || is_tag() ) && ! empty( $native_sponsors ) ) :
 					// Get description for native archive sponsors.
 					newspack_sponsor_archive_description( $native_sponsors );
-				elseif ( is_author() && 'guest-author' === get_post_type( $queried->ID ) && '' !== $queried->description ) :
-					echo '<div class="taxonomy-description">' . wp_kses_post( wpautop( $queried->description ) ) . '</div>';
 				elseif ( '' !== get_the_archive_description() ) :
-					echo '<div class="taxonomy-description">' . wp_kses_post( wpautop( get_the_archive_description() ) ) . '</div>';
-				endif;
+					?>
+					<div class="taxonomy-description">
+						<?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?>
+					</div>
+				<?php endif; ?>
 
+				<?php
 				if ( ( is_category() || is_tag() ) && ! empty( $underwriter_sponsors ) ) {
 					// Get info for underwriter archive sponsors.
 					newspack_sponsored_underwriters_info( $underwriter_sponsors );

--- a/newspack-theme/archive.php
+++ b/newspack-theme/archive.php
@@ -17,8 +17,6 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 
 $feature_latest_post = get_theme_mod( 'archive_feature_latest_post', true );
 $show_excerpt        = get_theme_mod( 'archive_show_excerpt', false );
-$queried             = get_queried_object();
-
 ?>
 
 	<section id="primary" class="content-area">
@@ -26,6 +24,7 @@ $queried             = get_queried_object();
 		<header class="page-header">
 			<?php
 			if ( is_author() ) {
+				$queried       = get_queried_object();
 				$author_avatar = '';
 
 				if ( function_exists( 'coauthors_posts_links' ) ) {

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -95,16 +95,7 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 			$i            = 1;
 
 			foreach ( $authors as $author ) {
-				if ( 'guest-author' === get_post_type( $author->ID ) ) {
-					if ( get_post_thumbnail_id( $author->ID ) ) {
-						$author_avatar = coauthors_get_avatar( $author, 80 );
-					} else {
-						// If there is no avatar, force it to return the current fallback image.
-						$author_avatar = get_avatar( ' ' );
-					}
-				} else {
-					$author_avatar = coauthors_get_avatar( $author, 80 );
-				}
+				$author_avatar = coauthors_get_avatar( $author, 80 );
 
 				echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 			}

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -21,17 +21,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	foreach ( $authors as $author ) {
 
 		if ( '' !== $author->description ) {
-
-			if ( 'guest-author' === get_post_type( $author->ID ) ) {
-				if ( get_post_thumbnail_id( $author->ID ) ) {
-					$author_avatar = coauthors_get_avatar( $author, 80 );
-				} else {
-					// If there is no avatar, force it to return the current fallback image.
-					$author_avatar = get_avatar( ' ' );
-				}
-			} else {
-				$author_avatar = coauthors_get_avatar( $author, 80 );
-			}
+			$author_avatar = coauthors_get_avatar( $author, 80 );
 			?>
 
 			<div class="author-bio">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a couple issues that arise when a regular user and a CoAuthors Plus guest user share the same ID:
* The 'regular user' ends up with the incorrect avatar ([caused by an old fix to make sure CoAuthors didn't pick up post featured images as a fallback](https://github.com/Automattic/newspack-theme/pull/569))
* The guest user ends up with the wrong name/description on the Author Archives page.

This PR also fixes an issue where guest author information was not displaying on the archive pages. 

Closes 1200133283606042/1203581044315819

### How to test the changes in this Pull Request:

1. Start with a test site where at least one WP User shares an ID with a CoAuthors Plus Guest Author. If you don't already have a site with this, you can recreate it by:
   * Spin up a new Newspack site (opting NOT to install the demo content)
   * Add two Guest Authors, both with names, bios, but no avatars for now. To make testing easier, prefix the bios with the user name.  
   * Checking the ID of the first Guest Author; and add enough WP Users to get up to that ID number -- for me, it was ID 13. Make sure at least this 'ID twin' WP User has a bio that starts with their user name.
2.  Set up a few posts:
    * Posts just by your "ID twin" Guest Author
    * Posts just by your "ID twin" WP User
    * Posts by both together
    * Posts by your "ID twin" Guest Author and another random user
    * Posts by the Guest Author that doesn't have an ID twin. 
3. Make sure your "ID Twin" WP User has an avatar (either through Gravatar or Simple Avatars), but your "ID Twin" Guest Author does not. 
4. Visit the post by the "ID twin" WP User; note that rather than using its avatar, it's using the 'fallback' option -- this is because it's picking up the Guest Author's avatar:

_WP User's settings:_ 
![image](https://user-images.githubusercontent.com/177561/208987864-891c8b1d-c0c3-4d73-aaee-c34669e4dea8.png)

_WP User's byline:_
![image](https://user-images.githubusercontent.com/177561/208987672-72967e1a-7773-4180-92c1-f3722d83c46f.png)
  
6. Visit the archive of the "ID twin" guest author; note that it's using the WP User's name and description.

_Note the URL points to guest author 'Jane Doe' but the name/description does not -- the posts should match the right person though:_
![image](https://user-images.githubusercontent.com/177561/208987989-302bf201-f700-40b3-8f8c-ec96fc0572d4.png)

7. Visit the regular Guest Author that doesn't have an "ID twin"; notice that its not displaying any information:

![image](https://user-images.githubusercontent.com/177561/208988327-b154669d-b8a9-46ce-ac25-60c29f5f1ac0.png)

9. Apply the PR.
10. Visit the post by the "ID twin" WP User; confirm that its using the correct avatar.

![image](https://user-images.githubusercontent.com/177561/208989702-33aa57e2-c261-4ee3-972e-f463b5c2049d.png)

11. Visit the archive of the "ID twin" guest author, and confirm that it's displaying the correct name and description.

![image](https://user-images.githubusercontent.com/177561/208989754-f5e6c4d6-7950-4903-87e4-e6617c09ced3.png)

12. Visit the regular Guest Author that doesn't have an "ID twin" and confirm their information is displaying:

![image](https://user-images.githubusercontent.com/177561/208989609-73c3ebdf-3503-4a45-a92b-80bcf6badefe.png)

13. Test adding/removing avatars from the Guest Authors (both with ID twins and without), and confirm that they correctly fall back to the placeholder image set under Settings > Discussion, and not featured images. 

14. Swap to Newspack Sacha, and comfirm that the Author Bios at the bottom of posts are using the correct images as well -- this is the only child theme that has a unique template part for this section.

(Note: the avatar issue still needs to be addressed separately in the blocks). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
