### PR TITLE
fix: skip flex rule for newspack ad

### DIFF
--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -7,7 +7,7 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
-	> *:not( #content ) {
+	> *:not( #content ):not( .newspack_global_ad ) {
 		flex: 0;
 	}
 }

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -7,8 +7,8 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
-	> *:not( #content ):not( .newspack_global_ad ) {
-		flex: 0;
+	> *:not( #content ) {
+		flex-grow: 0;
 	}
 }
 #content {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#1922 introduced a bug that breaks the fixed height option for the Below Header placement. This PR ensures to not apply the `flex: 0;` rule for `.newspack_global_ad`.

### How to test the changes in this Pull Request:

1. While on master, configure an ad unit and enable fixed height for "Below Header"
2. Visit the frontend and confirm you get CLS
3. Switch to this branch, build, refresh, and confirm the fixed height is applied and there's no CLS

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
