### PR TITLE
feat: add Mastodon icon to the social links menu

### DIFF
--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -245,6 +245,20 @@ class Newspack_SVG_Icons {
 		'mail'        => array(
 			'mailto:',
 		),
+		'mastodon'    => array(
+			// Regex pattern to match any .tld for the mastodon host name.
+			'#https?:\/\/(www\.)?mastodon\.(\w+)(\.\w+)?#',
+			// Regex pattern to match any .tld for the mstdn host name.
+			'#https?:\/\/(www\.)?mstdn\.(\w+)(\.\w+)?#',
+			'counter.social',
+			'fosstodon.org',
+			'gc2.jp',
+			'hachyderm.io',
+			'infosec.exchange',
+			'mas.to',
+			'newsie.social',
+			'pawoo.net',
+		),
 		'phone'       => array(
 			'tel:',
 		),
@@ -410,6 +424,16 @@ class Newspack_SVG_Icons {
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 	<path d="M0 0h24v24H0z" fill="none"/>
 	<path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H4V8l8 5 8-5v10zm-8-7L4 6h16l-8 5z"/>
+</svg>',
+
+		'mastodon'    => '
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<path d="M21.3,9.4c0-4.3-2.8-5.6-2.8-5.6c-1.4-0.7-3.9-0.9-6.4-1H12c-2.6,0-5,0.3-6.4,1c0,0-2.8,1.3-2.8,5.6c0,1,0,2.2,0,3.4
+	c0.1,4.2,0.8,8.4,4.7,9.4c1.8,0.5,3.4,0.6,4.6,0.5c2.3-0.1,3.5-0.8,3.5-0.8l-0.1-1.6c0,0-1.6,0.5-3.4,0.4c-1.8-0.1-3.7-0.2-4-2.4
+	c0-0.2,0-0.4,0-0.6c0,0,1.8,0.4,4,0.5c1.4,0.1,2.7-0.1,4-0.2c2.5-0.3,4.7-1.8,5-3.2C21.3,12.6,21.3,9.4,21.3,9.4z M18,15h-2.1V9.9
+	c0-1.1-0.5-1.6-1.4-1.6c-1,0-1.5,0.6-1.5,1.9V13H11v-2.8c0-1.3-0.5-1.9-1.5-1.9c-0.9,0-1.4,0.5-1.4,1.6V15H6V9.7
+	c0-1.1,0.3-1.9,0.8-2.6c0.6-0.6,1.3-1,2.2-1c1.1,0,1.9,0.4,2.4,1.2L12,8.3l0.5-0.9c0.5-0.8,1.3-1.2,2.4-1.2c0.9,0,1.7,0.3,2.2,1
+	C17.7,7.8,18,8.6,18,9.7V15z"/>
 </svg>',
 
 		'meetup'      => '

--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -246,10 +246,8 @@ class Newspack_SVG_Icons {
 			'mailto:',
 		),
 		'mastodon'    => array(
-			// Regex pattern to match any .tld for the mastodon host name.
-			'#https?:\/\/(www\.)?mastodon\.(\w+)(\.\w+)?#',
-			// Regex pattern to match any .tld for the mstdn host name.
-			'#https?:\/\/(www\.)?mstdn\.(\w+)(\.\w+)?#',
+			'mastodon.',
+			'mstdn.',
 			'counter.social',
 			'fosstodon.org',
 			'gc2.jp',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a Mastodon icon to the social links menu, as well as a list of common Mastodon URLs to match to it. 

See 1203536997639429-as-1203401705449116

### How to test the changes in this Pull Request:

1. Add one of the common Mastodon URLs to the social links menu - the URLs include the following, and account links are formatted like https://[mastodon URL]/@[mastodon username]

* counter.social
* fosstodon.org
* gc2.jp
* hachyderm.io
* infosec.exchange
* mas.to
* mastodon.art
* mastodon.cloud
* mastodon.lol
* mastodon.online
* mastodon.social
* mastodon.world
* mstdn.jp
* mstdn.social
* newsie.social
* pawoo.net

2. Note that the menu uses the 'link' icon placeholder for this link

![image](https://user-images.githubusercontent.com/177561/211696064-c1020da5-682f-4cf3-8f91-47a942d9f025.png)

3. Apply the PR.
4. Confirm that the Mastodon icon is now loading:

![image](https://user-images.githubusercontent.com/177561/211696022-c3e41cf4-cbd8-4c27-8c63-67c1df497117.png)

5. Depending where your social links menu is displaying (header or footer), switch the background colour to the opposite contrast to what it is now. So for example, if the icon is showing on a dark blue background, change it to white; if it's on a light grey background change it to something dark. This is just to make sure the icon is picking up the contrasting colour correctly.

The list of common Mastodon URLs comes from this [Jetpack Social Icons PR](https://github.com/Automattic/jetpack/pull/28175/files#diff-569b9a627b3b65759e6e3e44a97e6c34f3f4f1c68c4843dea4080e428005a2a5R440-R453); something else that was done in that PR that we could also consider is adding a filter so the URLs can be added to on a per-site basis. Mastodon is odd in that the URLs it could use are endless; I think it's worthwhile trying to add really common ones to the theme, but if we get requests for more that might be the way to go. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
