### PR TITLE
Feat: add 'flipped' option to display updated date per post

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -905,6 +905,16 @@ function newspack_register_meta() {
 	);
 
 	register_post_meta(
+		'post',
+		'newspack_show_updated_date',
+		array(
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'boolean',
+		)
+	);
+
+	register_post_meta(
 		'page',
 		'newspack_hide_page_title',
 		array(
@@ -1133,12 +1143,16 @@ function newspack_get_featured_image_post_types() {
  */
 function newspack_get_post_toggle_post_types() {
 	$hide_date_post_types = [];
+	$show_date_post_types = [];
 	if ( true === get_theme_mod( 'post_updated_date', false ) ) {
 		$hide_date_post_types[] = 'post';
+	} else {
+		$show_date_post_types[] = 'post';
 	}
 
 	return array(
 		'hide_date'          => $hide_date_post_types,
+		'show_date'          => $show_date_post_types,
 		'hide_title'         => [ 'page' ],
 		'show_share_buttons' => function_exists( 'sharing_display' ) ? [ 'page' ] : [],
 	);

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -726,7 +726,12 @@ function newspack_convert_modified_to_time_ago( $post_time, $format, $post ) {
  * Check whether updated date should be displayed.
  */
 function newspack_should_display_updated_date() {
-	if ( is_single() && true === get_theme_mod( 'post_updated_date', false ) && ! get_post_meta( get_the_ID(), 'newspack_hide_updated_date', true ) ) {
+	$show_updated_date_sitewide = get_theme_mod( 'post_updated_date', false );
+
+	$hide_updated_date_post     = get_post_meta( get_the_ID(), 'newspack_hide_updated_date', true );
+	$show_updated_date_post     = get_post_meta( get_the_ID(), 'newspack_show_updated_date', true ) && ! $show_updated_date_sitewide;
+
+	if ( is_single() && ( ( $show_updated_date_sitewide && ! $hide_updated_date_post ) || $show_updated_date_post ) ) {
 		$post          = get_post();
 		$publish_date  = $post->post_date;
 		$modified_date = $post->post_modified;
@@ -735,7 +740,8 @@ function newspack_should_display_updated_date() {
 		$modified_timestamp = strtotime( $modified_date );
 		$modified_cutoff    = strtotime( 'tomorrow midnight', $publish_timestamp );
 
-		if ( $modified_timestamp > $modified_cutoff ) {
+		// Show the updated date either if it's enabled site-wide and more than 24 hours past the publish date, or if it's enabled on this specific post:
+		if ( ( $modified_timestamp > $modified_cutoff && $show_updated_date_sitewide ) || $show_updated_date_post ) {
 			return true;
 		} else {
 			return false;

--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -15,8 +15,12 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 	if ( ! meta ) {
 		return null;
 	}
-	const { newspack_hide_page_title, newspack_hide_updated_date, newspack_show_updated_date, newspack_show_share_buttons } =
-		meta;
+	const {
+		newspack_hide_page_title,
+		newspack_hide_updated_date,
+		newspack_show_updated_date,
+		newspack_show_share_buttons
+	} = meta;
 	const {
 		hide_date = [],
 		show_date = [],

--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -19,7 +19,7 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 		newspack_hide_page_title,
 		newspack_hide_updated_date,
 		newspack_show_updated_date,
-		newspack_show_share_buttons
+		newspack_show_share_buttons,
 	} = meta;
 	const {
 		hide_date = [],

--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -40,7 +40,7 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 		<PluginPostStatusInfo className="newspack__post-meta-toggles">
 			{ hideDate && 'post' === postType && (
 				<div>
-					<label htmlFor="hide_updated_date">{ __( 'Hide updated date', 'newspack' ) }</label>
+					<label htmlFor="hide_updated_date">{ __( 'Hide last updated date', 'newspack' ) }</label>
 					<FormToggle
 						checked={ newspack_hide_updated_date }
 						onChange={ () =>
@@ -52,7 +52,7 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 			) }
 			{ showDate && 'post' === postType && (
 				<div>
-					<label htmlFor="show_updated_date">{ __( 'Show updated date', 'newspack' ) }</label>
+					<label htmlFor="show_updated_date">{ __( 'Show last updated date', 'newspack' ) }</label>
 					<FormToggle
 						checked={ newspack_show_updated_date }
 						onChange={ () =>

--- a/newspack-theme/js/src/post-meta-toggles.js
+++ b/newspack-theme/js/src/post-meta-toggles.js
@@ -15,18 +15,20 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 	if ( ! meta ) {
 		return null;
 	}
-	const { newspack_hide_page_title, newspack_hide_updated_date, newspack_show_share_buttons } =
+	const { newspack_hide_page_title, newspack_hide_updated_date, newspack_show_updated_date, newspack_show_share_buttons } =
 		meta;
 	const {
 		hide_date = [],
+		show_date = [],
 		hide_title = [],
 		show_share_buttons = [],
 	} = window.newspack_post_meta_post_types;
 	const hideDate = 0 <= hide_date.indexOf( postType );
+	const showDate = 0 <= show_date.indexOf( postType );
 	const hideTitle = 0 <= hide_title.indexOf( postType );
 	const showShareButtons = 0 <= show_share_buttons.indexOf( postType );
 
-	if ( ! hideDate && ! hideTitle && ! showShareButtons ) {
+	if ( ! hideDate && ! showDate && ! hideTitle && ! showShareButtons ) {
 		return null;
 	}
 
@@ -41,6 +43,18 @@ const PostStatusExtensions = ( { meta, postType, updateMetaValue } ) => {
 							updateMetaValue( 'newspack_hide_updated_date', ! newspack_hide_updated_date )
 						}
 						id="hide_updated_date"
+					/>
+				</div>
+			) }
+			{ showDate && 'post' === postType && (
+				<div>
+					<label htmlFor="show_updated_date">{ __( 'Show updated date', 'newspack' ) }</label>
+					<FormToggle
+						checked={ newspack_show_updated_date }
+						onChange={ () =>
+							updateMetaValue( 'newspack_show_updated_date', ! newspack_show_updated_date )
+						}
+						id="show_updated_date"
 					/>
 				</div>
 			) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Newspack theme includes an option in the Customizer where you can display the updated date on posts. This updated date compares the publish date and last modified date, and if they're more than 24 hours apart, displays the updated date prefixed with 'Updated' -- this was to avoid showing the date for minor immediate edits. There's also a per-post option to hide the updated date.

Since this feature launched, we had a few requests to flip the logic, and instead have an option to show the updated date on a per-post basis. 

This PR adds a toggle to 'Show updated date'; it displays on posts when the site-wide Customizer option is not turned on. When the site-wide Customizer option is turned on, it's replaced by the existing Hide updated date toggle. 

Unlike the original implementation, this per-post 'Show updated date' option will show the date regardless how close it is to the published date -- since the option is manually turned on per post, this leaves it up to the publication when they want it to show; if they're displaying times with their publish dates, showing it sooner could make more sense.

See 1203536997639429-as-1203666315519082; Closes #1198.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Navigate to Customizer > Template Settings > Post Settings, and confirm that "Show "last updated" date on single posts" is unchecked. 
3. Edit an existing post that's a few days old; confirm that a "Show updated date" toggle is present, and unchecked. 
4. Check the "Show updated date" toggle and click Publish.
5. Confirm that the 'Updated' date is displaying on the front-end. 

![image](https://user-images.githubusercontent.com/177561/212985542-29a3547d-82c3-4003-ae1d-17bbc79f5f61.png)

6. Create a new post and check "Show updated date"; click Publish. Make another change and click 'Publish' again. View the front-end and confirm that your updated date is displaying, even if your publishes were minutes apart (you can also enable showing the publish time in the date line by navigating to Settings > General and changing the date format to `F j, Y g:i a` -- this can be more helpful with immediate or frequent updates). 
7. Navigate to Customizer > Template Settings > Post Settings, and check "Show "last updated" date on single posts"; click 'Publish'. 
8. Revisit your newer, edited post and confirm that the Updated Date is no longer showing, since it was re-edited less than 24 hours after it was created -- this maintains the existing behaviour. 
9. Revisit your older, edited post and confirm that the Updated Date is showing. 
10. Edit your older, edited post; confirm that you have a "Hide updated date" toggle in the sidebar. Enable the toggle and click 'Publish'. 
11. Confirm that the updated date is no longer displayed. 
12. Toggle the Customizer setting off again and confirm that the Updated date is back because the post should go back to using the per-post "Show updated date" option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
