### PR TITLE
feat: remove inline CSS minification (in favor of newspack-plugin)

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -669,19 +669,6 @@ function newspack_fse_blocks_to_remove() {
 }
 
 /**
- * Minify CSS.
- *
- * @param string $css string CSS string.
- */
-function newspack_minify_css( $css ) {
-	return preg_replace(
-		[ '/(,|\{|\}|;|\*\/)\s+/', '/\s+(,|\{|\}|;|\*\/)/' ],
-		'\1',
-		$css
-	);
-}
-
-/**
  * Fix skip link focus in IE11.
  *
  * This does not enqueue the script because it is tiny and because it is only for IE11,
@@ -972,7 +959,7 @@ function newspack_colors_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-colors">
-		<?php echo newspack_minify_css( newspack_custom_colors_css() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo newspack_custom_colors_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 	<?php
 }
@@ -1045,7 +1032,7 @@ function newspack_typography_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-fonts">
-		<?php echo newspack_minify_css( newspack_custom_typography_css() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<?php echo newspack_custom_typography_css(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</style>
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes inline CSS minification (#1989) in favor of Newspack Plugin's whole-document CSS minification. 

### How to test the changes in this Pull Request:

_Follow steps in https://github.com/Automattic/newspack-plugin/pull/2239_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->