### PR TITLE
Update menu ARIA labels, add missing button text

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -424,23 +424,28 @@ function newspack_scripts() {
 
 	wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 
+	$newspack_l10n = array(
+		'open_search'         => esc_html__( 'Open Search', 'newspack' ),
+		'close_search'        => esc_html__( 'Close Search', 'newspack' ),
+		'expand_comments'     => esc_html__( 'Expand Comments', 'newspack' ),
+		'collapse_comments'   => esc_html__( 'Collapse Comments', 'newspack' ),
+		'show_order_details'  => esc_html__( 'Show details', 'newspack' ),
+		'hide_order_details'  => esc_html__( 'Hide details', 'newspack' ),
+		'open_dropdown_menu'  => esc_html__( 'Open dropdown menu', 'newspack' ),
+		'close_dropdown_menu' => esc_html__( 'Close dropdown menu', 'newspack' ),
+	);
+
 	if ( ! newspack_is_amp() ) {
 		if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}
 
-		$newspack_l10n = array(
-			'open_search'        => esc_html__( 'Open Search', 'newspack' ),
-			'close_search'       => esc_html__( 'Close Search', 'newspack' ),
-			'expand_comments'    => esc_html__( 'Expand Comments', 'newspack' ),
-			'collapse_comments'  => esc_html__( 'Collapse Comments', 'newspack' ),
-			'show_order_details' => esc_html__( 'Show details', 'newspack' ),
-			'hide_order_details' => esc_html__( 'Hide details', 'newspack' ),
-		);
-
 		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), wp_get_theme()->get( 'Version' ), true );
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}
+
+	wp_enqueue_script( 'newspack-menu-accessibility', get_theme_file_uri( '/js/dist/menu-accessibility.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+	wp_localize_script( 'newspack-menu-accessibility', 'newspackScreenReaderText', $newspack_l10n );
 
 	if ( class_exists( '\Newspack\AMP_Enhancements' ) && \Newspack\AMP_Enhancements::is_amp_plus_configured() ) {
 		wp_enqueue_script( 'newspack-amp-plus', get_theme_file_uri( '/js/dist/amp-plus.js' ), array(), wp_get_theme()->get( 'Version' ), true );

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -433,6 +433,7 @@ function newspack_scripts() {
 		'hide_order_details'  => esc_html__( 'Hide details', 'newspack' ),
 		'open_dropdown_menu'  => esc_html__( 'Open dropdown menu', 'newspack' ),
 		'close_dropdown_menu' => esc_html__( 'Close dropdown menu', 'newspack' ),
+		'is_amp'              => newspack_is_amp(),
 	);
 
 	if ( ! newspack_is_amp() ) {

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -462,7 +462,7 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		$menu_state = 'setState' . $item->ID;
 
 		$output .= sprintf(
-			 '<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $menu_state . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $menu_state . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $menu_state . ': !' . $menu_state . ' } )" aria-haspopup="true">
+			 '<button aria-expanded="false" class="submenu-expand" [class]="' . $menu_state . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $menu_state . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $menu_state . ': !' . $menu_state . ' } )" aria-haspopup="true">
 					%1$s
 					<span class="screen-reader-text" [text]="' . $menu_state . ' ? \'%3$s\' : \'%2$s\'">%2$s</span>
 				</button>',

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -462,7 +462,7 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 		$menu_state = 'setState' . $item->ID;
 
 		$output .= sprintf(
-			 '<button aria-expanded="false" class="submenu-expand" [class]="' . $menu_state . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $menu_state . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $menu_state . ': !' . $menu_state . ' } )" aria-haspopup="true">
+			 '<button aria-expanded="false" class="submenu-expand" [class]="' . $menu_state . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $menu_state . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $menu_state . ': !' . $menu_state . ' } )" aria-haspopup="true" data-toggle-parent-id="toggle-' . $item->ID . '">
 					%1$s
 					<span class="screen-reader-text" [text]="' . $menu_state . ' ? \'%3$s\' : \'%2$s\'">%2$s</span>
 				</button>',

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -440,25 +440,6 @@ function newspack_get_discussion_data() {
 }
 
 /**
- * Get and store current menu's ID so it can be shared across functions.
- *
- * @return string Current menu item ID.
- */
-class Newspack_Current_Menu_ID {
-	private static $currentMenuId = '';
-
-	// Sets the current Menu ID value in newspack_add_dropdown_icons().
-	public static function set_current_ID( $value ) {
-		self::$currentMenuId = $value;
-	}
-
-	// Gets the current Menu ID for Newspack_Custom_Submenu_Walker().
-	public static function get_current_ID() {
-		return self::$currentMenuId;
-	}
-}
-
-/**
  * Add a dropdown icon to top-level menu items.
  *
  * @param string $output Nav menu item start element.
@@ -478,41 +459,24 @@ function newspack_add_dropdown_icons( $output, $item, $depth, $args ) {
 
 		// Add SVG icon to parent items.
 		$icon = newspack_get_icon_svg( 'keyboard_arrow_down', 24 );
-
-		$toggle_id = "toggle_" . $item->ID ;
+		$menu_state = 'setState' . $item->ID;
 
 		$output .= sprintf(
-			'<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $toggle_id . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $toggle_id . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $toggle_id . ' : !' . $toggle_id . ' } )" aria-haspopup="true">%s</button>',
-			$icon
+			 '<button aria-controls="submenu-'. $item->ID . '" aria-expanded="false" class="submenu-expand" [class]="' . $menu_state . ' ? \'submenu-expand open-dropdown\' : \'submenu-expand\'" [aria-expanded]="' . $menu_state . ' ? \'true\' : \'false\'" on="tap:AMP.setState( { ' . $menu_state . ': !' . $menu_state . ' } )" aria-haspopup="true">
+					%1$s
+					<span class="screen-reader-text" [text]="' . $menu_state . ' ? \'%3$s\' : \'%2$s\'">%2$s</span>
+				</button>',
+			$icon,
+			esc_html__( 'Open dropdown menu', 'newspack' ),
+			esc_html__( 'Close dropdown menu', 'newspack' )
 		);
-
-		// Set the current menu ID so it can be accessed by other functions.
-		Newspack_Current_Menu_ID::set_current_ID( $item->ID );
 	}
+
+	//tap:AMP.setState( { searchVisible: !searchVisible
 
 	return $output;
 }
 add_filter( 'walker_nav_menu_start_el', 'newspack_add_dropdown_icons', 10, 4 );
-
-/**
- * Add an ID with parent menu item's ID to each submenu.
- *
- * @param string $output Nav menu item start element.
- * @param int    $depth  Depth.
- * @param object $args   Nav menu args.
- * @return string Nav menu level start element.
- */
-class Newspack_Custom_Submenu_Walker extends Walker_Nav_Menu {
-	function start_lvl( &$output, $depth = 0, $args = array() ) {
-
-		// Get the current stored menu ID.
-		$menu_parent_id = Newspack_Current_Menu_ID::get_current_ID();
-
-		$submenu_ID = "submenu-" . esc_attr( $menu_parent_id );
-		$indent = str_repeat("\t", $depth);
-		$output .= "\n$indent<ul class=\"sub-menu\" id=\"$submenu_ID\">\n";
-	}
-}
 
 /**
  * The default color used for the primary color throughout this theme

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -551,7 +551,6 @@ function newspack_primary_menu() {
 				'menu_class'     => 'main-menu',
 				'container'      => false,
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-				'walker'         => new Newspack_Custom_Submenu_Walker(),
 			)
 		);
 		?>
@@ -582,7 +581,6 @@ function newspack_secondary_menu() {
 				'menu_class'     => 'secondary-menu',
 				'container'      => false,
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-				'walker'         => new Newspack_Custom_Submenu_Walker(),
 			)
 		);
 		?>

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -164,11 +164,7 @@
 	const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 	if ( 0 < dropdownToggle.length ) {
 		for ( let i = 0; i < dropdownToggle.length; i++ ) {
-			const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
-				subMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
-				subMenu = dropdownToggle[ i ].nextElementSibling;
-
-			subMenu.setAttribute( 'id', subMenuID );
+			const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' );
 
 			dropdownToggle[ i ].addEventListener(
 				'click',

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -161,16 +161,26 @@
 	} );
 
 	// Menu toggle variables.
-	const dropdownToggle = document.getElementsByClassName( 'submenu-expand' );
+	const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 	if ( 0 < dropdownToggle.length ) {
 		for ( let i = 0; i < dropdownToggle.length; i++ ) {
+			let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
+				subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+				subMenu             = dropdownToggle[ i ].nextElementSibling;
+
+			subMenu.setAttribute( 'id', subMenuID );
+
 			dropdownToggle[ i ].addEventListener(
 				'click',
 				function () {
 					if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
 						dropdownToggle[ i ].classList.remove( 'open-dropdown' );
+						dropdownToggle[ i ].setAttribute( 'aria-expanded', 'false' );
+						dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
 					} else {
 						dropdownToggle[ i ].classList.add( 'open-dropdown' );
+						dropdownToggle[ i ].setAttribute( 'aria-expanded', 'true' );
+						dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
 					}
 				},
 				false

--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -164,9 +164,9 @@
 	const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 	if ( 0 < dropdownToggle.length ) {
 		for ( let i = 0; i < dropdownToggle.length; i++ ) {
-			let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
-				subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
-				subMenu             = dropdownToggle[ i ].nextElementSibling;
+			const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
+				subMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+				subMenu = dropdownToggle[ i ].nextElementSibling;
 
 			subMenu.setAttribute( 'id', subMenuID );
 

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -15,9 +15,9 @@
 		// Loop through each dropdown menu toggle.
 		if ( 0 < dropdownToggle.length ) {
 			for ( let i = 0; i < dropdownToggle.length; i++ ) {
-				const parentMenuID = dropdownToggle[ i ].parentNode.getAttribute( 'id' ),
+				const parentMenuID = dropdownToggle[ i ].getAttribute( 'data-toggle-parent-id' ),
 					subMenu = dropdownToggle[ i ].nextElementSibling,
-					subMenuId = parentMenuID.replace( 'menu-item-', 'submenu-' );
+					subMenuId = parentMenuID.replace( 'toggle-', 'submenu-' );
 
 				// Give each submenu an ID based on their parent item ID.
 				subMenu.setAttribute( 'id', subMenuId );

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -1,0 +1,62 @@
+/* globals newspackScreenReaderText */
+
+/**
+ * File amp-fallback.js.
+ *
+ * AMP fallback JavaScript.
+ */
+
+( function () {
+
+	const primaryMenu = document.getElementById( 'site-navigation' );
+
+	// Options for the observer (which mutations to observe)
+	const config = { childList: true };
+
+	// Callback function to execute when mutations are observed.
+	const callback = ( mutationList, observer ) => {
+		for ( const mutation of mutationList ) {
+			if ( mutation.type === 'childList' ) {
+				updateMenu();
+			}
+		}
+	};
+
+// Create an observer instance linked to the callback function
+const observer = new MutationObserver( callback );
+
+// Start observing the target node for configured mutations
+observer.observe( primaryMenu, config );
+
+function updateMenu() {
+	// Get menu toggles.
+	const headerContain = document.getElementById( 'masthead' ),
+		dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
+
+	if ( 0 < dropdownToggle.length ) {
+		for ( let i = 0; i < dropdownToggle.length; i++ ) {
+			let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
+				subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+				subMenu             = dropdownToggle[ i ].nextElementSibling;
+
+			subMenu.setAttribute( 'id', subMenuID );
+
+			dropdownToggle[ i ].addEventListener(
+				'click',
+				function () {
+					if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
+						dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
+					} else {
+						dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
+					}
+				},
+				false
+			);
+		}
+	}
+
+	// Later, you can stop observing
+	observer.disconnect();
+}
+
+} )();

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -7,25 +7,6 @@
  */
 
 ( function () {
-	// Watch when primary menu is loaded by AMP.
-	const primaryMenu = document.getElementById( 'site-navigation' ),
-		config = { childList: true };
-
-	// Callback function to execute when mutations are observed.
-	const callback = mutationList => {
-		for ( const mutation of mutationList ) {
-			if ( mutation.type === 'childList' ) {
-				updateMenu();
-			}
-		}
-	};
-
-	// Create an observer instance linked to the callback function
-	const observer = new MutationObserver( callback );
-
-	// Start observing the target node for configured mutations
-	observer.observe( primaryMenu, config );
-
 	function updateMenu() {
 		// Get menu toggles.
 		const headerContain = document.getElementById( 'masthead' ),
@@ -33,26 +14,40 @@
 
 		if ( 0 < dropdownToggle.length ) {
 			for ( let i = 0; i < dropdownToggle.length; i++ ) {
-				const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
-					subMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+				const parentMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
 					subMenu = dropdownToggle[ i ].nextElementSibling;
 
-				subMenu.setAttribute( 'id', subMenuID );
-
-				dropdownToggle[ i ].addEventListener(
-					'click',
-					function () {
-						if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
-							dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
-						} else {
-							dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
-						}
-					},
-					false
-				);
+				subMenu.setAttribute( 'id', parentMenuID );
 			}
 		}
-		// Later, you can stop observing
-		observer.disconnect();
+	}
+
+	// If AMP is on, we need to hold off running this JavaScript until we're sure the menus are in their right spots:
+	if ( newspackScreenReaderText.is_amp ) {
+
+		const primaryMenu = document.getElementById( 'site-navigation' ),
+			secondaryMenu = document.getElementById( 'secondary-nav-contain' ),
+			config = { childList: true };
+
+		// Callback function to execute when mutations are observed.
+		const callback = mutationList => {
+			for ( const mutation of mutationList ) {
+				if ( mutation.type === 'childList' ) {
+					updateMenu();
+
+					// Stop observing
+					observer.disconnect();
+				}
+			}
+		};
+
+		// Create an observer instance linked to the callback function
+		const observer = new MutationObserver( callback );
+
+		// Start observing the target node for configured mutations
+		observer.observe( primaryMenu, config );
+		observer.observe( secondaryMenu, config );
+	} else {
+		updateMenu();
 	}
 } )();

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -8,16 +8,21 @@
 
 ( function () {
 	function updateMenu() {
-		// Get menu toggles.
+		// Get dropdown menu toggles in the header.
 		const headerContain = document.getElementById( 'masthead' ),
 			dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 
+		// Loop through each dropdown menu toggle.
 		if ( 0 < dropdownToggle.length ) {
 			for ( let i = 0; i < dropdownToggle.length; i++ ) {
-				const parentMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
-					subMenu = dropdownToggle[ i ].nextElementSibling;
+				const parentMenuID = dropdownToggle[ i ].parentNode.getAttribute( 'id' ),
+					subMenu = dropdownToggle[ i ].nextElementSibling,
+					subMenuId = parentMenuID.replace( 'menu-item-', 'submenu-' );
 
-				subMenu.setAttribute( 'id', parentMenuID );
+				// Give each submenu an ID based on their parent item ID.
+				subMenu.setAttribute( 'id', subMenuId );
+				// Give each dropdown toggle an aria-controls attribute that matches the submenu ID.
+				dropdownToggle[i].setAttribute( 'aria-controls', subMenuId );
 			}
 		}
 	}

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -13,7 +13,7 @@
 	const config = { childList: true };
 
 	// Callback function to execute when mutations are observed.
-	const callback = ( mutationList, observer ) => {
+	const callback = ( mutationList ) => {
 		for ( const mutation of mutationList ) {
 			if ( mutation.type === 'childList' ) {
 				updateMenu();
@@ -34,9 +34,9 @@
 
 		if ( 0 < dropdownToggle.length ) {
 			for ( let i = 0; i < dropdownToggle.length; i++ ) {
-				let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
-					subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
-					subMenu             = dropdownToggle[ i ].nextElementSibling;
+				const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
+					subMenuID = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+					subMenu = dropdownToggle[ i ].nextElementSibling;
 
 				subMenu.setAttribute( 'id', subMenuID );
 

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -49,8 +49,12 @@
 		const observer = new MutationObserver( callback );
 
 		// Start observing the target node for configured mutations
-		observer.observe( primaryMenu, config );
-		observer.observe( secondaryMenu, config );
+		if ( primaryMenu ) {
+			observer.observe( primaryMenu, config );
+		}
+		if ( secondaryMenu ) {
+			observer.observe( secondaryMenu, config );
+		}
 	} else {
 		updateMenu();
 	}

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -22,7 +22,7 @@
 				// Give each submenu an ID based on their parent item ID.
 				subMenu.setAttribute( 'id', subMenuId );
 				// Give each dropdown toggle an aria-controls attribute that matches the submenu ID.
-				dropdownToggle[i].setAttribute( 'aria-controls', subMenuId );
+				dropdownToggle[ i ].setAttribute( 'aria-controls', subMenuId );
 			}
 		}
 	}

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -7,7 +7,6 @@
  */
 
 ( function () {
-
 	const primaryMenu = document.getElementById( 'site-navigation' );
 
 	// Options for the observer (which mutations to observe)
@@ -22,41 +21,39 @@
 		}
 	};
 
-// Create an observer instance linked to the callback function
-const observer = new MutationObserver( callback );
+	// Create an observer instance linked to the callback function
+	const observer = new MutationObserver( callback );
 
-// Start observing the target node for configured mutations
-observer.observe( primaryMenu, config );
+	// Start observing the target node for configured mutations
+	observer.observe( primaryMenu, config );
 
-function updateMenu() {
-	// Get menu toggles.
-	const headerContain = document.getElementById( 'masthead' ),
-		dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
+	function updateMenu() {
+		// Get menu toggles.
+		const headerContain = document.getElementById( 'masthead' ),
+			dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 
-	if ( 0 < dropdownToggle.length ) {
-		for ( let i = 0; i < dropdownToggle.length; i++ ) {
-			let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
-				subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
-				subMenu             = dropdownToggle[ i ].nextElementSibling;
+		if ( 0 < dropdownToggle.length ) {
+			for ( let i = 0; i < dropdownToggle.length; i++ ) {
+				let dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' ),
+					subMenuID           = dropdownToggle[ i ].getAttribute( 'aria-controls' ),
+					subMenu             = dropdownToggle[ i ].nextElementSibling;
 
-			subMenu.setAttribute( 'id', subMenuID );
+				subMenu.setAttribute( 'id', subMenuID );
 
-			dropdownToggle[ i ].addEventListener(
-				'click',
-				function () {
-					if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
-						dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
-					} else {
-						dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
-					}
-				},
-				false
-			);
+				dropdownToggle[ i ].addEventListener(
+					'click',
+					function () {
+						if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
+							dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
+						} else {
+							dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
+						}
+					},
+					false
+				);
+			}
 		}
+		// Later, you can stop observing
+		observer.disconnect();
 	}
-
-	// Later, you can stop observing
-	observer.disconnect();
-}
-
 } )();

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -7,13 +7,13 @@
  */
 
 ( function () {
-	const primaryMenu = document.getElementById( 'site-navigation' );
 
-	// Options for the observer (which mutations to observe)
-	const config = { childList: true };
+	// Watch when primary menu is loaded by AMP.
+	const primaryMenu = document.getElementById( 'site-navigation' ),
+		config = { childList: true };
 
 	// Callback function to execute when mutations are observed.
-	const callback = ( mutationList ) => {
+	const callback = mutationList => {
 		for ( const mutation of mutationList ) {
 			if ( mutation.type === 'childList' ) {
 				updateMenu();

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -24,7 +24,6 @@
 
 	// If AMP is on, we need to hold off running this JavaScript until we're sure the menus are in their right spots:
 	if ( newspackScreenReaderText.is_amp ) {
-
 		const primaryMenu = document.getElementById( 'site-navigation' ),
 			secondaryMenu = document.getElementById( 'secondary-nav-contain' ),
 			config = { childList: true };

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -7,7 +7,6 @@
  */
 
 ( function () {
-
 	// Watch when primary menu is loaded by AMP.
 	const primaryMenu = document.getElementById( 'site-navigation' ),
 		config = { childList: true };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR reworks the approach I used in #1808 to add ARIA labels to the theme's dropdown menus:

I had originally used PHP and a menu walker to add the parent menu ID to each submenu to associate them with the dropdown toggle. 

This worked well with AMP because it doesn't require JavaScript. However, it did not work with how AMP handles mobile menus: the theme uses AMP's [Toolbar functionality](https://amp.dev/documentation/components/amp-sidebar#toolbar), which lets you set up the menus in the mobile `amp-sidebar`, and then use the `toolbar-target` attribute to copy the menus to the header at a certain breakpoint. The copied menus resulted in duplicate IDs that started turning up in Lighthouse reports. 

To fix, I've reworked the approach to use JavaScript. This makes it way easier to avoid the duplication, but it also means sites running AMP will need to allow two JavaScript files to have the full range of ARIA attributes in their menus.

**Note:** Due to using AMP Toolbar for the menus, the menus aren't in the header immediately on pageload when AMP is enabled. 

I ended up using `MutationObserver` to make sure the two menus with dropdowns -- the primary and secondary menus -- were actually moved before firing the JavaScript when AMP is enabled. 

Another approach I considered was getting rid of the AMP Toolbar code all together, and just duplicating the menus in header and mobile sidebar code. I went with the current approach because it changed fewer files, but I'm happy to revisit removing the Toolbar code if that seems like a better approach!

This PR also adds the text labels to the dropdown button toggles. 

Closes #1963 and #1991.

### How to test the changes in this Pull Request:

<details>
<summary><strong>1. Confirm Lighthouse errors are gone</strong></summary>

1. Set up a site with two menus - one in the primary menu location and one in the secondary menu location. 
2. Make sure both menus have at least one dropdown that's more than one level deep. 
3. Run a Lighthouse test on the desktop version of your site -- you should get reports for the following issues under the Accessibility section:

Duplicate ARIA IDs:
![image](https://user-images.githubusercontent.com/177561/213829167-94f2c646-e62a-4b35-93b0-b96d30b4a934.png)

Buttons without accessible names:
![image](https://user-images.githubusercontent.com/177561/213829150-f5a1e370-9dd5-49b7-8ca9-721c75a95436.png)

4. Apply the PR and run `npm run build`. 
5. Rerun the Lighthouse test -- both errors should now be gone. But now we have to make sure everything else still works! 
</details>

<details>
<summary><strong>2. Re-test original functionality - without new JavaScript files</strong></summary>

1. Start by testing the AMP version of your page; first we're going to test how things look without the JavaScript -- it will be missing one attribute-ID pair, but otherwise should function the same. 
2. Open the element inspector and view the code for one of your dropdowns; confirm that the button toggle (the arrow) now has the text label "Open dropdown menu", wrapped in a span with the CSS class `screen-reader-text`:

![image](https://user-images.githubusercontent.com/177561/213829874-e88ca839-009e-4a8e-bd30-f165b5022af7.png)

3. With the element inspector still open, use the keyboard to tab through the page until you're focused on the same dropdown menu toggle:

![image](https://user-images.githubusercontent.com/177561/213829895-7363c9f8-d620-4685-874a-777179159320.png)

4. Click 'Return' to open the menu.
5. Confirm that the following happens:
    * That the dropdown menu opens.
    * That the button's screen reader text label changed to "Close dropdown menu"
    * That the `aria-expanded` attribute on the button changed from `false` to `true`. 
6. Confirm that clicking 'Return' again while focused on the dropdown toggle resets things -- the menu closes, and the button's text label and `aria-expanded` attribute return to "Open dropdown menu" and `false`, respectively.
7. Click 'Return' again to reopen the dropdown menu; click Tab a few more times to to tab through the dropdown menu and repeat steps 5 and 6 on any lower levels of dropdown menu, confirming that the changes only happen on the level of menu you're operating. 
8. Repeat the above in the other menu -- so if you started with the primary menu, make sure to test the secondary menu.

</details>

<details>
<summary><strong>3. Re-testing original functionality - with new JavaScript files</strong></summary>

1. In the WP Toolbar, hover over the AMP menu item, and click 'Validate URL' from the dropdown:

![image](https://user-images.githubusercontent.com/177561/213830216-10a142f6-00c4-494c-9f69-d0e9083095d1.png)

2. On the next screen, look for two JavaScript files coming from the theme -- one will be called menu-accessibility.js, and the other is inline but probably right before it -- if you click the arrow toggle right after teh 'Invalid inline script' label, you should be able to see the script's ID, `newspack-menu-accessibility-js-extra`:

![image](https://user-images.githubusercontent.com/177561/213830888-235ca5ce-a6cd-4f54-b721-06d91050ab52.png) 

3. Mark both of these scripts as "Kept", and click "Update".
4. The JavaScript adds IDs to the submenus, so this is a good time to try re-running the Lighthouse Accessibility test again, to make sure you're not getting any duplicate errors. 
5. Inspect one of your dropdowns again. The button toggle should now have an `aria-controls` attribute with a value like `submenu-###`. The submenu `ul` right after it should have a matching ID. 
6. Confirm that steps 5 and 6 from the previous section still work as described (toggling open the menu with the keyboard works; the `aria-expanded` value and button text update).
7. Unassign the primary menu; confirm that the steps 4-5 from this section, and 5-6 from the previous section still work on the remaining secondary menu.
8. Reassign the primary menu.
9. Disable AMP. 
10. Repeat 5-6 from the previous section, and steps 4-5 and 7 from this section to make everything works the same without AMP (this is especially important because things like the `aria-expanded` and button text use additional JavaScript when AMP is off).
</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
