### PR TITLE
fix: tweak styles for slideshow block's pagination

### DIFF
--- a/newspack-theme/inc/typography.php
+++ b/newspack-theme/inc/typography.php
@@ -77,6 +77,7 @@ function newspack_custom_typography_css() {
 		.wp-caption-text,
 		.gallery-caption,
 		.amp-image-lightbox-caption,
+		.swiper-pagination-simple,
 
 		/* _infinite_scroll.scss */
 		.site-main #infinite-handle span button,
@@ -252,6 +253,7 @@ function newspack_custom_typography_css() {
 		.editor-styles-wrapper .block-editor-block-list__layout h6,
 		.block-editor-block-list__layout .block-editor-block-list__block figcaption,
 		.block-editor-block-list__layout .block-editor-block-list__block .gallery-caption,
+		.block-editor-block-list__layout .block-editor-block-list__block .swiper-pagination-simple,
 		.block-editor-block-list__layout .block-editor-block-list__block .cat-links,
 
 		/* Post Title */

--- a/newspack-theme/sass/media/_captions.scss
+++ b/newspack-theme/sass/media/_captions.scss
@@ -13,7 +13,8 @@
 }
 
 figcaption,
-.wp-caption-text {
+.wp-caption-text,
+.swiper-pagination-simple {
 	color: colors.$color__text-light;
 	margin: 0 auto;
 	padding: 0;
@@ -29,7 +30,8 @@ figcaption,
 
 figcaption,
 .wp-caption-text,
-.amp-image-lightbox-caption {
+.amp-image-lightbox-caption,
+.swiper-pagination-simple {
 	font-size: fonts.$font__size-xs;
 	font-family: fonts.$font__heading;
 	line-height: fonts.$font__line-height-pre;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -127,7 +127,8 @@ table th {
 
 figcaption,
 .gallery-caption,
-.wp-caption-text {
+.wp-caption-text,
+.swiper-pagination-simple {
 	color: colors.$color__text-light;
 	font-family: fonts.$font__heading;
 	font-size: fonts.$font__size-xxs;

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -54,7 +54,8 @@ body.newspack-single-wide-template {
 		}
 	}
 
-	figcaption {
+	figcaption,
+	.swiper-pagination-simple {
 		max-width: 1230px;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some minor tweaks to Jetpack's Slideshow block's new pagination, just to make sure they fit in with the theme, and work with the theme options.

See 1203695565716937-as-1203665389908099

### How to test the changes in this Pull Request:

1. Add a Jetpack slideshow block to a post or page, and add more than five images.
2. Note that the block now displays pagination underneath the slideshow in both the editor and on the front end. 
- When AMP is enabled, this pagination doesn't work 100%, and doesn't look right. I've filed an issue with Jetpack about the AMP support, though I'm not sure they'll want to add it -- in the meantime, though, might as well make sure the pagination looks okay with and without: 

![image](https://user-images.githubusercontent.com/177561/215887885-956af246-fe0c-47c4-a4a6-4c88501087fe.png)
- When AMP is disabled, the pagination works and is sized correctly, but it doesn't pick up the correct fonts (it uses the body font but should be using the heading font):

![image](https://user-images.githubusercontent.com/177561/215887968-235a4f95-39ba-4f5e-8587-0f3ad183d338.png)

3. Apply the PR and run `npm run build`. 
4. Confirm that the pagination is smaller and dark grey (not black) when AMP is enabled.
5. Navigate to Customizer > Typography and change your header font to something noticeably different (my fave is  `Chalkboard` on mac). 
6. Confirm that the pagination is picking up your custom font, both in the editor and on the front-end with and without AMP.

![image](https://user-images.githubusercontent.com/177561/215888254-5ccb3597-352f-44dd-bbd0-631d2dae0014.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
