### PR TITLE
fix: Sacha author bio link

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -119,7 +119,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<?php else : ?>
 			<?php echo wp_kses_post( wpautop( get_the_author_meta( 'description' ) ) ); ?>
 
-			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */
 					printf( esc_html__( 'More by %s', 'newspack' ), esc_html( get_the_author() ) );


### PR DESCRIPTION
Updates Sacha to use `get_the_author_meta` for the "Read more" link in the author bio; otherwise, the nicename isn't obtained and the link points to `/author/` with no slug.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Brings Sacha's `author-bio.php` template part in line with the Newspack parent theme. See https://github.com/Automattic/newspack-theme/pull/1053

### How to test the changes in this Pull Request:

1. Activate the Newspack Sacha theme.
2. Publish a post and assign it to any author (say, `newspack`) who has a bio.
3. Ensure the Customizer's "Display Author Bio" option is enabled and "Truncate Author Bio" is disabled.
4. Scroll to the bottom of a single post and click the author's "More by" link. It will point to `https://example.com/author/`
5. Switch to this branch and test again. The link will now go to `https://example.com/author/newspack/`

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
