### PR TITLE
fix: handle header-less layout in amp-fallback script

### DIFF
--- a/newspack-theme/js/src/amp-fallback.js
+++ b/newspack-theme/js/src/amp-fallback.js
@@ -129,7 +129,7 @@
 	}
 
 	// 'Subpage' menu fallback.
-	if ( 0 < subpageToggle.length ) {
+	if ( 0 < subpageToggle.length && headerContain ) {
 		const subpageSidebar = document.getElementById( 'subpage-sidebar-fallback' ),
 			subpageOpenButton = headerContain.querySelector( '.subpage-toggle' ),
 			subpageCloseButton = subpageSidebar.querySelector( '.subpage-toggle' );
@@ -161,26 +161,28 @@
 	} );
 
 	// Menu toggle variables.
-	const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
-	if ( 0 < dropdownToggle.length ) {
-		for ( let i = 0; i < dropdownToggle.length; i++ ) {
-			const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' );
+	if ( headerContain ) {
+		const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
+		if ( 0 < dropdownToggle.length ) {
+			for ( let i = 0; i < dropdownToggle.length; i++ ) {
+				const dropdownToggleLabel = dropdownToggle[ i ].querySelector( 'span.screen-reader-text' );
 
-			dropdownToggle[ i ].addEventListener(
-				'click',
-				function () {
-					if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
-						dropdownToggle[ i ].classList.remove( 'open-dropdown' );
-						dropdownToggle[ i ].setAttribute( 'aria-expanded', 'false' );
-						dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
-					} else {
-						dropdownToggle[ i ].classList.add( 'open-dropdown' );
-						dropdownToggle[ i ].setAttribute( 'aria-expanded', 'true' );
-						dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
-					}
-				},
-				false
-			);
+				dropdownToggle[ i ].addEventListener(
+					'click',
+					function () {
+						if ( dropdownToggle[ i ].classList.contains( 'open-dropdown' ) ) {
+							dropdownToggle[ i ].classList.remove( 'open-dropdown' );
+							dropdownToggle[ i ].setAttribute( 'aria-expanded', 'false' );
+							dropdownToggleLabel.innerText = newspackScreenReaderText.close_dropdown_menu;
+						} else {
+							dropdownToggle[ i ].classList.add( 'open-dropdown' );
+							dropdownToggle[ i ].setAttribute( 'aria-expanded', 'true' );
+							dropdownToggleLabel.innerText = newspackScreenReaderText.open_dropdown_menu;
+						}
+					},
+					false
+				);
+			}
 		}
 	}
 

--- a/newspack-theme/js/src/menu-accessibility.js
+++ b/newspack-theme/js/src/menu-accessibility.js
@@ -9,20 +9,22 @@
 ( function () {
 	function updateMenu() {
 		// Get dropdown menu toggles in the header.
-		const headerContain = document.getElementById( 'masthead' ),
-			dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
+		const headerContain = document.getElementById( 'masthead' );
+		if ( headerContain ) {
+			const dropdownToggle = headerContain.getElementsByClassName( 'submenu-expand' );
 
-		// Loop through each dropdown menu toggle.
-		if ( 0 < dropdownToggle.length ) {
-			for ( let i = 0; i < dropdownToggle.length; i++ ) {
-				const parentMenuID = dropdownToggle[ i ].getAttribute( 'data-toggle-parent-id' ),
-					subMenu = dropdownToggle[ i ].nextElementSibling,
-					subMenuId = parentMenuID.replace( 'toggle-', 'submenu-' );
+			// Loop through each dropdown menu toggle.
+			if ( 0 < dropdownToggle.length ) {
+				for ( let i = 0; i < dropdownToggle.length; i++ ) {
+					const parentMenuID = dropdownToggle[ i ].getAttribute( 'data-toggle-parent-id' ),
+						subMenu = dropdownToggle[ i ].nextElementSibling,
+						subMenuId = parentMenuID.replace( 'toggle-', 'submenu-' );
 
-				// Give each submenu an ID based on their parent item ID.
-				subMenu.setAttribute( 'id', subMenuId );
-				// Give each dropdown toggle an aria-controls attribute that matches the submenu ID.
-				dropdownToggle[ i ].setAttribute( 'aria-controls', subMenuId );
+					// Give each submenu an ID based on their parent item ID.
+					subMenu.setAttribute( 'id', subMenuId );
+					// Give each dropdown toggle an aria-controls attribute that matches the submenu ID.
+					dropdownToggle[ i ].setAttribute( 'aria-controls', subMenuId );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The JS scripts assume the site header is always present, but with the (kinda) recent addition of header/footer-less layout, this is not true.

### How to test the changes in this Pull Request:

1. On `master`, create a page with "No header or footer" template in page settings
2. With AMP off, visit the page and notice JS console errors ("Cannot read properties of null…")
3. Switch to this branch, rebuild JS, load the page again – observe no errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->