### PR TITLE
RAS: Improve header spacing when My Account link is visible

### DIFF
--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -67,16 +67,6 @@ function newspack_customize_logo_resize( $html ) {
 
 		$logo_max_width = ( $logo['width'] > 600 ) ? 600 : $logo['width'];
 
-		// Update the max-width to match the RAS max-width in the CSS - this improves the Customizer preview accuracy.
-		if ( class_exists( '\Newspack\Reader_Activation' ) ) {
-			$header_simplified     = get_theme_mod( 'header_simplified', false );
-			$header_center_logo    = get_theme_mod( 'header_center_logo', false );
-			$ras_settings = \Newspack\Reader_Activation::get_settings();
-			if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] && ( $header_simplified || $header_center_logo ) ) {
-				$logo_max_width = ( $logo['width'] > 350 ) ? 350 : $logo['width'];
-			}
-		}
-
 		// Check for max height and width, default to image sizes if none set in theme
 		$max['height'] = isset( $sizes[0]['height'] ) ? $sizes[0]['height'] : $logo['height'];
 		$max['width']  = isset( $sizes[0]['width'] ) ? $sizes[0]['width'] : $logo_max_width;
@@ -113,9 +103,12 @@ function newspack_customize_logo_resize( $html ) {
 		$sticky_max_width  = 400;
 		$sticky_max_height = 90;
 
+		$ras_max_width  = 300;
+
 		$mobile  = newspack_logo_small_sizes( $img['width'], $img['height'], $mobile_max_width, $mobile_max_height );
 		$subhead = newspack_logo_small_sizes( $img['width'], $img['height'], $subhead_max_width, $subhead_max_height );
 		$sticky  = newspack_logo_small_sizes( $img['width'], $img['height'], $sticky_max_width, $sticky_max_height );
+		$ras     = newspack_logo_small_sizes( $img['width'], $img['height'], $ras_max_width, $max['height'] );
 
 		// add the CSS
 		$css = '
@@ -150,6 +143,13 @@ function newspack_customize_logo_resize( $html ) {
 			.h-stk.h-cl:not(.h-sub):not(.has-ras-link) .site-header .custom-logo {
 				max-width: 100%;
 				width: auto;
+			}
+		}
+
+		@media (max-width: 1310px) and (min-width: 960px) {
+			.h-sh.has-ras-link .site-header .custom-logo,
+			.h-dh.h-cl.has-ras-link .site-header .custom-logo {
+				max-width: ' . $ras['width'] . 'px;
 			}
 		}
 

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -69,8 +69,10 @@ function newspack_customize_logo_resize( $html ) {
 
 		// Update the max-width to match the RAS max-width in the CSS - this improves the Customizer preview accuracy.
 		if ( class_exists( '\Newspack\Reader_Activation' ) ) {
+			$header_simplified     = get_theme_mod( 'header_simplified', false );
+			$header_center_logo    = get_theme_mod( 'header_center_logo', false );
 			$ras_settings = \Newspack\Reader_Activation::get_settings();
-			if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] ) {
+			if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] && ( $header_simplified || $header_center_logo ) ) {
 				$logo_max_width = ( $logo['width'] > 350 ) ? 350 : $logo['width'];
 			}
 		}
@@ -145,7 +147,7 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (max-width: 1199px) and (min-width: 782px) {
-			.h-stk.h-cl:not(.h-sub):not(:has-ras-link) .site-header .custom-logo {
+			.h-stk.h-cl:not(.h-sub):not(.has-ras-link) .site-header .custom-logo {
 				max-width: 100%;
 				width: auto;
 			}

--- a/newspack-theme/inc/logo-resizer.php
+++ b/newspack-theme/inc/logo-resizer.php
@@ -67,6 +67,14 @@ function newspack_customize_logo_resize( $html ) {
 
 		$logo_max_width = ( $logo['width'] > 600 ) ? 600 : $logo['width'];
 
+		// Update the max-width to match the RAS max-width in the CSS - this improves the Customizer preview accuracy.
+		if ( class_exists( '\Newspack\Reader_Activation' ) ) {
+			$ras_settings = \Newspack\Reader_Activation::get_settings();
+			if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] ) {
+				$logo_max_width = ( $logo['width'] > 350 ) ? 350 : $logo['width'];
+			}
+		}
+
 		// Check for max height and width, default to image sizes if none set in theme
 		$max['height'] = isset( $sizes[0]['height'] ) ? $sizes[0]['height'] : $logo['height'];
 		$max['width']  = isset( $sizes[0]['width'] ) ? $sizes[0]['width'] : $logo_max_width;
@@ -137,7 +145,7 @@ function newspack_customize_logo_resize( $html ) {
 		}
 
 		@media (max-width: 1199px) and (min-width: 782px) {
-			.h-stk.h-cl:not(.h-sub) .site-header .custom-logo {
+			.h-stk.h-cl:not(.h-sub):not(:has-ras-link) .site-header .custom-logo {
 				max-width: 100%;
 				width: auto;
 			}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -164,6 +164,14 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'has-highlight-menu';
 	}
 
+	// Adds class if the RAS account link is enabled.
+	if ( class_exists( '\Newspack\Reader_Activation' ) ) {
+		$ras_settings = \Newspack\Reader_Activation::get_settings();
+		if ( $ras_settings['enabled_account_link'] ) {
+			$classes[] = 'has-ras-link';
+		}
+	}
+
 	// Adds a class of has-sidebar when there is a sidebar present and populated.
 	if ( is_active_sidebar( 'sidebar-1' )
 		&& ( ( ! is_archive() && newspack_is_default_template() && ! ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) )

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -167,7 +167,7 @@ function newspack_body_classes( $classes ) {
 	// Adds class if the RAS account link is enabled.
 	if ( class_exists( '\Newspack\Reader_Activation' ) ) {
 		$ras_settings = \Newspack\Reader_Activation::get_settings();
-		if ( $ras_settings['enabled_account_link'] ) {
+		if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] ) {
 			$classes[] = 'has-ras-link';
 		}
 	}
@@ -275,6 +275,7 @@ function newspack_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );
+
 
 /**
  * Adds custom class to the array of posts classes.

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -165,9 +165,9 @@ function newspack_body_classes( $classes ) {
 	}
 
 	// Adds class if the RAS account link is enabled.
-	if ( class_exists( '\Newspack\Reader_Activation' ) ) {
-		$ras_settings = \Newspack\Reader_Activation::get_settings();
-		if ( $ras_settings['enabled'] && $ras_settings['enabled_account_link'] ) {
+	if ( class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+		$account_link_enabled = \Newspack\Reader_Activation::get_setting( 'enabled_account_link' );
+		if ( $account_link_enabled ) {
 			$classes[] = 'has-ras-link';
 		}
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -276,7 +276,6 @@ function newspack_body_classes( $classes ) {
 }
 add_filter( 'body_class', 'newspack_body_classes' );
 
-
 /**
  * Adds custom class to the array of posts classes.
  */

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -84,7 +84,7 @@
 		}
 
 		+ .newspack-reader__account-link__mobile {
-			margin-left: 4px;
+			margin-left: 2px;
 		}
 	}
 }

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -114,35 +114,38 @@
 
 @include utilities.media( tablet ) {
 	// Header default height
+	.h-dh:not( .has-ras-link ) {
+		// Mobile Menu toggle
+		.site-header .mobile-menu-toggle,
+		&.h-sub .site-header .mobile-menu-toggle,
+		.site-header .mb-cta {
+			display: none;
+		}
 
-	// Mobile Menu toggle
-	.h-dh .site-header .mobile-menu-toggle,
-	.h-dh.h-sub .site-header .mobile-menu-toggle,
-	.h-dh .site-header .mb-cta {
-		display: none;
-	}
-
-	// Desktop Menu toggle
-	.h-dh .site-header .desktop-menu-toggle,
-	.h-dh .subpage-toggle-contain {
-		display: flex;
+		// Desktop Menu toggle
+		.site-header .desktop-menu-toggle,
+		.subpage-toggle-contain {
+			display: flex;
+		}
 	}
 }
 
 @include utilities.media( narrowdesktop ) {
-	// Header - short height
+	// Header - short height & RAS link
+	.h-sh,
+	.has-ras-link {
+		// Mobile Menu toggle
+		.site-header .mobile-menu-toggle,
+		&.h-sub .site-header .mobile-menu-toggle,
+		.site-header .mb-cta {
+			display: none;
+		}
 
-	// Mobile Menu toggle
-	.h-sh .site-header .mobile-menu-toggle,
-	.h-sh.h-sub .site-header .mobile-menu-toggle,
-	.h-sh .site-header .mb-cta {
-		display: none;
-	}
-
-	// Desktop Menu toggle
-	.h-sh .site-header .desktop-menu-toggle,
-	.h-sh.h-sub .subpage-toggle-contain {
-		display: flex;
+		// Desktop Menu toggle
+		.site-header .desktop-menu-toggle,
+		&.h-sub .subpage-toggle-contain {
+			display: flex;
+		}
 	}
 }
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -52,9 +52,9 @@
 .site-header .mb-cta {
 	background: #d33;
 	color: #fff;
-	font-size: 0.7em;
+	font-size: 0.65em;
 	margin-left: auto;
-	padding: #{0.6 * structure.$size__spacing-unit} #{0.5 * structure.$size__spacing-unit};
+	padding: #{0.5 * structure.$size__spacing-unit};
 
 	&:hover {
 		background: colors.$color__text-main;
@@ -130,7 +130,7 @@
 	}
 }
 
-@include utilities.media( narrowdesktop ) {
+@include utilities.media( desktop ) {
 	// Header - short height & RAS link
 	.h-sh,
 	.has-ras-link {

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -9,6 +9,7 @@
 .subpage-toggle {
 	align-items: center;
 	background-color: transparent;
+	border-radius: 0;
 	color: inherit;
 	display: flex;
 	padding: 0;
@@ -48,6 +49,11 @@
 	margin-left: auto;
 }
 
+// RAS My Account link
+.newspack-reader__account-link__mobile {
+	margin-right: -7px; // offset the right padding
+}
+
 // Mobile CTA
 .site-header .mb-cta {
 	background: #d33;
@@ -62,7 +68,8 @@
 	}
 
 	+ .mobile-menu-toggle {
-		margin-left: #{0.5 * structure.$size__spacing-unit};
+		margin-left: #{0.75 * structure.$size__spacing-unit};
+		padding: 5px;
 
 		span {
 			display: inline-block;
@@ -71,8 +78,13 @@
 		}
 
 		svg {
-			height: 29px;
-			width: 29px;
+			height: 28px;
+			margin: 0;
+			width: 28px;
+		}
+
+		+ .newspack-reader__account-link__mobile {
+			margin-left: #{0.25 * structure.$size__spacing-unit};
 		}
 	}
 }

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -68,7 +68,7 @@
 	}
 
 	+ .mobile-menu-toggle {
-		margin-left: #{0.75 * structure.$size__spacing-unit};
+		margin-left: 12px;
 		padding: 5px;
 
 		span {
@@ -84,7 +84,7 @@
 		}
 
 		+ .newspack-reader__account-link__mobile {
-			margin-left: #{0.25 * structure.$size__spacing-unit};
+			margin-left: 4px;
 		}
 	}
 }
@@ -142,9 +142,26 @@
 	}
 }
 
+@include utilities.media( narrowdesktop ) {
+	// Header - short height
+	.h-sh:not( .has-ras-link ) {
+		// Mobile Menu toggle
+		.site-header .mobile-menu-toggle,
+		&.h-sub .site-header .mobile-menu-toggle,
+		.site-header .mb-cta {
+			display: none;
+		}
+
+		// Desktop Menu toggle
+		.site-header .desktop-menu-toggle,
+		&.h-sub .subpage-toggle-contain {
+			display: flex;
+		}
+	}
+}
+
 @include utilities.media( desktop ) {
 	// Header - short height & RAS link
-	.h-sh,
 	.has-ras-link {
 		// Mobile Menu toggle
 		.site-header .mobile-menu-toggle,

--- a/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
@@ -64,7 +64,7 @@ body.h-db.h-dh .site-header {
 
 		@include utilities.media( tablet ) {
 			&:nth-child( n + 2 ) {
-				margin: 0 0 0 #{structure.$size__spacing-unit * 0.5};
+				margin: 0 0 0 #{structure.$size__spacing-unit * 0.35};
 			}
 		}
 	}

--- a/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
@@ -64,7 +64,7 @@ body.h-db.h-dh .site-header {
 
 		@include utilities.media( tablet ) {
 			&:nth-child( n + 2 ) {
-				margin: 0 0 0 #{structure.$size__spacing-unit * 0.25};
+				margin: 0 0 0 #{structure.$size__spacing-unit * 0.5};
 			}
 		}
 	}

--- a/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
@@ -64,7 +64,7 @@ body.h-db.h-dh .site-header {
 
 		@include utilities.media( tablet ) {
 			&:nth-child( n + 2 ) {
-				margin: 0 0 0 #{structure.$size__spacing-unit * 0.75};
+				margin: 0 0 0 #{structure.$size__spacing-unit * 0.5};
 			}
 		}
 	}

--- a/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
@@ -64,7 +64,7 @@ body.h-db.h-dh .site-header {
 
 		@include utilities.media( tablet ) {
 			&:nth-child( n + 2 ) {
-				margin: 0 0 0 #{structure.$size__spacing-unit * 0.5};
+				margin: 0 0 0 #{structure.$size__spacing-unit * 0.25};
 			}
 		}
 	}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -48,17 +48,6 @@
 	}
 }
 
-/*
-.has-ras-link.h-cl.has-tertiary-menu .site-header .custom-logo-link .custom-logo {
-	height: auto;
-	max-width: 250px;
-
-	@include utilities.media( tablet ) {
-		max-width: 200px;
-	}
-}
-*/
-
 // Site identity
 .site-identity {
 	align-items: baseline;
@@ -96,6 +85,14 @@
 	padding: 0 structure.$size__spacing-unit;
 
 	@include utilities.media( mobile ) {
+		display: block;
+	}
+}
+
+.has-ras-link .site-description {
+	display: none;
+
+	@include utilities.media( desktop ) {
 		display: block;
 	}
 }
@@ -285,13 +282,6 @@
 				width: 100%;
 			}
 		}
-
-		&.has-ras-link .site-header {
-			.custom-logo {
-				max-width: 175px;
-				width: auto;
-			}
-		}
 	}
 
 	@include utilities.media( narrowdesktop ) {
@@ -328,10 +318,6 @@
 			.middle-header-contain .wrapper > div.site-branding {
 				flex: 0.5;
 			}
-
-			.custom-logo {
-				max-width: 250px;
-			}
 		}
 	}
 
@@ -352,8 +338,12 @@
 	}
 
 	@include utilities.media( wide ) {
-		&.has-ras-link.h-dh .site-header .custom-logo {
-			max-width: 350px;
+		&.has-ras-link.h-dh {
+			.site-header {
+				.middle-header-contain .wrapper > div.site-branding {
+					flex: 1;
+				}
+			}
 		}
 	}
 }
@@ -724,6 +714,26 @@
 					width: 1200px;
 				}
 			}
+		}
+	}
+}
+
+// RAS logo sizing
+.h-sh,
+.h-dh.h-cl,
+.h-stk:not( .h-sub ) {
+	&.has-ras-link .site-header .custom-logo {
+		@include utilities.media( tablet ) {
+			height: auto;
+			max-width: 175px;
+		}
+
+		@include utilities.media( desktop ) {
+			max-width: 225px;
+		}
+
+		@include utilities.media( wide ) {
+			max-width: 350px;
 		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -720,8 +720,7 @@
 
 // RAS logo sizing
 .h-sh,
-.h-dh.h-cl,
-.h-stk:not( .h-sub ) {
+.h-dh.h-cl {
 	&.has-ras-link .site-header .custom-logo {
 		@include utilities.media( tablet ) {
 			height: auto;

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -48,10 +48,12 @@
 	}
 }
 
-@include utilities.media( tablet ) {
-	.has-ras-link.h-cl.has-tertiary-menu .site-header .custom-logo-link .custom-logo {
-		height: auto;
-		max-width: 150px;
+.has-ras-link.h-cl.has-tertiary-menu .site-header .custom-logo-link .custom-logo {
+	height: auto;
+	max-width: 250px;
+
+	@include utilities.media( tablet ) {
+		max-width: 200px;
 	}
 }
 
@@ -309,6 +311,12 @@
 
 		.site-header .custom-logo {
 			max-width: inherit;
+		}
+
+		&.has-ras-link .site-header .middle-header-contain .wrapper > div {
+			&.site-branding {
+				flex: 0.5;
+			}
 		}
 	}
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -48,6 +48,13 @@
 	}
 }
 
+@include utilities.media( tablet ) {
+	.has-ras-link.h-cl.has-tertiary-menu .site-header .custom-logo-link .custom-logo {
+		height: auto;
+		max-width: 150px;
+	}
+}
+
 // Site identity
 .site-identity {
 	align-items: baseline;
@@ -170,14 +177,17 @@
 }
 
 @include utilities.media( tablet ) {
-	.h-dh .header-search-contain {
+	.h-dh:not( .has-ras-link ) .header-search-contain {
 		display: block;
 	}
 }
 
 @include utilities.media( narrowdesktop ) {
-	.h-sh .header-search-contain {
-		display: block;
+	.h-sh,
+	.has-ras-link {
+		.header-search-contain {
+			display: block;
+		}
 	}
 }
 
@@ -255,7 +265,7 @@
 			margin: auto;
 		}
 
-		&.h-dh {
+		&.h-dh:not( .has-ras-link ) {
 			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;
@@ -271,7 +281,8 @@
 	}
 
 	@include utilities.media( narrowdesktop ) {
-		&.h-sh {
+		&.h-sh,
+		&.has-ras-link {
 			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;
@@ -577,7 +588,7 @@
 			}
 		}
 
-		&.h-cl .site-header .middle-header-contain .wrapper > div {
+		&.h-cl:not( .has-ras-link ) .site-header .middle-header-contain .wrapper > div {
 			width: 31%;
 
 			&.site-branding {
@@ -591,15 +602,18 @@
 	}
 
 	&.h-cl {
-		&.h-dh .site-header .custom-logo {
+		&.h-dh:not( .has-ras-link ) .site-header .custom-logo {
 			@include utilities.media( tablet ) {
 				object-position: center center;
 			}
 		}
 
-		&.h-sh .site-header .custom-logo {
-			@include utilities.media( narrowdesktop ) {
-				object-position: center center;
+		&.h-sh,
+		&.has-ras-link {
+			.site-header .custom-logo {
+				@include utilities.media( narrowdesktop ) {
+					object-position: center center;
+				}
 			}
 		}
 	}
@@ -681,14 +695,17 @@
 
 @include utilities.media( tablet ) {
 	// Header default height
-	.h-dh .desktop-only {
+	.h-dh:not( .has-ras-link ) .desktop-only {
 		display: inherit;
 	}
 }
 
 @include utilities.media( narrowdesktop ) {
 	// Header short height
-	.h-sh .desktop-only {
-		display: inherit;
+	.h-sh,
+	.has-ras-link {
+		.desktop-only {
+			display: inherit;
+		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -33,8 +33,10 @@
 		max-width: 140px;
 
 		.custom-logo {
+			height: auto;
 			max-width: 100%;
 			object-position: left center;
+			width: 100%;
 		}
 	}
 }
@@ -52,6 +54,14 @@
 .site-identity {
 	align-items: baseline;
 	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+.has-ras-link .site-identity {
+	@media ( max-width: 1260px ) {
+		display: block;
+	}
 }
 
 // Site title
@@ -74,6 +84,14 @@
 	}
 }
 
+.has-ras-link .site-title {
+	display: none;
+
+	@include utilities.media( tablet ) {
+		display: block;
+	}
+}
+
 // Site description
 .site-description {
 	color: colors.$color__text-light;
@@ -82,7 +100,6 @@
 	font-size: fonts.$font__size-sm;
 	font-style: italic;
 	margin: 0;
-	padding: 0 structure.$size__spacing-unit;
 
 	@include utilities.media( mobile ) {
 		display: block;
@@ -405,6 +422,12 @@
 		flex-basis: auto;
 	}
 
+	&.has-ras-link {
+		.site-branding {
+			flex: 0.5;
+		}
+	}
+
 	.site-description {
 		margin: 0;
 	}
@@ -714,25 +737,6 @@
 					width: 1200px;
 				}
 			}
-		}
-	}
-}
-
-// RAS logo sizing
-.h-sh,
-.h-dh.h-cl {
-	&.has-ras-link .site-header .custom-logo {
-		@include utilities.media( tablet ) {
-			height: auto;
-			max-width: 175px;
-		}
-
-		@include utilities.media( desktop ) {
-			max-width: 225px;
-		}
-
-		@include utilities.media( wide ) {
-			max-width: 350px;
 		}
 	}
 }

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -48,6 +48,7 @@
 	}
 }
 
+/*
 .has-ras-link.h-cl.has-tertiary-menu .site-header .custom-logo-link .custom-logo {
 	height: auto;
 	max-width: 250px;
@@ -56,6 +57,7 @@
 		max-width: 200px;
 	}
 }
+*/
 
 // Site identity
 .site-identity {
@@ -184,7 +186,7 @@
 	}
 }
 
-@include utilities.media( narrowdesktop ) {
+@include utilities.media( desktop ) {
 	.h-sh,
 	.has-ras-link {
 		.header-search-contain {
@@ -280,9 +282,16 @@
 				width: 100%;
 			}
 		}
+
+		&.has-ras-link .site-header {
+			.custom-logo {
+				max-width: 175px;
+				width: auto;
+			}
+		}
 	}
 
-	@include utilities.media( narrowdesktop ) {
+	@include utilities.media( desktop ) {
 		&.h-sh,
 		&.has-ras-link {
 			.site-header .middle-header-contain .wrapper .site-branding {
@@ -297,34 +306,36 @@
 				width: 100%;
 			}
 		}
-	}
 
-	@include utilities.media( desktop ) {
-		.site-header .middle-header-contain .wrapper > div {
-			flex: 1;
-			width: auto;
-
-			&.site-branding {
+		.site-header {
+			.middle-header-contain .wrapper > div {
+				flex: 1;
 				width: auto;
+
+				&.site-branding {
+					width: auto;
+				}
+			}
+
+			.custom-logo {
+				max-width: inherit;
 			}
 		}
 
-		.site-header .custom-logo {
-			max-width: inherit;
-		}
-
-		&.has-ras-link .site-header .middle-header-contain .wrapper > div {
-			&.site-branding {
+		&.has-ras-link .site-header {
+			.middle-header-contain .wrapper > div.site-branding {
 				flex: 0.5;
 			}
+
+			.custom-logo {
+				max-width: 250px;
+			}
 		}
 	}
 
-	// IE 11-specific logo fix
-	@media screen and ( -ms-high-contrast: none ) and ( min-width: structure.$desktop_width ) {
-		.site-header .custom-logo-link img {
-			height: auto;
-			max-width: 100%;
+	@include utilities.media( wide ) {
+		&.has-ras-link.h-dh .site-header .custom-logo {
+			max-width: 350px;
 		}
 	}
 }
@@ -619,7 +630,7 @@
 		&.h-sh,
 		&.has-ras-link {
 			.site-header .custom-logo {
-				@include utilities.media( narrowdesktop ) {
+				@include utilities.media( desktop ) {
 					object-position: center center;
 				}
 			}
@@ -708,7 +719,7 @@
 	}
 }
 
-@include utilities.media( narrowdesktop ) {
+@include utilities.media( desktop ) {
 	// Header short height
 	.h-sh,
 	.has-ras-link {

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -186,12 +186,15 @@
 	}
 }
 
+@include utilities.media( narrowdesktop ) {
+	.h-sh:not( .has-ras-link ) .header-search-contain {
+		display: block;
+	}
+}
+
 @include utilities.media( desktop ) {
-	.h-sh,
-	.has-ras-link {
-		.header-search-contain {
-			display: block;
-		}
+	.has-ras-link .header-search-contain {
+		display: block;
 	}
 }
 
@@ -291,9 +294,8 @@
 		}
 	}
 
-	@include utilities.media( desktop ) {
-		&.h-sh,
-		&.has-ras-link {
+	@include utilities.media( narrowdesktop ) {
+		&.h-sh:not( .has-ras-link ) {
 			.site-header .middle-header-contain .wrapper .site-branding {
 				display: flex;
 				justify-content: center;
@@ -329,6 +331,22 @@
 
 			.custom-logo {
 				max-width: 250px;
+			}
+		}
+	}
+
+	@include utilities.media( desktop ) {
+		&.has-ras-link {
+			.site-header .middle-header-contain .wrapper .site-branding {
+				display: flex;
+				justify-content: center;
+			}
+
+			.site-header .custom-logo-link,
+			.site-title,
+			.site-description {
+				text-align: center;
+				width: 100%;
 			}
 		}
 	}
@@ -627,12 +645,15 @@
 			}
 		}
 
-		&.h-sh,
-		&.has-ras-link {
-			.site-header .custom-logo {
-				@include utilities.media( desktop ) {
-					object-position: center center;
-				}
+		&.h-sh:not( .has-ras-link ) .site-header .custom-logo {
+			@include utilities.media( narrowdesktop ) {
+				object-position: center center;
+			}
+		}
+
+		&.has-ras-link .site-header .custom-logo {
+			@include utilities.media( desktop ) {
+				object-position: center center;
 			}
 		}
 	}
@@ -719,12 +740,15 @@
 	}
 }
 
-@include utilities.media( desktop ) {
+@include utilities.media( narrowdesktop ) {
 	// Header short height
-	.h-sh,
-	.has-ras-link {
-		.desktop-only {
-			display: inherit;
-		}
+	.h-sh:not( .has-ras-link ) .desktop-only {
+		display: inherit;
+	}
+}
+
+@include utilities.media( desktop ) {
+	.has-ras-link .desktop-only {
+		display: inherit;
 	}
 }

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -35,7 +35,7 @@
 		border-radius: 5px;
 		font-size: fonts.$font__size-sm;
 		font-weight: 700;
-		padding: #{structure.$size__spacing-unit * 0.5} #{structure.$size__spacing-unit * 0.75};
+		padding: #{structure.$size__spacing-unit * 0.5};
 	}
 
 	.menu-highlight a {

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -35,7 +35,7 @@
 		border-radius: 5px;
 		font-size: fonts.$font__size-sm;
 		font-weight: 700;
-		padding: #{structure.$size__spacing-unit * 0.5};
+		padding: #{structure.$size__spacing-unit * 0.5} #{structure.$size__spacing-unit * 0.75};
 	}
 
 	.menu-highlight a {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR attempts to create some more space for the RAS My Account link, without changing very much about the spacing and appearance of the header when the link is not enabled. 

To hopefully avoid causing too many changes to live sites, I tried to target these changes to only be applied when the logo is centred or the header is short, and when the My Account link is enabled. 

See 203981098043663-as-1203870203438177

### How to test the changes in this Pull Request:

This is one of those pull requests that ideally will be tested with a bunch of different header settings, and different logo shapes (a vertical logo, and a horizontal logo). 

<details><summary><strong>Some tester logos if you'd like them!</strong></summary>

![logo-1](https://user-images.githubusercontent.com/177561/222634833-7f2493a5-0303-4906-8780-525ff575802b.png)

![logo-2](https://user-images.githubusercontent.com/177561/222634845-62d08bf2-f344-4935-8b18-6452e9b9f83f.png)

![logo-3](https://user-images.githubusercontent.com/177561/222634848-f1b18f58-b467-47e6-8668-4d3e39c63196.png)

![logo-4](https://user-images.githubusercontent.com/177561/222634873-3b2bbb05-8aa4-4e18-9a30-3a1b922031c2.png)
</details>

I've tried to break this down into different specific things to test, if you really want to get into the weeds -- I've gone through all of these as well, so it's really just to help spook out anything I may have missed! 😬 

This PR should be tested with https://github.com/Automattic/newspack-plugin/pull/2311.

#### Code

1. Is the approach for checking for RAS a good one, or is there another way we'd prefer this be handled?

#### Comparing non-RAS views

1. Turn off RAS.
2. Cycle through the following combinations and compare master to this PR - the vertical spacing may differ a bit, but the logo sizes should be the same:

- [ ] Default height with left aligned logo
- [ ] Default height with left aligned logo + sticky
- [ ] Default height with centre aligned logo
- [ ] Default height with centre aligned logo + sticky
- [ ] Short height with a left aligned logo
- [ ] Short height with a left aligned logo + sticky
- [ ] Short height with a centre aligned logo
- [ ] Short height with a centre aligned logo + sticky

<details><summary><strong>Screenshots - Default Height Header</strong></summary>

In these screenshots, you can see the slight spacing difference in the tertiary menu, but the logo should be the same size in the before and after.

I set the logos to a larger, but reasonable size (it is set to a smaller size for the short header).

Default header, centred logo - before
![default-centre-master](https://user-images.githubusercontent.com/177561/222615552-d0174daa-4c0c-4141-bbca-42bd7c9fbc74.png)

Default header, centred logo - after
![default-centre](https://user-images.githubusercontent.com/177561/222613153-ed2a4797-8c4a-4abc-89b0-0f18120448f2.png)

Default header, centred logo, sticky - before
![default-centre-sticky-master](https://user-images.githubusercontent.com/177561/222613296-1e6e99cc-8585-4b69-8789-c94dd000f7a1.png)

Default header, centred logo, sticky - after
![default-centre-sticky](https://user-images.githubusercontent.com/177561/222613291-7e475cc8-98a8-479c-98bb-312f6b02f370.png)

Default header, left logo - before
![default-left-master](https://user-images.githubusercontent.com/177561/222613422-70e3ce36-7480-4a51-a6f2-2a3fd3520c48.png)

Default header, left logo - after
![default-left](https://user-images.githubusercontent.com/177561/222616331-a64f10c5-e0b2-4e7a-924e-7874267f6647.png)

Default header, left logo, sticky - before
![default-left-sticky-master](https://user-images.githubusercontent.com/177561/222615066-b92fa453-8619-4d68-84f0-6e59f7239163.png)

Default header, left logo, sticky - after
![default-left-sticky](https://user-images.githubusercontent.com/177561/222615079-a51d3960-c721-4e8c-9cab-de71710373a6.png)
</details>

<details><summary><strong>Screenshots - Short Height Header</strong></summary>

In these screenshots, you can see the slight spacing difference in the tertiary menu, but the logo should be the same size in the before and after.

I set the logos to a larger, but reasonable size (it is set to a smaller size for the short header).

Short header, centre logo - before
![short-centre-master](https://user-images.githubusercontent.com/177561/222615171-7604a4d0-cd3a-449c-ab37-6f0e1d432a2a.png)

Short header, centre logo - after
![short-centre](https://user-images.githubusercontent.com/177561/222615180-7fcc5929-2ed5-4115-b4c1-0ed6b593ce79.png)

Short header, centre logo, sticky - before
![short-centre-sticky-master](https://user-images.githubusercontent.com/177561/222615223-97eb61ce-11bc-46a6-97e7-8b291b12d9b0.png)

Short header, centre logo, sticky - after
![short-centre-sticky](https://user-images.githubusercontent.com/177561/222615235-fd08a291-fc4c-41c2-ab47-a3726207c96b.png)

Short header, left logo - before
![short-left-master](https://user-images.githubusercontent.com/177561/222615375-4d5b7568-a11f-4ca6-b99b-52b9bb7df21c.png)

Short header, left logo - after
![short-left](https://user-images.githubusercontent.com/177561/222615392-de6bf6a7-5709-489a-9103-a1a1188be77a.png)

Short header, left logo, sticky - before
![short-left-sticky-master](https://user-images.githubusercontent.com/177561/222615406-67438d58-b6d1-40c7-8d32-b08493263f91.png)

Short header, left logo, sticky - after
![short-left-sticky](https://user-images.githubusercontent.com/177561/222615416-4198e650-cd1c-4629-851d-f99ff06f74b8.png)
</details>

#### Comparing RAS views

1. Turn on RAS.
2. Apply this PR.
3. Cycle through the following combinations and confirm that non-sticky headers have a new max-width of 350px for the logos.
4. Try scaling down each view from desktop to mobile, and confirm that your menus _usually_ have enough space, and that things look okay. This isn't going to work with every combination of longer menus, but your tertiary menu + My Account link should work pretty well before it switches to the mobile view:

- [ ] Default height with centre aligned logo
- [ ] Default height with centre aligned logo + sticky
- [ ] Short height with a left aligned logo
- [ ] Short height with a left aligned logo + sticky
- [ ] Short height with a centre aligned logo
- [ ] Short height with a centre aligned logo + sticky

<details>
<summary><strong>Screenshots - Default Height Header</strong></summary>

In testing these header settings, it's expected that the default height, centred logo should be smaller than the non-RAS example above and their "before" counterparts. 

Default height, centre logo -before
![ras-default-centre-master](https://user-images.githubusercontent.com/177561/222636138-215c4dad-4ebd-4e5b-b68e-7b79af6253c0.png)

Default height, centre logo - after 
![ras-default-centre](https://user-images.githubusercontent.com/177561/222635462-6c7f5883-1c51-457f-abfa-0ddf310ea2f0.png)

Default height, centre logo, sticky - before
![ras-default-centre-sticky-master](https://user-images.githubusercontent.com/177561/222636179-81ca7dc2-a18f-4090-8885-9de86435d0c8.png)

Default height, centre logo, sticky - after
![ras-default-centre-sticky](https://user-images.githubusercontent.com/177561/222615701-b2b3a517-494a-4a8d-abcf-fd66c162fc3d.png)

Default height, mobile - before
![ras-default-centre-mobile-master](https://user-images.githubusercontent.com/177561/222636218-ed1b8308-0d7f-40d7-a905-699bfac97ebc.png)

Default height, mobile - after
![ras-default-left-mobile](https://user-images.githubusercontent.com/177561/222616543-eb648211-54f4-46d7-b842-54bf26060a13.png)
</details>


<details>
<summary><strong>Screenshots - Short Height Header</strong></summary>

It's expected that the short header should have a smaller logo than the non-RAS screenshots above, for both the centred and left aligned options. 

Like with the default height header, the logos in the sticky headers should be roughly the same as their non-RAS counterparts.

Short header, centre logo - before:
![ras-short-centre-master](https://user-images.githubusercontent.com/177561/222636424-80fdc078-204f-4917-8b63-c01a0cbcb975.png)

Short header, centre logo - after:
![ras-short-centre](https://user-images.githubusercontent.com/177561/222618172-8edad0ca-9a2f-42ed-a169-e0e2e32db70b.png)

Short header, centre logo, sticky - before:
![ras-short-centre-sticky-master](https://user-images.githubusercontent.com/177561/222636443-33829144-8cfc-48c9-a726-1b7b57b34f75.png)

Short header, centre logo, sticky - after:
![ras-short-centre-sticky](https://user-images.githubusercontent.com/177561/222618189-babff12f-2b59-4fe7-9225-1da0801a53f3.png)

Short header, left logo - before:
![ras-short-left-master](https://user-images.githubusercontent.com/177561/222636465-cacb4432-e126-4d38-a4c3-b6552b0170c7.png)

Short header, left logo - after:
![ras-short-left](https://user-images.githubusercontent.com/177561/222618203-035cfa8b-9c7d-42bf-89a9-f8b1d1fc2691.png)

Short header, left logo, sticky - before:
![ras-short-left-sticky-master](https://user-images.githubusercontent.com/177561/222636486-c6bb82d0-a148-45ef-8336-62855f4c950e.png)

Short header, left logo, sticky - after:
![ras-short-left-sticky](https://user-images.githubusercontent.com/177561/222618210-7006cd04-3841-4a6f-a5a3-b4956dbfe0e0.png)

Short header, mobile - before:
![ras-short-centre-mobile-master](https://user-images.githubusercontent.com/177561/222777136-d17e2d15-36cc-4603-8e21-6a70c0576740.png)

Short header, mobile - after:
![ras-short-left-mobile](https://user-images.githubusercontent.com/177561/222618221-3933f08b-89f2-4b13-aa8b-ff191ca5e260.png)

</details>

#### Awesome AMP testing that everyone loves

1. Turn on RAS
2. Apply this PR
3. Spot check a few of the header options below with AMP and without AMP -- you're specifically checking:
* With AMP enabled: do smaller/portrait-sized logos have excessive space around them?
* With AMP disabled: are logos of any size/shape distorted?

Randomly testing and resizing some of these settings with a tall + small logo, and a horizontal one, would be much appreciated! 

- [ ] Default height with centre aligned logo
- [ ] Default height with centre aligned logo + sticky
- [ ] Short height with a left aligned logo
- [ ] Short height with a left aligned logo + sticky
- [ ] Short height with a centre aligned logo
- [ ] Short height with a centre aligned logo + sticky


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
