### PR TITLE
fix: css :not() rules with multi-selectors broken in AMP

### DIFF
--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -42,7 +42,7 @@ Newspack Katharine Editor Styles
 	font-weight: bold;
 }
 
-.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption, .show-category)
+.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 	.post-has-image {
 	.entry-title {
 		background-color: colors.$color__background-body;
@@ -69,7 +69,7 @@ Newspack Katharine Editor Styles
 
 .wpnbha.has-text-align-center {
 	.article-section-title::before,
-	&.show-image.image-aligntop:not(.show-caption, .show-category)
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		margin-left: auto;
@@ -88,7 +88,7 @@ Newspack Katharine Editor Styles
 			top: 0;
 		}
 	}
-	&.show-image.image-aligntop:not(.show-caption, .show-category)
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		margin-left: 15%;
@@ -97,7 +97,7 @@ Newspack Katharine Editor Styles
 
 .wp-block-cover,
 .wp-block-group {
-	.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not(.show-caption, .show-category)
+	.wp-block-newspack-blocks-homepage-articles.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		background-color: transparent;
@@ -115,7 +115,7 @@ figure.wp-block-pullquote {
 	font-weight: bold;
 	position: relative;
 
-	&:not(.is-style-solid-color, .has-background) {
+	&:not( .is-style-solid-color ):not( .has-background ) {
 		blockquote {
 			padding-left: #{2 * structure.$size__spacing-unit};
 		}

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -51,7 +51,7 @@
 
 .wpnbha.has-text-align-center {
 	.article-section-title::before,
-	&.show-image.image-aligntop:not(.show-caption, .show-category)
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		margin-left: auto;
@@ -70,7 +70,7 @@
 		}
 	}
 
-	&.show-image.image-aligntop:not(.show-caption, .show-category)
+	&.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		margin-left: 15%;
@@ -150,7 +150,7 @@ div.wpnbha .article-section-title,
 	border-bottom-color: colors.$color__text-main;
 }
 
-.wpnbha.show-image.image-aligntop:not(.show-caption, .show-category) .post-has-image {
+.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category ) .post-has-image {
 	.entry-title {
 		background-color: colors.$color__background-body;
 		margin-top: -1.5em;
@@ -166,7 +166,7 @@ div.wpnbha .article-section-title,
 }
 
 .widget
-	.wpnbha.show-image.image-aligntop:not(.show-caption, .show-category)
+	.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 	.post-has-image {
 	.entry-title {
 		background: transparent;
@@ -189,7 +189,7 @@ div.wpnbha .article-section-title,
 
 .wp-block-cover,
 .wp-block-group {
-	.wpnbha.show-image.image-aligntop:not(.show-caption, .show-category)
+	.wpnbha.show-image.image-aligntop:not( .show-caption ):not( .show-category )
 		.post-has-image
 		.entry-title {
 		background-color: transparent;
@@ -303,8 +303,8 @@ figcaption,
 		}
 	}
 
-	&.has-text-align-right:not(.alignleft, .alignright),
-	&.has-text-align-left:not(.alignleft, .alignright) {
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
 		@include utilities.media( tablet ) {
 			p {
 				font-size: fonts.$font__size-xl;
@@ -332,7 +332,7 @@ figcaption,
 		text-transform: uppercase;
 	}
 
-	&:not(.is-style-solid-color, .has-background) {
+	&:not( .is-style-solid-color ):not( .has-background ) {
 		blockquote {
 			padding-left: #{2 * structure.$size__spacing-unit};
 		}
@@ -368,7 +368,7 @@ figcaption,
 			}
 		}
 
-		&:not(.is-style-solid-color, .has-background) {
+		&:not( .is-style-solid-color ):not( .has-background ) {
 			padding-top: structure.$size__spacing-unit;
 
 			blockquote {
@@ -381,7 +381,7 @@ figcaption,
 		}
 	}
 
-	&.alignfull:not(.is-style-solid-color, .has-background)::before {
+	&.alignfull:not( .is-style-solid-color ):not( .has-background )::before {
 		left: 8px;
 	}
 }

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -161,7 +161,7 @@ blockquote {
 		}
 	}
 
-	&:not(.is-style-dots, .is-style-wide) {
+	&:not( .is-style-dots ):not( .is-style-wide ) {
 		border-top: 5px solid colors.$color__text-main;
 
 		&.has-background {

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -58,7 +58,7 @@
 body:not( .h-stk ) .site-content,
 body:not( .h-stk ).hide-page-title .site-content,
 body:not( .h-stk ).newspack-front-page.hide-homepage-title .site-content,
-body:not(.h-stk, .newspack-front-page)
+body:not( .h-stk ):not( .newspack-front-page )
 	.newspack_global_ad.global_below_header
 	+ .site-content,
 body:not( .h-stk ) .site-breadcrumb {
@@ -404,8 +404,8 @@ blockquote {
 		}
 	}
 
-	&.has-text-align-right:not(.alignleft, .alignright),
-	&.has-text-align-left:not(.alignleft, .alignright) {
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
 		@include utilities.media( tablet ) {
 			p {
 				font-size: fonts.$font__size-xl;
@@ -476,7 +476,7 @@ blockquote {
 		border-top: 2px solid currentcolor;
 	}
 
-	&:not(.is-style-dots, .is-style-wide) {
+	&:not( .is-style-dots ):not( .is-style-wide ) {
 		border-top: 5px solid colors.$color__text-main;
 		height: 0;
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -172,8 +172,8 @@ cite {
 		}
 	}
 
-	&.has-text-align-right:not(.alignleft, .alignright),
-	&.has-text-align-left:not(.alignleft, .alignright) {
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
 		@include utilities.media( tablet ) {
 			p {
 				font-size: fonts.$font__size-xl;

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -140,8 +140,8 @@ div.wpnbha .article-section-title {
 		}
 	}
 
-	&.has-text-align-right:not(.alignleft, .alignright),
-	&.has-text-align-left:not(.alignleft, .alignright) {
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
 		@include utilities.media( tablet ) {
 			p {
 				font-size: fonts.$font__size-xl;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -120,7 +120,7 @@
 		.wp-block-group {
 			&.alignfull,
 			&.alignwide {
-				> div > *:not( .alignfull, .alignwide ) {
+				> div > *:not( .alignfull ):not( .alignwide ) {
 					margin-left: auto;
 					margin-right: auto;
 					max-width: 1200px;
@@ -424,8 +424,8 @@ p.has-background {
 		}
 	}
 
-	&.has-text-align-right:not( .alignleft, .alignright ),
-	&.has-text-align-left:not( .alignleft, .alignright ) {
+	&.has-text-align-right:not( .alignleft ):not( .alignright ),
+	&.has-text-align-left:not( .alignleft ):not( .alignright ) {
 		p {
 			font-size: fonts.$font__size-lg;
 			@include utilities.media( tablet ) {
@@ -1499,7 +1499,7 @@ $colors: (
 		> .wp-block-group {
 			&.alignfull,
 			&.alignwide {
-				> div > *:not( .alignfull, .alignwide ) {
+				> div > *:not( .alignfull ):not( .alignwide ) {
 					margin-left: auto;
 					margin-right: auto;
 					max-width: 780px;
@@ -1541,7 +1541,7 @@ $colors: (
 	// Make sure content in a full-width group block doesn't touch edges
 	.entry .entry-content > .wp-block-group,
 	[id='pico'] > .wp-block-group {
-		&.alignfull:not( .has-background, .is-style-border ) {
+		&.alignfull:not( .has-background ):not( .is-style-border ) {
 			padding-left: 5.5%;
 			padding-right: 5.5%;
 		}

--- a/newspack-theme/sass/layout/_layout.scss
+++ b/newspack-theme/sass/layout/_layout.scss
@@ -169,7 +169,7 @@
 		}
 	}
 
-	&:not(.hide-page-title, [class*='single-featured-image-']) {
+	&:not( .hide-page-title ):not( [class*='single-featured-image-'] ) {
 		.entry-header {
 			margin-top: structure.$size__spacing-unit;
 		}

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -125,6 +125,18 @@ body {
 			z-index: 1;
 		}
 	}
+
+	&.single-featured-image-behind:not( .newspack-front-page ) .global_below_header + .site-content {
+		margin-top: 0;
+	}
+
+	@include utilities.media( tablet ) {
+		&.single-featured-image-beside:not( .newspack-front-page )
+			.global_below_header
+			+ .site-content {
+			margin-top: 0;
+		}
+	}
 }
 
 .single-featured-image-behind .newspack_global_ad.global_below_header {

--- a/newspack-theme/sass/plugins/newspack-ads.scss
+++ b/newspack-theme/sass/plugins/newspack-ads.scss
@@ -125,20 +125,6 @@ body {
 			z-index: 1;
 		}
 	}
-
-	&.single-featured-image-behind:not(.newspack-front-page, .style-pack-style-2)
-		.global_below_header
-		+ .site-content {
-		margin-top: 0;
-	}
-
-	@include utilities.media( tablet ) {
-		&.single-featured-image-beside:not(.newspack-front-page, .style-pack-style-2)
-			.global_below_header
-			+ .site-content {
-			margin-top: 0;
-		}
-	}
 }
 
 .single-featured-image-behind .newspack_global_ad.global_below_header {

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -446,7 +446,7 @@ div[data-align='full'] {
 /** === Blockquote === */
 
 .wp-block-quote {
-	&:not(.is-large, .is-style-large) {
+	&:not( .is-large ):not( .is-style-large ) {
 		border-width: 2px;
 		border-color: colors.$color__link;
 	}
@@ -729,7 +729,7 @@ div[data-align='full'] {
 		border-top: 1px solid colors.$color__border;
 	}
 
-	&:not(.is-style-wide, .is-style-dots) {
+	&:not( .is-style-wide ):not( .is-style-dots ) {
 		max-width: #{5 * structure.$size__spacing-unit};
 		margin-left: auto;
 		margin-right: auto;

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -45,7 +45,7 @@ body.newspack-single-wide-template {
 
 	.wp-block[data-type='core/group'][data-align='wide'],
 	.wp-block[data-type='core/group'][data-align='full'] {
-		.wp-block:not([data-align='wide'], [data-align='full']) {
+		.wp-block:not( [data-align='wide'] ):not( [data-align='full'] ) {
 			max-width: 1230px; // 1200px + 30px to offset padding
 		}
 
@@ -73,7 +73,7 @@ body.newspack-single-column-template {
 			padding: 0 structure.$size__spacing-unit;
 		}
 
-		.wp-block-group:not(.has-background, .is-style-border) {
+		.wp-block-group:not( .has-background ):not( .is-style-border ) {
 			padding-left: #{0.5 * structure.$size__spacing-unit};
 			padding-right: #{0.5 * structure.$size__spacing-unit};
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes several instances of a CSS selector that AMP doesn't like:

```css
.selector:not( .sub-selector-1, .sub-selector-2 )
```

should be:

```css
.selector:not( .sub-selector-1 ):not( .sub-selector-2 )
```

These selectors tend to target highly specific groups of blocks that mainly appear on homepages.

### How to test the changes in this Pull Request:

1. On a fresh test site, enable AMP and install the [bad theme version](https://github.com/Automattic/newspack-theme/releases/tag/v1.69.1).
2. View the homepage and observe that it's broken, mainly because all the CSS below the first instance of the `:not` combo-selector is not compiled by AMP.

<img width="1117" alt="Screen Shot 2023-03-14 at 4 38 05 PM" src="https://user-images.githubusercontent.com/2230142/225157663-00a04ecb-7d9b-4eca-b046-5934fe275f7a.png">

3. Check out this branch, rebuild CSS, confirm that the homepage renders as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
