### PR TITLE
fix: display underwriters with default placement value

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -481,7 +481,7 @@ function newspack_sponsored_underwriters_info( $sponsors = null, $id = null, $sc
 							return false;
 						}
 
-						return isset( $sponsor['sponsor_underwriter_placement'] ) ? 'inherit' === $sponsor['sponsor_underwriter_placement'] : true;
+						return isset( $sponsor['sponsor_underwriter_placement'] ) ? 'top' === $sponsor['sponsor_underwriter_placement'] || 'inherit' === $sponsor['sponsor_underwriter_placement'] : true;
 					}
 				);
 				$underwriters_bottom = array_filter(

--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -73,7 +73,7 @@ function newspack_get_native_sponsors( $sponsors = [] ) {
 	}
 
 	// Scope override: if post is set to display as underwritten, return nothing.
-	if ( 'underwritten'  === $scope_override ) {
+	if ( 'underwritten' === $scope_override ) {
 		return [];
 	}
 
@@ -106,7 +106,7 @@ function newspack_get_underwriter_sponsors( $sponsors = [] ) {
 	}
 
 	// Scope override: if post is set to display as underwritten, return all sponsors.
-	if ( 'underwritten'  === $scope_override ) {
+	if ( 'underwritten' === $scope_override ) {
 		return $sponsors;
 	}
 
@@ -221,7 +221,7 @@ if ( ! function_exists( 'newspack_sponsor_byline' ) ) :
 				}
 				?>
 			</span><!-- .byline -->
-		<?php
+			<?php
 		}
 	}
 endif;
@@ -276,7 +276,7 @@ if ( ! function_exists( 'newspack_sponsor_label' ) ) :
 					</span>
 				<?php endif; ?>
 			</span><!-- .sponsor-label -->
-		<?php
+			<?php
 		endif;
 	}
 endif;
@@ -297,19 +297,19 @@ if ( ! function_exists( 'newspack_sponsor_logo_list' ) ) :
 
 		if ( ! empty( $sponsors ) ) {
 			echo '<span class="sponsor-logos">';
-				foreach ( $sponsors as $sponsor ) {
-					if ( ! empty( $sponsor['sponsor_logo'] ) ) :
-						if ( '' !== $sponsor['sponsor_url'] ) {
-							echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
-						}
-						?>
+			foreach ( $sponsors as $sponsor ) {
+				if ( ! empty( $sponsor['sponsor_logo'] ) ) :
+					if ( '' !== $sponsor['sponsor_url'] ) {
+						echo '<a href="' . esc_url( $sponsor['sponsor_url'] ) . '" target="_blank">';
+					}
+					?>
 							<img src="<?php echo esc_url( $sponsor['sponsor_logo']['src'] ); ?>" width="<?php echo esc_attr( $sponsor['sponsor_logo']['img_width'] ); ?>" height="<?php echo esc_attr( $sponsor['sponsor_logo']['img_height'] ); ?>">
 						<?php if ( '' !== $sponsor['sponsor_url'] ) : ?>
 							</a>
 						<?php endif; ?>
 					<?php
 					endif;
-				}
+			}
 			echo '</span>';
 		}
 	}
@@ -337,7 +337,7 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 				ob_start();
 				if ( ! empty( $sponsors ) ) {
 					foreach ( $sponsors as $sponsor ) {
-					?>
+						?>
 
 						<div class="author-bio sponsor-bio">
 
@@ -387,7 +387,7 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 
 							</div><!-- .author-bio-text -->
 						</div><!-- .author-bio -->
-					<?php
+						<?php
 					}
 				}
 
@@ -447,7 +447,7 @@ function newspack_sponsor_archive_description( $sponsors = null, $id = null, $sc
 					<?php echo wp_kses_post( $sponsor['sponsor_blurb'] ); ?>
 				</div><!-- .info -->
 			</div><!-- .sponsor-archive -->
-		<?php
+			<?php
 		}
 	}
 }
@@ -471,7 +471,7 @@ function newspack_sponsored_underwriters_info( $sponsors = null, $id = null, $sc
 		add_filter(
 			'the_content',
 			function( $content ) use ( $sponsors, $override_style, $override_placement ) {
-				$underwriters_top = array_filter(
+				$underwriters_top    = array_filter(
 					$sponsors,
 					function( $sponsor ) use ( $override_placement ) {
 						if ( 'top' === $override_placement ) {
@@ -481,7 +481,7 @@ function newspack_sponsored_underwriters_info( $sponsors = null, $id = null, $sc
 							return false;
 						}
 
-						return isset( $sponsor['sponsor_underwriter_placement'] ) ? 'top' === $sponsor['sponsor_underwriter_placement'] : true;
+						return isset( $sponsor['sponsor_underwriter_placement'] ) ? 'inherit' === $sponsor['sponsor_underwriter_placement'] : true;
 					}
 				);
 				$underwriters_bottom = array_filter(
@@ -518,7 +518,8 @@ function newspack_sponsors_get_underwriter_content( $sponsor, $style = 'standard
 	if (
 		( 'simple' === $style ) ||
 		( 'standard' !== $style && isset( $sponsor['sponsor_underwriter_style'] ) && 'simple' === $sponsor['sponsor_underwriter_style'] )
-	) : ?>
+	) :
+		?>
 		<div class="sponsor-uw-info__simple">
 			<?php if ( ! empty( $sponsor['sponsor_url'] ) ) : ?>
 				<a href="<?php echo esc_url( $sponsor['sponsor_url'] ); ?>" target="_blank">
@@ -547,7 +548,8 @@ function newspack_sponsors_get_underwriter_content( $sponsor, $style = 'standard
 				<?php echo wp_kses_post( $sponsor['sponsor_blurb'] ); ?>
 			</div>
 		</div>
-	<?php endif;
+		<?php
+	endif;
 
 	return ob_get_clean();
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with default sponsor meta values. The default values for several meta fields is `inherit`, but the theme expects them to be something else, which causes some issues with display when defaults are used. This mainly affects the display of underwriter-type sponsors when no post-level overrides are set.

Closes `1200550061930446/1204158091646412`

### How to test the changes in this Pull Request:

1. On `master`, publish a new sponsor with a title and some content and set the scope to Underwritten Content. Leave everything else default/blank.
2. Apply the underwriter to a post and leave all Sponsor Display Overrides to their defaults ("Inherit from sponsor").
3. On the front-end observe that the underwriter info isn't displayed at all.
4. Check out this branch, confirm that now the underwriter info is displayed at the top of the post (the default placement).
5. Play with different sponsor settings in the sponsor and the corresponding override settings in the post, and ensure that the display settings are reflected on the front-end (sponsor settings are used unless a different override is set on the post).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
