### PR TITLE
Fix spelling in german translation

### DIFF
--- a/newspack-theme/languages/de_DE.po
+++ b/newspack-theme/languages/de_DE.po
@@ -1168,7 +1168,7 @@ msgid ""
 "Sorry, but nothing matched your search terms. Please try again with some "
 "different keywords."
 msgstr ""
-"Es tut uns leid. Ihre Sucher ergab keinen Treffer, Bitte versuchen Sie es "
+"Es tut uns leid. Ihre Suche ergab keinen Treffer, Bitte versuchen Sie es "
 "mit einem anderen Begriff."
 
 #: template-parts/content/content-none.php:44


### PR DESCRIPTION
The spelling of "Ihre Sucher" is wrong, no "r" at the end.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->