### PR TITLE
fix: remove post author, comments blocks from displayed list

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -634,6 +634,7 @@ function newspack_fse_blocks_to_remove() {
 	// List of all FSE blocks to remove from the editor.
 	$fse_blocks = array(
 		'core/loginout',
+		'core/comments',
 		'core/post-comments-form',
 		'core/comments-query-loop',
 		'core/query',
@@ -644,6 +645,7 @@ function newspack_fse_blocks_to_remove() {
 		'core/post-terms',
 		'core/post-date',
 		'core/post-author',
+		'core/post-author-name',
 		'core/post-navigation-link',
 		'core/read-more',
 		'core/avatar',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the list of "allowed" FSE blocks in the theme, to remove a couple more renamed (?) blocks by default. More information hiding these blocks can be found in this PR: #1823.

See 1204166503564710-as-1204180767149438

### How to test the changes in this Pull Request:

1. In the editor, open the Block inserter and scroll down to the "Themes" section.
2. Note that the blocks there include a couple blocks that are intended for the post query: Post Author and Comments:

![image](https://user-images.githubusercontent.com/177561/230653413-351596cc-36f5-4d09-8032-87126c0f75e5.png)

3. Apply the PR, and run `npm run build.
4. Refresh the editor and confirm those blocks are now gone from the list, but the others remain (Navigation, Site Logo, Site Title, Site Tagline). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
