### PR TITLE
fix: allow woo required field asterisk toggle

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -56,7 +56,6 @@ a.button {
 		.required {
 			color: firebrick;
 			text-decoration: none;
-			display: none; // Only show optional by default.
 
 			&[title] {
 				border: 0 !important;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove CSS rule that is overwriting the Woo setting for toggling the asterisk from required fields during checkout:

<img width="1206" alt="Captura de Tela 2023-04-12 às 15 39 20" src="https://user-images.githubusercontent.com/820752/231554368-6b7998d3-9b25-42de-8ebb-860b5a34ba9f.png">

### How to test the changes in this Pull Request:

1. While in the master branch, navigate to the customizer and visit WooCommerce -> Checkout
2. Toggle the field highlighted above and confirm the asterisks never render
3. Check out this branch and confirm the asterisks toggles as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
