### PR TITLE
fix: correct the default color used for the highlight menu label

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -80,7 +80,6 @@ function newspack_custom_colors_css() {
 			.mobile-sidebar .nav1 .sub-menu > li > a,
 			.mobile-sidebar .nav1 ul.main-menu > li > a,
 			.wp-block-file .wp-block-file__button,
-			.highlight-menu .menu-label,
 			/* Header default background; default height */
 			body.h-db.h-dh .site-header .nav3 .menu-highlight a,
 			.comment .comment-author .post-author-badge,

--- a/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
@@ -32,7 +32,7 @@
 	}
 
 	.menu-label {
-		color: colors.$color__primary;
+		color: colors.$color__secondary;
 		font-weight: bold;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The "Highlight" menu displays the menu's name as a label. In the default styles, this label was set to use the primary colour, but in the custom colours code, it was set to use the secondary colour, so it only ever used the primary colour when a site used the default colours (so basically, only on demo sites).

This PR updates the default styles, and removes a duplicated instance of the menu label style in the color-patterns.php file (it was set to use the primary then secondary colour there, with the latter overriding the former).

See 1204261432690303-as-1204394333707405

### How to test the changes in this Pull Request:

1. Assign a menu to the "Highlight" menu space.
2. Switch your site to use the default colour palette; note that the menu label is blue:

![image](https://user-images.githubusercontent.com/177561/232123878-53d78cba-9a58-4599-a997-23da79c9b2a7.png)

3. Switch your site to use custom colours
4. Note that the menu label uses your secondary colour (or if your secondary colour is very light, note that it is using a mid-grey as a legible fallback):

![image](https://user-images.githubusercontent.com/177561/232123950-b4b718a1-77c9-4e99-b842-f97eae831008.png)

![image](https://user-images.githubusercontent.com/177561/232123986-ea34a558-d264-4045-b24b-3568de1b9381.png)

5. Apply this PR and run `npm run build`.
6. Confirm the custom colours act the same, but if you switch to the default colours, you now get the secondary colour (also grey):

![image](https://user-images.githubusercontent.com/177561/232124535-fe20384b-27d3-4a44-9395-1ccbb534cf91.png)

7. Switch to Newspack Nelson, and enable the header background colour if it isn't already. The highlight menu appears against this header, so the label should be black against lighter custom headers, and white against darker custom headers. It should use the secondary colour if there's no header background.

No background (the theme defaults to a light grey to distinguish the header from content area):

![image](https://user-images.githubusercontent.com/177561/232124843-2ba8cc2d-4081-4b9c-b546-60aeadaeb5f8.png)

Dark background:
![image](https://user-images.githubusercontent.com/177561/232125276-12973626-9d1a-4105-8835-0c99849e9332.png)

Light background:
![image](https://user-images.githubusercontent.com/177561/232125217-126f4126-2910-4e5e-b034-d6306249756c.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
