### PR TITLE
feat: add archive title for custom taxonomies

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -340,11 +340,11 @@ function newspack_get_the_archive_title() {
 	} elseif ( is_post_type_archive() ) {
 		$title = esc_html__( 'Post Type Archives: ', 'newspack' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
 	} elseif ( is_tax() ) {
-		$tax      = get_taxonomy( get_queried_object()->taxonomy );
-		$taxonomy = get_queried_object();
+		$tax  = get_taxonomy( get_queried_object()->taxonomy );
+		$term = get_queried_object();
 
 		/* translators: %s: Taxonomy singular name */
-		$title = sprintf( esc_html__( '%s Archives:', 'newspack' ), $tax->labels->singular_name ) . '<span class="page-description">' . $taxonomy->name . '</span>';
+		$title = sprintf( esc_html__( '%s Archives:', 'newspack' ), $tax->labels->singular_name ) . '<span class="page-description">' . $term->name . '</span>';
 	} else {
 		$title = esc_html__( 'Archives:', 'newspack' );
 	}

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -340,9 +340,11 @@ function newspack_get_the_archive_title() {
 	} elseif ( is_post_type_archive() ) {
 		$title = esc_html__( 'Post Type Archives: ', 'newspack' ) . '<span class="page-description">' . post_type_archive_title( '', false ) . '</span>';
 	} elseif ( is_tax() ) {
-		$tax = get_taxonomy( get_queried_object()->taxonomy );
+		$tax      = get_taxonomy( get_queried_object()->taxonomy );
+		$taxonomy = get_queried_object();
+
 		/* translators: %s: Taxonomy singular name */
-		$title = sprintf( esc_html__( '%s Archives:', 'newspack' ), $tax->labels->singular_name );
+		$title = sprintf( esc_html__( '%s Archives:', 'newspack' ), $tax->labels->singular_name ) . '<span class="page-description">' . $taxonomy->name . '</span>';
 	} else {
 		$title = esc_html__( 'Archives:', 'newspack' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes sure the archives for custom taxonomies display a complete archive title, matching WordPress's built-in taxonomies (categories and tags). 

See 1204323000227080-as-1204392456338623

### How to test the changes in this Pull Request:

1. Set up a plugin that adds a custom taxonomy to your site -- a good example is [Newspack Multibranded Sites](https://github.com/Automattic/newspack-multibranded-site).
2. Create a custom taxonomy with the plugin, and assign it to at least one post.
3. View a custom taxonomy's archive -- you should see the type of taxonomy in the title, but not the name of the specific tag you created:

![image](https://user-images.githubusercontent.com/177561/234400983-ef5465e1-3d2a-42cb-a253-5ee2d7dd6cc5.png)

4. Apply the PR.
5. Confirm the individual tag now displays in the archive title:

![image](https://user-images.githubusercontent.com/177561/234400935-28294595-2d84-442e-b0af-8c8143a2f61d.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
