### PR TITLE
feat: inform current colors to multi-branded plugi

### DIFF
--- a/newspack-theme/inc/newspack-multibranded-site-plugin.php
+++ b/newspack-theme/inc/newspack-multibranded-site-plugin.php
@@ -15,17 +15,17 @@ add_filter(
 			[
 				'theme_mod_name' => 'primary_color_hex',
 				'label'          => __( 'Primary Color', 'newspack-theme' ),
-				'default'        => newspack_get_primary_color(),
+				'default'        => 'default' !== get_theme_mod( 'theme_colors' ) ? get_theme_mod( 'primary_color_hex', newspack_get_primary_color() ) : newspack_get_primary_color(),
 			],
 			[
 				'theme_mod_name' => 'secondary_color_hex',
 				'label'          => __( 'Secondary Color', 'newspack-theme' ),
-				'default'        => newspack_get_secondary_color(),
+				'default'        => 'default' !== get_theme_mod( 'theme_colors' ) ? get_theme_mod( 'secondary_color_hex', newspack_get_secondary_color() ) : newspack_get_secondary_color(),
 			],
 			[
 				'theme_mod_name' => 'ads_color_hex',
 				'label'          => __( 'Background color to the ads', 'newspack-theme' ),
-				'default'        => '#ffffff',
+				'default'        => get_theme_mod( 'ads_color_hex', '#ffffff' ),
 			],
 		];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Instead of passing the default to multi-branded plugin, let's use the current custom color as the defaults.

### How to test the changes in this Pull Request:

1. Make sure you have this PR merged in your copy of multi-branded site plugin -> https://github.com/Automattic/newspack-multibranded-site/pull/21
2. Go to Multi-Branded site and edit a brand
3. Confirm that you can change colors and when you click "Reset default" the default color is restored
4. Go to Appearance > Customize
5. Change the theme colors and save
6. Go back to Multi-branded site
7. Confirm that now when you reset the default colors, it shows the custom colors you set in the customizer, and not the default values

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
