### PR TITLE
fix: prevent sponsor strings from overwriting theme script strings

### DIFF
--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -30,7 +30,7 @@ function newspack_sponsors_enqueue_scripts() {
 		);
 
 		wp_enqueue_script( 'newspack-amp-fallback-sponsors', get_theme_file_uri( '/js/dist/amp-fallback-newspack-sponsors.js' ), array(), wp_get_theme()->get( 'Version' ), true );
-		wp_localize_script( 'newspack-amp-fallback-sponsors', 'newspackScreenReaderText', $newspack_l10n );
+		wp_localize_script( 'newspack-amp-fallback-sponsors', 'newspackScreenReaderTextSponsors', $newspack_l10n );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_sponsors_enqueue_scripts' );

--- a/newspack-theme/js/src/amp-fallback-newspack-sponsors.js
+++ b/newspack-theme/js/src/amp-fallback-newspack-sponsors.js
@@ -1,4 +1,4 @@
-/* globals newspackScreenReaderText */
+/* globals newspackScreenReaderTextSponsors */
 
 /**
  * File amp-fallback.js.
@@ -22,7 +22,7 @@
 				supportLabel.classList.toggle( 'show-info' );
 				// Toggle screen reader text label and aria settings.
 				if ( supportToggleTextDefault === supportToggleTextContain.innerText ) {
-					supportToggleTextContain.innerText = newspackScreenReaderText.close_info;
+					supportToggleTextContain.innerText = newspackScreenReaderTextSponsors.close_info;
 
 					supportInfo.setAttribute( 'aria-expanded', 'true' );
 					supportToggle.setAttribute( 'aria-expanded', 'true' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Both the theme's general JS and it's sponsors JS use the same variable name for translations; this causes the Sponsor's translations to overwrite the theme's translations when the plugin is active. 

### How to test the changes in this Pull Request:

1. If not already, enable the Sponsors plugin on your test site. 
2. Navigate to Customize > Comments, and enable Comment Collapsing -- this is one of the easiest ways to see the strings being overwritten. 
3. Add a couple random comments to a post; note that the 'Expand Comments' link appears:

![image](https://user-images.githubusercontent.com/177561/236358537-a7d282fa-a35f-4a42-991b-12bf963190a2.png)

4. Click the link to open and close the comments; note that it now says `undefined`. 

![image](https://user-images.githubusercontent.com/177561/236358560-aac5bad9-b85a-4198-89af-6c0ae14850cc.png)

5. Apply the PR and run `npm run build`.
6. Confirm that the comment text string now correctly toggles between an Expand and Collapse label.
7. Now we need to double-check that the Sponsor strings are still working as expected. Set up a post with a native sponsor. 
8. Inspect the `?` that appears next to the Sponsored label at the top, and find the 'Learn More' screen reader text in the inspector:

![image](https://user-images.githubusercontent.com/177561/236358711-fccf9c34-e183-4744-84d9-6a65aee31edd.png)

9. Click the '?' icon a couple times, toggling the information bubble open and closed; confirm that the label still correctly toggles between the 'Learn More' and 'Close' string.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
