### PR TITLE
Replace contrast-related colours code with CSS variables

### DIFF
--- a/newspack-joseph/inc/child-color-patterns.php
+++ b/newspack-joseph/inc/child-color-patterns.php
@@ -8,18 +8,12 @@
  * Add child theme-specific custom colours.
  */
 function newspack_joseph_custom_colors_css() {
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
 	$header_color    = '#111';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
-
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
 		}
-
 		if ( 'default' !== get_theme_mod( 'footer_color', 'default' ) ) {
 			$footer_color          = get_theme_mod( 'footer_color_hex', '' );
 			$footer_color_contrast = newspack_get_color_contrast( $footer_color );
@@ -27,8 +21,6 @@ function newspack_joseph_custom_colors_css() {
 	}
 
 	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	$theme_css = '

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -21,12 +21,10 @@ function newspack_katharine_custom_colors_css() {
 		}
 	}
 
-	$theme      = '';
+	$theme_css  = '';
 	$editor_css = '';
 
 	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {

--- a/newspack-katharine/inc/child-color-patterns.php
+++ b/newspack-katharine/inc/child-color-patterns.php
@@ -8,14 +8,9 @@
  * Add child theme-specific custom colours.
  */
 function newspack_katharine_custom_colors_css() {
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
 	$header_color    = '#333';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
-
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
 		}
@@ -26,58 +21,15 @@ function newspack_katharine_custom_colors_css() {
 		}
 	}
 
+	$theme      = '';
+	$editor_css = '';
+
 	// Set colour contrasts.
 	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
 	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
-	$theme_css = '
-		.archive .page-title,
-		.entry-meta .byline a,
-		.entry-meta .byline a:visited,
-		.cat-links,
-		.cat-links a,
-		.cat-links a:visited,
-		.article-section-title,
-		.entry .entry-footer,
-		.accent-header,
-		#secondary .widgettitle {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-		}
-
-		.mobile-sidebar .accent-header:before,
-		.mobile-sidebar div.wpnbha .article-section-title:before,
-		.mobile-sidebar .cat-links:before,
-		.mobile-sidebar figcaption:after,
-		.mobile-sidebar .wp-caption-text:after {
-			background-color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-
-		@media only screen and (min-width: 782px) {
-			.featured-image-beside a,
-			.featured-image-beside a:visited,
-			.featured-image-beside .cat-links a {
-				color: ' . esc_html( $primary_color_contrast ) . ';
-			}
-
-			.featured-image-beside .cat-links:before {
-				background-color: ' . esc_html( $primary_color_contrast ) . ';
-			}
-		}
-	';
-
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
-		$theme_css .= '
-			/* Featured Image Beside styles */
-			@media only screen and (min-width: 782px) {
-				.h-sb .featured-image-beside,
-				.h-sb .featured-image-beside a {
-					color: ' . esc_html( $primary_color_contrast ) . ';
-				}
-			}
-		';
-
-
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$theme_css .= '
 				/* Header solid background */
@@ -124,14 +76,6 @@ function newspack_katharine_custom_colors_css() {
 			}
 		';
 	}
-
-	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
-		.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-		}
-	';
 
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {
 		$theme_css = $editor_css;

--- a/newspack-katharine/sass/style-editor.scss
+++ b/newspack-katharine/sass/style-editor.scss
@@ -11,7 +11,7 @@ Newspack Katharine Editor Styles
 
 .accent-header,
 .article-section-title {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	font-size: var( --newspack-theme-font-size-xs );
 	margin-bottom: #{1.5 * structure.$size__spacing-unit};
 	margin-top: 0;

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -20,6 +20,16 @@
 	.bottom-header-contain {
 		background-color: var( --newspack-theme-color-bg-dark-darken-5 );
 	}
+
+	.site-header,
+	.site-title a,
+	.site-title a:visited,
+	.site-description,
+	.middle-header-contain,
+	.middle-header-contain .nav1 .main-menu > li,
+	.middle-header-contain .nav1 .main-menu > li > a {
+		color: #fff;
+	}
 }
 
 // Mobile CTA
@@ -210,11 +220,11 @@ div.wpnbha .article-section-title,
 @include utilities.media( tablet ) {
 	.featured-image-beside {
 		.cat-links a {
-			color: var( --newspack-theme-color-bg-body );
+			color: var( --newspack-theme-color-against-primary );
 		}
 
 		.cat-links::before {
-			background-color: var( --newspack-theme-color-bg-body );
+			background-color: var( --newspack-theme-color-against-primary );
 		}
 	}
 }

--- a/newspack-katharine/sass/style.scss
+++ b/newspack-katharine/sass/style.scss
@@ -33,8 +33,9 @@
 .article-section-title,
 .cat-links,
 .archive .page-title,
+#secondary .widget-title,
 #secondary .widgettitle {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 
 	&::before {
 		background-color: var( --newspack-theme-color-primary );
@@ -80,6 +81,14 @@
 	.cat-links {
 		color: inherit;
 	}
+
+	.accent-header::before,
+	div.wpnbha .article-section-title::before,
+	.cat-links::before,
+	figcaption::after,
+	.wp-caption-text::after {
+		background-color: var( --newspack-theme-color-against-primary );
+	}
 }
 
 .accent-header,
@@ -115,7 +124,7 @@ div.wpnbha .article-section-title,
 .cat-links a,
 .cat-links a:hover,
 .cat-links a:visited {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 }
 
 .author-bio {
@@ -227,7 +236,7 @@ div.wpnbha .article-section-title,
 }
 
 .entry .entry-footer {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 }
 
 .entry .entry-footer a,
@@ -255,6 +264,15 @@ div.wpnbha .article-section-title,
 	// Header - Solid background
 	.h-sb .featured-image-beside {
 		background-color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-against-primary );
+
+		a {
+			color: inherit;
+		}
+
+		.cat-links::before {
+			background-color: var( --newspack-theme-color-against-primary );
+		}
 	}
 }
 

--- a/newspack-nelson/inc/child-color-patterns.php
+++ b/newspack-nelson/inc/child-color-patterns.php
@@ -9,12 +9,10 @@
  */
 function newspack_nelson_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
 	$header_color    = $primary_color;
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
@@ -29,30 +27,10 @@ function newspack_nelson_custom_colors_css() {
 	}
 
 	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
-	$theme_css = '
-		.site-header,
-		/* Header default background */
-		.h-db .site-header,
-		/* Header short height; default background */
-		.h-sh.h-db .site-header,
-		.site-content #primary,
-		#page .site-header,
-		.tec-wrapper {
-			border-color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-		}
-
-		.site-footer {
-			color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-
-		.has-drop-cap:not(:focus)::first-letter {
-			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
-		}
-	';
+	$theme_css  = '';
+	$editor_css = '';
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		$theme_css .= '
@@ -131,12 +109,6 @@ function newspack_nelson_custom_colors_css() {
 			}
 		';
 	}
-
-	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
-			color: ' . esc_html( newspack_color_with_contrast( $secondary_color ) ) . ';
-		}
-	';
 
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {
 		$theme_css = $editor_css;

--- a/newspack-nelson/sass/style-editor.scss
+++ b/newspack-nelson/sass/style-editor.scss
@@ -77,7 +77,7 @@ blockquote {
 }
 
 .has-drop-cap:not( :focus )::first-letter {
-	color: var( --newspack-theme-color-secondary );
+	color: var( --newspack-theme-color-secondary-against-white );
 	font-family: var( --newspack-theme-font-heading );
 	font-weight: 800;
 }

--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -366,7 +366,7 @@ blockquote {
 
 //! Paragraph
 .has-drop-cap:not( :focus )::first-letter {
-	color: var( --newspack-theme-color-secondary );
+	color: var( --newspack-theme-color-secondary-against-white );
 	font-family: var( --newspack-theme-font-heading );
 	font-weight: 800;
 }
@@ -562,7 +562,7 @@ blockquote {
 
 .site-footer {
 	background-color: var( --newspack-theme-color-primary );
-	color: var( --newspack-theme-color-bg-body );
+	color: var( --newspack-theme-color-against-primary );
 
 	a,
 	a:hover,

--- a/newspack-sacha/inc/child-color-patterns.php
+++ b/newspack-sacha/inc/child-color-patterns.php
@@ -8,14 +8,9 @@
  * Add child theme-specific custom colours.
  */
 function newspack_sacha_custom_colors_css() {
-	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
 	$header_color    = '#333';
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
-		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
-
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
 		}
@@ -27,35 +22,10 @@ function newspack_sacha_custom_colors_css() {
 	}
 
 	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
-	$theme_css = '
-		.archive .page-title,
-		.h-sb .featured-image-beside .cat-links,
-		.entry-meta .byline a,
-		.entry-meta .byline a:visited,
-		.entry .entry-meta a:hover,
-		.accent-header,
-		#secondary .widgettitle,
-		.article-section-title,
-		.cat-links,
-		.entry .entry-footer,
-		.site-footer .widget .widget-title,
-		.site-footer .widget .widgettitle {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-		}
-
-		.entry-meta .byline a:hover,
-		.entry-meta .byline a:hover:visited {
-			color: ' . esc_html( newspack_adjust_brightness( $primary_color, -40 ) ) . ';
-		}
-
-		.has-drop-cap:not(:focus)::first-letter {
-			color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-	';
+	$theme_css  = '';
+	$editor_css = '';
 
 	if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
@@ -100,19 +70,6 @@ function newspack_sacha_custom_colors_css() {
 			}
 		';
 	}
-
-	$editor_css = '
-		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
-		.block-editor-block-list__layout .block-editor-block-list__block.accent-header,
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title {
-			color: ' . esc_html( newspack_color_with_contrast( $primary_color ) ) . ';
-		}
-
-		.block-editor-block-list__layout .block-editor-block-list__block.has-drop-cap:not(:focus)::first-letter {
-			color: ' . esc_html( $primary_color_contrast ) . ';
-		}
-
-	';
 
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {
 		$theme_css = $editor_css;

--- a/newspack-sacha/sass/style-editor.scss
+++ b/newspack-sacha/sass/style-editor.scss
@@ -18,7 +18,7 @@ h1.wp-block-post-title,
 .accent-header,
 .article-section-title {
 	align-items: center;
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	display: flex;
 	font-size: var( --newspack-theme-font-size-xs );
 	margin-bottom: #{1.5 * structure.$size__spacing-unit};
@@ -46,7 +46,7 @@ h1.wp-block-post-title,
 
 .has-drop-cap:not( :focus )::first-letter {
 	background-color: var( --newspack-theme-color-primary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 	font-family: var( --newspack-theme-font-heading );
 	font-weight: bold;
 	font-size: var( --newspack-theme-font-size-xxl );

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -56,7 +56,7 @@
 #secondary .widgettitle,
 .article-section-title,
 .cat-links {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	margin-bottom: structure.$size__spacing-unit;
 	text-align: center;
 }
@@ -153,7 +153,7 @@ cite {
 //! Paragraph
 .has-drop-cap:not( :focus )::first-letter {
 	background-color: var( --newspack-theme-color-primary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 	font-family: var( --newspack-theme-font-heading );
 	font-weight: bold;
 	font-size: var( --newspack-theme-font-size-xxl );
@@ -318,7 +318,7 @@ cite {
 		}
 
 		.cat-links {
-			color: var( --newspack-theme-color-primary );
+			color: var( --newspack-theme-color-primary-against-white );
 		}
 	}
 
@@ -335,7 +335,7 @@ cite {
 }
 
 .entry .entry-footer {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	text-align: center;
 
 	a,
@@ -502,7 +502,7 @@ cite {
 
 	.widget .widget-title,
 	.widget .widgettitle {
-		color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-primary-against-white );
 		font-weight: bold;
 	}
 

--- a/newspack-sacha/sass/style.scss
+++ b/newspack-sacha/sass/style.scss
@@ -19,6 +19,16 @@
 	.bottom-header-contain {
 		background-color: var( --newspack-theme-color-bg-dark-darken-5 );
 	}
+
+	.site-header,
+	.site-title a,
+	.site-title a:visited,
+	.site-description,
+	.middle-header-contain,
+	.middle-header-contain .nav1 .main-menu > li,
+	.middle-header-contain .nav1 .main-menu > li > a {
+		color: #fff;
+	}
 }
 
 // Subpage header with a solid background

--- a/newspack-scott/inc/child-color-patterns.php
+++ b/newspack-scott/inc/child-color-patterns.php
@@ -9,12 +9,10 @@
  */
 function newspack_scott_custom_colors_css() {
 	$primary_color   = newspack_get_primary_color();
-	$secondary_color = newspack_get_secondary_color();
 	$header_color    = $primary_color;
 
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 		$primary_color   = get_theme_mod( 'primary_color_hex', $primary_color );
-		$secondary_color = get_theme_mod( 'secondary_color_hex', $secondary_color );
 
 		if ( 'default' !== get_theme_mod( 'header_color', 'default' ) ) {
 			$header_color = get_theme_mod( 'header_color_hex', '#666666' );
@@ -29,26 +27,15 @@ function newspack_scott_custom_colors_css() {
 	}
 
 	// Set colour contrasts.
-	$primary_color_contrast   = newspack_get_color_contrast( $primary_color );
-	$secondary_color_contrast = newspack_get_color_contrast( $secondary_color );
 	$header_color_contrast    = newspack_get_color_contrast( $header_color );
 
-	$theme_css = '
-		.mobile-sidebar .article-section-title,
-		.mobile-sidebar .accent-header {
-			color: ' . esc_html( $primary_color_contrast ) . ';
-		}
+	$theme_css  = '';
+	$editor_css = '';
 
+	$theme_css .= '
 		.mobile-sidebar .article-section-title::before,
 		.mobile-sidebar .accent-header::before {
 			background-color: ' . esc_html( newspack_adjust_brightness( $header_color, -30 ) ) . ';
-		}
-
-		@media only screen and (min-width: 782px) {
-			/* Header default background */
-			.h-db .featured-image-beside .cat-links:before {
-				background-color: ' . esc_html( $primary_color_contrast ) . ';
-			}
 		}
 	';
 
@@ -100,8 +87,6 @@ function newspack_scott_custom_colors_css() {
 			}
 		';
 	}
-
-	$editor_css = '';
 
 	if ( function_exists( 'register_block_type' ) && is_admin() ) {
 		$theme_css = $editor_css;

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -49,7 +49,7 @@ div.wpnbha .article-section-title {
 @include utilities.media( tablet ) {
 	.featured-image-beside {
 		.cat-links::before {
-			background-color: var( --newspack-theme-color-bg-body );
+			background-color: var( --newspack-theme-color-against-primary );
 		}
 	}
 }
@@ -375,7 +375,7 @@ div.wpnbha .article-section-title {
 .site-footer {
 	.article-section-title,
 	.accent-header {
-		color: inherit;
+		color: var( --newspack-theme-color-against-primary );
 	}
 }
 

--- a/newspack-scott/sass/style.scss
+++ b/newspack-scott/sass/style.scss
@@ -375,7 +375,7 @@ div.wpnbha .article-section-title {
 .site-footer {
 	.article-section-title,
 	.accent-header {
-		color: var( --newspack-theme-color-against-primary );
+		color: inherit;
 	}
 }
 

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -40,6 +40,12 @@ function newspack_custom_colors_css() {
 			:root .editor-styles-wrapper { ' . $css_variables . ' }
 		';
 
+		$theme_css .= '
+			input[type="checkbox"]::before {
+				background-image: url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' width=\'24\' height=\'24\'%3E%3Cpath d=\'M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z\' fill=\'' . esc_attr( $colors['secondary_contrast'] ) . '\'%3E%3C/path%3E%3C/svg%3E");
+			}
+		';
+
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
 				.mobile-sidebar {

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -51,7 +51,8 @@ function newspack_custom_colors_css() {
 				.mobile-sidebar a,
 				.mobile-sidebar a:visited,
 				.mobile-sidebar .nav1 .sub-menu > li > a,
-				.mobile-sidebar .nav1 ul.main-menu > li > a {
+				.mobile-sidebar .nav1 ul.main-menu > li > a,
+				.mobile-sidebar .nav3 a {
 					color: ' . esc_attr( $colors['header_contrast'] ) . ';
 				}
 			';
@@ -115,6 +116,7 @@ function newspack_custom_colors_css() {
 				$theme_css .= '
 					.mobile-sidebar .nav3 .menu-highlight a {
 						background: ' . esc_attr( newspack_adjust_brightness( $colors['header'], -20 ) ) . ';
+						color: ' . esc_attr( $colors['header_contrast'] ) . ';
 					}
 					.h-sb .site-header .nav3 a {
 						background-color: ' . newspack_adjust_brightness( $colors['header'], -17 ) . ';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -28,6 +28,9 @@ function newspack_custom_colors_css() {
 				--newspack-theme-color-primary-against-white: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 				--newspack-theme-color-secondary-against-white: ' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
 
+				--newspack-theme-color-primary-variation-against-white: ' . esc_attr( newspack_color_with_contrast( newspack_adjust_brightness( $colors['primary'], -30 ) ) ) . ';
+				--newspack-theme-color-secondary-variation-against-white: ' . esc_attr( newspack_color_with_contrast( newspack_adjust_brightness( $colors['secondary'], -40 ) ) ) . ';
+
 				--newspack-theme-color-against-primary: ' . esc_attr( $colors['primary_contrast'] ) . ';
 				--newspack-theme-color-against-secondary: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 		';

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -24,6 +24,12 @@ function newspack_custom_colors_css() {
 
 				--newspack-theme-color-primary-darken-5: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -5 ) ) . ';
 				--newspack-theme-color-primary-darken-10: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -10 ) ) . ';
+
+				--newspack-theme-color-primary-against-white: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
+				--newspack-theme-color-secondary-against-white: ' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
+
+				--newspack-theme-color-against-primary: ' . esc_attr( $colors['primary_contrast'] ) . ';
+				--newspack-theme-color-against-secondary: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 		';
 
 		$theme_css = '
@@ -33,85 +39,6 @@ function newspack_custom_colors_css() {
 		$editor_css = '
 			:root .editor-styles-wrapper { ' . $css_variables . ' }
 		';
-
-		$theme_css .= '
-			/* Set primary color that contrasts against white */
-			.more-link:hover,
-			.nav1 .main-menu > li > a + svg,
-			form.search-form button:active,
-			form.search-form button:hover,
-			form.search-form button:focus,
-			.entry-footer a,
-			.comment .comment-metadata > a:hover,
-			.comment .comment-metadata .comment-edit-link:hover,
-			.site-info a:hover,
-			.comments-toggle:hover, .comments-toggle:focus,
-			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover,
-			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover:visited,
-			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover,
-			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li a:hover:visited {
-				color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
-			}
-
-			/* Set color that contrasts against the primary color */
-			.mobile-sidebar,
-			.mobile-sidebar button:hover,
-			.mobile-sidebar a,
-			.mobile-sidebar a:visited,
-			.mobile-sidebar .nav1 .sub-menu > li > a,
-			.mobile-sidebar .nav1 ul.main-menu > li > a,
-			.wp-block-file .wp-block-file__button,
-			/* Header default background; default height */
-			body.h-db.h-dh .site-header .nav3 .menu-highlight a,
-			.comment .comment-author .post-author-badge,
-			.woocommerce .onsale,
-			.woocommerce-store-notice,
-			.logged-in.page-template-single-wide.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a,
-			.logged-in.page-template-single-feature.woocommerce-account .woocommerce-MyAccount-navigation ul li.is-active a {
-				color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-			}
-
-			.mobile-sidebar nav + nav,
-			.mobile-sidebar nav + .widget,
-			.mobile-sidebar .widget + .widget {
-				border-color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-			}
-
-			@media only screen and (min-width: 782px) {
-				/* Header default background */
-				.h-db .featured-image-beside .entry-header,
-				.h-db.h-sub.single-featured-image-beside .middle-header-contain {
-					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-				}
-			}
-
-			/* Set colour that contrasts against the secondary background */
-			.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color):not(:hover),
-			.button,
-			.button:visited,
-			button,
-			input[type="button"],
-			input[type="reset"],
-			input[type="submit"],
-			.wp-block-search__button {
-				color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
-			}
-
-			input[type="checkbox"]::before {
-				background-image: url("data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 24 24\' width=\'24\' height=\'24\'%3E%3Cpath d=\'M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z\' fill=\'' . esc_attr( $colors['secondary_contrast'] ) . '\'%3E%3C/path%3E%3C/svg%3E");
-			}
-
-			/* Set secondary color with contrast */
-			.site-header .highlight-menu .menu-label,
-			.entry-content a,
-			.author-bio .author-link,
-			.is-style-outline .wp-block-button__link, /* legacy selector */
-			.wp-block-button__link.is-style-outline,
-			.is-style-outline > .wp-block-button__link:not(.has-text-color):not(:hover) {
-				color:' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
-			}
-
-			';
 
 		if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 			$theme_css .= '
@@ -176,30 +103,11 @@ function newspack_custom_colors_css() {
 				.mobile-sidebar .nav3 a {
 					background: transparent;
 				}
-				.mobile-sidebar .nav3 .menu-highlight a {
-					background: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -20 ) ) . ';
-				}
+
 				.mobile-sidebar .accent-header,
 				.mobile-sidebar .article-section-title {
 					border-color: ' . newspack_adjust_brightness( $colors['header'], -20 ) . ';
 					color: ' . esc_attr( $colors['header_contrast'] ) . ';
-				}
-				.cat-links a,
-				.cat-links a:visited,
-				.site-header .nav3 .menu-highlight a,
-				.subpage-sidebar .nav3 .menu-highlight a {
-					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-				}
-				.cat-links a:hover {
-					background-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -40 ) ) . ';
-					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-				}
-				.accent-header,
-				#secondary .widgettitle,
-				.article-section-title,
-				.entry .entry-footer a:hover,
-				div.author-bio .author-link {
-					color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 				}
 			';
 
@@ -211,9 +119,6 @@ function newspack_custom_colors_css() {
 					.h-sb .site-header .nav3 a {
 						background-color: ' . newspack_adjust_brightness( $colors['header'], -17 ) . ';
 						color: ' . esc_attr( $colors['header_contrast'] ) . ';
-					}
-					.h-sb .site-header .nav3 .menu-highlight a {
-						color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 					}
 				';
 			}
@@ -236,22 +141,6 @@ function newspack_custom_colors_css() {
 					}
 				';
 			}
-		}
-
-		if ( ! is_child_theme() ) {
-			$theme_css .= '
-				.archive .page-title,
-				.entry-meta .byline a,
-				.entry-meta .byline a:visited {
-					color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
-				}
-
-				.entry-meta .byline a:hover,
-				.entry-meta .byline a:visited:hover,
-				footer.entry-footer a {
-					color: ' . esc_attr( newspack_color_with_contrast( newspack_adjust_brightness( $colors['primary'], -40 ) ) ) . ';
-				}
-			';
 
 			if ( true === get_theme_mod( 'header_solid_background', false ) ) {
 				$theme_css .= '
@@ -310,40 +199,8 @@ function newspack_custom_colors_css() {
 	$editor_css .= '
 		/* This is editor CSS */
 
-		.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a {
-			color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . '; /* base: #0073a8; */
-		}
-
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__button {
-			color: ' . esc_attr( $colors['primary_contrast'] ) . ';
-		}
-
-		.edit-post-visual-editor .editor-styles-wrapper .has-primary-variation-background-color,
-		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link.has-primary-variation-background-color, /* legacy selector */
-		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link.has-primary-variation-background-color {
-			background-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
-		}
-
-		.edit-post-visual-editor.editor-styles-wrapper .has-primary-variation-border-color {
-			border-color: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
-		}
-
-		/* Secondary color */
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-donate button[type="submit"],
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-search__button {
-			color: ' . esc_attr( $colors['secondary_contrast'] ) . '; /* base: #0073a8; */
-		}
-
-		/* Hover colors */
-		.block-editor-block-list__layout .block-editor-block-list__block a,
-		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline .wp-block-button__link:not(.has-text-color), /* legacy selector */
-		.block-editor-block-list__layout .block-editor-block-list__block .is-style-outline.wp-block-button__link:not(.has-text-color),
-		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-file .wp-block-file__textlink {
-			color: ' . esc_attr( newspack_color_with_contrast( $colors['secondary'] ) ) . ';
-		}
-
 		/* Do not overwrite solid color pullquote or cover links */
+		/*
 		.block-editor-block-list__layout .block-editor-block-list__block a.more-link,
 		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a,
 		.block-editor-block-list__layout .block-editor-block-list__block .has-text-color a:hover,
@@ -353,18 +210,9 @@ function newspack_custom_colors_css() {
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles .entry-title a:hover,
 		.block-editor-block-list__layout .block-editor-block-list__block .wp-block-cover .article-section-title {
 			color: inherit;
-	}
+		}
+	*/
 	';
-
-	if ( ! is_child_theme() ) {
-		$editor_css .= '
-			.block-editor-block-list__layout .block-editor-block-list__block .entry-meta .byline a,
-			.block-editor-block-list__layout .block-editor-block-list__block .wp-block-newspack-blocks-homepage-articles:not(.has-text-color) .article-section-title,
-			.block-editor-block-list__layout .block-editor-block-list__block.accent-header {
-				color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
-			}
-		';
-	}
 
 	if ( 'default' !== get_theme_mod( 'ads_color', 'default' ) ) {
 		$editor_css .= '

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -686,12 +686,13 @@ p.has-background {
 //! Button
 .wp-block-buttons {
 	--wp--style--block-gap: 0.5rem;
+	.wp-block-button__link {
+		color: var( --newspack-theme-color-against-secondary );
+	}
 }
 
 .wp-block-button__link {
 	background-color: var( --newspack-theme-color-secondary );
-	color: var( --newspack-theme-color-against-secondary );
-
 	@include utilities.button-transition;
 
 	border: none;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -690,7 +690,7 @@ p.has-background {
 
 .wp-block-button__link {
 	background-color: var( --newspack-theme-color-secondary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-secondary );
 
 	@include utilities.button-transition;
 
@@ -744,7 +744,7 @@ p.has-background {
 .wp-block-button__link.is-style-outline,
 .is-style-outline > .wp-block-button__link:not( .has-text-color ),
 .wp-block-button.is-style-outline > .wp-block-button__link:not(.has-text-color) {
-	color: var( --newspack-theme-color-secondary );
+	color: var( --newspack-theme-color-secondary-against-white );
 }
 
 .wp-block-button {
@@ -1057,7 +1057,7 @@ hr {
 		text-decoration: none;
 		font-weight: bold;
 		padding: ( structure.$size__spacing-unit * 0.75 ) structure.$size__spacing-unit;
-		color: #fff;
+		color: var( --newspack-theme-color-against-secondary );
 		margin-left: 0;
 		margin-top: calc( 0.75 * #{structure.$size__spacing-unit} );
 

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -697,6 +697,7 @@ p.has-background {
 
 	border: none;
 	border-radius: 5px;
+	color: var( --newspack-theme-color-against-secondary );
 	font-family: var( --newspack-theme-font-heading );
 	font-size: var( --newspack-theme-font-size-sm );
 	line-height: var( --newspack-theme-font-line-height-heading );

--- a/newspack-theme/sass/forms/_buttons.scss
+++ b/newspack-theme/sass/forms/_buttons.scss
@@ -14,7 +14,7 @@ input[type='submit'],
 	border-radius: 5px;
 	box-sizing: border-box;
 	display: inline-block;
-	color: var( --newspack-theme-color-bg-body );
+	color: var( --newspack-theme-color-against-secondary );
 	font-family: var( --newspack-theme-font-heading );
 	font-size: var( --newspack-theme-font-size-sm );
 	font-weight: 700;

--- a/newspack-theme/sass/forms/_fields.scss
+++ b/newspack-theme/sass/forms/_fields.scss
@@ -59,7 +59,7 @@ input[type='checkbox'] {
 	background: white;
 	border: solid 1px var( --newspack-theme-color-border );
 	border-radius: 2px;
-	color: white;
+	color: var( --newspack-theme-color-against-secondary );
 	cursor: pointer;
 	display: inline-grid;
 	font: inherit;
@@ -70,7 +70,7 @@ input[type='checkbox'] {
 
 	&::before {
 		background: transparent
-			url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'%3E%3C/path%3E%3C/svg%3E" )
+			url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white' %3E%3C/path%3E%3C/svg%3E" )
 			0 0 no-repeat;
 		content: '';
 		display: block;

--- a/newspack-theme/sass/forms/_search.scss
+++ b/newspack-theme/sass/forms/_search.scss
@@ -26,7 +26,7 @@
 		&:active,
 		&:hover,
 		&:focus {
-			color: var( --newspack-theme-color-primary );
+			color: var( --newspack-theme-color-primary-against-white );
 		}
 	}
 }

--- a/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
@@ -31,7 +31,7 @@
 	}
 
 	.menu-label {
-		color: var( --newspack-theme-color-secondary );
+		color: var( --newspack-theme-color-secondary-against-white );
 		font-weight: bold;
 	}
 

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -305,7 +305,7 @@
 	nav + nav,
 	nav + .widget,
 	.widget + .widget {
-		border-top: 1px solid #fff;
+		border-top: 1px solid var( --newspack-theme-color-against-primary );
 	}
 
 	nav + nav {
@@ -355,11 +355,11 @@
 // Mobile Sidebar and Menu styles
 .mobile-sidebar {
 	background-color: var( --newspack-theme-color-primary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 
 	a,
 	.nav1 .sub-menu > li > a {
-		color: #fff;
+		color: var( --newspack-theme-color-against-primary );
 	}
 
 	a:hover,

--- a/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-mobile-navigation.scss
@@ -358,7 +358,8 @@
 	color: var( --newspack-theme-color-against-primary );
 
 	a,
-	.nav1 .sub-menu > li > a {
+	.nav1 .sub-menu > li > a,
+	.nav3 a {
 		color: var( --newspack-theme-color-against-primary );
 	}
 

--- a/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-tertiary-navigation.scss
@@ -40,7 +40,7 @@ body.h-db.h-dh .site-header {
 		.menu-highlight a {
 			background-color: var( --newspack-theme-color-primary );
 			border: 0;
-			color: var( --newspack-theme-color-bg-body );
+			color: var( --newspack-theme-color-against-primary );
 
 			&:hover {
 				background-color: var( --newspack-theme-color-text-main );

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -988,7 +988,7 @@ table.variations {
 				font-weight: 700;
 
 				&:hover {
-					color: var( --newspack-theme-color-against-primary );
+					color: var( --newspack-theme-color-primary );
 					text-decoration: underline;
 				}
 			}

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -31,7 +31,7 @@ a.button {
 	text-align: center;
 	box-sizing: border-box;
 	word-break: break-all;
-	color: #fff;
+	color: var( --newspack-theme-color-against-secondary );
 	text-decoration: none !important;
 
 	&:hover,
@@ -197,11 +197,11 @@ a.button {
 
 .woocommerce-store-notice__dismiss-link {
 	float: right;
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 
 	&:hover {
 		text-decoration: underline;
-		color: #fff;
+		color: var( --newspack-theme-color-against-primary );
 	}
 }
 
@@ -1851,7 +1851,8 @@ table.woocommerce-table--order-details.shop_table,
 				&.is-active {
 					a {
 						background: var( --newspack-theme-color-primary );
-						color: var( --newspack-theme-color-bg-body );
+						color: var( --newspack-theme-color-against-primary );
+						pointer-events: none;
 
 						&:focus-visible {
 							outline-color: var( --newspack-theme-color-bg-body );

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -106,7 +106,7 @@ a.button {
 	left: 0;
 	display: inline-block;
 	background: var( --newspack-theme-color-primary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 	font-size: 0.7111em;
 	font-weight: 700;
 	letter-spacing: -0.02em;
@@ -182,7 +182,7 @@ a.button {
 
 .woocommerce-store-notice {
 	background: var( --newspack-theme-color-primary );
-	color: #fff;
+	color: var( --newspack-theme-color-against-primary );
 	padding: 1rem;
 	position: absolute;
 	top: 0;
@@ -988,13 +988,15 @@ table.variations {
 				font-weight: 700;
 
 				&:hover {
-					color: #005177;
+					color: var( --newspack-theme-color-against-primary );
 					text-decoration: underline;
 				}
 			}
 
 			&.is-active {
 				a {
+					background: var( --newspack-theme-color-primary );
+					color: var( --newspack-theme-color-against-primary );
 					text-decoration: underline;
 				}
 			}
@@ -1225,8 +1227,8 @@ table.variations {
 		}
 
 		input[type='checkbox']:checked + span::before {
-			border-color: var( --newspack-theme-color-secondary-variation );
-			background: var( --newspack-theme-color-secondary-variation );
+			border-color: var( --newspack-theme-color-secondary-against-white );
+			background: var( --newspack-theme-color-secondary-against-white );
 		}
 	}
 }
@@ -1830,7 +1832,7 @@ table.woocommerce-table--order-details.shop_table,
 					&:hover,
 					&:hover:visited {
 						background: var( --newspack-theme-color-bg-body );
-						color: var( --newspack-theme-color-primary );
+						color: var( --newspack-theme-color-primary-against-white );
 						cursor: pointer;
 					}
 

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -135,7 +135,7 @@
 		display: block;
 
 		&:hover {
-			color: var( --newspack-theme-color-against-primary );
+			color: var( --newspack-theme-color-primary-against-white );
 			text-decoration: none;
 		}
 	}

--- a/newspack-theme/sass/site/footer/_site-footer.scss
+++ b/newspack-theme/sass/site/footer/_site-footer.scss
@@ -135,6 +135,7 @@
 		display: block;
 
 		&:hover {
+			color: var( --newspack-theme-color-against-primary );
 			text-decoration: none;
 		}
 	}

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -654,6 +654,7 @@
 			div.middle-header-contain {
 				background: rgba( 0, 0, 0, 0.5 );
 				background: linear-gradient( 180deg, rgba( 0, 0, 0, 0.85 ) 0%, rgba( 0, 0, 0, 0 ) 100% );
+				color: var( --newspack-theme-color-against-primary );
 				max-width: 100%;
 				width: 100%;
 

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -321,7 +321,7 @@
 	.middle-header-contain,
 	.middle-header-contain .nav1 .main-menu > li,
 	.middle-header-contain .nav1 .main-menu > li > a {
-		color: #fff;
+		color:  var( --newspack-theme-color-against-primary );
 	}
 
 	.top-header-contain {

--- a/newspack-theme/sass/site/header/_site-header.scss
+++ b/newspack-theme/sass/site/header/_site-header.scss
@@ -654,7 +654,7 @@
 			div.middle-header-contain {
 				background: rgba( 0, 0, 0, 0.5 );
 				background: linear-gradient( 180deg, rgba( 0, 0, 0, 0.85 ) 0%, rgba( 0, 0, 0, 0 ) 100% );
-				color: var( --newspack-theme-color-against-primary );
+				color: #fff;
 				max-width: 100%;
 				width: 100%;
 

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -71,7 +71,7 @@
 
 .archive {
 	.page-title {
-		color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-primary-against-white );
 	}
 
 	@include utilities.media( tablet ) {

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -222,7 +222,7 @@
 		.post-author-badge {
 			background: var( --newspack-theme-color-primary );
 			border-radius: 100%;
-			color: #fff;
+			color: var( --newspack-theme-color-against-primary );
 			display: inline-block;
 			height: 16px;
 			line-height: 16px;
@@ -259,7 +259,7 @@
 			}
 
 			&:hover {
-				color: var( --newspack-theme-color-primary-variation );
+				color: var( --newspack-theme-color-against-primary );
 				text-decoration: none;
 			}
 		}
@@ -291,7 +291,7 @@
 			z-index: 1;
 
 			&:hover {
-				color: var( --newspack-theme-color-primary );
+				color: var( --newspack-theme-color-primary-against-white );
 			}
 		}
 	}
@@ -440,7 +440,7 @@
 	&:hover,
 	&:focus {
 		background: transparent;
-		color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-against-primary );
 	}
 }
 

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -214,7 +214,7 @@
 				color: inherit;
 
 				&:hover {
-					color: var( --newspack-theme-color-primary-variation );
+					color: var( --newspack-theme-color-primary-against-white );
 				}
 			}
 		}
@@ -259,7 +259,7 @@
 			}
 
 			&:hover {
-				color: var( --newspack-theme-color-primary-variation );
+				color: var( --newspack-theme-color-primary-against-white );
 				text-decoration: none;
 			}
 		}

--- a/newspack-theme/sass/site/primary/_comments.scss
+++ b/newspack-theme/sass/site/primary/_comments.scss
@@ -259,7 +259,7 @@
 			}
 
 			&:hover {
-				color: var( --newspack-theme-color-against-primary );
+				color: var( --newspack-theme-color-primary-variation );
 				text-decoration: none;
 			}
 		}
@@ -440,7 +440,7 @@
 	&:hover,
 	&:focus {
 		background: transparent;
-		color: var( --newspack-theme-color-against-primary );
+		color: var( --newspack-theme-color-primary-against-white );
 	}
 }
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -136,11 +136,11 @@ amp-script .cat-links {
 		}
 
 		a {
-			color: var( --newspack-theme-color-primary );
+			color: var( --newspack-theme-color-primary-against-white );
 			text-decoration: none;
 
 			&:visited {
-				color: var( --newspack-theme-color-primary );
+				color: var( --newspack-theme-color-primary-against-white );
 			}
 
 			&:hover {
@@ -174,7 +174,7 @@ amp-script .cat-links {
 	}
 
 	a {
-		color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-primary-variation );
 	}
 
 	.edit-link {
@@ -222,12 +222,17 @@ amp-script .cat-links {
 		color: inherit;
 		display: block;
 		font-size: 0.8em;
+		margin: 0.5em 0;
+
 		@include utilities.link-transition;
 
-		margin: 0.5em 0;
+		&:hover {
+			color: var( --newspack-theme-color-primary-against-white );
+		}
 	}
 
 	a {
+		color: var( --newspack-theme-color-secondary-against-white );
 		text-decoration: underline;
 
 		&:hover,
@@ -520,7 +525,7 @@ div.sharedaddy {
 	}
 
 	.author-link {
-		color: var( --newspack-theme-color-secondary );
+		color: var( --newspack-theme-color-secondary-against-white );
 		font-size: var( --newspack-theme-font-size-sm );
 		font-weight: bold;
 		text-decoration: none;
@@ -709,6 +714,11 @@ div.sharedaddy {
 	// Header - default background
 	.h-db .featured-image-beside {
 		background-color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-against-primary );
+
+		.entry-header {
+			color: var( --newspack-theme-color-against-primary );
+		}
 	}
 
 	// Header - solid background

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -278,9 +278,9 @@ amp-script .cat-links {
 
 .entry .entry-content {
 	a.button {
+		color: var( --newspack-theme-color-against-secondary );
 		text-decoration: none;
 
-		&,
 		&:hover {
 			color: var( --newspack-theme-color-bg-body );
 		}

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -174,7 +174,7 @@ amp-script .cat-links {
 	}
 
 	a {
-		color: var( --newspack-theme-color-primary-variation );
+		color: var( --newspack-theme-color-primary-against-white );
 	}
 
 	.edit-link {

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -227,7 +227,7 @@ amp-script .cat-links {
 		@include utilities.link-transition;
 
 		&:hover {
-			color: var( --newspack-theme-color-primary-against-white );
+			color: var( --newspack-theme-color-link-hover );
 		}
 	}
 

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -144,7 +144,7 @@ amp-script .cat-links {
 			}
 
 			&:hover {
-				color: var( --newspack-theme-color-primary-variation );
+				color: var( --newspack-theme-color-primary-variation-against-white );
 			}
 		}
 	}

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -220,6 +220,10 @@ h1.wp-block-post-title {
 	.more-link + .entry-meta {
 		margin-top: #{0.75 * structure.$size__spacing-unit};
 	}
+
+	.cat-links a {
+		color: inherit;
+	}
 }
 
 /** === Newspack Carousel === */

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -98,11 +98,11 @@ h6 {
 a {
 	@include utilities.link-transition;
 
-	color: var( --newspack-theme-color-link );
+	color: var( --newspack-theme-color-secondary-against-white );
 
 	&:hover,
 	&:active {
-		color: var( --newspack-theme-color-link );
+		color: var( --newspack-theme-color-secondary-against-white );
 		outline: 0;
 		text-decoration: none;
 	}
@@ -181,7 +181,7 @@ h1.wp-block-post-title {
 	font-size: var( --newspack-theme-font-size-base );
 
 	a {
-		color: var( --newspack-theme-color-primary );
+		color: var( --newspack-theme-color-primary-against-white );
 		font-weight: bold;
 		text-decoration: none;
 	}
@@ -446,7 +446,7 @@ div[data-align='full'] {
 	}
 
 	&:not( .has-text-color ) {
-		color: #fff;
+		color: var( --newspack-theme-color-against-secondary );
 	}
 }
 
@@ -457,7 +457,7 @@ div[data-align='full'] {
 	}
 
 	&:not( .has-text-color ) {
-		color: var( --newspack-theme-color-secondary );
+		color: var( --newspack-theme-color-secondary-against-white );
 	}
 }
 
@@ -640,20 +640,21 @@ div[data-align='full'] {
 
 	.wp-block-file__textlink {
 		text-decoration: underline;
-		color: var( --newspack-theme-color-link );
+		color: var( --newspack-theme-color-secondary-against-white );
 
 		&:hover {
-			color: var( --newspack-theme-color-link );
+			color: var( --newspack-theme-color-secondary-against-white );
 			text-decoration: none;
 		}
 	}
 
 	.wp-block-file__button {
+		color: var( --newspack-theme-color-against-secondary );
 		display: table;
 		line-height: 1.8;
 		font-size: inherit;
 		font-weight: bold;
-		background-color: var( --newspack-theme-color-link );
+		background-color: var( --newspack-theme-color-secondary );
 		border-radius: 5px;
 		padding: 10px 20px;
 	}
@@ -679,7 +680,7 @@ div[data-align='full'] {
 	background: var( --newspack-theme-color-secondary );
 	border: 0;
 	border-radius: 5px;
-	color: #fff;
+	color: var( --newspack-theme-color-against-secondary );
 	line-height: 1.8;
 	font-family: var( --newspack-theme-font-heading );
 	font-size: var( --newspack-theme-font-size-sm );

--- a/newspack-theme/sass/styles/style-default/style-default-editor.scss
+++ b/newspack-theme/sass/styles/style-default/style-default-editor.scss
@@ -3,7 +3,7 @@
 .accent-header,
 .article-section-title {
 	border-bottom: 4px solid var( --newspack-theme-color-border );
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	font-size: var( --newspack-theme-font-size-sm );
 	margin-top: 0;
 	margin-bottom: #{structure.$size__spacing-unit * 0.75};

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -7,7 +7,7 @@
 #secondary .widgettitle,
 .article-section-title {
 	border-bottom: 4px solid var( --newspack-theme-color-border );
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 	padding-bottom: #{structure.$size__spacing-unit * 0.33};
 }
 
@@ -39,7 +39,7 @@
 	.menu-highlight a {
 		background-color: var( --newspack-theme-color-primary );
 		border: 0;
-		color: #fff;
+		color: var( --newspack-theme-color-against-primary );
 		padding: #{structure.$size__spacing-unit * 0.5} #{structure.$size__spacing-unit * 0.75};
 	}
 }
@@ -47,11 +47,12 @@
 .h-sb .site-header .nav3 {
 	a {
 		background-color: var( --newspack-theme-color-primary-darken-10 );
-		color: #fff;
+		color: var( --newspack-theme-color-against-primary );
 	}
 
 	.menu-highlight a {
 		background-color: var( --newspack-theme-color-secondary );
+		color: var( --newspack-theme-color-against-secondary );
 	}
 }
 
@@ -76,6 +77,7 @@
 
 	.menu-highlight a {
 		background-color: var( --newspack-theme-color-primary-darken-10 );
+		color: var( --newspack-theme-color-against-primary );
 	}
 }
 
@@ -88,7 +90,7 @@
 .cat-links {
 	a {
 		background-color: var( --newspack-theme-color-primary );
-		color: #fff;
+		color: var( --newspack-theme-color-against-primary );
 		display: inline-block;
 		line-height: 1;
 		margin: 0 #{0.25 * structure.$size__spacing-unit} #{0.25 * structure.$size__spacing-unit} 0;
@@ -100,7 +102,7 @@
 
 		&:hover {
 			background-color: var( --newspack-theme-color-primary-variation );
-			color: #fff;
+			color: var( --newspack-theme-color-against-primary );
 		}
 	}
 }
@@ -176,7 +178,7 @@ footer.entry-footer a {
 }
 
 div.author-bio .author-link {
-	color: var( --newspack-theme-color-primary );
+	color: var( --newspack-theme-color-primary-against-white );
 }
 
 /* Archives */

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -173,8 +173,11 @@
 	}
 }
 
-div.author-bio .author-link {
-	color: var( --newspack-theme-color-primary-against-white );
+div.author-bio {
+	.author-link,
+	h2 a {
+		color: var( --newspack-theme-color-primary-against-white );
+	}
 }
 
 /* Archives */

--- a/newspack-theme/sass/styles/style-default/style-default.scss
+++ b/newspack-theme/sass/styles/style-default/style-default.scss
@@ -97,7 +97,7 @@
 		padding: 0.3em 0.5em;
 
 		&:visited {
-			color: #fff;
+			color: var( --newspack-theme-color-against-primary );
 		}
 
 		&:hover {
@@ -158,10 +158,6 @@
 			display: inline;
 		}
 	}
-}
-
-footer.entry-footer a {
-	color: var( --newspack-theme-color-primary-variation );
 }
 
 .tags-links a {

--- a/newspack-theme/sass/variables-site/_colors.scss
+++ b/newspack-theme/sass/variables-site/_colors.scss
@@ -35,7 +35,7 @@
 
 	// Links
 	--newspack-theme-color-link: var( --newspack-theme-color-secondary );
-	--newspack-theme-color-link-hover: var( --newspack-theme-color-secondary-variation );
+	--newspack-theme-color-link-hover: var( --newspack-theme-color-secondary-variation-against-white );
 
 	// Borders
 	--newspack-theme-color-border: #ccc;

--- a/newspack-theme/sass/variables-site/_colors.scss
+++ b/newspack-theme/sass/variables-site/_colors.scss
@@ -8,6 +8,14 @@
 	--newspack-theme-color-primary-darken-5: #1a53ff; // TODO: find a better approach than being this literal.
 	--newspack-theme-color-primary-darken-10: #0040ff; // TODO: find a better approach than being this literal.
 
+	// Constast colors - text against white background, if light changes to grey:
+	--newspack-theme-color-primary-against-white: var( --newspack-theme-color-primary ); // primary color against white bg.
+	--newspack-theme-color-secondary-against-white: var( --newspack-theme-color-secondary ); // secondary color against white bg.
+
+	// Contrast colors - text to use against primary or secondary (black or white)
+	--newspack-theme-color-against-primary: #fff; // text color on top of primary color bg.
+	--newspack-theme-color-against-secondary: #fff; // text color on top of primary color bg.
+
 	// Backgrounds
 	--newspack-theme-color-bg-body: #fff;
 	--newspack-theme-color-bg-input: var( --newspack-theme-color-bg-body );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a continuation of the work started in #2091 to replace the theme's colour code with CSS variables. 

This particular PR focuses on two areas:

* Creating variables for when the primary and secondary colours are used for text against a white background. The value of these variables is switched between the primary/secondary colours or grey, if those custom colours have insufficient contrast against white.
* Creating variables for text when used against the primary or secondary colour, and switching the variable values between white and black to contrast against those custom colours, depending how light/dark they are. 

The one exception is the checkbox style, which uses a SVG as a background image; unfortunately CSS variables don't work in the `fill` attribute. 

If you're picking up this task, I'm sincerely happy to set up one or more JN sites with all the content/settings you need to test, to make testing easier -- please ping me in Slack when this would be a helpful thing to do! (I don't want to do it too soon and have the site disappear before testing can start 😅 ).

See 1200550061930446-as-1203928233002238

### How to test the changes in this Pull Request:

_This PR resulted in a **bunch** of smaller things to check; I've outlined them to the best of my ability below and have included content examples to use when possible, but I apologize if this is a bear to test!_

#### Newspack - Header - General

1. Apply the PR and run `npm run build`.
2. Switch the site to the default theme.
3. Navigate to Customizer > Header Settings > Appearance, and turn off 'Solid Background' and 'Sticky' if enabled. 
4. Add a menu to the 'Tertiary Menu' space, with two links; give one the CSS class `menu-highlight`.
5. Assign a menu to the 'Topic Highlight' space.

**Things to test:**
* The Topic Highlight label should be secondary or grey
* When you open the search, search button should be primary or grey on hover
* The mobile menu should use the primary background, and all links and borders should contrast against it
* In the mobile menu, the link in the Tertiary menu with the `menu-highlight` class should use a slightly darker version of the primary colour with contrasting text.

<details>
<summary>Screenshots</summary>

Highlight menu - dark secondary colour
![image](https://user-images.githubusercontent.com/177561/236531965-5ef06654-29a9-43f4-a6d6-b0c3ec919004.png)

Highlight menu - light secondary colour
![image](https://user-images.githubusercontent.com/177561/236530064-6c9c5a4d-c17b-4094-943c-3b571c342850.png)

Search button hover - dark primary colour
![image](https://user-images.githubusercontent.com/177561/236530972-1c6b2e6e-2820-4138-a716-be91cad3010e.png)

Search button hover - light primary colour
![image](https://user-images.githubusercontent.com/177561/236530634-82d20088-299f-458a-96f6-07f3413ce2e9.png)

Mobile menu - dark primary colour with `menu-highlight` tertiary menu item
![image](https://user-images.githubusercontent.com/177561/236531255-8d971750-5fd5-407c-82d7-e1c7c98f4a38.png)

Mobile menu - light primary colour with `menu-highlight` tertiary menu item
![image](https://user-images.githubusercontent.com/177561/236531459-8a74c4c2-21e2-4c4d-989d-d6b173d25ffc.png)

</details>

----

#### Newspack - Header - Default Theme

1. Navigate to Customizer > Header Settings > Appearance, and turn on 'Solid Background'
    * The link in the Tertiary Menu with the `menu-highlight` class should use the secondary colour as a background with contrasting text, but only in the header. 

2. Navigate to Customizer > Header Settings > Appearance, and turn off 'Solid Background'
    * The link in the Tertiary Menu with the `menu-highlight` class should use the primary colour as a background with contrasting text, but only in the header. 

<details>
<summary>Screenshots</summary>

With header background  - tertiary menu with dark secondary colour:
![image](https://user-images.githubusercontent.com/177561/236532541-d1bb1830-4946-47d4-8c60-62ba27ff1fed.png)

With header background  - tertiary menu with light secondary colour:
![image](https://user-images.githubusercontent.com/177561/236532635-7a22a4f6-0379-428a-93d0-f2f1ec476ce1.png)

No header background - tertiary menu with dark primary colour: 

![image](https://user-images.githubusercontent.com/177561/236532179-8f3bad38-cc31-4931-bbec-bb33eb59f0e3.png)

No header background - tertiary menu with light primary colour:

![image](https://user-images.githubusercontent.com/177561/236532060-07471794-cc60-4eff-b088-e98bcb18ed4d.png)

</details>

----
----

#### Newspack - Footer - General

1. Set footer to have the default background colour

* "Site info" - should be primary or grey on hover

<details>
<summary>Screenshot</summary>

Site info links on hover with dark primary colour
![image](https://user-images.githubusercontent.com/177561/236532984-625bc608-be92-4fc8-b5c3-185713ac79c6.png)

Site info links on hover with light primary colour

![image](https://user-images.githubusercontent.com/177561/236533039-9bf7c827-5921-459d-9c7a-9455f997fa11.png)

</details>

----

#### Newspack - Footer - Newspack Nelson

1. Set footer to have the default background colour; the theme will default to the 'primary' colour as a background.

* Confirm the footer text and widgets contrast against the primary background colour.

<details>
<summary>Screenshots</summary>

Footer - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236544369-54d10d15-fd55-43be-a65a-2b4f68349aff.png)

Footer - light primary colour

![image](https://user-images.githubusercontent.com/177561/236544275-08daadc2-a134-4fca-b475-ace9b0455381.png)


</details>

----

#### Newspack - Footer - Newspack Sacha

1. Set footer to have the default background colour

* The footer widget titles should use the primary colour or grey

<details>
<summary>Screenshots</summary>

Footer widget title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236548157-d7d0dfb8-2d3f-40e5-bdcc-91dcfee261ea.png)

Footer widget title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236548088-4df1491a-264e-425b-866e-120b0c3ca542.png)

</details>

----
----

#### Newspack - Single Post - General

1. Navigate to Customizer > Comment Settings and turn on 'Collapse Comments'
3. Add at least two comments to the post.
4. Set up a post with the 'featured image behind' setting, and set the header to use the default background
6. Make sure the Author Bio is displaying (you may need to add 'Bio Details' to the post's author to get it to display, and enable the bio under Customizer > Author Bio settings). 

* Entry footer links - should be primary or grey
* Comment meta data on hover - should be primary or grey
* Comment toggle - should be primary or grey
* 'Post Author' icon next to comments by the post author should use the primary colour as a background and a contrasting icon on top
* The Featured Image behind text should contrast against the primary colour.
* The Author Bio 'More by [name] link should use the secondary colour or grey.

<details>
<summary>Screenshots</summary>

Entry footer - dark primary colour
![image](https://user-images.githubusercontent.com/177561/236536083-d2eb9ee6-a95a-471d-bab1-3ddba3acbd9e.png)

Entry footer - light primary colour
![image](https://user-images.githubusercontent.com/177561/236536150-1688a86c-2441-400c-8217-1feded7880ec.png)

Comments - meta on hover + post author icon - dark primary colour
![image](https://user-images.githubusercontent.com/177561/236536586-bcf3f261-7e1d-408e-8872-a1908b8dab43.png)

Comments - meta on hover + post author icon - light primary colour

![image](https://user-images.githubusercontent.com/177561/236536513-485b3e4e-2f53-4314-997f-de91f1a394c2.png)

Featured image beside, dark primary colour, no header bg

![image](https://user-images.githubusercontent.com/177561/236537124-e2b398eb-d594-4c6f-845a-e6bb639329c2.png)

Featured image beside, light primary colour, no header bg

![image](https://user-images.githubusercontent.com/177561/236537057-44446b26-a568-4bfc-9ae4-44a9e09c9da4.png)

Author bio - "more by" link, dark primary colour
![image](https://user-images.githubusercontent.com/177561/236536687-39178165-45c0-4cf3-a34d-71ca0d97f516.png)

Author bio - "more by" link, light primary colour

![image](https://user-images.githubusercontent.com/177561/236536895-f32c8b23-2d32-4a01-9fdf-88893043bb48.png)

</details>

----

#### Newspack - Single Post - Default Theme

* The category should use the primary colour as a background, with contrasting text. 
* The byline should use the primary colour or grey for the text.
* The sidebar widgets titles should use the primary colour or grey

<details>
<summary>Screenshots</summary>

Single post category and byline - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236537805-0ea28ffb-2aab-4f6e-abb1-9965729357fb.png)

Single post category and byline - light primary colour

![image](https://user-images.githubusercontent.com/177561/236537763-83c6ec8d-ae97-48f5-9f76-839eaf43696d.png)

Sidebar widget title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236537961-9205fbe6-5c57-485e-8225-f903b5979c20.png)

Sidebar widget title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236538005-4fb1cba7-a580-4b41-a54c-620de764f3f6.png)

</details>

----

#### Newspack - Single Post - Newspack Katharine Theme

* The category should use the primary colour or grey for the text.
* The byline should use the primary colour or grey for the text.
* The sidebar widgets titles should use the primary colour or grey
* The featured-image beside should use the primary colour with and without a solid header, with sufficient contrast

<details>
<summary>Screenshots</summary>

Single post category and byline - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236538934-c2cdbbd5-3ed3-44f2-bf8c-7d901d924bdb.png)

Single post category and byline - light primary colour

![image](https://user-images.githubusercontent.com/177561/236539005-354ea64b-c411-4293-accd-2dc9fe0880db.png)

Sidebar widget title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236538953-62d4032e-c799-430d-8982-9060736e547c.png)

Sidebar widget title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236539049-2c43f4dc-601f-4448-8b75-07441bb7459a.png)

Featured image beside - dark primary colour, default header background

![image](https://user-images.githubusercontent.com/177561/236542021-0a5ab6ed-47f6-413e-a959-330c8897e12c.png)

Featured image beside - light primary colour, default header background

![image](https://user-images.githubusercontent.com/177561/236541856-bea063fc-9ef0-4209-9180-1d9b9262f4ff.png)

Featured image beside - dark primary colour, solid header background

![image](https://user-images.githubusercontent.com/177561/236542114-25180f7e-2763-41af-b106-55dfb0b2a320.png)

Featured image beside - light primary colour, solid header background

![image](https://user-images.githubusercontent.com/177561/236542201-a27871d9-aec3-4b15-b1a5-d31d1a6f8921.png)


</details>

----

#### Newspack - Single Post - Newspack Sacha Theme

* The category should use the primary colour or grey for the text.
* The byline should use the primary colour or grey for the text.
* The sidebar widgets titles should use the primary colour or grey
* The featured image beside should use a light grey when a header colour is assigned instead of the primary/dark grey

<details>
<summary>Screenshots</summary>

Single post category and byline - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236548421-3a764cda-faa2-4fa8-af91-c41130a722d0.png)

Single post category and byline - light primary colour

![image](https://user-images.githubusercontent.com/177561/236548515-39d2c777-5201-49b2-9d49-2d2ad846a1c4.png)

Sidebar widget title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236548445-b70423b1-fa5d-4fbd-86df-03fda24b7367.png)

Sidebar widget title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236548544-282da66d-3a0f-4088-9322-400f875a87cd.png)

Featured image beside - dark primary colour, default header background

![image](https://user-images.githubusercontent.com/177561/236549091-ac61f9eb-6fc6-46ca-9dd9-999612f0f04b.png)

Featured image beside - light primary colour, default header background

![image](https://user-images.githubusercontent.com/177561/236548646-cf4322b1-299c-4f7b-9a13-b1bf87c90dce.png)

Featured image beside - dark primary colour, solid header background (should be light grey bg, primary colour on category)

![image](https://user-images.githubusercontent.com/177561/236548921-edebcab6-fcb2-44c4-8053-5d1e20c38636.png)

Featured image beside - light primary colour, solid header background (should be light grey bg, medium grey on category)

![image](https://user-images.githubusercontent.com/177561/236548736-afb1bfd2-0289-4f5a-bff2-20a37858ea23.png)

</details>

----

#### Newspack - Single Post - Newspack Scott Theme

* The 'block' before the category should contrast against the background when using the 'featured image beside' setting.

<details>
<summary>Screenshots</summary>

Single post featured image beside - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236553265-f3ba0034-691b-4189-887e-8318b64d77db.png)

Single post featured image beside - light primary colour

![image](https://user-images.githubusercontent.com/177561/236553556-a8bc13c0-08fe-4119-97f6-9f089de9aa7c.png)

</details>

----
----

#### Newspack - Archive - Default Theme

* The archive section page title should use the primary colour or grey.

<details>
<summary>Screenshots</summary>

Archive title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236538165-21102781-71d2-4814-872c-cf8e423567f8.png)

Archive title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236538137-9d9dfaca-6681-43ff-aff6-9a5fbaacb51c.png)

</details>

---- 

#### Newspack - Archive - Newspack Katharine

* The archive section page title should use the primary colour or grey.

<details>
<summary>Screenshots</summary>

Archive title - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236539221-870a14c6-f372-4763-8646-0dabea7b48ea.png)

Archive title - light primary colour

![image](https://user-images.githubusercontent.com/177561/236539163-eddeafe7-17fb-49f3-bcec-b78a87b24f7f.png)


</details>

---- 

#### Newspack - Archive - Newspack Sacha

* The archive section page title should use the primary colour or grey.

<details>
<summary>Screenshots</summary>

Archives - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236549246-45495d1b-5e45-43c0-a270-4c39491b2b49.png)

Archives - light primary colour

![image](https://user-images.githubusercontent.com/177561/236549305-a7828871-7681-430c-a421-9a2d812ec064.png)

</details>

----
----

#### Newspack - Blocks - General

<details>
<summary><strong>Optional - copy paste this code to get all the blocks to test</strong></summary>

```
<!-- wp:paragraph {"dropCap":true} -->
<p class="has-drop-cap">Lorem ipsum dolor sit amet, consectetur adipiscing elit. <a href="#">Mauris purus urna, vulputate at convallis hendrerit, mattis id mi</a>. Nulla mauris justo, sodales vitae sodales nec, fermentum at elit. </p>
<!-- /wp:paragraph -->

<!-- wp:heading {"className":"accent-header"} -->
<h2 class="wp-block-heading accent-header">This is a Heading Block with the "Accent-Header" class</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>And a bit more text.</p>
<!-- /wp:paragraph -->

<!-- wp:newspack-blocks/homepage-articles {"excerptLength":37,"showReadMore":true,"moreButton":true,"moreButtonText":"Load More","showCategory":true,"postLayout":"grid","typeScale":2,"sectionHeader":"This is the homepage Posts Block header"} /-->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button default</a></div>
<!-- /wp:button -->

<!-- wp:button {"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">Button outline</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"primary"} -->
<div class="wp-block-button"><a class="wp-block-button__link has-primary-background-color has-background wp-element-button">Button primary</a></div>
<!-- /wp:button -->

<!-- wp:button {"textColor":"primary","className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-primary-color has-text-color wp-element-button">Button primary</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"style":{"color":{"gradient":"linear-gradient(135deg,rgb(255,128,254) 0%,rgb(80,169,191) 100%)"}}} -->
<div class="wp-block-button"><a class="wp-block-button__link has-background wp-element-button" style="background:linear-gradient(135deg,rgb(255,128,254) 0%,rgb(80,169,191) 100%)">Button custom</a></div>
<!-- /wp:button -->

<!-- wp:button {"style":{"color":{"text":"#f73ef4"}},"className":"is-style-outline"} -->
<div class="wp-block-button is-style-outline"><a class="wp-block-button__link has-text-color wp-element-button" style="color:#f73ef4">Button custom</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:search {"label":"Search","buttonText":"Search"} /-->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:file {"id":108,"href":"https://lfulford.ngrok.io/wp-content/uploads/2023/04/automated_upload-33.jpg"} -->
<div class="wp-block-file"><a id="wp-block-file--media-4e67195f-5179-4fd9-a343-f7210c4cec7c" href="https://lfulford.ngrok.io/wp-content/uploads/2023/04/automated_upload-33.jpg">automated_upload-33</a><a href="https://lfulford.ngrok.io/wp-content/uploads/2023/04/automated_upload-33.jpg" class="wp-block-file__button wp-element-button" download aria-describedby="wp-block-file--media-4e67195f-5179-4fd9-a343-f7210c4cec7c">Download</a></div>
<!-- /wp:file -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>The donate block button is the only one that shouldn't pick up the button styles.</p>
<!-- /wp:paragraph -->

<!-- wp:newspack-blocks/donate {"amounts":{"once":[9,20,90,20],"month":[7,15,30,15],"year":[84,180,360,180]},"disabledFrequencies":{"once":false,"month":false,"year":false},"minimumDonation":5} /-->

<!-- wp:pullquote -->
<figure class="wp-block-pullquote"><blockquote><p>This is a pullquote</p><cite>This is a citation.</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator -->
```
</details>

1. Homepage Posts Block - more link should be primary or grey on hover
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/177561/236519982-25e4c16a-abc4-4804-b14d-18764ddb7f38.png)

</details>

2. Button block - solid background should use the secondary colour as the background with contrasting text, and the outline styles should use the secondary colour or grey as the text/outline colour.

<details>
<summary>Screenshots</summary>

Dark secondary colour:
![image](https://user-images.githubusercontent.com/177561/236520477-bfd1d146-042e-4d94-b905-5a96a93693e6.png)

Light secondary colour:
![image](https://user-images.githubusercontent.com/177561/236520639-47b791f6-bebd-4a40-8e32-922eb7b971f4.png)

</details>

3. Add a paragraph with a link in it; the link should use the secondary colour or grey.

<details>
<summary>Screenshots</summary>

Dark secondary colour:
![image](https://user-images.githubusercontent.com/177561/236520755-44838767-f255-4be5-aab6-0806297e2d65.png)

Light secondary colour:
![image](https://user-images.githubusercontent.com/177561/236520707-9d6054a1-e833-42b5-8fc5-a46b5b6666c0.png)

</details>

4. Add a File block - the link should use the secondary or grey colour. The button should have the secondary colour as a background, with contrasting text.

<details>
<summary>Screenshot</summary>

Dark secondary colour:
![image](https://user-images.githubusercontent.com/177561/236520882-a008726f-1254-4b95-9354-4011b5f1721f.png)

Light secondary colour: 
![image](https://user-images.githubusercontent.com/177561/236520925-60d5f950-617d-4d1a-b697-022a632aecdb.png)
</details>


9. Add a search block - the button should use the secondary colour as the background with contrasting text.

<details>
<summary>Screenshots</summary>

Dark secondary colour:
![image](https://user-images.githubusercontent.com/177561/236521106-a2fcb26b-8e04-444f-bd76-d37251f2d3a9.png)

Light secondary colour: 
![image](https://user-images.githubusercontent.com/177561/236521037-2e42f84f-21d1-4dd0-911d-36d6d246dfcb.png)


</details>

-----

#### Newspack - Blocks - Default theme

* Homepage Posts block - the 'Section title' (and headers with the `accent-header` CSS class) should use the primary colour or grey for the text

<details>
<summary>Screenshots</summary>

Dark primary colour:
![image](https://user-images.githubusercontent.com/177561/236523760-59293eb3-65a5-41a7-817b-3c2ee456e34e.png)

Light primary colour:
![image](https://user-images.githubusercontent.com/177561/236523643-7b95645b-0741-4bbc-8eab-d080719d76e5.png)
</details>


* Homepage post blocks - the author link should use the primary colour or grey

<details>
<summary>Screenshots</summary>

Dark primary colour:
![image](https://user-images.githubusercontent.com/177561/236523842-bbbbddfb-d7f3-4bf0-9eee-f21973021c28.png)

Light primary colour:
![image](https://user-images.githubusercontent.com/177561/236523903-6f6f0a56-9a18-4fb8-be94-e804af11cd4c.png)

----

#### Newspack - Blocks - Newspack Katharine

* Homepage Posts block - the 'Section title' (and headers with the `accent-header` CSS class) should use the primary colour or grey for the text
* HPB - the byline should use the primary colour or grey

<details>
<summary>Screenshots</summary>

Homepage Post block - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236539406-60b80a64-f765-4e21-ae54-345624da9825.png)

![image](https://user-images.githubusercontent.com/177561/236539436-e6073829-bdcd-45d9-93b2-bcd382e20ca0.png)

Homepage Post block - light primary colour

![image](https://user-images.githubusercontent.com/177561/236539543-0da7571b-1646-48d3-a72a-78f287162d3d.png)

![image](https://user-images.githubusercontent.com/177561/236539559-e2d50755-834c-45ac-bb2b-02026d2c29cc.png)

</details>

----

#### Newspack - Blocks - Newspack Nelson

* Paragraph block - the drop cap should use the secondary colour or grey.

<details>
<summary>Screenshots</summary>

Dropcap - dark secondary colour

![image](https://user-images.githubusercontent.com/177561/236544643-ed5d460b-88ed-427f-ad81-8a7fac1a4556.png)

Dropcap - light secondary colour

![image](https://user-images.githubusercontent.com/177561/236544580-b3404732-8957-4d30-897d-acee0914f020.png)

</details>

----

#### Newspack - Blocks - Newspack Sacha

* Homepage Posts block - the 'Section title' (and headers with the `accent-header` CSS class) should use the primary colour or grey for the text
* HPB - the byline should use the primary colour or grey
* Paragraph block - the drop cap should use the primary colour as a background, with contrasting text

<details>
<summary>Screenshots</summary>

Homepage Post block - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236549808-74a03a97-5de8-44c1-ac62-7f902631a7b0.png)

![image](https://user-images.githubusercontent.com/177561/236549843-43fbe813-ef16-4bd5-bcd1-85bb452cf8cd.png)

Homepage Post block - light primary colour

![image](https://user-images.githubusercontent.com/177561/236549657-116bb58b-377d-4fd3-813e-24bd1cf3a0d0.png)

![image](https://user-images.githubusercontent.com/177561/236549670-7e0939ef-cc5f-4a85-a01e-ca058c35a09f.png)

Dropcap - dark primary colour 

![image](https://user-images.githubusercontent.com/177561/236549872-4987620f-e6f2-48fa-81de-3f718bd3d46b.png)

Dropcap - light primary colour

![image](https://user-images.githubusercontent.com/177561/236549609-6ce5cb7a-8ce6-4207-8be0-ae3f19d5fd1f.png)

</details>

-----

#### Newspack - Blocks - Newspack Scott

* Homepage Posts block - the categories should use the secondary colour

<details>
<summary>Screenshots</summary>

Homepage Post Block - dark secondary colour

![image](https://user-images.githubusercontent.com/177561/236554227-40ff48ae-a33d-4502-bf79-43aa40b0c571.png)

Homepage Post Block - light secondary colour

![image](https://user-images.githubusercontent.com/177561/236554393-29add10b-b80e-45e1-bfa0-7dcc073ffb87.png)

</details>

----
----

#### Newspack - WooCommerce 'My Account' pages - General

* 'My account' nav should use primary or grey on hover or focus
* The active 'My account' nav link should use a primary background and contrasting text on top

<details>
<summary>Screenshots</summary>

My Account Nav active (account details link) + hover (newsletters link) - dark primary colour 

![image](https://user-images.githubusercontent.com/177561/236554583-88846417-71a2-4126-ae2a-6ef902821ff5.png)

My Account Nav active (account details link) + hover (newsletters link) - light primary colour 

![image](https://user-images.githubusercontent.com/177561/236554850-08ef146d-d3a6-42e7-bab3-49d6d551a414.png)

</details>

----

#### Newspack - WooCommerce - General

1. Make at least one product on sale
2. Enable the Store Notice under Customize > WooCommerce > Store Notice

* The On Sale badge should have the primary colour as background, with contrasting text
* The WooCommerce Store Notice should have the primary colour as background, with contrasting text

<details>
<summary>Screenshot</summary>

On Sale - dark primary colour 

![image](https://user-images.githubusercontent.com/177561/236555159-4401a9f3-d22a-407b-b409-9f3746e22c1a.png)

On Sale - light primary colour 

![image](https://user-images.githubusercontent.com/177561/236555089-38bd6a1d-004a-468b-a61b-07c952c9b4a7.png)

WooCommerce Store Notice - dark primary colour

![image](https://user-images.githubusercontent.com/177561/236556380-93fac8e5-5b72-4954-ba5d-f1606bf285de.png)

WooCommerce Store Notice - light primary colour

![image](https://user-images.githubusercontent.com/177561/236556271-9e6413a0-53b8-4c59-896f-ae174bfd1879.png)

</details>


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
