### PR TITLE
fix: correct highlight menu colour

### DIFF
--- a/newspack-nelson/sass/style.scss
+++ b/newspack-nelson/sass/style.scss
@@ -118,8 +118,11 @@ body:not( .h-sb ) .site-header {
 	}
 }
 
-.h-sb .highlight-menu a {
-	color: #fff;
+.h-sb .highlight-menu {
+	a,
+	.menu-label {
+		color: #fff;
+	}
 }
 
 // Header - sticky

--- a/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
+++ b/newspack-theme/sass/navigation/_menu-highlight-navigation.scss
@@ -37,7 +37,7 @@
 
 	a,
 	a:visited {
-		color: var( --newspack-theme-color-link );
+		color: var( --newspack-theme-color-text-light );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR corrects an issue in the 'highlight menu', where it was picking up the secondary colour for links where it should use a medium grey.

Note: this fix is also included in #2109 but it's more of a bear to test; a smaller PR will help get it into the next release!

### How to test the changes in this Pull Request:

1. Add a topic highlight menu to the site. 
2. Change your secondary colour to something not-grey.
3. View on the front-end; note  that the links in the menu are incorrectly picking up your secondary colour.
4. Apply the PR and run `npm run build`.
5. Confirm that the topic highlight menu is now correctly using grey for the links.
6. Switch your site to Newspack Nelson; this theme is a little different because it places the topic highlight menu "inside" of the menu space, so we need to make sure the colours are still working right. 
7. Navigate to Customizer > Header > Appearance and turn off the Solid Background; confirm the menu uses grey text.
8. Navigate to Customizer > Header > Appearance and turn on Solid background; navigate to Customizer > Colours, and turn off custom colours, so it's using the default Newspack blue. Confirm that the menu uses white text.
9. Navigate to Customizer > Colours and change the header to a darker, then lighter colour. Confirm that the menu has adequate contrast against each (switching between black or white). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
