### PR TITLE
feat: add links to the author bio

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -27,11 +27,17 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 			<div class="author-bio">
 				<div class="author-bio-text">
 					<div class="author-bio-header">
-						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
+						<?php if ( $author_avatar ) { ?>
+							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+								<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
+							</a>
+						<?php } ?>
 
 						<div>
 							<h2 class="accent-header">
-								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								</a>
 							</h2>
 
 							<?php if ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) : ?>
@@ -84,15 +90,20 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<div class="author-bio-header">
 			<?php
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-			if ( $author_avatar ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo $author_avatar;
-			}
-			?>
+				if ( $author_avatar ) { ?>
+				<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+					<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo $author_avatar;
+					?>
+				</a>
+			<?php } ?>
 
 			<div>
 				<h2 class="accent-header">
-					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+						<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					</a>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) ) : ?>

--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -197,7 +197,8 @@ function newspack_custom_colors_css() {
 				.accent-header,
 				#secondary .widgettitle,
 				.article-section-title,
-				.entry .entry-footer a:hover {
+				.entry .entry-footer a:hover,
+				div.author-bio .author-link {
 					color: ' . esc_attr( newspack_color_with_contrast( $colors['primary'] ) ) . ';
 				}
 			';

--- a/newspack-theme/inc/newspack-sponsors.php
+++ b/newspack-theme/inc/newspack-sponsors.php
@@ -359,10 +359,10 @@ if ( ! function_exists( 'newspack_sponsor_footer_bio' ) ) :
 								<div class="author-bio-header">
 									<h2 class="accent-header">
 										<?php
-										echo esc_html( $sponsor['sponsor_byline'] ) . ' ';
 										if ( '' !== $sponsor['sponsor_url'] ) {
 											echo '<a target="_blank" href="' . esc_url( $sponsor['sponsor_url'] ) . '">';
 										}
+										echo esc_html( $sponsor['sponsor_byline'] ) . ' ';
 										echo esc_html( $sponsor['sponsor_name'] );
 										if ( '' !== $sponsor['sponsor_url'] ) {
 											echo '</a>';

--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -494,6 +494,7 @@ div.sharedaddy {
 
 	h2 {
 		font-size: 1em;
+
 		span {
 			color: var( --newspack-theme-color-text-light );
 			display: block;
@@ -505,6 +506,11 @@ div.sharedaddy {
 				display: inline;
 				margin: 0 0 0 0.5em;
 			}
+		}
+
+		a {
+			color: inherit;
+			text-decoration: none;
 		}
 	}
 

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -25,11 +25,11 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 			?>
 
 			<div class="author-bio">
-				<?php if ( $author_avatar ) { ?>
+				<?php if ( $author_avatar ) : ?>
 					<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
 					</a>
-				<?php } ?>
+				<?php endif; ?>
 
 				<div class="author-bio-text">
 					<div class="author-bio-header">
@@ -84,21 +84,19 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	}
 
 elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
+	$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
 	?>
 
 <div class="author-bio">
 
-	<?php
-		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-	if ( $author_avatar ) { 
-		?>
+	<?php if ( $author_avatar ) : ?>
 		<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 			<?php
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo $author_avatar;
 			?>
 		</a>
-	<?php } ?>
+	<?php endif; ?>
 
 	<div class="author-bio-text">
 		<div class="author-bio-header">

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -25,17 +25,19 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 			?>
 
 			<div class="author-bio">
-				<?php
-				if ( $author_avatar ) {
-					echo wp_kses( $author_avatar, newspack_sanitize_avatars() );
-				}
-				?>
+				<?php if ( $author_avatar ) { ?>
+					<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
+					</a>
+				<? } ?>
 
 				<div class="author-bio-text">
 					<div class="author-bio-header">
 						<div>
 							<h2 class="accent-header">
-								<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								</a>
 							</h2>
 
 							<?php if ( ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -88,18 +90,23 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 	<?php
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-	if ( $author_avatar ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $author_avatar;
-	}
-	?>
+		if ( $author_avatar ) { ?>
+		<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+			<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $author_avatar;
+			?>
+		</a>
+	<?php } ?>
 
 	<div class="author-bio-text">
 		<div class="author-bio-header">
 
 			<div>
 				<h2 class="accent-header">
-					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
+						<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					</a>
 				</h2>
 
 				<?php if ( true === get_theme_mod( 'show_author_email', false ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -128,7 +135,6 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			</p>
 		<?php else : ?>
 			<?php echo wp_kses_post( wpautop( get_the_author_meta( 'description' ) ) ); ?>
-
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -29,7 +29,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
 					</a>
-				<? } ?>
+				<?php } ?>
 
 				<div class="author-bio-text">
 					<div class="author-bio-header">
@@ -90,11 +90,12 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 	<?php
 		$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-		if ( $author_avatar ) { ?>
+	if ( $author_avatar ) { 
+		?>
 		<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 			<?php
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo $author_avatar;
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $author_avatar;
 			?>
 		</a>
 	<?php } ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds links from the author bio avatar and author name to each author's archive, and makes a small change to the sponsor bio to make the link behaviour similar. 

It also fixes a small bug with the Newspack default theme's author bio link contrast, likely introduced in #2091. Rather than switching to a medium grey when the primary colour is too like, the 'More by...' link continued to use the too-light primary colour. 

See 1200550061930446-as-1204508674733864.

### How to test the changes in this Pull Request:

**Test the link updates for authors:**
1. Apply the PR and run `npm run build`
2. Create a post that has both a regular and Co-Author Plus guest author assigned to it. 
3. Confirm that each author's avatar and name link to their archive page.
4. Turn off Co-Author Plus and confirm it still works with the regular author. 
5. Switch to Newspack Sacha, and repeat steps 2 and 3 (this theme has a different template part for the author bio to achieve the centred layout). 

**Test the link update for sponsors:**
This change involved adding the "Sponsored by" text into the existing sponsor link in the bio, just to make the click area more consistent with regular authors (whose whole title is clickable).

1. Assign a Sponsor to the post, and make sure they have a link
2. Confirm their whole title name "Sponsored by [Name]", not just the name part, links to their website in the sponsor bio at the bottom of the post. 
3. Remove the URL from the Sponsor's settings and confirm nothing weird happens to the sponsor output. 

**Test the link contrast:**
1. Switch to the Newspack default theme
2. Switch the Primary colour to a dark colour and confirm it's being used for the "More by..." link at the end of the bio.
3. Switch the Primary colour to a light colour and confirm the "More by..." link falls back to a medium grey that's still legible against the white background. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
