### PR TITLE
fix: remove unnecessary sponsor logo spacing

### DIFF
--- a/newspack-theme/sass/plugins/newspack-sponsors.scss
+++ b/newspack-theme/sass/plugins/newspack-sponsors.scss
@@ -93,7 +93,7 @@ amp-script .sponsor-label {
 	}
 }
 
-.sponsor-logos {
+.sponsor-logos:not(:empty) {
 	align-items: center;
 	display: inline-flex;
 	line-height: 1;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you have a sponsor assigned to a post, but the sponsor doesn't have a logo, you get an unnecessary space to the left of the sponsor byline on single posts.

This PR removes that space.

### How to test the changes in this Pull Request:

1. Set up a post with a sponsor that doesn't have a logo and view on the front-end. 
2. Note the space on the left:

![image](https://github.com/Automattic/newspack-theme/assets/177561/1bff8a0c-5708-4179-a3d2-8a7f4818c996)

3. Apply the PR and run `npm run build`
4. Confirm that the space is gone.

![image](https://github.com/Automattic/newspack-theme/assets/177561/4b54ceda-f3ba-4880-88f8-a4238dfd54f2)

5. Confirm that things look okay when you re-add the logo. 

![image](https://github.com/Automattic/newspack-theme/assets/177561/6b90fbd5-8380-403d-9506-bef4b1167c6d)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
