### PR TITLE
feat: register header and footer colors to Multibranded plugin

### DIFF
--- a/newspack-theme/inc/newspack-multibranded-site-plugin.php
+++ b/newspack-theme/inc/newspack-multibranded-site-plugin.php
@@ -27,6 +27,21 @@ add_filter(
 				'label'          => __( 'Background color to the ads', 'newspack-theme' ),
 				'default'        => get_theme_mod( 'ads_color_hex', '#ffffff' ),
 			],
+			[
+				'theme_mod_name' => 'header_color_hex',
+				'label'          => __( 'Header background (Requires the Solid brackroung option to be enabled)', 'newspack-theme' ),
+				'default'        => get_theme_mod( 'header_color_hex', '#666666' ),
+			],
+			[
+				'theme_mod_name' => 'header_primary_menu_color_hex',
+				'label'          => __( 'Background color to the primary menu (Requires the Solid brackroung option to be enabled)', 'newspack-theme' ),
+				'default'        => get_theme_mod( 'header_primary_menu_color_hex', '' ),
+			],
+			[
+				'theme_mod_name' => 'footer_color_hex',
+				'label'          => __( 'Footer background color', 'newspack-theme' ),
+				'default'        => get_theme_mod( 'footer_color_hex', '#666666' ),
+			],
 		];
 	}
 );
@@ -57,6 +72,38 @@ add_filter(
 			return $value;
 		}
 		if ( Newspack_Multibranded_Site\Customizations\Theme_Colors::current_brand_has_custom_colors( [ 'primary_color_hex', 'secondary_color_hex' ] ) ) {
+			return 'custom';
+		}
+		return $value;
+	}
+);
+
+/**
+ * Custom colors will only be applied if the theme_colors theme_mod is set to 'custom', so we need to filter it if they are being set by the Newspack Multi-branded site plugin.
+ */
+add_filter(
+	'theme_mod_header_color',
+	function( $value ) {
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() || ! class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
+			return $value;
+		}
+		if ( Newspack_Multibranded_Site\Customizations\Theme_Colors::current_brand_has_custom_colors( [ 'header_color_hex', 'header_primary_menu_color_hex', 'header_primary_menu_color_hex' ] ) ) {
+			return 'custom';
+		}
+		return $value;
+	}
+);
+
+/**
+ * Custom colors will only be applied if the theme_colors theme_mod is set to 'custom', so we need to filter it if they are being set by the Newspack Multi-branded site plugin.
+ */
+add_filter(
+	'theme_mod_footer_color',
+	function( $value ) {
+		if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() || ! class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
+			return $value;
+		}
+		if ( Newspack_Multibranded_Site\Customizations\Theme_Colors::current_brand_has_custom_colors( [ 'footer_color_hex' ] ) ) {
 			return 'custom';
 		}
 		return $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Inform the Multibranded site plugin about header and footer color customizations.

### How to test the changes in this Pull Request:

1. Go to the Customize > Header > Appearance and enable the "Solid background" option
2. Go to the multi branded options and confirm you see 3 new color options (header background, header primary menu and footer background)
3. Play with these colors and confirm they work as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
