### PR TITLE
fix: move caption check to fix campaigns issue

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -410,9 +410,13 @@ if ( ! function_exists( 'newspack_post_thumbnail_caption' ) ) {
 			return;
 		}
 
-		$caption = get_the_excerpt( get_post_thumbnail_id() );
 		// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
 		$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
+
+		// Only get the caption if one exists.
+		if ( $caption_exists ) {
+			$caption = get_the_excerpt( get_post_thumbnail_id() );
+		}
 
 		// Account for featured images that have a credit but no caption.
 		if ( ! $caption_exists && class_exists( '\Newspack\Newspack_Image_Credits' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Ooof, this is a weird one:

This PR fixes an odd issue with featured image captions, featured image descriptions and campaigns. It doesn't make sense to me that it's doing what it's doing, and consequently, I'm not sure if this is the best fix. It's very possible that this should be fixed in the Campaigns plugin; I opted to deal with it in the theme, though, since it does seem to be specific to our theme's featured image caption behaviour (if you switch themes, the issue goes away). 

**Issue**
We've had two reports of sites where campaigns didn't appear on random posts. Switching the theme to a non-Newspack theme appeared to fix the issue on both, as did adding a caption to the featured image. The weird bit is, some posts without featured image captions worked fine. 

I did some testing and the common culprit seems to be featured images that have a _description_ but no caption: in those cases the description text seems to be grabbed instead [here](https://github.com/Automattic/newspack-theme/blob/master/newspack-theme/inc/template-tags.php#L413) where the theme tries to get the featured image caption, and the prompt text seems to be appended to it. 

If I add `echo $caption;` to the line after [this one](https://github.com/Automattic/newspack-theme/blob/master/newspack-theme/inc/template-tags.php#L413), and set up a post with a featured image and no description and no caption, I get: 

![image](https://github.com/Automattic/newspack-theme/assets/177561/6872e20f-b4e9-4f38-8009-a933b90602ca)

Which is correct, `$caption` should be empty. But if I add a description to the featured image, I get the description text, and a text version of the prompt from echoing `$caption` (the prompt itself doesn't appear in the content, though my lousy screenshot cropping messes that up):

![image](https://github.com/Automattic/newspack-theme/assets/177561/2c1a0b5e-3abc-4000-b424-8a0fedeae0eb)

I'm not sure why this is, so I'm not sure if this is the best fix, so I'm very open to theories and feedback! 

See 1200550061930446-as-1204649235598444 and 1200024937525366-as-1202683962169569

### How to test the changes in this Pull Request:

1. Set up a prompt to appear inline on all pageviews.
2. Set up a post with a featured image.
3. Confirm your prompt displays as expected.
4. Add a description to your featured image.
5. Confirm your prompt is now gone.
6. Apply this PR. 
7. Confirm your prompt is now back.
8. Try adding just a caption, just a credit, and a caption and a credit, and confirm they all still work as expected. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
