### PR TITLE
fix: correct sponsor logo size

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -863,10 +863,10 @@ div.sharedaddy {
 		@include utilities.media( tablet ) {
 			margin-bottom: #{2 * structure.$size__spacing-unit};
 		}
-	}
 
-	img {
-		width: 100%;
+		img {
+			width: 100%;
+		}
 	}
 
 	figcaption {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where the Sponsor logo in the byline was picking up some featured image sizes. 

See 1200550061930446-as-1204229987899794.

### How to test the changes in this Pull Request:

1. Set up a post with the featured image set to 'Above' the title, and with a native sponsor with a logo.
2. View on the front-end -- the logo is weirdly huge 😐 

![image](https://github.com/Automattic/newspack-theme/assets/177561/ee9e301c-d9ef-49e3-9fe6-f38b5d9dbbab)

3. Apply the PR and run `npm run build`.
4. Refresh your post - the logo should look more normal 😌 

![image](https://github.com/Automattic/newspack-theme/assets/177561/301ce16f-e000-4fa1-bef8-c621d6aa1bd7)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
