### PR TITLE
feat: hide/unset alternative logos when multibranded is enabled

### DIFF
--- a/newspack-theme/inc/newspack-multibranded-site-plugin.php
+++ b/newspack-theme/inc/newspack-multibranded-site-plugin.php
@@ -109,3 +109,33 @@ add_filter(
 		return $value;
 	}
 );
+
+/**
+ * Certain customizer options make multibranded site excessively complicated, so they're removed when the plugin is active.
+ *
+ * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ */
+function newspack_multibranded_remove_customizer_options( $wp_customize ) {
+	// Remove the footer-specific logo control from Site Identity.
+	$wp_customize->remove_control( 'newspack_footer_logo' );
+
+	// Remove the alternative logo control from Header Settings > Subpage Header.
+	$wp_customize->remove_control( 'newspack_alternative_logo' );
+}
+add_action( "customize_register", "newspack_multibranded_remove_customizer_options" );
+
+/**
+ * Filter the footer logo to return nothing when plugin is active.
+ */
+function newspack_multibranded_unset_footer_logo( $newspack_footer_logo ) {
+	return '';
+}
+add_filter( 'theme_mod_newspack_footer_logo', 'newspack_multibranded_unset_footer_logo' );
+
+/**
+ * Filter the Subpage Header alternative logo to return nothing when plugin is active.
+ */
+function newspack_multibranded_unset_alternative( $newspack_alternative_logo ) {
+	return '';
+}
+add_filter( 'theme_mod_newspack_alternative_logo', 'newspack_multibranded_unset_alternative' );

--- a/newspack-theme/inc/newspack-multibranded-site-plugin.php
+++ b/newspack-theme/inc/newspack-multibranded-site-plugin.php
@@ -116,8 +116,9 @@ add_filter(
  * @param WP_Customize_Manager $wp_customize Theme Customizer object.
  */
 function newspack_multibranded_remove_customizer_options( $wp_customize ) {
-	// Remove the footer-specific logo control from Site Identity.
+	// Remove the footer-specific logo controls from Site Identity.
 	$wp_customize->remove_control( 'newspack_footer_logo' );
+	$wp_customize->remove_control( 'footer_logo_size' );
 
 	// Remove the alternative logo control from Header Settings > Subpage Header.
 	$wp_customize->remove_control( 'newspack_alternative_logo' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Newspack theme includes a couple different alternative logos: one for the footer (if you need to change the colour for contrast purposes), and one for the Simplified Subpage header that's used when you have the featured image behind or beside setting, in case you need different contrast. 

Both of these potentially add a lot of complexity to the Multibranded site settings, since it adds two more logo uploads to each brand. So for now, this PR removes those options when the Multibranded plugin is active, and filters the theme_mod values so both fall back to the default site logo while the plugin is active. 

See 1204179187018802-as-1204472840187025

### How to test the changes in this Pull Request:

1. Start on a test site running the Multibranded plugin.
2. Prior to applying the PR, add a Footer logo to the Site Identity panel, and navigate to Header Settings > Subpage Header, enable the option, and add a logo there.
3. Apply this PR. 
4. Navigate back to both the Site Identity and Header Settings > Subpage Header, and confirm the logo options are no longer there. 
5. View the footer, and confirm that the footer is picking up the brand's main site logo - check both the primary and one of the sub-brands.
6. Set up a couple posts with the featured image behind or beside, one for the primary brand and one for the secondary brand. Check both and confirm that both are using each brand's main logo.
7. Deactivate the plugin, and confirm the footer and Subpage Header logo options return in the Customizer, and they go back to using your assigned alternative logos. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
