### PR TITLE
feat: add option to disable archive image cropping

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -67,6 +67,11 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_image_size( 'newspack-archive-image-large', 1200, 900, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999 );
 
+		if ( ! get_theme_mod( 'archive_enable_cropping' ) ) {
+			add_image_size( 'newspack-archive-image', 800, 9999, false );
+			add_image_size( 'newspack-archive-image-large', 1200, 9999, false );
+		}
+
 		/**
 		 * Enable feature support for specific post types.
 		 */

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1047,6 +1047,23 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to enable image cropping in the archive pages.
+	$wp_customize->add_setting(
+		'archive_enable_cropping',
+		array(
+			'default'           => true,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'archive_enable_cropping',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Crop archive images to a 4:3 aspect ratio (changes require regenerating thumbnails for existing featured images)', 'newspack' ),
+			'section' => 'archive_options',
+		)
+	);
+
 	// Add option to change archive layouts.
 	$wp_customize->add_setting(
 		'archive_layout',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to disable the archive page's image cropping. 

It's most recently come up for a publisher hoping to use the archives to display their magazine's full covers, but the image size has come up in the past. Unfortunately it's a little clunky for existing featured images, and requires regenerating thumbnails.

See 1200550061930446-as-1204865890896058

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to Customizer > Template Settings > Archive Settings.
3. Confirm you now have an option to Crop images to a 4:3 aspect ratio, and that it's checked by default.

![image](https://github.com/Automattic/newspack-theme/assets/177561/02cc1593-7058-48e3-9395-8e82e1ab6856)

4. Uncheck the option.
5. Regenerate your site's thumbnails using CLI or a plugin like [Regenerate Thumbnails](https://wordpress.org/plugins/regenerate-thumbnails/); you only need to regenerate featured images, not all thumbnails.
6. View an archive page; confirm that the images are no longer cropped to 4:3. 
7. Navigate back to Customizer > Template Settings > Archive Settings and recheck the option.
8. Repeat step 5-6 to confirm the images are back to a 4:3 aspect ratio (note: if the images are smaller than the archive crop sizes, they may not crop to the exactly shape; that will be the case prior to this PR, too). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
