### PR TITLE
fix(woocommerce): account page grid on member area

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1879,7 +1879,7 @@ table.woocommerce-table--order-details.shop_table,
 	}
 
 	@include utilities.media( tablet ) {
-		.entry-content > .woocommerce {
+		.entry-content .woocommerce {
 			align-items: start;
 			display: grid;
 			gap: 3.2rem;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The "Members area" provided by WC Memberships contains the `.woocommerce` container in another div, hence, not hitting the `.entry-content > .woocommerce` CSS selector.

This PR removes the child combinator from the selector.

| Before | After | 
| --- | --- |
| <img width="876" alt="image" src="https://github.com/Automattic/newspack-theme/assets/820752/0131269f-150a-438a-a148-2a36faab6ce7"> | <img width="892" alt="image" src="https://github.com/Automattic/newspack-theme/assets/820752/22106863-4054-4b00-be6d-b0f1f88a276e"> |

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/2530
2. Confirm you have WC Memberships configured
3. Authenticate to an account that is a member of a plan
4. Visit the "My Account" page
5. Confirm there's no regression for the "Account details" and "Newsletters" pages layout
6. Click on "Memberships", navigate the plan and confirm the layout behaves the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
