### PR TITLE
fix: add default for the archive image cropping

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -67,7 +67,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		add_image_size( 'newspack-archive-image-large', 1200, 900, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999 );
 
-		if ( ! get_theme_mod( 'archive_enable_cropping' ) ) {
+		if ( ! get_theme_mod( 'archive_enable_cropping', true ) ) {
 			add_image_size( 'newspack-archive-image', 800, 9999, false );
 			add_image_size( 'newspack-archive-image-large', 1200, 9999, false );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a default fallback for the new 'archive enable cropping' theme mod. Without it, the check is not returning the correct value initially, until the customizer is saved. 

### How to test the changes in this Pull Request:

There isn't much to test here outside of confirming the theme mod has a default set in the code, but if you want to make sure it's doing its job, try the following.

1. Add `remove_theme_mod( 'archive_enable_cropping' )` to the theme's header.php, load your test site in your browser, and then remove it again. This just clears the value and resets it back to how it would act in a freshly installed theme. (Alternatively, you can test in a brand new site, but this seemed easier!)
2. Create a new post with a large, vertical image.
3. View the post in its archive; note the image not cropped, though it should be. 
4. Apply the PR.
5. Repeat steps 2 and 3; confirm that the image is indeed cropped to 4:3 now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
