### PR TITLE
fix: Correct author bio truncation logic

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -53,7 +53,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 
 					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
-							<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( $author->description, $author_bio_length ) ) ); ?>
+							<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( $author->description ), $author_bio_length ) ); ?>
 							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 							<?php
 								/* translators: %s is the current author's name. */
@@ -119,7 +119,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 		<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 			<p>
-				<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ) ); ?>
+				<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( get_the_author_meta( 'description' ) ), $author_bio_length ) ); ?>
 				<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -57,7 +57,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 
 					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
-							<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( $author->description, $author_bio_length ) ) ); ?>
+							<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( $author->description ), $author_bio_length ) ); ?>
 							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
 							<?php
 								/* translators: %s is the current author's name. */
@@ -124,7 +124,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 
 		<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 			<p>
-				<?php echo esc_html( wp_strip_all_tags( newspack_truncate_text( get_the_author_meta( 'description' ), $author_bio_length ) ) ); ?>
+				<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( get_the_author_meta( 'description' ) ), $author_bio_length ) ); ?>
 				<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php
 					/* translators: %s is the current author's name. */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a logic error in the code that truncates the author bio: it makes sure the HTML tags are stripped before the bio is truncated, not afterwards -- otherwise, the HTML tags get counted in the total length.

Note: We'd talked about also allowing HTML in the truncated bios with this change, but for some reason I originally set this up to truncate the text based on a character count, instead of a word count 🤦‍♀️ This makes it harder to use logic similar to what [we're using in the homepage post block](https://github.com/Automattic/newspack-blocks/pull/1364), since we'd have to figure out some way to still count characters but skip the ones inside of the HTML tags. 

This may be possible, but seems like it could get messy and isn't something we've been explicitly asked for yet -- I opted to go the simpler route for now to fix the bug.

See: 1200550061930446-as-1204988384295183


### How to test the changes in this Pull Request:

1. Set up an author bio with some HTML at the start; links or strong tags work well. Make sure the bio is decently long.
2. If not already enabled, navigate to Customizer > Author Bio Settings, and turn on the Author Bio, and Truncate Author Bio.
3. View a single post with your bio on the front end.
4. Apply the PR.
5. Refresh your single post and note the bio is now longer -- this is because the HTML characters are no longer included in the total count. 
6. Cycle through these different combinations to make sure there aren't any errors (all the themes but Newspack Sacha share the exact same author bio code, and different code is run for the bio depending on whether or not CoAuthors Plus is enabled):
* Any theme but Sacha + CoAuthors Plus enabled
* Any theme but Sacha + CoAuthors Plus disabled
* Newspack Sacha + CoAuthors Plus enabled
* Newspack Sacha + CoAuthors Plus disabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
