### PR TITLE
fix: add clamp to higher spacing values

### DIFF
--- a/newspack-theme/sass/variables-site/_structure.scss
+++ b/newspack-theme/sass/variables-site/_structure.scss
@@ -1,4 +1,4 @@
-// Responsive widths.
+// Misc measurements.
 
 $size__spacing-unit: 1rem;
 $size__site-main: 1200px;
@@ -15,3 +15,13 @@ $tablet_width: 782px;
 $narrow_desktop_width: 960px;
 $desktop_width: 1168px;
 $wide_width: 1379px;
+
+// Gutenberg spacing variables.
+
+body {
+	--wp--preset--spacing--50: clamp( 1.25rem, 1rem + 0.8333vw, 1.5rem );
+	--wp--preset--spacing--60: clamp( 1.5rem, 0.75rem + 2.5vw, 2.25rem);
+	--wp--preset--spacing--70: clamp( 1.75rem, 0.12rem + 5.4333vw, 3.38rem);
+	--wp--preset--spacing--80: clamp( 2rem, -1.06rem + 10.2vw, 5.06rem);
+}
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

One of the sizing options included in Gutenberg is a somewhat arbitrary "stepped" slider that lets you select a value between one and seven. These values map to CSS variables whose defaults come from Gutenberg.

Typically these values can be overridden in block themes through the theme.json; since our theme doesn't have a theme.json, this PR overrides them in the SCSS files instead. It changes the higher values (4, 5, 6, 7) to use `clamp()` so they can be scaled down on smaller screens.

See 1200550061930446-as-1204946804697768.

### How to test the changes in this Pull Request:

1. Set up five blocks like paragraphs with backgrounds, and with padding values of 3, 4, 5, 6 and 7, or copy the test content below. (The "3" value isn't changed in this PR, but can be used for comparison to the other values):

<details>
<summary><strong>Test paragraphs with padding</strong></summary>

```
<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40"}}},"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">Paragraph with a padding of "3".</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","right":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50"}}},"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">Paragraph with a padding of "4".</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">Paragraph with a padding of "5".</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">Paragraph with a padding of "6".</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","right":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80"}}},"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)">Paragraph with a padding of "7".</p>
<!-- /wp:paragraph -->
```

</details>

2. View on the front end and scale down your browser window; note how crowded things get, especially with the blocks using the 6 and 7 padding:

![image](https://github.com/Automattic/newspack-theme/assets/177561/cea582af-2449-47ba-ae56-e455ee3110df)

3. Apply the PR and run `npm run build`.
4. Repeat step 2; note that the padding decreases significantly on smaller screens for the higher numbers, but there is still a slight hierachy, with 7 still having the most padding:

![image](https://github.com/Automattic/newspack-theme/assets/177561/4c0367a1-0f6b-4d52-a74b-bbab5b28b680)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
