### PR TITLE
feat: add downloads details to checkout

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1378,7 +1378,8 @@ table.woocommerce-table--order-details.shop_table,
 .woocommerce-product-attributes,
 .woocommerce-grouped-product-list.group_table,
 .woocommerce-cart-form .woocommerce-cart-form__contents,
-.cart-collaterals .shop_table_responsive {
+.cart-collaterals .shop_table_responsive,
+.woocommerce-table--order-downloads {
 	border-top: 1px solid var( --newspack-theme-color-border );
 
 	thead {
@@ -1555,10 +1556,6 @@ table.woocommerce-table--order-details.shop_table,
 		table.shop_table_responsive {
 			tr {
 				margin: 0 0 1.5rem;
-
-				&:first-child {
-					border-top: 1px solid;
-				}
 
 				&:last-child {
 					margin-bottom: 0;

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1232,13 +1232,6 @@ table.variations {
 }
 
 /**
- * Thank you page
- */
-.woocommerce-thankyou-order-details + .woocommerce-order-downloads .woocommerce-order-downloads__title {
-	font-size: 1.2rem;
-}
-
-/**
  * One-page checkout
  */
 /* stylelint-disable selector-id-pattern  */

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1232,6 +1232,13 @@ table.variations {
 }
 
 /**
+ * Thank you page
+ */
+.woocommerce-thankyou-order-details + .woocommerce-order-downloads .woocommerce-order-downloads__title {
+	font-size: 1.2rem;
+}
+
+/**
  * One-page checkout
  */
 /* stylelint-disable selector-id-pattern  */

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -97,11 +97,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		$downloads = $order->get_downloadable_items();
 		if ( $downloads ) {
+		?>
+			<h4><?php esc_html_e( 'Downloads', 'newspack' ); ?></h4>
+
+			<?php
 			wc_get_template(
 				'order/order-downloads.php',
 				array(
-					'downloads'  => $downloads,
-					'show_title' => true,
+					'downloads' => $downloads,
 				)
 			);
 		}

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -116,7 +116,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$downloads = $order->get_downloadable_items();
 
 		if ( $downloads ) : ?>
-			<h4><?php esc_html_e( 'Downloads', 'newspack' ); ?></h4>
+			<h4><?php esc_html_e( 'Download your purchase', 'newspack' ); ?></h4>
 
 			<section class="woocommerce-order-downloads">
 				<?php if ( isset( $show_title ) ) : ?>

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -93,6 +93,85 @@ if ( ! defined( 'ABSPATH' ) ) {
 				}
 			?>
 		<?php endif; ?>
+
+		<?php
+		/**
+		 * Copied from the Order Downloads template - full details below:
+		 *
+		 * This template can be overridden by copying it to yourtheme/woocommerce/order/order-downloads.php.
+		 *
+		 * HOWEVER, on occasion WooCommerce will need to update template files and you
+		 * (the theme developer) will need to copy the new files to your theme to
+		 * maintain compatibility. We try to do this as little as possible, but it does
+		 * happen. When this occurs the version of the template file will be bumped and
+		 * the readme will list any important changes.
+		 *
+		 * @see     https://docs.woocommerce.com/document/template-structure/
+		 * @package WooCommerce\Templates
+		 * @version 3.3.0
+		 */
+		?>
+
+		<?php
+		$downloads = $order->get_downloadable_items();
+
+		if ( $downloads ) : ?>
+			<h4><?php esc_html_e( 'Downloads', 'newspack' ); ?></h4>
+
+			<section class="woocommerce-order-downloads">
+				<?php if ( isset( $show_title ) ) : ?>
+					<h2 class="woocommerce-order-downloads__title"><?php esc_html_e( 'Downloads', 'newspack' ); ?></h2>
+				<?php endif; ?>
+
+				<table class="woocommerce-table woocommerce-table--order-downloads shop_table shop_table_responsive order_details">
+					<thead>
+						<tr>
+							<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
+							<th class="<?php echo esc_attr( $column_id ); ?>"><span class="nobr"><?php echo esc_html( $column_name ); ?></span></th>
+							<?php endforeach; ?>
+						</tr>
+					</thead>
+
+					<?php foreach ( $downloads as $download ) : ?>
+						<tr>
+							<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
+								<td class="<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
+									<?php
+									if ( has_action( 'woocommerce_account_downloads_column_' . $column_id ) ) {
+										do_action( 'woocommerce_account_downloads_column_' . $column_id, $download );
+									} else {
+										switch ( $column_id ) {
+											case 'download-product':
+												if ( $download['product_url'] ) {
+													echo '<a href="' . esc_url( $download['product_url'] ) . '">' . esc_html( $download['product_name'] ) . '</a>';
+												} else {
+													echo esc_html( $download['product_name'] );
+												}
+												break;
+											case 'download-file':
+												echo '<a href="' . esc_url( $download['download_url'] ) . '" class="woocommerce-MyAccount-downloads-file button alt">' . esc_html( $download['download_name'] ) . '</a>';
+												break;
+											case 'download-remaining':
+												echo is_numeric( $download['downloads_remaining'] ) ? esc_html( $download['downloads_remaining'] ) : esc_html__( '&infin;', 'newspack' );
+												break;
+											case 'download-expires':
+												if ( ! empty( $download['access_expires'] ) ) {
+													echo '<time datetime="' . esc_attr( date( 'Y-m-d', strtotime( $download['access_expires'] ) ) ) . '" title="' . esc_attr( strtotime( $download['access_expires'] ) ) . '">' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $download['access_expires'] ) ) ) . '</time>';
+												} else {
+													esc_html_e( 'Never', 'newspack' );
+												}
+												break;
+										}
+									}
+									?>
+								</td>
+							<?php endforeach; ?>
+						</tr>
+					<?php endforeach; ?>
+				</table>
+			</section>
+		<?php endif; ?>
+
 	<?php else : ?>
 
 		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -98,7 +98,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$downloads = $order->get_downloadable_items();
 		if ( $downloads ) {
 		?>
-			<h4><?php esc_html_e( 'Downloads', 'newspack' ); ?></h4>
+			<h4><?php esc_html_e( 'Download your purchase', 'newspack' ); ?></h4>
 
 			<?php
 			wc_get_template(

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -95,82 +95,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php endif; ?>
 
 		<?php
-		/**
-		 * Copied from the Order Downloads template - full details below:
-		 *
-		 * This template can be overridden by copying it to yourtheme/woocommerce/order/order-downloads.php.
-		 *
-		 * HOWEVER, on occasion WooCommerce will need to update template files and you
-		 * (the theme developer) will need to copy the new files to your theme to
-		 * maintain compatibility. We try to do this as little as possible, but it does
-		 * happen. When this occurs the version of the template file will be bumped and
-		 * the readme will list any important changes.
-		 *
-		 * @see     https://docs.woocommerce.com/document/template-structure/
-		 * @package WooCommerce\Templates
-		 * @version 3.3.0
-		 */
-		?>
-
-		<?php
 		$downloads = $order->get_downloadable_items();
-
-		if ( $downloads ) : ?>
-			<h4><?php esc_html_e( 'Download your purchase', 'newspack' ); ?></h4>
-
-			<section class="woocommerce-order-downloads">
-				<?php if ( isset( $show_title ) ) : ?>
-					<h2 class="woocommerce-order-downloads__title"><?php esc_html_e( 'Downloads', 'newspack' ); ?></h2>
-				<?php endif; ?>
-
-				<table class="woocommerce-table woocommerce-table--order-downloads shop_table shop_table_responsive order_details">
-					<thead>
-						<tr>
-							<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
-							<th class="<?php echo esc_attr( $column_id ); ?>"><span class="nobr"><?php echo esc_html( $column_name ); ?></span></th>
-							<?php endforeach; ?>
-						</tr>
-					</thead>
-
-					<?php foreach ( $downloads as $download ) : ?>
-						<tr>
-							<?php foreach ( wc_get_account_downloads_columns() as $column_id => $column_name ) : ?>
-								<td class="<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
-									<?php
-									if ( has_action( 'woocommerce_account_downloads_column_' . $column_id ) ) {
-										do_action( 'woocommerce_account_downloads_column_' . $column_id, $download );
-									} else {
-										switch ( $column_id ) {
-											case 'download-product':
-												if ( $download['product_url'] ) {
-													echo '<a href="' . esc_url( $download['product_url'] ) . '">' . esc_html( $download['product_name'] ) . '</a>';
-												} else {
-													echo esc_html( $download['product_name'] );
-												}
-												break;
-											case 'download-file':
-												echo '<a href="' . esc_url( $download['download_url'] ) . '" class="woocommerce-MyAccount-downloads-file button alt">' . esc_html( $download['download_name'] ) . '</a>';
-												break;
-											case 'download-remaining':
-												echo is_numeric( $download['downloads_remaining'] ) ? esc_html( $download['downloads_remaining'] ) : esc_html__( '&infin;', 'newspack' );
-												break;
-											case 'download-expires':
-												if ( ! empty( $download['access_expires'] ) ) {
-													echo '<time datetime="' . esc_attr( date( 'Y-m-d', strtotime( $download['access_expires'] ) ) ) . '" title="' . esc_attr( strtotime( $download['access_expires'] ) ) . '">' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $download['access_expires'] ) ) ) . '</time>';
-												} else {
-													esc_html_e( 'Never', 'newspack' );
-												}
-												break;
-										}
-									}
-									?>
-								</td>
-							<?php endforeach; ?>
-						</tr>
-					<?php endforeach; ?>
-				</table>
-			</section>
-		<?php endif; ?>
+		if ( $downloads ) {
+			wc_get_template(
+				'order/order-downloads.php',
+				array(
+					'downloads'  => $downloads,
+					'show_title' => true,
+				)
+			);
+		}
+		?>
 
 	<?php else : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the downloads table to the thank you screen in the WooCommerce checkout.

It's normally shown by default, but our simplified thankyou.php template removes the hooks where that and other information are normally inserted. So this PR re-adds it by adding a check for downloads, and then manually inserts what's normally the contents of the [woocommerce/order/order-downloads.php template](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/order/order-downloads.php). 

See 1200550061930446-as-1204781973711258

### How to test the changes in this Pull Request:

1. If your test site doesn't have one yet, create a downloadable product. 
2. Apply this PR and run `npm run build`.
3. Go to your /shop screen, add your downloadable product to the cart, and run through the checkout process; on the final Thank You screen, confirm that a table with the download appears below the order information:

![image](https://github.com/Automattic/newspack-theme/assets/177561/919f52ac-ce78-4e8a-81ee-fb5a03fba4de)

4. Set up a page with the Checkout button, with your downloadable product.
5. Run through the checkout using the Checkout button, and confirm you get to download your product from the thank you screen:

![image](https://github.com/Automattic/newspack-theme/assets/177561/bb9ea71c-aced-4237-b82d-e97eeabfd795)

6. To make sure this change doesn't cause any other issues, repeat steps 3 and 5 with non-downloadable products, and with carts with both a non-downloadable and a downloadable product.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
