### PR TITLE
feat: add styles for the details block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1162,6 +1162,28 @@ hr {
 	}
 }
 
+//! Details block
+.wp-block-details {
+	border: solid var( --newspack-theme-color-border );
+	border-width: 1px 0;
+	padding: 0.5rem 0.5rem 0.5rem 1.5rem;
+
+	> :not(summary) {
+		margin-bottom: 16px;
+		margin-top: 16px;
+	}
+
+	summary {
+		font-family: var( --newspack-theme-font-heading );
+		margin-left: -1rem;
+	}
+
+	+ .wp-block-details {
+		border-top: 0;
+		margin-top: -32px;
+	}
+}
+
 //! Navigtation block
 .wp-block-navigation a {
 	text-decoration: none;

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1166,7 +1166,7 @@ hr {
 .wp-block-details {
 	border: solid var( --newspack-theme-color-border );
 	border-width: 1px 0;
-	padding: 0.5rem 0.5rem 0.5rem 1.5rem;
+	padding: 0.5rem 1.5rem;
 
 	> :not(summary) {
 		margin-bottom: 16px;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -998,6 +998,28 @@ ul.wp-block-archives,
 	}
 }
 
+/** === Details block === */
+.wp-block-details {
+	border: solid var( --newspack-theme-color-border );
+	border-width: 1px 0;
+	padding: 0.8rem;
+
+	> :not(summary) {
+		margin-bottom: 16px;
+		margin-top: 16px;
+	}
+
+	summary {
+		font-family: var( --newspack-theme-font-heading );
+	}
+
+	+ .wp-block-details {
+		border-top: 0;
+		margin-top: -28px;
+		padding-top: 16px;
+	}
+}
+
 /** === Organic Profile Block === */
 .wp-block-organic-profile-block {
 	box-shadow: none;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -1002,7 +1002,7 @@ ul.wp-block-archives,
 .wp-block-details {
 	border: solid var( --newspack-theme-color-border );
 	border-width: 1px 0;
-	padding: 0.8rem;
+	padding: 0.5rem 1.5rem;
 
 	> :not(summary) {
 		margin-bottom: 16px;
@@ -1016,7 +1016,6 @@ ul.wp-block-archives,
 	+ .wp-block-details {
 		border-top: 0;
 		margin-top: -28px;
-		padding-top: 16px;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some default theme styles for the Details block coming in WordPress 6.3. 

See 1204989005688794-as-1205113460196715.

### How to test the changes in this Pull Request:

1. Test on a site running the current WP 6.3 RC -- you can use the [Beta Tester plugin](https://en-ca.wordpress.org/plugins/wordpress-beta-tester/) to set this up on any test site.
2. Apply the PR and run `npm run build`. 
3. Add several variations of the Details block to the editor: a single block, two or more blocks back to back, blocks with backgrounds... 
4. View on the front-end and in the editor and do a visual review:
* The details summary should use the theme's header font
* The details block should be framed by a top and bottom border
* When more than one block appears in a row, the blocks should appear spaced evenly

Single block:

![image](https://github.com/Automattic/newspack-theme/assets/177561/90fec7f1-aa18-463f-9e78-4670abeec9be)

Group of blocks:

![image](https://github.com/Automattic/newspack-theme/assets/177561/4eb85f0b-9c9c-4e6b-ba53-4e219964fedb)

![image](https://github.com/Automattic/newspack-theme/assets/177561/92130509-7e21-418a-83be-ba23f7d01fd1)

Blocks when opened:

![image](https://github.com/Automattic/newspack-theme/assets/177561/53741e73-54e8-4ff0-9cbe-1abbf16de50a)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
