### PR TITLE
feat: add styles for the footnote block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1185,22 +1185,29 @@ hr {
 }
 
 //! Footnote styles
+.wp-block-footnotes li:focus {
+	outline: thin dotted;
+}
+
 .h-stk {
-	sup.fn a {
-		scroll-margin-top: 80px;
+	sup.fn a,
+	.wp-block-footnotes li {
+		scroll-margin-top: 115px;
 
 		@include utilities.media( tablet ) {
 			scroll-margin-top: 180px;
 		}
 	}
 
-	&.h-dh sup.fn a {
+	&.h-dh sup.fn a,
+	&.h-dh .wp-block-footnotes li {
 		@include utilities.media( tablet ) {
 			scroll-margin-top: 210px;
 		}
 	}
 
-	&.h-sub:not(.home) sup.fn a {
+	&.h-sub:not(.home) sup.fn a,
+	&.h-sub:not(.home) .wp-block-footnotes li {
 		@include utilities.media( tablet ) {
 			scroll-margin-top: 100px;
 		}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1184,6 +1184,29 @@ hr {
 	}
 }
 
+//! Footnote styles
+.h-stk {
+	sup.fn a {
+		scroll-margin-top: 80px;
+
+		@include utilities.media( tablet ) {
+			scroll-margin-top: 180px;
+		}
+	}
+
+	&.h-dh sup.fn a {
+		@include utilities.media( tablet ) {
+			scroll-margin-top: 210px;
+		}
+	}
+
+	&.h-sub:not(.home) sup.fn a {
+		@include utilities.media( tablet ) {
+			scroll-margin-top: 100px;
+		}
+	}
+}
+
 //! Navigtation block
 .wp-block-navigation a {
 	text-decoration: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a `scroll-margin` to the new footnote block's anchors when the theme's header is set to sticky.

See 1204989005688794-as-1205113460196718

### How to test the changes in this Pull Request:

1. Test on a site running the current WP 6.3 RC -- you can use the [Beta Tester plugin](https://en-ca.wordpress.org/plugins/wordpress-beta-tester/) to set this up on any test site.
2. Set up a page with the footnote block, and add a few footnotes throughout the content.
3. Turn on the sticky header under Customizer > Header Settings > Appearance. 
4. Try clicking the footnote links at the bottom; note that when the links go to content near the top of the page, they get covered by the header.
5. Apply this PR and run `npm run build`. 
6. Repeat step 4 and confirm your links don't get covered. 
7. Test this setting at different breakpoints.
8. Navigate to Customizer > Header Setttings > Appearance and enable the short header; repeat testing the links at different breakpoints.
9. Navigate to Customizer > Header Settings > Subpage Header, and check the "Use simple header on subpages" box; repeat testing at different breakpoints.

Note: since this fix uses static CSS, the footnote may be a bit further away from the header, depending on your settings; this is because the distance is based on approximate guesses. If this is subpar -- or if we run into too many issues with live sites and the exact distance (especially in cases where they may have customized their header with CSS) we can look at a JS-based solution.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
