### PR TITLE
fix: improve new search setting appearance for WP 6.3

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1070,6 +1070,13 @@ hr {
 			}
 		}
 	}
+
+	&__button-behavior-expand:not(.wp-block-search__searchfield-hidden) {
+		.wp-block-search__button {
+			border-top-left-radius: 0;
+			border-bottom-left-radius: 0;
+		}
+	}
 }
 
 //! Code

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -721,6 +721,13 @@ div[data-align='full'] {
 			}
 		}
 	}
+
+	&__button-behavior-expand:not(.wp-block-search__searchfield-hidden) {
+		.wp-block-search__button {
+			border-top-left-radius: 0;
+			border-bottom-left-radius: 0;
+		}
+	}
 }
 
 /** === Code === */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the appearance of the search block when using the new "button only" display option, coming out in WordPress 6.3.

See 1204989005688794-as-1205128703011548

### How to test the changes in this Pull Request:

1. Start with a test site running the latest WP 6.3 RC.
2. Create a page and add a search block; change the button position to 'Button Only':

![image](https://github.com/Automattic/newspack-theme/assets/177561/4a095496-2c62-4800-890d-3f598ca2d426)

3. View on the front end and click the button; this opens the search. Note that the button and input are a little funky looking, with the button touching in the input, with rounded corners inbetween:

![image](https://github.com/Automattic/newspack-theme/assets/177561/8dc9e1b5-ff2a-45ed-a819-30d63b669db2)

4. Apply the PR and run `npm run build`
5. Retest the block in the editor and on the front-end; it's a small change, but the button corners next to the search input should no longer be rounded:

![image](https://github.com/Automattic/newspack-theme/assets/177561/7730f249-ccae-4a71-8c31-9901cd013e4b)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
