### PR TITLE
fix: add padding to the file block when it has a background

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -998,6 +998,10 @@ hr {
 	font-family: var( --newspack-theme-font-heading );
 	font-size: var( --newspack-theme-font-size-sm );
 
+	&.has-background {
+		padding: structure.$size__spacing-unit;
+	}
+
 	.wp-block-file__button {
 		display: table;
 		@include utilities.button-transition;

--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -626,6 +626,10 @@ div[data-align='full'] {
 	font-family: var( --newspack-theme-font-heading );
 	font-size: var( --newspack-theme-font-size-sm );
 
+	&.has-background {
+		padding: structure.$size__spacing-unit;
+	}
+
 	.wp-block-file__textlink {
 		text-decoration: underline;
 		color: var( --newspack-theme-color-link );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The File block will have an option to add a background colour in WordPress 6.3; right now, the theme doesn't add a padding to go with the background option, which makes things look a little weird. This PR adds a bit of padding to the File block when it has a background colour. 

See 1204989005688794-as-1205128703011536

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WordPress 6.3 RC.
2. Create a page and add a File block, and assign it a file. In the right sidebar, give the block a background colour.
3. Note that the block has no padding on the front-end or in the editor, which makes the background look a little strange:

![image](https://github.com/Automattic/newspack-theme/assets/177561/89b026af-f2a0-43fe-a95d-d47391adf370)

4. Apply the PR and run `npm run build`.
5. Check the page again on the front-end and in the editor, and confirm that the block now has padding when it has a background:

![image](https://github.com/Automattic/newspack-theme/assets/177561/638feecd-16a6-43dd-9996-da0590f39787)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
