### PR TITLE
Introduce a filter for the social icons map

### DIFF
--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -50,7 +50,17 @@ class Newspack_SVG_Icons {
 		static $regex_map; // Only compute regex map once, for performance.
 		if ( ! isset( $regex_map ) ) {
 			$regex_map = array();
-			$map       = &self::$social_icons_map; // Use reference instead of copy, to save memory.
+
+			/**
+			 * Filters the mapping of social icons to URLs.
+			 * 
+			 * Allows plugins or child themes to insert alternative mappings for recognition in the social links menu.
+			 * 
+			 * @since 1.76.0
+			 * 
+			 * @param array $servers Social icons map.
+			 */
+			$map = apply_filters( 'newspack_social_icons_map', self::$social_icons_map );
 			foreach ( array_keys( self::$social_icons ) as $icon ) {
 				$domains            = array_key_exists( $icon, $map ) ? $map[ $icon ] : array( sprintf( '%s.com', $icon ) );
 				$domains            = array_map( 'trim', $domains ); // Remove leading/trailing spaces, to prevent regex from failing to match.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduces a new hook for filtering the social icons map used to determine which logo to show in the social links menu.

With the introduction of Mastodon and the plethora of instances that could be used, including self-hosted instances, it would good to allow plugins and/or child themes to filter the social icons map to add additional mastodon instance addresses. This filter achieves that and can be used like so:

```
/**
 * Add our mastodon server to social icon map in Newspack.
 * 
 * @param array $social_icons_map Array of matches for social icons.
 * 
 * @return array Modified array of matches for social icons.
 */
function lichfieldlive_newspack_social_icons_map( $social_icons_map ) {
	$social_icons_map['mastodon'] = array_merge(
		$social_icons_map['mastodon'],
		[
			'social.lichfieldlive.co.uk',
		]
	);
	return $social_icons_map;
}
add_filter( 'newspack_social_icons_map', 'lichfieldlive_newspack_social_icons_map' );
```

It could also be used, for example, by Mastodon plugins such as the [ActivityPub plugin](https://wordpress.org/plugins/activitypub/) to ensure the connected server is recognised. A further change to the Newspack Theme could add a compatibility layer for plugins like ActivityPub.

### How to test the changes in this Pull Request:

1. Create or edit the Social Links Menu
2. Add a custom link to a Mastodon server account that does not already exist in the Newspack Theme's list (e.g. https://social.lichfieldlive.co.uk/@news)
3. Using a small plugin, or child theme, create a function to add the social.lichfieldlive.co.uk domain to the social icons map (see the above example)
4. Observe that the new item in the Social Links Menu has the Mastodon icon correctly applied (see screenshot below)

![Screenshot from 2023-08-07 10-43-42](https://github.com/Automattic/newspack-theme/assets/136342/18210c32-9db8-4a37-a608-63ad3f9f5c64)

Note that as the social icons map is a static class variable it wasn't possible to add the filter to that array directly to only focus on the Mastodon map, so instead I had to filter the whole list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

