### PR TITLE
fix: force height: auto on images to fix scaling issue in 6.3

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -910,6 +910,10 @@ p.has-background {
 	figcaption {
 		text-align: left;
 	}
+
+	img:not([style*='object-fit']) {
+		height: auto !important; // !important to override inline styles.
+	}
 }
 
 //! Galleries


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Since 6.3 we've had some reports of existing images in stories being stretched out on mobile; I'm also able to recreate this with adding new images and resizing them using the little image 'handles'.

This is due to the height and width now being added in the `style` attribute on images; the width is still responsive because of the a `max-width` overriding it, but the inline pixel height overrides the `height: auto` that should be helping it scale down.

This PR adds the `height: auto` with `!important`, but only in cases where the image block doesn't have the new `contain` or `cover` scale options enabled. 

See: https://github.com/WordPress/gutenberg/issues/53555

### How to test the changes in this Pull Request:

1. Add an image to the editor. 
2. Use the little handles on the image to scale the image down a hair. Note that the 'Scale' option in the sidebar doesn't select either option (Cover or Contain):

![image](https://github.com/Automattic/newspack-theme/assets/177561/c8553fc9-4fac-45fe-9f43-e4026c3985d1)

4. Publish and view on the front-end; scale down browser window to mobile size. 
5. Note that the image is distorted: 

![image](https://github.com/Automattic/newspack-theme/assets/177561/2de0217e-bc64-48ac-9afc-cefd09ffd9b6)

6. Apply the PR and confirm that the image is fixed. 
7. Test the PR with the other image options, just to make sure this change doesn't affect how those options work -- for example
* Pick a couple different aspect ratios 
* Change the image size using the fields in the right sidebar, or use the handles and manually enable Contain or Cover. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
