### PR TITLE
fix: correct group block alignment in editor preview

### DIFF
--- a/newspack-theme/sass/style-editor-base.scss
+++ b/newspack-theme/sass/style-editor-base.scss
@@ -421,6 +421,14 @@ div[data-align='full'] {
 	}
 }
 
+[data-type="core/group"]{
+	&.is-selected .block-list-appender,
+	.block-list-appender:only-child {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
 /** === Button === */
 .wp-block-buttons {
 	--wp--style--block-gap: 10px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixed a preview issue with the Group block, where the placeholder in wide or full-width group blocks would not be centred. 

See 1200550061930446-as-1203439986426071; Closes #1973

### How to test the changes in this Pull Request:

1. Create a new post or page and set it to use the one column template; publish and refresh (to make sure the editor is using the correct preview behaviour). 
2. Add a group block and make it full width. 
3. Note the preview placeholder placement when this empty block is selected - it's flush left rather than being centred:

![image](https://github.com/Automattic/newspack-theme/assets/177561/e222e347-c961-48a6-90a7-eca5eabbfe7d)

4. Apply the PR and run `npm run build`.
5. Confirm that the placeholder is now centred.

![image](https://github.com/Automattic/newspack-theme/assets/177561/5e6cd9f5-6acc-4ec2-a565-da4ce6467253)

6. Test with the Row and Stack options, and the wide and regular width options to confirm there aren't any issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
