### PR TITLE
Update WooCommerce template to v8.1.0

### DIFF
--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -112,9 +112,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php else : ?>
 
-		<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
-			<?php echo wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), null ) ); ?>
-		</p>
+	<?php wc_get_template( 'checkout/order-received.php', array( 'order' => false ) ); ?>
 
 	<?php endif; ?>
 

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -10,9 +10,11 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
- * @version 3.7.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 8.1.0
+ *
+ * @var WC_Order $order
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -43,9 +45,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php else : ?>
 
-			<p class="woocommerce-notice woocommerce-notice--success woocommerce-thankyou-order-received">
-				<?php echo wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', __( 'Thank you. Your order has been received.', 'newspack' ), $order ) ); ?>
-			</p>
+			<?php wc_get_template( 'checkout/order-received.php', array( 'order' => $order ) ); ?>
 
 			<h4><?php esc_html_e( 'Summary', 'newspack' ); ?></h4>
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the release of WooCommerce 8.1.0 on 12 Sep 2023, Newspack themes (including, but not limited to, Katharine and Scott) are receiving this notice:

![templates](https://github.com/Automattic/newspack-theme/assets/12199101/3d3446d1-d881-4611-8632-126d9f891a18)

This PR updates the `thankyou.php` template from v3.7.0 to v8.1.0, per this documentation:

https://woocommerce.com/document/template-structure/

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Switch to the theme repo's `fix/woo810` branch.
2. Place a WooCommerce order.
3. Ensure that the thank-you page shown at the end of the order displays correctly.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
