### PR TITLE
feat(woocommerce): thank you template hook

### DIFF
--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -110,9 +110,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 
+		<?php do_action( 'newspack_woocommerce_thankyou', $order->get_id() ); ?>
+
 	<?php else : ?>
 
-	<?php wc_get_template( 'checkout/order-received.php', array( 'order' => false ) ); ?>
+		<?php wc_get_template( 'checkout/order-received.php', array( 'order' => false ) ); ?>
 
 	<?php endif; ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements a hook similar to WC's `woocommerce_thankyou`. We'll not be using the same hook because we want to prevent all the default template parts that hook into the default `woocommerce_thankyou` from rendering in our checkout.

Testing instructions at https://github.com/Automattic/newspack-blocks/pull/1521

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
