### PR TITLE
feat(customizer): change default template's name

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -408,7 +408,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'    => 'radio',
 			'label'   => __( 'Colors', 'newspack' ),
-			'choices'  => array(
+			'choices' => array(
 				'default' => _x( 'Default', 'primary color', 'newspack' ),
 				'custom'  => _x( 'Custom', 'primary color', 'newspack' ),
 			),
@@ -580,7 +580,7 @@ function newspack_customize_register( $wp_customize ) {
 		array(
 			'type'    => 'radio',
 			'label'   => __( 'Ads Background Color', 'newspack' ),
-			'choices'   => array(
+			'choices' => array(
 				'default' => _x( 'Default', 'primary color', 'newspack' ),
 				'custom'  => _x( 'Custom', 'primary color', 'newspack' ),
 			),
@@ -863,7 +863,7 @@ function newspack_customize_register( $wp_customize ) {
 			'label'       => __( 'Default Post Template', 'newspack' ),
 			'description' => esc_html__( 'This option changes the selected template used for newly created posts going forward. The template can still be changed on a per-post basis.', 'newspack' ),
 			'choices'     => array(
-				'default'            => esc_html__( 'Default Template', 'newspack' ),
+				'default'            => esc_html__( 'With Sidebar', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
 				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
@@ -1011,7 +1011,7 @@ function newspack_customize_register( $wp_customize ) {
 			'label'       => __( 'Default Page Template', 'newspack' ),
 			'description' => esc_html__( 'This option changes the selected template used for newly created pages going forward. The template can still be changed on a per-page basis.', 'newspack' ),
 			'choices'     => array(
-				'default'            => esc_html__( 'Default Template', 'newspack' ),
+				'default'            => esc_html__( 'With Sidebar', 'newspack' ),
 				'single-feature.php' => esc_html__( 'One Column', 'newspack' ),
 				'single-wide.php'    => esc_html__( 'One Column Wide', 'newspack' ),
 			),
@@ -1078,7 +1078,7 @@ function newspack_customize_register( $wp_customize ) {
 			'type'    => 'radio',
 			'label'   => esc_html__( 'Archive Layout', 'newspack' ),
 			'choices' => array(
-				'default'         => esc_html__( 'Default', 'newspack' ),
+				'default'         => esc_html__( 'With sidebar', 'newspack' ),
 				'one-column'      => esc_html__( 'One column', 'newspack' ),
 				'one-column-wide' => esc_html__( 'One column wide', 'newspack' ),
 			),

--- a/newspack-theme/languages/de_DE.po
+++ b/newspack-theme/languages/de_DE.po
@@ -720,7 +720,7 @@ msgid "Default Post Template"
 msgstr ""
 
 #: inc/customizer.php:829 inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr ""
 
 #: inc/customizer.php:830 inc/customizer.php:976

--- a/newspack-theme/languages/es_ES.po
+++ b/newspack-theme/languages/es_ES.po
@@ -725,7 +725,7 @@ msgid "Default Post Template"
 msgstr ""
 
 #: inc/customizer.php:829 inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr ""
 
 #: inc/customizer.php:830 inc/customizer.php:976

--- a/newspack-theme/languages/fr_BE.po
+++ b/newspack-theme/languages/fr_BE.po
@@ -756,7 +756,7 @@ msgid "Default Post Template"
 msgstr "Défaut"
 
 #: inc/customizer.php:829 inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr "Défaut"
 
 #: inc/customizer.php:830 inc/customizer.php:976

--- a/newspack-theme/languages/newspack-theme.pot
+++ b/newspack-theme/languages/newspack-theme.pot
@@ -721,7 +721,7 @@ msgstr ""
 
 #: inc/customizer.php:829
 #: inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr ""
 
 #: inc/customizer.php:830

--- a/newspack-theme/languages/pl_PL.po
+++ b/newspack-theme/languages/pl_PL.po
@@ -722,7 +722,7 @@ msgstr "Domyślny szablon postu"
 
 #: inc/customizer.php:829
 #: inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr "Domyślny szablon"
 
 #: inc/customizer.php:830

--- a/newspack-theme/languages/pt_BR.po
+++ b/newspack-theme/languages/pt_BR.po
@@ -720,7 +720,7 @@ msgid "Default Post Template"
 msgstr ""
 
 #: inc/customizer.php:829 inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr ""
 
 #: inc/customizer.php:830 inc/customizer.php:976

--- a/newspack-theme/languages/pt_PT.po
+++ b/newspack-theme/languages/pt_PT.po
@@ -722,7 +722,7 @@ msgid "Default Post Template"
 msgstr "Modelo de postagem padrão"
 
 #: inc/customizer.php:829 inc/customizer.php:975
-msgid "Default Template"
+msgid "With Sidebar"
 msgstr "Modelo Padrão"
 
 #: inc/customizer.php:830 inc/customizer.php:976


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As [suggested here](https://github.com/Automattic/newspack-plugin/pull/2670/files#r1341655482), the "Default" name for the default template is not too descriptive. This PR changes the name to "With sidebar". 

### How to test the changes in this Pull Request:

1. Open the Customizer, navigate to Template Settings -> Post Settings
2. Observe that the first option in the "Default Post Template" select is named "With Sidebar"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->