### PR TITLE
chore: newspack.pub > newspack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Newspack
 
-Welcome to the Newspack theme repository on GitHub. Here you can browse the source, look at open issues and keep track of development. We also recommend everyone [follow the Newspack blog](https://newspack.blog/) to stay up to date about everything happening in the project.
+Welcome to the Newspack theme repository on GitHub. Here you can browse the source, look at open issues and keep track of development. We also recommend everyone [follow the Newspack blog](https://newspack.com/) to stay up to date about everything happening in the project.
 
 The Newspack theme is a forward-looking news theme designed and developed to be highly customizable with the WordPress block editor.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "automattic/newspack-theme",
-	"description": "A theme for Newspack. https://newspack.blog/",
-	"homepage": "https://newspack.blog/",
+	"description": "A theme for Newspack. https://newspack.com/",
+	"homepage": "https://newspack.com/",
 	"type": "package",
 	"license": "GPL-2.0-or-later",
 	"support": {

--- a/newspack-theme/languages/de_DE.po
+++ b/newspack-theme/languages/de_DE.po
@@ -29,7 +29,7 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
+msgid "https://newspack.com"
 msgstr ""
 
 #: 404.php:18

--- a/newspack-theme/languages/es_ES.po
+++ b/newspack-theme/languages/es_ES.po
@@ -37,8 +37,8 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
-msgstr "https://newspack.blog"
+msgid "https://newspack.com"
+msgstr "https://newspack.com"
 
 #: 404.php:18
 msgid "Oops! That page can&rsquo;t be found."

--- a/newspack-theme/languages/fr_BE.po
+++ b/newspack-theme/languages/fr_BE.po
@@ -29,8 +29,8 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
-msgstr "https://newspack.blog"
+msgid "https://newspack.com"
+msgstr "https://newspack.com"
 
 #: 404.php:18
 msgid "Oops! That page can&rsquo;t be found."

--- a/newspack-theme/languages/newspack-theme.pot
+++ b/newspack-theme/languages/newspack-theme.pot
@@ -27,7 +27,7 @@ msgid "Automattic"
 msgstr ""
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
+msgid "https://newspack.com"
 msgstr ""
 
 #: 404.php:18

--- a/newspack-theme/languages/pl_PL.po
+++ b/newspack-theme/languages/pl_PL.po
@@ -27,8 +27,8 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
-msgstr "https://newspack.blog/"
+msgid "https://newspack.com"
+msgstr "https://newspack.com/"
 
 #: 404.php:18
 msgid "Oops! That page can&rsquo;t be found."

--- a/newspack-theme/languages/pt_BR.po
+++ b/newspack-theme/languages/pt_BR.po
@@ -27,8 +27,8 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
-msgstr "https://newspack.blog"
+msgid "https://newspack.com"
+msgstr "https://newspack.com"
 
 #: 404.php:18
 msgid "Oops! That page can&rsquo;t be found."

--- a/newspack-theme/languages/pt_PT.po
+++ b/newspack-theme/languages/pt_PT.po
@@ -29,8 +29,8 @@ msgid "Automattic"
 msgstr "Automattic"
 
 #. Author URI of the theme
-msgid "https://newspack.blog"
-msgstr "https://newspack.blog"
+msgid "https://newspack.com"
+msgstr "https://newspack.com"
 
 #: 404.php:18
 msgid "Oops! That page can&rsquo;t be found."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newspack",
   "version": "1.78.0",
-  "description": "A theme for Newspack. https://newspack.blog",
+  "description": "A theme for Newspack. https://newspack.com",
   "bugs": {
     "url": "https://github.com/Automattic/newspack-theme/issues"
   },

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
-The theme for Newspack. https://newspack.blog.
+The theme for Newspack. https://newspack.com.
 
 == Description ==
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates some lingering legacy URLs throughout the code. All instances of newspack.pub or newspack.blog should be newspack.com

### How to test the changes in this Pull Request:

No functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
