### PR TITLE
Tweaks for post-checkout newsletter signup

### DIFF
--- a/newspack-theme/inc/color-patterns.php
+++ b/newspack-theme/inc/color-patterns.php
@@ -9,14 +9,14 @@
  * Generate the CSS for the current primary color.
  */
 function newspack_custom_colors_css() {
-	$colors = newspack_get_colors();
-	$theme_css = '';
+	$colors     = newspack_get_colors();
+	$theme_css  = '';
 	$editor_css = '';
 
 	// Front-end colors that require the theme_colors to be set to 'custom':
 	if ( 'default' !== get_theme_mod( 'theme_colors', 'default' ) ) {
 
-		$css_variables =  '
+		$css_variables = '
 				--newspack-theme-color-primary: ' . esc_attr( $colors['primary'] ) . ';
 				--newspack-theme-color-primary-variation: ' . esc_attr( newspack_adjust_brightness( $colors['primary'], -30 ) ) . ';
 				--newspack-theme-color-secondary: ' . esc_attr( $colors['secondary'] ) . ' !important;
@@ -83,18 +83,6 @@ function newspack_custom_colors_css() {
 				.h-db.h-sub.single-featured-image-beside .middle-header-contain {
 					color: ' . esc_attr( $colors['primary_contrast'] ) . ';
 				}
-			}
-
-			/* Set colour that contrasts against the secondary background */
-			.wp-block-button:not(.is-style-outline) .wp-block-button__link:not(.has-text-color):not(:hover),
-			.button,
-			.button:visited,
-			button,
-			input[type="button"],
-			input[type="reset"],
-			input[type="submit"],
-			.wp-block-search__button {
-				color: ' . esc_attr( $colors['secondary_contrast'] ) . ';
 			}
 
 			input[type="checkbox"]::before {

--- a/newspack-theme/woocommerce/checkout/thankyou.php
+++ b/newspack-theme/woocommerce/checkout/thankyou.php
@@ -85,19 +85,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php
 				// Copied from templates/order/order-details.php
 				$show_customer_details = is_user_logged_in() && $order->get_user_id() === get_current_user_id();
-				if ( false === get_theme_mod( 'thank_you_customer_details_display', false ) ) {
-					$show_customer_details = false;
-				}
-				if ( $show_customer_details ) {
-					wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
-				}
+			if ( false === get_theme_mod( 'thank_you_customer_details_display', false ) ) {
+				$show_customer_details = false;
+			}
+			if ( $show_customer_details ) {
+				wc_get_template( 'order/order-details-customer.php', array( 'order' => $order ) );
+			}
 			?>
 		<?php endif; ?>
 
 		<?php
 		$downloads = $order->get_downloadable_items();
 		if ( $downloads ) {
-		?>
+			?>
 			<h4><?php esc_html_e( 'Download your purchase', 'newspack' ); ?></h4>
 
 			<?php
@@ -109,8 +109,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			);
 		}
 		?>
-
-		<?php do_action( 'newspack_woocommerce_thankyou', $order->get_id() ); ?>
 
 	<?php else : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-blocks/pull/1561

@laurelfulford – I'd appreciate your take on the changes in 3e887ed1d3bb4fd7dab3a26430e29fe852b5bc4b. The color for buttons is also set in the `newspack-theme/newspack-theme/sass/forms/_buttons.scss` file. The declaration removed in this PR was overriding the styles in that file. 

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-blocks/pull/1561_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->