### PR TITLE
fix: reinstate WC CSS modifications

### DIFF
--- a/newspack-theme/inc/woocommerce.php
+++ b/newspack-theme/inc/woocommerce.php
@@ -32,10 +32,6 @@ add_action( 'after_setup_theme', 'newspack_woocommerce_setup' );
  * @return void
  */
 function newspack_woocommerce_scripts() {
-	// Load WooCommerce styles from theme.
-	if ( true === get_theme_mod( 'woocommerce_styles_home_dequeue', false ) && is_front_page() ) {
-		return;
-	}
 	if (
 		function_exists( 'is_woocommerce' ) && is_woocommerce()
 		|| function_exists( 'is_cart' ) && is_cart()
@@ -47,6 +43,15 @@ function newspack_woocommerce_scripts() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'newspack_woocommerce_scripts' );
+
+/**
+ * Remove WooCommerce general styles.
+ */
+function newspack_dequeue_styles( $enqueue_styles ) {
+	unset( $enqueue_styles['woocommerce-general'] );
+	return $enqueue_styles;
+}
+add_filter( 'woocommerce_enqueue_styles', 'newspack_dequeue_styles' );
 
 /**
  * Remove WooCommerce sidebar - this theme doesn't have a traditional sidebar.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixing a regression introduced by #2191, The WC general styles should be removed, so the theme can apply its styling. 

Also removing an unneeded statement from `newspack_woocommerce_scripts` function – it returns when on homepage, but only deals with WC pages afterwards. 

### How to test the changes in this Pull Request:

1. On `master`, load `/my-account` and `/shop` pages, observe the layout is broken on the former and Newspack styles not applied on the latter
2. Switch to this branch, reload the pages – observe that all is well now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->