### PR TITLE
feat: add single post option to display custom excerpt in lieu of subtitle

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -959,6 +959,23 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to display previous and next links on single posts.
+	$wp_customize->add_setting(
+		'post_excerpt_instead_of_subtitle',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'post_excerpt_instead_of_subtitle',
+		array(
+			'type'    => 'checkbox',
+			'label'   => __( 'Display the excerpt at the top of single posts instead of the article subtitle.', 'newspack' ),
+			'section' => 'post_default_settings',
+		)
+	);
+
 	/**
 	 * Page Template Settings
 	 */

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -971,7 +971,7 @@ function newspack_customize_register( $wp_customize ) {
 		'post_excerpt_instead_of_subtitle',
 		array(
 			'type'    => 'checkbox',
-			'label'   => __( 'Display the excerpt at the top of single posts instead of the article subtitle.', 'newspack' ),
+			'label'   => __( 'Display the custom excerpt at the top of single posts instead of the article subtitle.', 'newspack' ),
 			'section' => 'post_default_settings',
 		)
 	);

--- a/newspack-theme/template-parts/header/entry-header.php
+++ b/newspack-theme/template-parts/header/entry-header.php
@@ -20,7 +20,11 @@ if ( function_exists( 'newspack_get_all_sponsors' ) ) {
 $page_hide_title = get_post_meta( $post->ID, 'newspack_hide_page_title', true );
 
 // Get post subtitle.
-$subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
+if ( true === get_theme_mod( 'post_excerpt_instead_of_subtitle', false ) ) {
+	$subtitle = $post->post_excerpt;
+} else {
+	$subtitle = get_post_meta( $post->ID, 'newspack_post_subtitle', true );
+}
 ?>
 
 <?php if ( is_singular() ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We have a handful of publishers who would rather display custom excerpts at the top of single posts, in lieu of the article subtitle.

This PR adds an option to the Customizer to do just that, and if toggled on, places the custom excerpt below the post title on single posts on the front-end. 

See 1200550061930446-as-1205502642122803

### How to test the changes in this Pull Request:

1. Create a post and give it an article subtitle, and a custom excerpt.
2. View on the front-end and confirm you see your article subtitle.
3. Navigate to Customizer > Template Settings > Post Settings, and check "Display the custom excerpt at the top of single posts instead of the article subtitle", then Save.
4. View your post again; confirm that it's displaying your custom excerpt instead of the article subtitle.
5. Edit the post and remove the custom excerpt. 
6. Confirm that nothing shows in the place of the article subtitle on the front-end. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
