### PR TITLE
fix: add a scroll-margin to anchors for sticky header

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -177,6 +177,39 @@
 	}
 }
 
+//! Scroll offsets
+.h-stk {
+	sup.fn a,
+	.wp-block-footnotes li,
+	.entry-content *[id] {
+		scroll-margin-top: 115px;
+
+		@include utilities.media( tablet ) {
+			scroll-margin-top: 180px;
+		}
+	}
+
+	@include utilities.media( tablet ) {
+		&.h-dh {
+			sup.fn a,
+			.wp-block-footnotes li,
+			.entry-content *[id] {
+				scroll-margin-top: 210px;
+			}
+		}
+	}
+
+	@include utilities.media( tablet ) {
+		&.h-sub:not(.home) {
+			sup.fn a,
+			.wp-block-footnotes li,
+			.entry-content *[id] {
+				scroll-margin-top: 100px;
+			}
+		}
+	}
+}
+
 //! Headings
 h1,
 h2,
@@ -1202,31 +1235,6 @@ hr {
 //! Footnote styles
 .wp-block-footnotes li:focus {
 	outline: thin dotted;
-}
-
-.h-stk {
-	sup.fn a,
-	.wp-block-footnotes li {
-		scroll-margin-top: 115px;
-
-		@include utilities.media( tablet ) {
-			scroll-margin-top: 180px;
-		}
-	}
-
-	&.h-dh sup.fn a,
-	&.h-dh .wp-block-footnotes li {
-		@include utilities.media( tablet ) {
-			scroll-margin-top: 210px;
-		}
-	}
-
-	&.h-sub:not(.home) sup.fn a,
-	&.h-sub:not(.home) .wp-block-footnotes li {
-		@include utilities.media( tablet ) {
-			scroll-margin-top: 100px;
-		}
-	}
 }
 
 //! Navigtation block


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Our theme's sticky header is at odds with anchors in post and page content, and can cover the linked content.

This PR expands the styles added for the footnote block to anything with an `id`, so when the header is set to sticky, it won't cover the linked content. This may leave some edge cases -- like if a site has an especially large header thanks to CSS -- but should cover most cases!

See 1200550061930446-as-1205635621203968

### How to test the changes in this Pull Request:

1. Set up a page with some content that has anchor links; alternatively, copy-paste the below content into a new page. 
<details>
<summary>Example content with anchors</summary>

```
<!-- wp:list -->
<ul><!-- wp:list-item -->
<li><a href="#heading-one">Heading One</a></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li><a href="#heading-two">Heading Two</a></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li><a href="#heading-three">Heading Three</a></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris purus urna, vulputate at convallis hendrerit, mattis id mi. Nulla mauris justo, sodales vitae sodales nec, fermentum at elit. Proin condimentum risus sed venenatis mollis. Donec auctor euismod sodales. Donec sodales congue metus, sit amet tempor odio maximus in. Ut vestibulum nisl a maximus scelerisque. Donec aliquam eleifend metus, eget iaculis ante vestibulum id. Nulla facilisi. Nullam interdum sagittis accumsan. Phasellus egestas elementum enim nec condimentum. Sed mattis purus odio. Curabitur vehicula rutrum porttitor. Phasellus tempus dui id turpis fermentum, auctor dictum mauris mollis.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Curabitur orci ipsum, sodales vel ullamcorper sit amet, porta sed leo. Curabitur mattis lorem lectus, eu auctor felis mattis sit amet. Aliquam nibh justo, pharetra vel gravida sit amet, dictum vel massa. Sed pulvinar ante turpis, at lobortis urna pharetra in. Nulla facilisi. Mauris neque magna, gravida nec consequat sit amet, sagittis nec neque. Duis et faucibus arcu. Duis ultricies pharetra mauris, sed volutpat nulla dignissim vel. Aenean et viverra urna. Aenean condimentum leo sed pharetra lobortis. Mauris finibus erat vel ultricies pharetra. Suspendisse mollis a diam quis dignissim. Curabitur lacinia dolor et rhoncus facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse sagittis, ipsum quis rutrum sodales, dui ex venenatis nisi, et gravida turpis libero a enim.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading" id="heading-one">Heading One</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Nullam placerat nulla quis tortor fermentum, vitae ornare sem finibus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi in eros interdum, convallis justo in, ultricies est. In neque felis, sollicitudin quis massa vitae, vehicula mattis dolor. Aliquam erat volutpat. Integer iaculis aliquet diam sed luctus. In a libero efficitur, aliquet neque quis, vehicula neque. Suspendisse potenti. Nullam ac lobortis quam, id efficitur massa. Aenean ornare faucibus ornare. Pellentesque vitae ultricies orci. Aliquam sit amet dolor ac orci consectetur cursus. Nunc faucibus fermentum nisl sit amet viverra. Aliquam nisi libero, cursus sit amet purus ac, luctus sodales urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis ac ante tincidunt, egestas enim at, efficitur magna.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris purus urna, vulputate at convallis hendrerit, mattis id mi. Nulla mauris justo, sodales vitae sodales nec, fermentum at elit. Proin condimentum risus sed venenatis mollis. Donec auctor euismod sodales. Donec sodales congue metus, sit amet tempor odio maximus in. Ut vestibulum nisl a maximus scelerisque. Donec aliquam eleifend metus, eget iaculis ante vestibulum id. Nulla facilisi. Nullam interdum sagittis accumsan. Phasellus egestas elementum enim nec condimentum. Sed mattis purus odio. Curabitur vehicula rutrum porttitor. Phasellus tempus dui id turpis fermentum, auctor dictum mauris mollis.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Curabitur orci ipsum, sodales vel ullamcorper sit amet, porta sed leo. Curabitur mattis lorem lectus, eu auctor felis mattis sit amet. Aliquam nibh justo, pharetra vel gravida sit amet, dictum vel massa. Sed pulvinar ante turpis, at lobortis urna pharetra in. Nulla facilisi. Mauris neque magna, gravida nec consequat sit amet, sagittis nec neque. Duis et faucibus arcu. Duis ultricies pharetra mauris, sed volutpat nulla dignissim vel. Aenean et viverra urna. Aenean condimentum leo sed pharetra lobortis. Mauris finibus erat vel ultricies pharetra. Suspendisse mollis a diam quis dignissim. Curabitur lacinia dolor et rhoncus facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse sagittis, ipsum quis rutrum sodales, dui ex venenatis nisi, et gravida turpis libero a enim.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading" id="heading-two">Heading Two</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Nullam placerat nulla quis tortor fermentum, vitae ornare sem finibus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi in eros interdum, convallis justo in, ultricies est. In neque felis, sollicitudin quis massa vitae, vehicula mattis dolor. Aliquam erat volutpat. Integer iaculis aliquet diam sed luctus. In a libero efficitur, aliquet neque quis, vehicula neque. Suspendisse potenti. Nullam ac lobortis quam, id efficitur massa. Aenean ornare faucibus ornare. Pellentesque vitae ultricies orci. Aliquam sit amet dolor ac orci consectetur cursus. Nunc faucibus fermentum nisl sit amet viverra. Aliquam nisi libero, cursus sit amet purus ac, luctus sodales urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis ac ante tincidunt, egestas enim at, efficitur magna.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris purus urna, vulputate at convallis hendrerit, mattis id mi. Nulla mauris justo, sodales vitae sodales nec, fermentum at elit. Proin condimentum risus sed venenatis mollis. Donec auctor euismod sodales. Donec sodales congue metus, sit amet tempor odio maximus in. Ut vestibulum nisl a maximus scelerisque. Donec aliquam eleifend metus, eget iaculis ante vestibulum id. Nulla facilisi. Nullam interdum sagittis accumsan. Phasellus egestas elementum enim nec condimentum. Sed mattis purus odio. Curabitur vehicula rutrum porttitor. Phasellus tempus dui id turpis fermentum, auctor dictum mauris mollis.</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Curabitur orci ipsum, sodales vel ullamcorper sit amet, porta sed leo. Curabitur mattis lorem lectus, eu auctor felis mattis sit amet. Aliquam nibh justo, pharetra vel gravida sit amet, dictum vel massa. Sed pulvinar ante turpis, at lobortis urna pharetra in. Nulla facilisi. Mauris neque magna, gravida nec consequat sit amet, sagittis nec neque. Duis et faucibus arcu. Duis ultricies pharetra mauris, sed volutpat nulla dignissim vel. Aenean et viverra urna. Aenean condimentum leo sed pharetra lobortis. Mauris finibus erat vel ultricies pharetra. Suspendisse mollis a diam quis dignissim. Curabitur lacinia dolor et rhoncus facilisis. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse sagittis, ipsum quis rutrum sodales, dui ex venenatis nisi, et gravida turpis libero a enim.</p>
<!-- /wp:paragraph -->

<!-- wp:heading -->
<h2 class="wp-block-heading" id="heading-three">Heading Three</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Nullam placerat nulla quis tortor fermentum, vitae ornare sem finibus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi in eros interdum, convallis justo in, ultricies est. In neque felis, sollicitudin quis massa vitae, vehicula mattis dolor. Aliquam erat volutpat. Integer iaculis aliquet diam sed luctus. In a libero efficitur, aliquet neque quis, vehicula neque. Suspendisse potenti. Nullam ac lobortis quam, id efficitur massa. Aenean ornare faucibus ornare. Pellentesque vitae ultricies orci. Aliquam sit amet dolor ac orci consectetur cursus. Nunc faucibus fermentum nisl sit amet viverra. Aliquam nisi libero, cursus sit amet purus ac, luctus sodales urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Duis ac ante tincidunt, egestas enim at, efficitur magna.</p>
<!-- /wp:paragraph -->
```
</details>

2. Navigate to Customizer > Header Settings > Appearance, and enable the sticky header; Save. 
3. View your page; click on one of your anchor links and note that the content it links to is covered by the header.
4. Apply the PR and run `npm run build`. 
5. Repeat step 3 and confirm the content is no longer covered by the header. 
6. Cycle through some of the header settings (particularily toggling between the short and taller header under Header Settings > Appearance), and different breakpoints, and make sure the linked content remains uncovered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
