### PR TITLE
Add script & style to HTML5 array

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -96,12 +96,12 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 			'html5',
 			array(
 				'caption',
- 				'comment-form',
- 				'comment-list',
- 				'gallery',
- 				'script',
- 				'search-form',
- 				'style',
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'script',
+				'search-form',
+				'style',
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In WordPress 5.3, two new arguments are now supported for the `html5` theme feature, `script` and `style`. When these arguments are passed, the `type` attribute will not be output for those tags. ([Source](https://make.wordpress.org/core/2019/10/15/miscellaneous-developer-focused-changes-in-5-3/)\)

For reasons still TBD, the omission of these arguments from Newspack Theme caused the [WordPress Popular Posts](https://wordpress.org/plugins/wordpress-popular-posts/) plugin to break after yesterday's release of WordPress 6.4. ([Source](https://wordpress.org/support/topic/popular-posts-disapeared-after-wp6-4-update/#post-17184460)\)

This PR adds those two arguments and alphabetizes the array.

Determined to warrant a hotfix in https://github.com/Automattic/newspack-theme/pull/2198.

### How to test the changes in this Pull Request:

1. Install the WPP plugin and add its widget to a sidebar.
2. Observe that it displays only a small scrollbar and no posts.
3. Switch to this branch.
4. WPP should now work correctly.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
