### PR TITLE
fix: clears woo template cache

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -1334,3 +1334,8 @@ if ( class_exists( 'Tribe__Events__Main' ) ) {
 if ( class_exists( 'Newspack_Multibranded_Site\Customizations\Theme_Colors' ) ) {
 	require get_template_directory() . '/inc/newspack-multibranded-site-plugin.php';
 }
+
+/**
+ * Woo Templates cache handling
+ */
+require get_template_directory() . '/woocommerce/templates.php';

--- a/newspack-theme/woocommerce/templates.php
+++ b/newspack-theme/woocommerce/templates.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This folder holds Woocommerce templates that override the default Woo templates.
+ *
+ * If you add or remove a template from this folder, it's a good idea to clear the template cache
+ * to make sure the changes take effect - and not break anything - on sites that use persistent caching
+ *
+ * @package newspack-theme
+ */
+
+/**
+ * When adding or removing a template from this folder, increase the templates_version variable below.
+ */
+$newspack_theme_woo_templates_version = 1;
+
+if ( get_option( 'newspack_theme_woo_templates_version', 0 ) !== $newspack_theme_woo_templates_version ) {
+	wc_clear_template_cache();
+	update_option( 'newspack_theme_woo_templates_version', $newspack_theme_woo_templates_version );
+}

--- a/newspack-theme/woocommerce/templates.php
+++ b/newspack-theme/woocommerce/templates.php
@@ -13,7 +13,7 @@
  */
 $newspack_theme_woo_templates_version = 1;
 
-if ( get_option( 'newspack_theme_woo_templates_version', 0 ) !== $newspack_theme_woo_templates_version ) {
+if ( function_exists( 'wc_clear_template_cache' ) && get_option( 'newspack_theme_woo_templates_version', 0 ) !== $newspack_theme_woo_templates_version ) {
 	wc_clear_template_cache();
 	update_option( 'newspack_theme_woo_templates_version', $newspack_theme_woo_templates_version );
 }


### PR DESCRIPTION
Needed after files removed in 498192a4323771803626e5695f60b79c0adaf10e

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In https://github.com/Automattic/newspack-theme/pull/2191 we removed two Woo templates from the theme.

In sites using persistent cache, Woo would still try to load the templates from the theme and the checkout page would break.

This PR will clear the cache to make sure it doesn't happen

⚠️ This change should be merged into the current alpha, too. 

### How to test the changes in this Pull Request:

Here is what you need if you want to test this

1. Make sure memcached is on
2. Checkout a version of the theme before https://github.com/Automattic/newspack-theme/pull/2191
3. Add a product to the cart and visit the checkout page (the regular checkout page, not our modal checkout)
4. Checkout theme on `master`
5. Visit checkout again and confirm the page is blank and there's an error in the log complaining about the missing file
6. Checkout this branch and confirm the Checkout page is back

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
