### PR TITLE
feat: filter JS and print styles enqueuing

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -433,6 +433,15 @@ function newspack_scripts() {
 		wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 	}
 
+	// Load custom fonts, if any.
+	if ( get_theme_mod( 'custom_font_import_code', '' ) ) {
+		wp_enqueue_style( 'newspack-font-import', newspack_custom_typography_link( 'custom_font_import_code' ), array(), null );
+	}
+
+	if ( get_theme_mod( 'custom_font_import_code_alternate', '' ) ) {
+		wp_enqueue_style( 'newspack-font-alternative-import', newspack_custom_typography_link( 'custom_font_import_code_alternate' ), array(), null );
+	}
+
 	if ( ! apply_filters( 'newspack_theme_enqueue_js', true ) ) {
 		return;
 	}
@@ -465,16 +474,6 @@ function newspack_scripts() {
 		wp_enqueue_script( 'amp-animation', 'https://cdn.ampproject.org/v0/amp-animation-0.1.js', array(), '0.1', true );
 		wp_enqueue_script( 'amp-position-observer', 'https://cdn.ampproject.org/v0/amp-position-observer-0.1.js', array(), '0.1', true );
 	}
-
-	// Load custom fonts, if any.
-	if ( get_theme_mod( 'custom_font_import_code', '' ) ) {
-		wp_enqueue_style( 'newspack-font-import', newspack_custom_typography_link( 'custom_font_import_code' ), array(), null );
-	}
-
-	if ( get_theme_mod( 'custom_font_import_code_alternate', '' ) ) {
-		wp_enqueue_style( 'newspack-font-alternative-import', newspack_custom_typography_link( 'custom_font_import_code_alternate' ), array(), null );
-	}
-
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
 

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -429,7 +429,13 @@ function newspack_scripts() {
 
 	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 
-	wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
+	if ( apply_filters( 'newspack_theme_enqueue_print_styles', true ) ) {
+		wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
+	}
+
+	if ( ! apply_filters( 'newspack_theme_enqueue_js', true ) ) {
+		return;
+	}
 
 	$newspack_l10n = array(
 		'open_search'         => esc_html__( 'Open Search', 'newspack' ),

--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -429,6 +429,11 @@ function newspack_scripts() {
 
 	wp_style_add_data( 'newspack-style', 'rtl', 'replace' );
 
+	/**
+	 * Filters whether to enqueue print styles.
+	 *
+	 * @param bool $should_enqueue_print_styles Whether to enqueue print styles.
+	 */
 	if ( apply_filters( 'newspack_theme_enqueue_print_styles', true ) ) {
 		wp_enqueue_style( 'newspack-print-style', get_template_directory_uri() . '/styles/print.css', array(), wp_get_theme()->get( 'Version' ), 'print' );
 	}
@@ -442,6 +447,11 @@ function newspack_scripts() {
 		wp_enqueue_style( 'newspack-font-alternative-import', newspack_custom_typography_link( 'custom_font_import_code_alternate' ), array(), null );
 	}
 
+	/**
+	 * Filters whether to enqueue JS.
+	 *
+	 * @param bool $should_enqueue_js Whether to enqueue JS.
+	 */
 	if ( ! apply_filters( 'newspack_theme_enqueue_js', true ) ) {
 		return;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds filters for dequeuing print styles and JS scripts.

### How to test the changes in this Pull Request:

Load a page, observe that print styles (`print.css`) and JS scripts (e.g. `amp-fallback.js`) are loaded as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->