### PR TITLE
Improve support for distributed guest authors

### DIFF
--- a/newspack-sacha/template-parts/post/author-bio.php
+++ b/newspack-sacha/template-parts/post/author-bio.php
@@ -21,23 +21,33 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	foreach ( $authors as $author ) {
 
 		if ( '' !== $author->description ) {
-			$author_avatar = coauthors_get_avatar( $author, 80 );
+			// avatar_img_tag is a property added by Newspack Network plugin to distributed posts.
+			$author_avatar = $author->avatar_img_tag ?? coauthors_get_avatar( $author, 80 );
+			$author_url    = get_author_posts_url( $author->ID, $author->user_nicename );
 			?>
 
 			<div class="author-bio">
 				<div class="author-bio-text">
 					<div class="author-bio-header">
 						<?php if ( $author_avatar ) { ?>
-							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+							<?php if ( '#' !== $author_url ) : ?>
+								<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+							<?php endif; ?>
 								<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
-							</a>
+							<?php if ( '#' !== $author_url ) : ?>
+								</a>
+							<?php endif; ?>
 						<?php } ?>
 
 						<div>
 							<h2 class="accent-header">
-								<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
-								</a>
+								<?php if ( '#' !== $author_url ) : ?>
+									<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php endif; ?>
+									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID, $author ), array( 'span' => array( 'class' => array() ) ) ); ?>
+								<?php if ( '#' !== $author_url ) : ?>
+									</a>
+								<?php endif; ?>
 							</h2>
 
 							<?php if ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) : ?>
@@ -54,22 +64,25 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
 							<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( $author->description ), $author_bio_length ) ); ?>
-							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-							<?php
-								/* translators: %s is the current author's name. */
-								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-							?>
-							</a>
+							<?php if ( '#' !== $author_url ) : ?>
+								<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php
+									/* translators: %s is the current author's name. */
+									printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+								?>
+								</a>
+							<?php endif; ?>
 						</p>
 					<?php else : ?>
 						<?php echo wp_kses_post( wpautop( $author->description ) ); ?>
-
-						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-							<?php
-								/* translators: %s is the current author's name. */
-								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-							?>
-						</a>
+						<?php if ( '#' !== $author_url ) : ?>
+							<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php
+									/* translators: %s is the current author's name. */
+									printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+								?>
+							</a>
+						<?php endif; ?>
 					<?php endif; ?>
 
 					<?php newspack_author_social_links( $author->ID ); ?>
@@ -90,7 +103,8 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 		<div class="author-bio-header">
 			<?php
 				$author_avatar = get_avatar( get_the_author_meta( 'ID' ), 80 );
-				if ( $author_avatar ) { ?>
+			if ( $author_avatar ) {
+				?>
 				<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 					<?php
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -102,7 +116,7 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			<div>
 				<h2 class="accent-header">
 					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-						<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+						<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ), get_user_by( 'id', get_the_author_meta( 'ID' ) ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
 					</a>
 				</h2>
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -95,7 +95,8 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 			$i            = 1;
 
 			foreach ( $authors as $author ) {
-				$author_avatar = coauthors_get_avatar( $author, 80 );
+				// avatar_url is a property added by Newspack Network plugin to distributed posts.
+				$author_avatar = $author->avatar_url ?? coauthors_get_avatar( $author, 80 );
 
 				echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 			}
@@ -117,11 +118,21 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 						$sep = '';
 					endif;
 
+					$author_link = ! empty( $author->user_nicename ) ? get_author_posts_url( $author->ID, $author->user_nicename ) : '';
+
+					if ( ! empty( $author->user_nicename ) ) {
+						$author_name = sprintf(
+							'<a class="url fn n" href="%1$s">%2$s</a>',
+							esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+							esc_html( $author->display_name )
+						);
+					} else {
+						$author_name = esc_html( $author->display_name );
+					}
+
 					printf(
-						/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
-						'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>%3$s ',
-						esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
-						esc_html( $author->display_name ),
+						'<span class="author vcard">%1$s</span>%2$s ',
+						$author_name, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 						esc_html( $sep )
 					);
 				}
@@ -625,7 +636,7 @@ if ( ! function_exists( 'newspack_tertiary_menu' ) ) :
 			</nav>
 		<?php
 	}
-endif;	
+endif;
 
 if ( ! function_exists( 'newspack_social_menu_settings' ) ) :
 	/**

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -118,12 +118,12 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 						$sep = '';
 					endif;
 
-					$author_link = ! empty( $author->user_nicename ) ? get_author_posts_url( $author->ID, $author->user_nicename ) : '';
+					$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
 
-					if ( ! empty( $author->user_nicename ) ) {
+					if ( '#' !== $author_link ) {
 						$author_name = sprintf(
 							'<a class="url fn n" href="%1$s">%2$s</a>',
-							esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+							esc_url( $author_link ),
 							esc_html( $author->display_name )
 						);
 					} else {

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -95,8 +95,8 @@ if ( ! function_exists( 'newspack_posted_by' ) ) :
 			$i            = 1;
 
 			foreach ( $authors as $author ) {
-				// avatar_url is a property added by Newspack Network plugin to distributed posts.
-				$author_avatar = $author->avatar_url ?? coauthors_get_avatar( $author, 80 );
+				// avatar_img_tag is a property added by Newspack Network plugin to distributed posts.
+				$author_avatar = $author->avatar_img_tag ?? coauthors_get_avatar( $author, 80 );
 
 				echo '<span class="author-avatar">' . wp_kses( $author_avatar, newspack_sanitize_avatars() ) . '</span>';
 			}

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -21,8 +21,8 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	foreach ( $authors as $author ) {
 
 		if ( '' !== $author->description ) {
-			// avatar_url is a property added by Newspack Network plugin to distributed posts.
-			$author_avatar = $author->avatar_url ?? coauthors_get_avatar( $author, 80 );
+			// avatar_img_tag is a property added by Newspack Network plugin to distributed posts.
+			$author_avatar = $author->avatar_img_tag ?? coauthors_get_avatar( $author, 80 );
 			$author_url    = ! empty( $author->user_nicename ) ? get_author_posts_url( $author->ID, $author->user_nicename ) : '';
 			?>
 

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -44,7 +44,16 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 								<?php if ( $author_url ) : ?>
 									<a href="<?php echo esc_url( $author_url ); ?>" rel="author">
 								<?php endif; ?>
-									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
+									<?php
+									/**
+									 * Filters the author name in the author bio.
+									 *
+									 * @param string $author_name The author name.
+									 * @param int    $author_id   The author ID.
+									 * @param object $author      The author object. Can be a WP_User object or a Co-Authors Plus Guest Author object.
+									 */
+									echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID, $author ), array( 'span' => array( 'class' => array() ) ) );
+									?>
 								<?php if ( $author_url ) : ?>
 									</a>
 								<?php endif; ?>
@@ -118,7 +127,8 @@ elseif ( (bool) get_the_author_meta( 'description' ) && is_single() ) :
 			<div>
 				<h2 class="accent-header">
 					<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-						<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
+					<?php // This filter is documented above. ?>
+					<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', get_the_author(), get_the_author_meta( 'ID' ), get_user_by( 'id', get_the_author_meta( 'ID' ) ) ), array( 'span' => array( 'class' => array() ) ) ); ?>
 					</a>
 				</h2>
 

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -21,23 +21,33 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 	foreach ( $authors as $author ) {
 
 		if ( '' !== $author->description ) {
-			$author_avatar = coauthors_get_avatar( $author, 80 );
+			// avatar_url is a property added by Newspack Network plugin to distributed posts.
+			$author_avatar = $author->avatar_url ?? coauthors_get_avatar( $author, 80 );
+			$author_url    = ! empty( $author->user_nicename ) ? get_author_posts_url( $author->ID, $author->user_nicename ) : '';
 			?>
 
 			<div class="author-bio">
 				<?php if ( $author_avatar ) : ?>
-					<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+					<?php if ( $author_url ) : ?>
+						<a href="<?php echo esc_url( $author_url ); ?>" rel="author">
+					<?php endif; ?>
 						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
-					</a>
+					<?php if ( $author_url ) : ?>
+						</a>
+					<?php endif; ?>
 				<?php endif; ?>
 
 				<div class="author-bio-text">
 					<div class="author-bio-header">
 						<div>
 							<h2 class="accent-header">
-								<a href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
+								<?php if ( $author_url ) : ?>
+									<a href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php endif; ?>
 									<?php echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID ), array( 'span' => array( 'class' => array() ) ) ); ?>
-								</a>
+								<?php if ( $author_url ) : ?>
+									</a>
+								<?php endif; ?>
 							</h2>
 
 							<?php if ( ( true === get_theme_mod( 'show_author_email', false ) && '' !== $author->user_email ) || true === get_theme_mod( 'show_author_social', false ) ) : ?>
@@ -58,22 +68,26 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
 							<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( $author->description ), $author_bio_length ) ); ?>
-							<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-							<?php
-								/* translators: %s is the current author's name. */
-								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-							?>
-							</a>
+							<?php if ( $author_url ) : ?>
+								<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php
+									/* translators: %s is the current author's name. */
+									printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+								?>
+								</a>
+							<?php endif; ?>
 						</p>
 					<?php else : ?>
 						<?php echo wp_kses_post( wpautop( $author->description ) ); ?>
 
-						<a class="author-link" href="<?php echo esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ); ?>" rel="author">
-							<?php
-								/* translators: %s is the current author's name. */
-								printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
-							?>
-						</a>
+						<?php if ( $author_url ) : ?>
+							<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
+								<?php
+									/* translators: %s is the current author's name. */
+									printf( esc_html__( 'More by %s', 'newspack' ), esc_html( $author->display_name ) );
+								?>
+							</a>
+						<?php endif; ?>
 					<?php endif; ?>
 
 				</div><!-- .author-bio-text -->

--- a/newspack-theme/template-parts/post/author-bio.php
+++ b/newspack-theme/template-parts/post/author-bio.php
@@ -23,16 +23,16 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 		if ( '' !== $author->description ) {
 			// avatar_img_tag is a property added by Newspack Network plugin to distributed posts.
 			$author_avatar = $author->avatar_img_tag ?? coauthors_get_avatar( $author, 80 );
-			$author_url    = ! empty( $author->user_nicename ) ? get_author_posts_url( $author->ID, $author->user_nicename ) : '';
+			$author_url    = get_author_posts_url( $author->ID, $author->user_nicename );
 			?>
 
 			<div class="author-bio">
 				<?php if ( $author_avatar ) : ?>
-					<?php if ( $author_url ) : ?>
+					<?php if ( '#' !== $author_url ) : ?>
 						<a href="<?php echo esc_url( $author_url ); ?>" rel="author">
 					<?php endif; ?>
 						<?php echo wp_kses( $author_avatar, newspack_sanitize_avatars() ); ?>
-					<?php if ( $author_url ) : ?>
+					<?php if ( '#' !== $author_url ) : ?>
 						</a>
 					<?php endif; ?>
 				<?php endif; ?>
@@ -41,7 +41,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<div class="author-bio-header">
 						<div>
 							<h2 class="accent-header">
-								<?php if ( $author_url ) : ?>
+								<?php if ( '#' !== $author_url ) : ?>
 									<a href="<?php echo esc_url( $author_url ); ?>" rel="author">
 								<?php endif; ?>
 									<?php
@@ -54,7 +54,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 									 */
 									echo wp_kses( apply_filters( 'newspack_author_bio_name', $author->display_name, $author->ID, $author ), array( 'span' => array( 'class' => array() ) ) );
 									?>
-								<?php if ( $author_url ) : ?>
+								<?php if ( '#' !== $author_url ) : ?>
 									</a>
 								<?php endif; ?>
 							</h2>
@@ -77,7 +77,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<?php if ( get_theme_mod( 'author_bio_truncate', true ) ) : ?>
 						<p>
 							<?php echo esc_html( newspack_truncate_text( wp_strip_all_tags( $author->description ), $author_bio_length ) ); ?>
-							<?php if ( $author_url ) : ?>
+							<?php if ( '#' !== $author_url ) : ?>
 								<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
 								<?php
 									/* translators: %s is the current author's name. */
@@ -89,7 +89,7 @@ if ( function_exists( 'coauthors_posts_links' ) && is_single() && ! empty( get_c
 					<?php else : ?>
 						<?php echo wp_kses_post( wpautop( $author->description ) ); ?>
 
-						<?php if ( $author_url ) : ?>
+						<?php if ( '#' !== $author_url ) : ?>
 							<a class="author-link" href="<?php echo esc_url( $author_url ); ?>" rel="author">
 								<?php
 									/* translators: %s is the current author's name. */


### PR DESCRIPTION
Handle guest authors distributed via Newspack Network and Distributor plugins

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the support for the distributed post authors by Newspack Network. 

Basically - remove the `a` tag for authors without a URL.

Also sends an extra information in the `newspack_author_bio_name` filter.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-network/pull/25

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
