### PR TITLE
fix: make sidebar donate block button style more specific

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -333,7 +333,7 @@ p.has-background {
 		margin-right: #{0.62 * structure.$size__spacing-unit};
 	}
 	.wpbnbd .thanks,
-	.wpbnbd button {
+	.wpbnbd button[type='submit'] {
 		margin-left: structure.$size__spacing-unit;
 		margin-right: structure.$size__spacing-unit;
 	}

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -339,17 +339,15 @@ p.has-background {
 			margin-left: structure.$size__spacing-unit;
 			margin-right: structure.$size__spacing-unit;
 		}
-
-		.freq-label {
-			font-size: 1em;
-		}
 	}
 }
 
-.site-info .widget .wpbnbd {
-	.thanks {
-		margin: 0.5rem 1.5rem;
-	}
+.widget .wpbnbd .freq-label {
+	font-size: 1em;
+}
+
+.site-info .widget .wpbnbd .thanks {
+	margin: 0.5rem 1.5rem;
 }
 
 .desktop-sidebar,

--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -328,14 +328,21 @@ p.has-background {
 	}
 
 	//! Newspack Donate Block
-	.wpbnbd.tiered .tiers {
-		margin-left: #{0.62 * structure.$size__spacing-unit};
-		margin-right: #{0.62 * structure.$size__spacing-unit};
-	}
-	.wpbnbd .thanks,
-	.wpbnbd button[type='submit'] {
-		margin-left: structure.$size__spacing-unit;
-		margin-right: structure.$size__spacing-unit;
+	.wpbnbd {
+		&.tiered .tiers {
+			margin-left: #{0.62 * structure.$size__spacing-unit};
+			margin-right: #{0.62 * structure.$size__spacing-unit};
+		}
+
+		.thanks,
+		button[type='submit'] {
+			margin-left: structure.$size__spacing-unit;
+			margin-right: structure.$size__spacing-unit;
+		}
+
+		.freq-label {
+			font-size: 1em;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As part of https://github.com/Automattic/newspack-blocks/pull/1622, the donate block tabs were switched to `<button>` to improve accessibility. The theme includes a bit of CSS that adds margins to all `<button>`s in the Donate Block when it appears in the sidebar, causing a bit of weirdness in the sidebar version. The font size of the tabs also increased.

This PR makes the button CSS more specific to fix the spacing issue, and specifically sets the tab size when in widgets.

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Widgets, and a Donate block to the sidebar widget area on your site.
2. View on the front-end; note the odd spaces between the tabs at the top. You may have a harder time telling, but the font size of the tabs is also larger, matching the scale of the block when it appears in the content.

<img width="391" alt="image" src="https://github.com/Automattic/newspack-theme/assets/177561/9dc1b02b-0f24-4c92-9061-8c5575c4666f">

3. Apply this PR and run `npm run build`.
5. Refresh the front-end view of the sidebar; confirm that the donate block tabs appear to be spaced normally, and that the "Donate Now" button is also placed in the correct location. Also confirm that the font size of the tabs is a little smaller (it should be 12.8px in the computed CSS). 

<img width="390" alt="image" src="https://github.com/Automattic/newspack-theme/assets/177561/b72eb62b-fce1-4fc7-b7ca-d56213d882e3">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
