### PR TITLE
fix(my-account): make active menu links clickable

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1850,7 +1850,6 @@ table.woocommerce-table--order-details.shop_table,
 					a {
 						background: var( --newspack-theme-color-primary );
 						color: var( --newspack-theme-color-bg-body );
-						pointer-events: none;
 
 						&:focus-visible {
 							outline-color: var( --newspack-theme-color-bg-body );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tiny usability change to My Account. Active menu links should remain clickable as some My Account subpages have deeper subpages of their own.

### How to test the changes in this Pull Request:

1. Register as a reader with a newsletter signup or purchase.
2. Visit My Account, verify if needed, and visit a subpage of My Account (such as Newsletters, Subscriptions, Payment Details, etc.)
3. On `master`, observe that the active menu links are not clickable. 
4. Check out this branch, refresh, and confirm that the active menu links are now clickable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
