### PR TITLE
feat: simplify footer credits

### DIFF
--- a/newspack-theme/footer.php
+++ b/newspack-theme/footer.php
@@ -52,7 +52,7 @@ if ( '' !== get_theme_mod( 'newspack_footer_logo', '' ) && 0 !== get_theme_mod( 
 				<?php endif; ?>
 
 				<a target="_blank" href="<?php echo esc_url( __( 'https://newspack.com/', 'newspack' ) ); ?>" class="imprint">
-					<?php echo esc_html__( 'Proudly powered by Newspack by Automattic', 'newspack' ); ?>
+					<?php echo esc_html__( 'Powered by Newspack', 'newspack' ); ?>
 				</a>
 
 				<?php

--- a/newspack-theme/languages/de_DE.po
+++ b/newspack-theme/languages/de_DE.po
@@ -115,8 +115,8 @@ msgid "https://newspack.com/"
 msgstr "https://newspack.com/"
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Stolz betrieben von Newspack von Automattic"
+msgid "Powered by Newspack"
+msgstr "Angetrieben von Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"

--- a/newspack-theme/languages/es_ES.po
+++ b/newspack-theme/languages/es_ES.po
@@ -122,8 +122,8 @@ msgid "https://newspack.com/"
 msgstr ""
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Orgullosamente impulsado por Newspack de Automattic"
+msgid "Powered by Newspack"
+msgstr "Impulsado por Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"

--- a/newspack-theme/languages/fr_BE.po
+++ b/newspack-theme/languages/fr_BE.po
@@ -115,8 +115,8 @@ msgid "https://newspack.com/"
 msgstr "https://newspack.com/"
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Propulsé par Newspack de Automattic"
+msgid "Powered by Newspack"
+msgstr "Propulsé par Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"

--- a/newspack-theme/languages/newspack-theme.pot
+++ b/newspack-theme/languages/newspack-theme.pot
@@ -114,7 +114,7 @@ msgid "https://newspack.com/"
 msgstr ""
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
+msgid "Powered by Newspack"
 msgstr ""
 
 #: functions.php:78

--- a/newspack-theme/languages/pl_PL.po
+++ b/newspack-theme/languages/pl_PL.po
@@ -115,8 +115,8 @@ msgid "https://newspack.com/"
 msgstr "https://newspack.com/"
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Oparte na Newspack od Automattic"
+msgid "Powered by Newspack"
+msgstr "Oparte na Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"

--- a/newspack-theme/languages/pt_BR.po
+++ b/newspack-theme/languages/pt_BR.po
@@ -111,8 +111,8 @@ msgid "https://newspack.com/"
 msgstr "https://newspack.com/"
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Feito por Newspack por Automattic"
+msgid "Powered by Newspack"
+msgstr "Feito por Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"

--- a/newspack-theme/languages/pt_PT.po
+++ b/newspack-theme/languages/pt_PT.po
@@ -113,8 +113,8 @@ msgid "https://newspack.com/"
 msgstr "https://newspack.com/"
 
 #: footer.php:49
-msgid "Proudly powered by Newspack by Automattic"
-msgstr "Feito por Newspack por Automattic"
+msgid "Powered by Newspack"
+msgstr "Feito por Newspack"
 
 #: functions.php:78
 msgid "Primary Menu"


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With the upcoming Block Theme, we have decided to change the footer credits from "Proudly powered by Newspack by Automattic" to simply "Powered by Newspack".

This PR updates the credit for our Classic Theme 🙂

### How to test the changes in this Pull Request:

1. Look at the footer
2. Switch to this branch
3. Refresh and take a new look at the footer

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
