### PR TITLE
feat: add large image size for larger featured images

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -63,6 +63,7 @@ if ( ! function_exists( 'newspack_setup' ) ) :
 		set_post_thumbnail_size( 1568, 9999 );
 
 		add_image_size( 'newspack-featured-image', 1200, 9999 );
+		add_image_size( 'newspack-featured-image-large', 2000, 9999 );
 		add_image_size( 'newspack-archive-image', 800, 600, true );
 		add_image_size( 'newspack-archive-image-large', 1200, 900, true );
 		add_image_size( 'newspack-footer-logo', 400, 9999 );

--- a/newspack-theme/template-parts/post/large-featured-image.php
+++ b/newspack-theme/template-parts/post/large-featured-image.php
@@ -11,7 +11,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 ?>
 
 	<div class="featured-image-behind">
-		<?php newspack_post_thumbnail(); ?>
+		<?php newspack_post_thumbnail( 'newspack-featured-image-large' ); ?>
 		<div class="wrapper">
 			<header class="entry-header">
 				<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>
@@ -30,7 +30,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 			</header>
 		</div><!-- .wrapper -->
 
-		<?php newspack_post_thumbnail(); ?>
+		<?php newspack_post_thumbnail( 'newspack-featured-image-large' ); ?>
 
 		<?php newspack_post_thumbnail_caption(); ?>
 	</div><!-- .featured-image-behind -->
@@ -38,7 +38,7 @@ if ( 'behind' === newspack_featured_image_position() ) :
 <?php elseif ( 'above' === newspack_featured_image_position() ) : ?>
 
 	<div class="featured-image-above">
-		<?php newspack_post_thumbnail(); ?>
+		<?php newspack_post_thumbnail( 'newspack-featured-image-large' ); ?>
 
 		<header class="entry-header">
 			<?php get_template_part( 'template-parts/header/entry', 'header' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Our theme uses 1200px for featured images, but this isn't really adequate for the large featured image sizes that came after the theme was first built -- specifically, the Behind, Above and sometimes Behind (due to height) image sizes. 

This PR adds an additional 2000px size to just use for those cases on single posts and pages. It does mean larger image sizes, but Jetpack's Site Accelerator should help balance that out. 

See 1200550061930446-as-1205443589299352

### How to test the changes in this Pull Request:

1. Create three posts with the above, behind and beside featured image placements, respectively.
2. Publish, and view on the front-end; note that the image quality isn't great, especially on larger screens.
3. Apply the PR; you will likely also need to regenerate thumbnails just to get your images up to date; you can use [this plugin](https://wordpress.org/plugins/regenerate-thumbnails/) or [the CLI command](https://developer.wordpress.org/cli/commands/media/regenerate/).
4. Refresh your posts and confirm they're loading a larger image size. Note: it still may not be ideal for all images -- like ones that are more illustrative/text heavy -- but it should be an improvement!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
