### PR TITLE
 feat: add theme option to show image captions/credits in archives

### DIFF
--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1081,6 +1081,24 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to show image credits in archives.
+	$wp_customize->add_setting(
+		'archive_show_credits',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'archive_show_credits',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Show image credits in archives and search results', 'newspack' ),
+			'section' => 'archive_options',
+		)
+	);
+
+
 	// Add option to change archive layouts.
 	$wp_customize->add_setting(
 		'archive_layout',

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1093,7 +1093,7 @@ function newspack_customize_register( $wp_customize ) {
 		'archive_show_captions',
 		array(
 			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Show image captions in archives and search results', 'newspack' ),
+			'label'   => esc_html__( 'Show image captions in archives and WordPress's default search results', 'newspack' ),
 			'section' => 'archive_options',
 		)
 	);

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1081,6 +1081,23 @@ function newspack_customize_register( $wp_customize ) {
 		)
 	);
 
+	// Add option to show image captions in archives.
+	$wp_customize->add_setting(
+		'archive_show_captions',
+		array(
+			'default'           => false,
+			'sanitize_callback' => 'newspack_sanitize_checkbox',
+		)
+	);
+	$wp_customize->add_control(
+		'archive_show_captions',
+		array(
+			'type'    => 'checkbox',
+			'label'   => esc_html__( 'Show image captions in archives and search results', 'newspack' ),
+			'section' => 'archive_options',
+		)
+	);
+
 	// Add option to show image credits in archives.
 	$wp_customize->add_setting(
 		'archive_show_credits',

--- a/newspack-theme/inc/customizer.php
+++ b/newspack-theme/inc/customizer.php
@@ -1093,7 +1093,7 @@ function newspack_customize_register( $wp_customize ) {
 		'archive_show_captions',
 		array(
 			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Show image captions in archives and WordPress's default search results', 'newspack' ),
+			'label'   => esc_html__( 'Show image captions in archives and WordPress’s default search results', 'newspack' ),
 			'section' => 'archive_options',
 		)
 	);
@@ -1110,7 +1110,7 @@ function newspack_customize_register( $wp_customize ) {
 		'archive_show_credits',
 		array(
 			'type'    => 'checkbox',
-			'label'   => esc_html__( 'Show image credits in archives and search results', 'newspack' ),
+			'label'   => esc_html__( 'Show image credits in archives and WordPress’s default search results', 'newspack' ),
 			'section' => 'archive_options',
 		)
 	);

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -398,10 +398,22 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 					<?php the_post_thumbnail( $size, $default_image_attributes ); ?>
 				</a>
-				<?php if ( get_theme_mod( 'archive_show_credits' ) && method_exists( 'Newspack\Newspack_Image_Credits', 'get_media_credit_string' ) ) : ?>
-					<figcaption>
-						<?php echo wp_kses_post( \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() ) ); ?>
-					</figcaption>
+				<?php if ( get_theme_mod( 'archive_show_captions' ) || get_theme_mod( 'archive_show_credits' ) ) : ?>
+					<?php
+					$featured_image_id = get_post_thumbnail_id();
+					$caption           = wp_get_attachment_caption( $featured_image_id );
+					$credit            = method_exists( 'Newspack\Newspack_Image_Credits', 'get_media_credit_string' ) && \Newspack\Newspack_Image_Credits::get_media_credit_string( $featured_image_id );
+					if ( $caption || $credit ) :
+						?>
+						<figcaption>
+							<?php if ( get_theme_mod( 'archive_show_captions' ) && $caption ) : ?>
+								<?php echo esc_html( $caption ); ?>
+							<?php endif; ?>
+							<?php if ( get_theme_mod( 'archive_show_credits' ) && $credit ) : ?>
+								<?php echo wp_kses_post( \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() ) ); ?>
+							<?php endif; ?>
+						</figcaption>
+					<?php endif; ?>
 				<?php endif; ?>
 			</figure>
 

--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -398,6 +398,11 @@ if ( ! function_exists( 'newspack_post_thumbnail' ) ) :
 				<a class="post-thumbnail-inner" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
 					<?php the_post_thumbnail( $size, $default_image_attributes ); ?>
 				</a>
+				<?php if ( get_theme_mod( 'archive_show_credits' ) && method_exists( 'Newspack\Newspack_Image_Credits', 'get_media_credit_string' ) ) : ?>
+					<figcaption>
+						<?php echo wp_kses_post( \Newspack\Newspack_Image_Credits::get_media_credit_string( get_post_thumbnail_id() ) ); ?>
+					</figcaption>
+				<?php endif; ?>
 			</figure>
 
 			<?php

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -34,6 +34,9 @@
 
 		figcaption {
 			margin-top: 8px;
+			@include utilities.media( tablet ) {
+				font-size: var(--newspack-theme-font-size-xxs);
+			}
 		}
 	}
 

--- a/newspack-theme/sass/site/primary/_archives.scss
+++ b/newspack-theme/sass/site/primary/_archives.scss
@@ -31,6 +31,10 @@
 
 	.post-thumbnail {
 		margin: 0 0 #{0.5 * structure.$size__spacing-unit};
+
+		figcaption {
+			margin-top: 8px;
+		}
 	}
 
 	.entry-content > p {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a Customizer option to show image captions and/or credits in archives and search results.

Closes `1206709674365921/1206688511006431`.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit the Customizer and go to **Template Settings > Archive Settings**. Confirm you see the new options at the top here:

<img width="454" alt="Screenshot 2024-03-05 at 3 15 22 PM" src="https://github.com/Automattic/newspack-theme/assets/2230142/eef27ff6-cb6d-4727-8bf1-45032174ba77">

3. Enable both options and visit an archive page that shows a post with a featured image that has a credit. Confirm that the credit shows with the thumbnail in both large and small archive styles:

<img width="811" alt="Screenshot 2024-03-05 at 3 15 29 PM" src="https://github.com/Automattic/newspack-theme/assets/2230142/ee6e35ca-475d-4d6b-b8dd-69fef5abf1a4">

4. Search for the article and confirm that the credit also shows up in search results:

<img width="821" alt="Screenshot 2024-03-05 at 2 47 03 PM" src="https://github.com/Automattic/newspack-theme/assets/2230142/4af3d8bc-c613-4017-a173-25626c6fafb2">

5. Retest in different combinations, namely:
  - Captions enabled, credits disabled
  - Captions disabled, credits enabled
  - Both enabled
  - Both disabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
