### PR TITLE
fix:  update template for woo 8.7.0

### DIFF
--- a/newspack-theme/woocommerce/order/order-details-customer.php
+++ b/newspack-theme/woocommerce/order/order-details-customer.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 5.6.0
+ * @version 8.7.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,6 +44,17 @@ $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_a
 		<?php if ( $order->get_billing_email() ) : ?>
 			<p class="woocommerce-customer-details--email"><?php echo esc_html( $order->get_billing_email() ); ?></p>
 		<?php endif; ?>
+
+		<?php
+			/**
+			 * Action hook fired after an address in the order customer details.
+			 *
+			 * @since 8.7.0
+			 * @param string $address_type Type of address (billing or shipping).
+			 * @param WC_Order $order Order object.
+			 */
+			do_action( 'woocommerce_order_details_after_customer_address', 'billing', $order );
+		?>
 	</address>
 
 	<?php if ( $show_shipping ) : ?>
@@ -54,6 +65,17 @@ $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_a
 			<h5 class="woocommerce-column__title"><?php esc_html_e( 'Shipping address', 'newspack' ); ?></h5>
 			<address>
 				<?php echo wp_kses_post( $order->get_formatted_shipping_address( esc_html__( 'N/A', 'newspack' ) ) ); ?>
+
+				<?php
+					/**
+					 * Action hook fired after an address in the order customer details.
+					 *
+					 * @since 8.7.0
+					 * @param string $address_type Type of address (billing or shipping).
+					 * @param WC_Order $order Order object.
+					 */
+					do_action( 'woocommerce_order_details_after_customer_address', 'shipping', $order );
+				?>
 			</address>
 		</div><!-- /.col-2 -->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces #2263; I switched it to a hotfix since these alerts can cause worries for publishers/lot of communication for support.

This PR gets the order-details-customer.php file in the Newspack theme up-to-date with what was changed in the template in the WooCommerce 8.7.0 release, to prevent a message from displaying.

See 1200550061930446-as-1206883834710822

### How to test the changes in this Pull Request:

1. Make sure WooCommerce is up-to-date on your test site.
2. View the WP Admin; note you have a notice like this: 

![image](https://github.com/Automattic/newspack-theme/assets/177561/5ce18abd-dfc2-4925-9847-1fb3f44ce9d1)

3. Apply this PR. 
4. Confirm that the notice goes away.
5. Navigate to /my-account > Orders, and confirm there are no issues. 
6. Spot-check the file's changes against the ones made in the WooCommerce plugin [here](https://github.com/woocommerce/woocommerce/commit/d858d2293044e844c1091350695f8e675eca41c4#diff-7cf3e3565d555bd9e8dd2c4691c99e8d67154b97cad3478343c46832f2c4dfae), to make sure they line up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
