### PR TITLE
fix: make single post subtitle styles more specific

### DIFF
--- a/newspack-theme/sass/site/primary/_posts-and-pages.scss
+++ b/newspack-theme/sass/site/primary/_posts-and-pages.scss
@@ -49,15 +49,19 @@
 }
 
 .newspack-post-subtitle {
-	margin-bottom: 1.3em;
 	font-style: italic;
-	@include utilities.media( mobile ) {
-		margin-bottom: 2.3em;
-	}
 
 	em,
 	i {
 		font-style: normal;
+	}
+}
+
+.entry-header .newspack-post-subtitle {
+	margin-bottom: 1.3em;
+
+	@include utilities.media( mobile ) {
+		margin-bottom: 2.3em;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a small issue where, if you had a Homepage Post block on a single post with the subtitle displaying, it would have a lot of extra space underneath it. This was because the subtitle styles in the theme aren't specific enough. 

See 1200024937525366-as-1206994171860195

### How to test the changes in this Pull Request:

1. Add a Homepage Posts block to a widget area on a single post, and enable the subtitles.
2. View on the front-end; note the extra space under the subtitle:

![image](https://github.com/Automattic/newspack-theme/assets/177561/d82688ea-56ae-4546-87d4-c2bb2ee1b0dd)

3. Apply this PR and run `npm run build`.
4. Refresh your post; confirm that the subtitle spacing looks okay in the homepage post block.

![image](https://github.com/Automattic/newspack-theme/assets/177561/01fdd6eb-8c96-460f-b7a3-7e3b8cc3988a)

5. If your single post doesn't have one already, add a subtitle to it and confirm it looks okay (applies spacing underneath the subtitle).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
