### PR TITLE
fix(homepage-posts): handle "time ago" format in HBP

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -680,6 +680,9 @@ function newspack_convert_to_time_ago( $post_time, $format, $post ) {
 	return $post_time;
 }
 add_filter( 'get_the_date', 'newspack_convert_to_time_ago', 10, 3 );
+add_filter( 'newspack_blocks_formatted_displayed_post_date', function($date_formatted, $post){
+	return newspack_math_to_time_ago( $date_formatted, '', $post, false );
+}, 10, 3 );
 
 /**
  * Apply time ago format to modified dates if enabled.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in https://github.com/Automattic/newspack-blocks/pull/1662 – "time ago" format is not respected by the HPB with this changes. This PR fixed that. 

### How to test the changes in this Pull Request:

1. Navigate to Customizer > Template Settings > Post Template and enable "Use "time ago" date format".
2. Add a homepage post block to a page; make sure it has at least one post new enough to fall inside of the 'time ago' range (it can also be changed in the Customizer). 
3. Observe that the "time ago" format is respected by the HPB both in the editor and on the frontend

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207084341012277