### PR TITLE
fix: handle attachement fetch failure

### DIFF
--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -31,8 +31,9 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			return $position;
 		}
 
+		$image_wide_width = 1200;
 		if ( (
-			'large' === $position && 1200 > $thumbnail_info['width'] )
+			'large' === $position && $image_wide_width > $thumbnail_info['width'] )
 			|| ! in_array( get_post_type(), newspack_get_featured_image_post_types() )
 		) {
 			$position = 'small';

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -17,31 +17,24 @@ if ( ! function_exists( 'newspack_featured_image_position' ) ) :
 			return '';
 		}
 
-		// Get thumbnail
-		$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
-		$img_width      = $thumbnail_info['width'];
+		$position = is_single() ? get_theme_mod( 'featured_image_default', 'large' ) : get_theme_mod( 'page_featured_image_default', 'small' );
 
 		// Get per-post image position setting.
 		$image_pos = get_post_meta( get_the_ID(), 'newspack_featured_image_position', true );
-
-		// Set a position value to return.
-		$position = '';
-
-		// First, check for a per-post image setting.
 		if ( '' !== $image_pos ) {
 			$position = $image_pos;
-		// If this post doesn't have a setting, fall back to the default.
-		} else {
-			if ( is_single() ) {
-				// Set default if a post:
-				$position = get_theme_mod( 'featured_image_default', 'large' );
-			} elseif ( is_page() ) {
-				// Set default if a page:
-				$position = get_theme_mod( 'page_featured_image_default', 'small' );
-			}
 		}
 
-		if ( ( 'large' === $position && 1200 > $img_width ) || ! in_array( get_post_type(), newspack_get_featured_image_post_types() ) ) {
+		// Get thumbnail
+		$thumbnail_info = wp_get_attachment_metadata( get_post_thumbnail_id() );
+		if ( $thumbnail_info === false ) {
+			return $position;
+		}
+
+		if ( (
+			'large' === $position && 1200 > $thumbnail_info['width'] )
+			|| ! in_array( get_post_type(), newspack_get_featured_image_post_types() )
+		) {
 			$position = 'small';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As seen on a live site, `wp_get_attachment_metadata` may return `false`. If it's not handled, a PHP Warning will be logged. This PR adds handling of a `false` return value from `wp_get_attachment_metadata`, and refactors code for readability.

### How to test the changes in this Pull Request:

Set a featured image on a post or page, observe it behaves as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->