### PR TITLE
Don't update option on every request

### DIFF
--- a/newspack-theme/woocommerce/templates.php
+++ b/newspack-theme/woocommerce/templates.php
@@ -13,7 +13,7 @@
  */
 $newspack_theme_woo_templates_version = 1;
 
-if ( function_exists( 'wc_clear_template_cache' ) && get_option( 'newspack_theme_woo_templates_version', 0 ) !== $newspack_theme_woo_templates_version ) {
+if ( function_exists( 'wc_clear_template_cache' ) && (int) get_option( 'newspack_theme_woo_templates_version', 0 ) !== $newspack_theme_woo_templates_version ) {
 	wc_clear_template_cache();
 	update_option( 'newspack_theme_woo_templates_version', $newspack_theme_woo_templates_version );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue I noticed while debugging something. The template check never succeeds, so the template cache is cleared on every page load and the template version option is updated on every page load. This is because the option value is the string `"1"` but the check does a strict compare with integer `1`.

<img width="471" alt="Screenshot 2024-05-22 at 8 58 59 PM" src="https://github.com/Automattic/newspack-theme/assets/7317227/4d8a1276-d968-48da-aba6-882abc456a0d">



I have this as a hotfix because removing this helps performance and it's a tiny change.

### How to test the changes in this Pull Request:

1. Install Query Monitor. Go to any page. In the DB section filter on UPDATE and see the option is updated on every page load.

<img width="1728" alt="Screenshot 2024-05-22 at 9 42 40 PM" src="https://github.com/Automattic/newspack-theme/assets/7317227/862ff598-e698-4267-ae90-9ca988c17dce">

2. Apply this patch. Refresh the page. See the option is not updated on every page load any more.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
