### PR TITLE
feat: add specific css for subscribe pattern 5 and 6

### DIFF
--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -2,6 +2,12 @@
 @use '../mixins/utilities';
 
 .newspack-pattern {
+	/* Subscribe Style 6 */
+
+	&.subscribe__style-6 {
+		gap: 0;
+	}
+
 	/* Subscribe Style 7 */
 
 	&.subscribe__style-7 {

--- a/newspack-theme/sass/blocks/_patterns.scss
+++ b/newspack-theme/sass/blocks/_patterns.scss
@@ -2,6 +2,25 @@
 @use '../mixins/utilities';
 
 .newspack-pattern {
+	/* Subscribe Style 5 */
+
+	&.subscribe__style-5 {
+		.wp-block-cover__inner-container {
+			> * {
+				margin-bottom: 32px;
+				margin-top: 32px;
+
+				&:first-child {
+					margin-top: 0;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+		}
+	}
+
 	/* Subscribe Style 6 */
 
 	&.subscribe__style-6 {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you apply https://github.com/Automattic/newspack-blocks/pull/1745 you'll notice that if you use Pattern 5, there isn't a gap between the intro and the form or, if you insert Pattern 6, there's a gap between the image and the card. This PR fixes both issues.

### How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/newspack-blocks/pull/1745
2. Insert Pattern 5 and Pattern 6 to a page
3. Notice the issues
4. Switch to this branch
5. Refresh page. Issues should be gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
