### PR TITLE
feat: add support for publisher media kit

### DIFF
--- a/newspack-theme/sass/plugins/newspack-publisher-media-kit.scss
+++ b/newspack-theme/sass/plugins/newspack-publisher-media-kit.scss
@@ -1,0 +1,24 @@
+.publisher-media-kit {
+	&__wrapper {
+		&.wp-block-group{
+			> .wp-block-group__inner-container {
+				> * {
+					margin-bottom: var( --wp--preset--spacing--80 );
+					margin-top: var( --wp--preset--spacing--80 );
+
+					&:first-child {
+						margin-top: 0;
+					}
+
+					&:last-child {
+						margin-bottom: 0;
+
+						.page-template-no-header-footer-php & {
+							margin-bottom: var( --wp--preset--spacing--80 );
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/newspack-theme/sass/style-base.scss
+++ b/newspack-theme/sass/style-base.scss
@@ -64,3 +64,7 @@
 /* Newspack Listings support */
 
 @use 'plugins/newspack-listings';
+
+/* Newspack Publisher Media Kit */
+
+@use 'plugins/newspack-publisher-media-kit';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is something I really wanted to avoid but unfortunately the theme doesn't support `blockGap` which means the Publisher Media Kit page rendered didn't have the correct spacing between patterns.

### How to test the changes in this Pull Request:

1. Switch the Publisher Media Kit plugin to https://github.com/Automattic/publisher-media-kit-for-newspack/pull/3
2. Activate and notice the small gaps (32px)
3. Switch to this branch
4. Refresh Media Kit page and now the blocks should have a much bigger gap between them

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
