### PR TITLE
fix: remove margins from grid block

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -1161,6 +1161,10 @@ hr {
 			}
 		}
 	}
+
+	& > .wp-block-group-is-layout-grid > * {
+		margin: 0;
+	}
 }
 
 .entry .entry-content > .wp-block-group.alignleft,
@@ -1181,8 +1185,8 @@ hr {
 	}
 }
 
-.wp-block-group.has-background + .wp-block-group.has-background,
-[id='pico'] > .wp-block-group.has-background + .wp-block-group.has-background {
+.wp-block-group.has-background.alignfull + .wp-block-group.has-background.alignfull,
+[id='pico'] > .wp-block-group.has-background.alignfull + .wp-block-group.has-background.alignfull {
 	margin-top: -32px;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes a couple tweaks to the group block spacing to make the new Grid style, coming in WP 6.6.

This change also fixes an issue where blocks that have solid backgrounds should have no gap between them -- this should only be applied when the blocks a full-width, not all the time.

See: 1207594452716169-as-1207669473649576

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 6.6 RC.
2. Add a Grid block to the editor (or add a Group block and select the Grid variation).
3. Add some blocks inside of the group block. This is easiest to test with blocks with backgrounds, like paragraphs or group blocks with stuff inside of them.
4. View on the front-end -- you should have kind of a mismatchy, spacy mess, like:

![image](https://github.com/Automattic/newspack-theme/assets/177561/869fc3a8-6903-43ca-93ba-cfaebab1af11)

5. Apply this PR and run `npm run build`.
6. Refresh the front-end and confirm you have a nicely formed grid:

![image](https://github.com/Automattic/newspack-theme/assets/177561/dd304787-2f0c-4c7e-ae55-63d762d406b7)

8. Try reordering/adding different blocks to make sure things behave fairly well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
