### PR TITLE
fix: correct title, subtitle order in the editor in WP 6.6

### DIFF
--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -11,7 +11,7 @@ export const META_FIELD_NAME = 'newspack_post_subtitle';
  *
  * @param {string} subtitle Subtitle text
  */
-export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
+export const appendSubtitleToTitleDOMElement = subtitle => {
 	let titleEl = document.querySelector( '.editor-post-title__block' ); // Legacy selector
 	if ( ! titleEl ) {
 		titleEl = document.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
@@ -19,15 +19,12 @@ export const appendSubtitleToTitleDOMElement = ( subtitle, isInCodeEditor ) => {
 
 	if ( titleEl && typeof subtitle === 'string' ) {
 		let subtitleEl = document.getElementById( SUBTITLE_ID );
+		const titleParent = titleEl.parentNode;
+
 		if ( ! subtitleEl ) {
 			subtitleEl = document.createElement( 'div' );
 			subtitleEl.id = SUBTITLE_ID;
-			// special style for the code (raw text) editor
-			if ( isInCodeEditor ) {
-				subtitleEl.style.paddingLeft = '14px';
-				subtitleEl.style.marginBottom = '4px';
-			}
-			titleEl.appendChild( subtitleEl );
+			titleParent.insertBefore( subtitleEl, titleEl.nextSibling );
 		}
 		subtitleEl.innerHTML = subtitle;
 	}

--- a/newspack-theme/js/src/post-subtitle/utils.js
+++ b/newspack-theme/js/src/post-subtitle/utils.js
@@ -12,10 +12,7 @@ export const META_FIELD_NAME = 'newspack_post_subtitle';
  * @param {string} subtitle Subtitle text
  */
 export const appendSubtitleToTitleDOMElement = subtitle => {
-	let titleEl = document.querySelector( '.editor-post-title__block' ); // Legacy selector
-	if ( ! titleEl ) {
-		titleEl = document.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
-	}
+	const titleEl = document.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 
 	if ( titleEl && typeof subtitle === 'string' ) {
 		let subtitleEl = document.getElementById( SUBTITLE_ID );

--- a/newspack-theme/sass/style-editor-overrides.scss
+++ b/newspack-theme/sass/style-editor-overrides.scss
@@ -135,11 +135,13 @@ body.newspack-single-column-template {
 body.post-type-post {
 	.editor-post-title__block,
 	.edit-post-visual-editor__post-title-wrapper,
-	.editor-styles-wrapper h1.wp-block-post-title {
+	.editor-styles-wrapper h1.wp-block-post-title,
+	#newspack-post-subtitle-element {
 		max-width: 1200px;
 	}
 
-	.edit-post-visual-editor__post-title-wrapper {
+	.edit-post-visual-editor__post-title-wrapper,
+	#newspack-post-subtitle-element {
 		margin-left: auto;
 		margin-right: auto;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates where the article subtitle preview is inserted in the editor, to correct an order issue that happens with WP 6.6. 

It also removes some unused code: 
* [A legacy selector needed for 5.9](https://github.com/Automattic/newspack-theme/pull/1660)
* Some styles related to the code view of the editor. The Subtitle doesn't seem to insert there in WP 6.5, and I think it's fine; we haven't heard anything about, and it's not editable there, anyway.

See 1207594452716169-as-1207669473649561

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 6.6 RC. 
2. Create a post, and add a subtitle in the sidebar; note the editor order:

![image](https://github.com/Automattic/newspack-theme/assets/177561/3ccd85a9-acc6-499a-8dce-37d43bdd51f6)

3. Apply this PR and run `npm run build`.
4. Confirm the editor order now looks better.

![image](https://github.com/Automattic/newspack-theme/assets/177561/30c0dbdd-2a06-481d-8dde-ab4b1438e02b)


6. Retest this PR on a site running WP 6.5.x, and confirm that it doesn't cause issues (if you're using the WordPress Beta plugin, you can also just roll back your original test site). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
