### PR TITLE
fix(ras-acc): remove redundant checkout styles

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -1581,13 +1581,6 @@ table.woocommerce-table--order-details.shop_table,
 	.woocommerce-product-gallery__trigger {
 		right: 1rem;
 	}
-
-	.wc_payment_method {
-		> label:first-of-type img {
-			float: none;
-			margin-left: 0.5 * structure.$size__spacing-unit;
-		}
-	}
 }
 
 @media only screen and ( min-width: 768px ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207878733150099/f

This PR removes some checkout specific styles that are impacting the credit card image alignment for some payment gateways:

Before:
![Screenshot 2024-07-25 at 12 11 58](https://github.com/user-attachments/assets/f446f4fa-020f-4cb6-825a-7be5aafef1fd)

After:
![Screenshot 2024-07-25 at 12 12 07](https://github.com/user-attachments/assets/faafcaa0-9057-4261-918a-2be2b22cbd45)


### How to test the changes in this Pull Request:

1. Enable woopayments as a payment method
2. As a reader, visit any page with a donate block
3. Initiate checkout, and get to the payment method screen
4. Confirm the credit card image is aligned as expected (pictured above in After)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
