### PR TITLE
fix: give the inline sign up form a max-width

### DIFF
--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -969,6 +969,12 @@ table.variations {
  * Account section
  */
 .woocommerce-account {
+	.entry-content .newspack-reader-auth__inline-wrapper {
+			margin-left: auto;
+			margin-right: auto;
+			max-width: var( --newspack-ui-modal-width-s, 410px );
+	}
+
 	.woocommerce-MyAccount-navigation {
 		margin: 0 0 2rem;
 

--- a/newspack-theme/sass/plugins/woocommerce.scss
+++ b/newspack-theme/sass/plugins/woocommerce.scss
@@ -969,7 +969,8 @@ table.variations {
  * Account section
  */
 .woocommerce-account {
-	.entry-content .newspack-reader-auth__inline-wrapper {
+	.woocommerce-notices-wrapper:has( + .newspack-reader-auth__inline-wrapper ),
+	.newspack-reader-auth__inline-wrapper {
 			margin-left: auto;
 			margin-right: auto;
 			max-width: var( --newspack-ui-modal-width-s, 410px );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR gives the inline sign-up form a max-width (along with https://github.com/Automattic/newspack-plugin/pull/3282 to add an extra CSS class).

I opted to add the styles in the theme because I'm not sure we're going to have the same setup/outcome with the block theme. Let me know if that doesn't make sense, though!

See 1205234045751551-as-1207890325042756

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-plugin/pull/3282 and run `npm run build`
2. Go to /my-account and confirm that the sign-up form appears roughly the same size as it does in the modal.
3. Try signing in, and confirm that the different screens (OTP, password) look okay.

![image](https://github.com/user-attachments/assets/321038fe-9906-4b6e-86c5-949e97944d80)

![image](https://github.com/user-attachments/assets/930435dc-ec40-4eac-bec8-9425e0971ca7)

![image](https://github.com/user-attachments/assets/7277707c-0d0f-42fb-86d9-a8f075a31e9b)

4. Log out and confirm the sign out message uses the max-width, too. 

![image](https://github.com/user-attachments/assets/c6c11d84-d8da-45a8-8fe9-919394234c89)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
