### PR TITLE
fix: avoid warnings

### DIFF
--- a/newspack-theme/inc/template-tags.php
+++ b/newspack-theme/inc/template-tags.php
@@ -439,7 +439,8 @@ if ( ! function_exists( 'newspack_post_thumbnail_caption' ) ) {
 		}
 
 		// Check the existance of the caption separately, so filters -- like ones that add ads -- don't interfere.
-		$caption_exists = get_post( get_post_thumbnail_id() )->post_excerpt;
+		$thumbnail      = get_post( get_post_thumbnail_id() );
+		$caption_exists = $thumbnail && $thumbnail->post_excerpt;
 
 		// Only get the caption if one exists.
 		if ( $caption_exists ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids this warnings I'm seeing:

```
[23-Aug-2024 19:39:57 UTC] PHP Warning:  Attempt to read property "post_excerpt" on null in /wordpress/themes/newspack-theme/2.0.0/inc/template-tags.php on line 442
```

### How to test the changes in this Pull Request:

Not sure what triggers that code. But test if things work as expected there. Changes look simple and safe.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
