### PR TITLE
fix: downgrade octokit version to v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "newspack",
 			"version": "2.0.0",
 			"devDependencies": {
-				"@octokit/rest": "^21.0.2",
+				"@octokit/rest": "^20.0.2",
 				"@rushstack/eslint-patch": "^1.10.4",
 				"@wordpress/browserslist-config": "^6.6.0",
 				"chokidar-cli": "^3.0.0",
@@ -3832,6 +3832,48 @@
 			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
 			"dev": true
 		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
+			"integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^13.5.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
+			"integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^13.5.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5"
+			}
+		},
 		"node_modules/@octokit/plugin-retry": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
@@ -3956,154 +3998,102 @@
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "21.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.2.tgz",
-			"integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
+			"version": "20.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+			"integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/core": "^6.1.2",
-				"@octokit/plugin-paginate-rest": "^11.0.0",
-				"@octokit/plugin-request-log": "^5.3.1",
-				"@octokit/plugin-rest-endpoint-methods": "^13.0.0"
+				"@octokit/core": "^5.0.2",
+				"@octokit/plugin-paginate-rest": "11.3.1",
+				"@octokit/plugin-request-log": "^4.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "13.2.2"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
-			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/core": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
-			"integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+			"integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/auth-token": "^5.0.0",
-				"@octokit/graphql": "^8.0.0",
-				"@octokit/request": "^9.0.0",
-				"@octokit/request-error": "^6.0.1",
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
 				"@octokit/types": "^13.0.0",
-				"before-after-hook": "^3.0.2",
-				"universal-user-agent": "^7.0.0"
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
-			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+			"integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^13.0.0",
-				"universal-user-agent": "^7.0.2"
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
-			"integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+			"integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/request": "^9.0.0",
+				"@octokit/request": "^8.3.0",
 				"@octokit/types": "^13.0.0",
-				"universal-user-agent": "^7.0.0"
+				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.3.tgz",
-			"integrity": "sha512-o4WRoOJZlKqEEgj+i9CpcmnByvtzoUYC6I8PD2SA95M+BJ2x8h7oLcVOg9qcowWXBOdcTRsMZiwvM3EyLm9AfA==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.5.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
-			"integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "13.2.4",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.4.tgz",
-			"integrity": "sha512-gusyAVgTrPiuXOdfqOySMDztQHv6928PQ3E4dqVGEtOvRXAKRbJR4b1zQyniIT9waqaWk/UDaoJ2dyPr7Bk7Iw==",
-			"dev": true,
-			"dependencies": {
-				"@octokit/types": "^13.5.0"
-			},
-			"engines": {
-				"node": ">= 18"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/request": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
-			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+			"integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/endpoint": "^10.0.0",
-				"@octokit/request-error": "^6.0.1",
+				"@octokit/endpoint": "^9.0.1",
+				"@octokit/request-error": "^5.1.0",
 				"@octokit/types": "^13.1.0",
-				"universal-user-agent": "^7.0.2"
+				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.4.tgz",
-			"integrity": "sha512-VpAhIUxwhWZQImo/dWAN/NpPqqojR6PSLgLYAituLM6U+ddx9hCioFGwBr5Mi+oi5CLeJkcAs3gJ0PYYzU6wUg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+			"integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^13.0.0"
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			}
-		},
-		"node_modules/@octokit/rest/node_modules/before-after-hook": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
-			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-			"dev": true
-		},
-		"node_modules/@octokit/rest/node_modules/universal-user-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-			"dev": true
 		},
 		"node_modules/@octokit/tsconfig": {
 			"version": "1.0.2",
@@ -4130,22 +4120,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/unts"
-			}
-		},
-		"node_modules/@playwright/test": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-			"integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright": "1.45.3"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -23528,53 +23502,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/playwright": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-			"integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"playwright-core": "1.45.3"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/playwright-core": {
-			"version": "1.45.3",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-			"integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
-			"dev": true,
-			"peer": true,
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"release:archive": "mkdir -p release && zip -r release/newspack-theme.zip newspack-theme -x .DS_Store && zip -r release/newspack-sacha.zip newspack-sacha -x .DS_Store && zip -r release/newspack-scott.zip newspack-scott -x .DS_Store && zip -r release/newspack-nelson.zip newspack-nelson -x .DS_Store  && zip -r release/newspack-katharine.zip newspack-katharine -x .DS_Store && zip -r release/newspack-joseph.zip newspack-joseph -x .DS_Store"
 	},
 	"devDependencies": {
-		"@octokit/rest": "^21.0.2",
+		"@octokit/rest": "^20.0.2",
 		"@rushstack/eslint-patch": "^1.10.4",
 		"@wordpress/browserslist-config": "^6.6.0",
 		"chokidar-cli": "^3.0.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a dependency conflict. [v21 of @octokit/rest](https://github.com/octokit/rest.js/releases/tag/v21.0.0) included a breaking change refactoring their exports to ESM instead of CommonJS. Our scripts expect CommonJS.

### How to test the changes in this Pull Request:

1. On `trunk`, run `npm start && npm run semantic-release` and observe an error:

```
➜  newspack-theme git:(trunk) ✗ npm run semantic-release

> newspack@2.0.0 semantic-release
> semantic-release

[5:21:53 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.5
[5:21:53 PM] [semantic-release] › ✖  An error occurred while running semantic-release: Error [ERR_REQUIRE_ESM]: require() of ES Module /repos/newspack-theme/node_modules/@octokit/rest/dist-src/index.js from /repos/newspack-theme/scripts/create-child-releases.js not supported.
Instead change the require of index.js in /repos/newspack-theme/scripts/create-child-releases.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/repos/newspack-theme/scripts/create-child-releases.js:5:21) {
  code: 'ERR_REQUIRE_ESM'
}
Error [ERR_REQUIRE_ESM]: require() of ES Module /repos/newspack-theme/node_modules/@octokit/rest/dist-src/index.js from /repos/newspack-theme/scripts/create-child-releases.js not supported.
Instead change the require of index.js in /repos/newspack-theme/scripts/create-child-releases.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/repos/newspack-theme/scripts/create-child-releases.js:5:21) {
  code: 'ERR_REQUIRE_ESM'
```

2. Check out this branch, run `npm start && npm run semantic-release` again and confirm that the dry run succeeds:

```
➜  newspack-theme git:(trunk) ✗ npm run semantic-release

> newspack@2.0.0 semantic-release
> semantic-release

[5:42:25 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.5
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/npm"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/npm"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "semantic-release-version-bump"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/git"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/npm"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/npm"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/github"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[5:42:25 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[5:42:25 PM] [semantic-release] › ⚠  This run was not triggered in a known CI environment, running in dry-run mode.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
