### PR TITLE
feat: add disabled button styles

### DIFF
--- a/newspack-theme/sass/forms/_buttons.scss
+++ b/newspack-theme/sass/forms/_buttons.scss
@@ -42,4 +42,11 @@ input[type="submit"],
 		outline: thin dotted;
 		outline-offset: -4px;
 	}
+
+	&[disabled],
+	&[disabled]:hover {
+		background: var(--newspack-ui-color-neutral-30, #ddd);
+		color: var(--newspack-ui-color-neutral-0, #fff);
+		cursor: default;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a disabled style for buttons.

The specific spot this is meant to address is the button on the password reset form. If your password is too short, the form displays a message and the button is disabled, but the latter looks the same as the regular button.

This PR fixes an issue reported in RAS-ACC, but it's also an issue on trunk, which is why I opted to fix it there. 

See: 1207817176293825-as-1208436941710286

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. As a reader, sign up for an account.
3. Go to My Account, and opt either to set or reset a password. You likely have to follow a link you receive in an email to get to the form:

![CleanShot 2024-10-09 at 16 27 15](https://github.com/user-attachments/assets/728e1e20-db7c-4633-a6f5-bb39e752f65b)

4. On the password reset page, enter only one character in the first input. Confirm that you get an error for the password being too short, and that the button greys out:

![CleanShot 2024-10-09 at 16 27 05](https://github.com/user-attachments/assets/2f075816-f673-4cbd-9a43-4dc65d032280)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
