### PR TITLE
fix: add parent theme to child theme description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.1.2-hotfix-add-parent-theme.1](https://github.com/Automattic/newspack-theme/compare/v2.1.1...v2.1.2-hotfix-add-parent-theme.1) (2024-11-12)
+
+
+### Bug Fixes
+
+* add parent theme to child theme description ([a300c60](https://github.com/Automattic/newspack-theme/commit/a300c605e7df730e168eaffe5b641c44f870ec62))
+
 ## [2.1.1](https://github.com/Automattic/newspack-theme/compare/v2.1.0...v2.1.1) (2024-11-11)
 
 

--- a/newspack-joseph/sass/theme-description.scss
+++ b/newspack-joseph/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/newspack-joseph/sass/theme-description.scss
+++ b/newspack-joseph/sass/theme-description.scss
@@ -9,6 +9,7 @@ Tested up to: 6.7
 Version: 2.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: newspack-theme
 Text Domain: newspack-joseph
 Tags: Newspack
 

--- a/newspack-katharine/sass/theme-description.scss
+++ b/newspack-katharine/sass/theme-description.scss
@@ -9,6 +9,7 @@ Tested up to: 6.7
 Version: 2.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: newspack-theme
 Text Domain: newspack-katharine
 Tags: Newspack
 

--- a/newspack-katharine/sass/theme-description.scss
+++ b/newspack-katharine/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/newspack-nelson/sass/theme-description.scss
+++ b/newspack-nelson/sass/theme-description.scss
@@ -9,6 +9,7 @@ Tested up to: 6.7
 Version: 2.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: newspack-theme
 Text Domain: newspack-nelson
 Tags: Newspack
 

--- a/newspack-nelson/sass/theme-description.scss
+++ b/newspack-nelson/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/newspack-sacha/sass/theme-description.scss
+++ b/newspack-sacha/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/newspack-sacha/sass/theme-description.scss
+++ b/newspack-sacha/sass/theme-description.scss
@@ -9,6 +9,7 @@ Tested up to: 6.7
 Version: 2.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: newspack-theme
 Text Domain: newspack-sacha
 Tags: Newspack
 

--- a/newspack-scott/sass/theme-description.scss
+++ b/newspack-scott/sass/theme-description.scss
@@ -9,6 +9,7 @@ Tested up to: 6.7
 Version: 2.1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Template: newspack-theme
 Text Domain: newspack-scott
 Tags: Newspack
 

--- a/newspack-scott/sass/theme-description.scss
+++ b/newspack-scott/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Template: newspack-theme

--- a/newspack-theme/sass/theme-description.scss
+++ b/newspack-theme/sass/theme-description.scss
@@ -6,7 +6,7 @@ Author URI: https://newspack.com
 Description: The official theme for Newspack, an all-in-one platform that simplifies publishing and drives audience and revenue right out of the box.
 Requires at least: 6.6
 Tested up to: 6.7
-Version: 2.1.1
+Version: 2.1.2-hotfix-add-parent-theme.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: newspack-theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack",
-	"version": "2.1.1",
+	"version": "2.1.2-hotfix-add-parent-theme.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack",
-			"version": "2.1.1",
+			"version": "2.1.2-hotfix-add-parent-theme.1",
 			"devDependencies": {
 				"@octokit/rest": "^20.0.2",
 				"@rushstack/eslint-patch": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack",
-	"version": "2.1.1",
+	"version": "2.1.2-hotfix-add-parent-theme.1",
 	"description": "A theme for Newspack. https://newspack.com",
 	"bugs": {
 		"url": "https://github.com/Automattic/newspack-theme/issues"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adding the parent theme back to the child theme descriptions.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Confirm you can see all the child themes under Themes > Appearance. 
3. With a child theme applied, edit a post and confirm you have featured image options.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
