### PR TITLE
fix: make button background styles more specific

### DIFF
--- a/newspack-theme/sass/forms/_buttons.scss
+++ b/newspack-theme/sass/forms/_buttons.scss
@@ -9,7 +9,7 @@ input[type="submit"],
 .wp-block-search__button {
 	@include utilities.button-transition;
 
-	background: var(--newspack-theme-color-secondary);
+	background-color: var(--newspack-theme-color-secondary);
 	border: none;
 	border-radius: 5px;
 	box-sizing: border-box;
@@ -26,7 +26,7 @@ input[type="submit"],
 
 	&:hover,
 	&:hover:visited {
-		background: var(--newspack-theme-color-bg-button-hover);
+		background-color: var(--newspack-theme-color-bg-button-hover);
 		color: var(--newspack-theme-color-bg-body);
 		cursor: pointer;
 	}
@@ -37,7 +37,7 @@ input[type="submit"],
 	}
 
 	&:focus {
-		background: var(--newspack-theme-color-bg-button-hover);
+		background-color: var(--newspack-theme-color-bg-button-hover);
 		color: var(--newspack-theme-color-bg-body);
 		outline: thin dotted;
 		outline-offset: -4px;
@@ -45,7 +45,7 @@ input[type="submit"],
 
 	&[disabled],
 	&[disabled]:hover {
-		background: var(--newspack-ui-color-neutral-30, #ddd);
+		background-color: var(--newspack-ui-color-neutral-30, #ddd);
 		color: var(--newspack-ui-color-neutral-0, #fff);
 		cursor: default;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue I noticed while working on https://github.com/Automattic/newspack-blocks/pull/1958 -- the background image used for the Link icon was getting overridden on hover by the non-specific background hover styles coming from the theme.

This PR fixes the issue by switching `background` to `background-color` so it won't affect background images; it's not specific to ras-acc, so I made the change in trunk.

### How to test the changes in this Pull Request:

1. Apply the PR and run `npm run build`.
2. Add some button blocks and confirm their hover styles still work.
3. Test around the theme and make sure other hover styles work as expected -- things like comment forms, the search and mobile menu toggle in the header, etc.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
