### PR TITLE
feat: add font-loading class

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -424,6 +424,13 @@ function newspack_content_width() {
 add_action( 'template_redirect', 'newspack_content_width', 0 );
 
 /**
+ * Return the list of custom fonts in use.
+ */
+function newspack_get_used_custom_fonts(): array {
+	return array_filter( [ get_theme_mod( 'font_header', '' ), get_theme_mod( 'font_body', '' ) ] );
+}
+
+/**
  * Enqueue scripts and styles.
  */
 function newspack_scripts() {
@@ -486,6 +493,15 @@ function newspack_scripts() {
 		wp_enqueue_script( 'amp-animation', 'https://cdn.ampproject.org/v0/amp-animation-0.1.js', array(), '0.1', true );
 		wp_enqueue_script( 'amp-position-observer', 'https://cdn.ampproject.org/v0/amp-position-observer-0.1.js', array(), '0.1', true );
 	}
+
+	wp_enqueue_script( 'newspack-font-loading', get_theme_file_uri( '/js/dist/font-loading.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+	wp_localize_script(
+		'newspack-font-loading',
+		'newspackFontLoading',
+		[
+			'fonts' => newspack_get_used_custom_fonts(),
+		]
+	);
 }
 add_action( 'wp_enqueue_scripts', 'newspack_scripts' );
 

--- a/newspack-theme/inc/template-functions.php
+++ b/newspack-theme/inc/template-functions.php
@@ -258,6 +258,11 @@ function newspack_body_classes( $classes ) {
 		$classes[] = 'fw-stacked';
 	}
 
+	// If custom fonts are used, add a class indicating that fonts will be loaded. The class will be removed by JS.
+	if ( ! empty( newspack_get_used_custom_fonts() ) ) {
+		$classes[] = 'newspack--font-loading';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'newspack_body_classes' );

--- a/newspack-theme/js/src/font-loading.js
+++ b/newspack-theme/js/src/font-loading.js
@@ -1,0 +1,8 @@
+const fontsToLoad = window.newspackFontLoading?.fonts || [];
+Promise.all(
+	fontsToLoad.map(fontName => document.fonts.load(`1rem ${fontName}`))
+).then(res => {
+	if (res.length === fontsToLoad.length) {
+		document.body.classList.remove('newspack--font-loading');
+	}
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a `newspack--font-loading` class to the `body` element until custom fonts are loaded. This will a enable font-loading-related performance improvement. 

Let's say a site is using a thick font for headings. In order to prevent layout shift on font load, the fallback font can be styled to match the thickness (e.g. by setting `letter-spacing` to something wide). On font load, the body class will be removed, and the custom font displayed as expected.

### How to test the changes in this Pull Request:

1. In Customizer -> Typography, set "Font Provider Import Code or URL" to e.g. `//fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;700&display=swap`, then set "Header Font" to `Anton` 
2. In Customizer -> Custom CSS, add e.g. `.newspack--font-loading h3 { letter-spacing: -1px; }`
3. Load the page, observe initially the `body` element has the `newspack--font-loading` class, which is then removed. The `h3` elements should match the `Anton` font on load. Enable network throttling for better observation. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->