### PR TITLE
fix: workaround for block editor crash

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -647,7 +647,7 @@ function newspack_fse_blocks_to_remove() {
 		'core/post-comments-form',
 		'core/comments-query-loop',
 		'core/query',
-		'core/post-title',
+		// 'core/post-title', Temporarily allow this block. Ref. https://github.com/woocommerce/woocommerce/pull/52209
 		'core/post-featured-image',
 		'core/post-excerpt',
 		'core/post-content',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Workaround fix for an issue publishers have reported. With WC 9.5.0, the block inserter crashes the post editor when opened.

### How to test the changes in this Pull Request:

**Note: This is a hotfix release.**

1. You can use woo-edit-issue.newspackstaging.com since WC 9.5.0 isn't publicly available yet. This site has just WC 9.5.0 and Newspack Theme active.
2. Edit a post. Click the + icon in the top left corner to open the block inserter. Observe the editor crashes with an error in the console about the post-title block.
3. Apply this patch. Edit a post. Click the + icon, etc. Observe the editor does not crash.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
