### PR TITLE
fix: make sure custom colours don't override newsletter modern style

### DIFF
--- a/newspack-theme/sass/blocks/_blocks.scss
+++ b/newspack-theme/sass/blocks/_blocks.scss
@@ -359,6 +359,17 @@ p.has-background {
 	}
 }
 
+//! Newspack Newlsetter Subscription Block
+.wp-block-newspack-newsletters-subscribe {
+	// Make sure custom colors don't override the color that should be used for the modern style.
+	&.is-style-modern input[type="checkbox"]::before {
+		background:
+			transparent
+			url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white' %3E%3C/path%3E%3C/svg%3E")
+			0 0 no-repeat;
+	}
+}
+
 //! Columns
 .wp-block-columns {
 	.wp-block-cover,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a contrast issue with the theme's checkbox styles, and the Newsletter Subscription Block's modern style -- the theme typically uses the secondary colour for the checkbox background, but the modern style always uses black. When you pick a light secondary colour, the checkmark ends up being black, which can't be seen against the black background.

See 1200550061930446-as-1208925182714392

### How to test the changes in this Pull Request:

1. Under Customizer > Custom Colours, change your secondary colour to something light.
2. Add a Newsletter Subscription block to a post or page, and enable at least two lists.
3. On the front end, test checking one of the lists (if they're not pre-selected), and note that you can't see the checkmark:

![CleanShot 2025-01-08 at 11 14 34](https://github.com/user-attachments/assets/7b87595e-9e88-43e5-90cb-0a8206629d04)

4. Apply the PR and run `npm run build`.
5. Refresh the page; confirm that the checkboxes look okay:

![CleanShot 2025-01-08 at 11 14 53](https://github.com/user-attachments/assets/b795b37f-eb7b-4b23-b081-a961a7eee740)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
