### PR TITLE
feat: add Nextdoor icon to the Social Links menu

### DIFF
--- a/newspack-theme/classes/class-newspack-svg-icons.php
+++ b/newspack-theme/classes/class-newspack-svg-icons.php
@@ -282,6 +282,9 @@ class Newspack_SVG_Icons {
 			'oldbytes.space',
 			'pawoo.net',
 		),
+		'nextdoor'    => array(
+			'nextdoor.com',
+		),
 		'phone'       => array(
 			'tel:',
 		),
@@ -494,6 +497,12 @@ class Newspack_SVG_Icons {
 </g>
 </svg>
 ',
+
+		'nextdoor'    => '
+<svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<path d="M8.07664 5.53693V3H4.82086V7.64405L1 10.1163L2.73222 12.9556L4.82086 11.6035V21H19.1791V11.6035L21.2678 12.9556L23 10.1163L11.9991 3L8.07664 5.53693Z" />
+</svg>',
+
 		'patreon'     => '
 <svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2267/social-links-menu-add-nextdoor-icon.

This PR adds the Nextdoor icon to the social links menu.

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Add a Nextdoor link (a Custom Link with the URL base nextdoor.com -- like https://about.nextdoor.com/us-media) to the Social Links menu.
3. Confirm you get the Nextdoor icon on the front end.
<img width="332" height="70" alt="Screenshot 2025-09-29 at 5 56 21 PM" src="https://github.com/user-attachments/assets/fd48552d-6781-4b72-a2f7-d91fc373bb0c" />

4. Change your header or footer background colour to make sure you get the inverse version of the Nextdoor icon and that it looks right.
<img width="332" height="70" alt="Screenshot 2025-09-29 at 5 55 50 PM" src="https://github.com/user-attachments/assets/dc56ae63-3059-4869-a6da-3a6d55de196e" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
