### PR TITLE
fix: unquoted font names (NPPM-2597)

### DIFF
--- a/newspack-theme/functions.php
+++ b/newspack-theme/functions.php
@@ -429,7 +429,7 @@ add_action( 'template_redirect', 'newspack_content_width', 0 );
  * Return the list of custom fonts in use.
  */
 function newspack_get_used_custom_fonts(): array {
-	return array_filter( array( get_theme_mod( 'font_header', '' ), get_theme_mod( 'font_body', '' ) ) );
+	return array_values( array_filter( [ get_theme_mod( 'font_header', '' ), get_theme_mod( 'font_body', '' ) ] ) );
 }
 
 /**

--- a/newspack-theme/js/src/font-loading.js
+++ b/newspack-theme/js/src/font-loading.js
@@ -1,7 +1,7 @@
 const fontsToLoad = window.newspackFontLoading?.fonts || [];
 Promise.all(
 	fontsToLoad.map( fontName => {
-		const escapedFontName = String( fontName ).replace( /(["\\])/g, '\\$1' );
+		const escapedFontName = String( fontName ).replace( /"/g, '\\"' );
 		return document.fonts.load( `1rem "${ escapedFontName }"` );
 	} )
 ).then( res => {

--- a/newspack-theme/js/src/font-loading.js
+++ b/newspack-theme/js/src/font-loading.js
@@ -1,5 +1,5 @@
 const fontsToLoad = window.newspackFontLoading?.fonts || [];
-Promise.all( fontsToLoad.map( fontName => document.fonts.load( `1rem ${ fontName }` ) ) ).then( res => {
+Promise.all( fontsToLoad.map( fontName => document.fonts.load( `1rem '${ fontName }'` ) ) ).then( res => {
 	if ( res.length === fontsToLoad.length ) {
 		document.body.classList.remove( 'newspack--font-loading' );
 	}

--- a/newspack-theme/js/src/font-loading.js
+++ b/newspack-theme/js/src/font-loading.js
@@ -1,8 +1,10 @@
 const fontsToLoad = window.newspackFontLoading?.fonts || [];
-Promise.all( fontsToLoad.map( fontName => {
-	const escapedFontName = String( fontName ).replace( /(["\\])/g, '\\$1' );
-	return document.fonts.load( `1rem "${ escapedFontName }"` );
-} ) ).then( res => {
+Promise.all(
+	fontsToLoad.map( fontName => {
+		const escapedFontName = String( fontName ).replace( /(["\\])/g, '\\$1' );
+		return document.fonts.load( `1rem "${ escapedFontName }"` );
+	} )
+).then( res => {
 	if ( res.length === fontsToLoad.length ) {
 		document.body.classList.remove( 'newspack--font-loading' );
 	}

--- a/newspack-theme/js/src/font-loading.js
+++ b/newspack-theme/js/src/font-loading.js
@@ -1,5 +1,8 @@
 const fontsToLoad = window.newspackFontLoading?.fonts || [];
-Promise.all( fontsToLoad.map( fontName => document.fonts.load( `1rem '${ fontName }'` ) ) ).then( res => {
+Promise.all( fontsToLoad.map( fontName => {
+	const escapedFontName = String( fontName ).replace( /(["\\])/g, '\\$1' );
+	return document.fonts.load( `1rem "${ escapedFontName }"` );
+} ) ).then( res => {
 	if ( res.length === fontsToLoad.length ) {
 		document.body.classList.remove( 'newspack--font-loading' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Specifying font names with spaces in them in the Customizer (`Appearance > Customize > Typography`) causes console errors on load.  No clear problems, but knock-on effects suspected.

This PR single-quotes the font names.

This PR also fixes a subtle issue discovered when *Body Font* was specified and *Header Font* was not--in those cases, `window.newspackFontLoading()` was emitting a JS object rather than the expected array since the array wasn't zero-indexed.  We've wrapped the offending `array_filter()` with an `array_values()` to ensure we end up with an array in JS.

Addresses [NPPM-2597: JavaScript Console Error - Font Names With Spaces Not Quoted in Font Loading](https://linear.app/a8c/issue/NPPM-2597/javascript-console-error-font-names-with-spaces-not-quoted-in-font).

### How to test the changes in this Pull Request:

#### Original issue:  font names with spaces.
(from the issue)

1. In any Newspack testing environment add a font name without spaces to *Header Font* or *Body Font* in Typography settings (`Appearance > Customize > Typography`).
2. Observe no related errors in console.
3. Add a space in the font name.
4. Observe Uncaught (in promise) SyntaxError.
5. Apply this PR.
6. Observe the errors are gone.

#### Additional issue:  *Body Font* specified, but *Header Font* not.
1. In any Newspack testing environment add a font name without spaces to both *Header Font* and *Body Font* in Typography settings (`Appearance > Customize > Typography`).
2. Observe no related errors in console.
3. Clear out *Header Font*.
4. Observe syntax error about nonexistent `map()` (variable containing font data is not an array).
5. Apply this PR.
6. Observe the errors are gone.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
